### PR TITLE
test: enforce orchestration guardrails

### DIFF
--- a/apps/backend/crates/orchestration/src/error.rs
+++ b/apps/backend/crates/orchestration/src/error.rs
@@ -5,6 +5,7 @@ pub enum OrchestrationError {
     ReplicaReadForbidden,
     PayloadHashEncodingFailed(String),
     EmptyExternalIdempotencyKey,
+    EmptyAuthoritativeWriteBatch,
     Database(String),
     EventAlreadyExists {
         event_id: Uuid,

--- a/apps/backend/crates/orchestration/src/lib.rs
+++ b/apps/backend/crates/orchestration/src/lib.rs
@@ -15,12 +15,12 @@ pub use error::OrchestrationError;
 pub use model::{
     ArchivedCommandInboxEntry, ArchivedOutboxMessage, AuthoritativeChange, ClaimedOutboxMessage,
     CommandBeginOutcome, CommandCompletion, CommandEnvelope, CommandInboxEntry, CommandInboxStatus,
-    CommandKey, ConsumeOutcome, DeliveryOutcome, DeliveryReceipt, ExternalIdempotencyKey,
-    NewOutboxMessage, OutboxAttempt, OutboxDeliveryStatus, OutboxMessage, ProcessingFailure,
-    PruneOutcome, QuarantineReason,
+    CommandKey, CommandQuarantine, ConsumeOutcome, DeliveryOutcome, DeliveryReceipt,
+    ExternalIdempotencyKey, NewOutboxMessage, NewOutboxMessageSpec, OutboxAttempt,
+    OutboxDeliveryStatus, OutboxMessage, ProcessingFailure, PruneOutcome, QuarantineReason,
 };
 pub use policy::{RetentionPolicy, RetryClass, RetryPolicy, SchemaCompatibilityPolicy};
-pub use postgres::PostgresOrchestrationStore;
+pub use postgres::{AuthoritativeSqlCommand, PostgresOrchestrationStore, SqlParam};
 pub use runtime::OrchestrationRuntime;
 pub use store::{InMemoryOrchestrationStore, OrchestrationStore, WriterReadSource};
 

--- a/apps/backend/crates/orchestration/src/model.rs
+++ b/apps/backend/crates/orchestration/src/model.rs
@@ -30,31 +30,34 @@ pub struct NewOutboxMessage {
     pub created_at: DateTime<Utc>,
 }
 
+#[derive(Clone, Debug, PartialEq)]
+pub struct NewOutboxMessageSpec {
+    pub event_id: Uuid,
+    pub idempotency_key: Uuid,
+    pub stream_key: String,
+    pub aggregate_type: String,
+    pub aggregate_id: Uuid,
+    pub event_type: String,
+    pub schema_version: i32,
+    pub payload_json: Value,
+    pub available_at: DateTime<Utc>,
+    pub created_at: DateTime<Utc>,
+}
+
 impl NewOutboxMessage {
-    pub fn new(
-        event_id: Uuid,
-        idempotency_key: Uuid,
-        stream_key: impl Into<String>,
-        aggregate_type: impl Into<String>,
-        aggregate_id: Uuid,
-        event_type: impl Into<String>,
-        schema_version: i32,
-        payload_json: Value,
-        available_at: DateTime<Utc>,
-        created_at: DateTime<Utc>,
-    ) -> Result<Self, OrchestrationError> {
+    pub fn new(spec: NewOutboxMessageSpec) -> Result<Self, OrchestrationError> {
         Ok(Self {
-            event_id,
-            idempotency_key,
-            stream_key: stream_key.into(),
-            aggregate_type: aggregate_type.into(),
-            aggregate_id,
-            event_type: event_type.into(),
-            schema_version,
-            payload_hash: payload_hash(&payload_json)?,
-            payload_json,
-            available_at,
-            created_at,
+            event_id: spec.event_id,
+            idempotency_key: spec.idempotency_key,
+            stream_key: spec.stream_key,
+            aggregate_type: spec.aggregate_type,
+            aggregate_id: spec.aggregate_id,
+            event_type: spec.event_type,
+            schema_version: spec.schema_version,
+            payload_hash: payload_hash(&spec.payload_json)?,
+            payload_json: spec.payload_json,
+            available_at: spec.available_at,
+            created_at: spec.created_at,
         })
     }
 }
@@ -310,6 +313,14 @@ pub enum CommandBeginOutcome {
 pub struct CommandCompletion {
     pub result_type: String,
     pub result_json: Value,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CommandQuarantine {
+    pub quarantined_at: DateTime<Utc>,
+    pub retain_until: DateTime<Utc>,
+    pub reason: QuarantineReason,
+    pub failure: ProcessingFailure,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/apps/backend/crates/orchestration/src/postgres.rs
+++ b/apps/backend/crates/orchestration/src/postgres.rs
@@ -1,7 +1,5 @@
-use std::{future::Future, pin::Pin};
-
 use chrono::{DateTime, Utc};
-use tokio_postgres::{Row, Transaction};
+use tokio_postgres::{Row, Transaction, types::ToSql};
 use uuid::Uuid;
 
 use crate::{
@@ -12,19 +10,29 @@ use crate::{
 
 pub struct PostgresOrchestrationStore;
 
+pub type SqlParam<'a> = &'a (dyn ToSql + Sync);
+
+pub struct AuthoritativeSqlCommand<'a> {
+    pub statement: &'a str,
+    pub params: Vec<SqlParam<'a>>,
+}
+
 impl PostgresOrchestrationStore {
-    pub async fn record_authoritative_write<Apply>(
+    pub async fn record_authoritative_write(
         tx: &Transaction<'_>,
+        commands: &[AuthoritativeSqlCommand<'_>],
         message: &NewOutboxMessage,
-        apply_authoritative_write: Apply,
-    ) -> Result<(), OrchestrationError>
-    where
-        Apply: for<'a> FnOnce(
-            &'a Transaction<'a>,
-        )
-            -> Pin<Box<dyn Future<Output = Result<(), OrchestrationError>> + 'a>>,
-    {
-        apply_authoritative_write(tx).await?;
+    ) -> Result<(), OrchestrationError> {
+        if commands.is_empty() {
+            return Err(OrchestrationError::EmptyAuthoritativeWriteBatch);
+        }
+
+        for command in commands {
+            tx.execute(command.statement, &command.params)
+                .await
+                .map_err(database_error)?;
+        }
+
         Self::insert_outbox_message(tx, message).await
     }
 

--- a/apps/backend/crates/orchestration/src/runtime.rs
+++ b/apps/backend/crates/orchestration/src/runtime.rs
@@ -4,9 +4,10 @@ use chrono::{DateTime, TimeDelta, Utc};
 
 use crate::{
     AuthoritativeChange, ClaimedOutboxMessage, CommandBeginOutcome, CommandCompletion,
-    CommandEnvelope, ConsumeOutcome, DeliveryOutcome, DeliveryReceipt, NewOutboxMessage,
-    OrchestrationError, OrchestrationStore, OutboxAttempt, ProcessingFailure, QuarantineReason,
-    RetentionPolicy, RetryClass, RetryPolicy, SchemaCompatibilityPolicy, WriterReadSource,
+    CommandEnvelope, CommandQuarantine, ConsumeOutcome, DeliveryOutcome, DeliveryReceipt,
+    NewOutboxMessage, OrchestrationError, OrchestrationStore, OutboxAttempt, ProcessingFailure,
+    QuarantineReason, RetentionPolicy, RetryClass, RetryPolicy, SchemaCompatibilityPolicy,
+    WriterReadSource,
 };
 
 pub struct OrchestrationRuntime<Store> {
@@ -351,10 +352,12 @@ where
                     consumer_name,
                     command_id,
                     expected_claimed_until,
-                    now,
-                    now + self.retention_policy.quarantined_command_for,
-                    reason,
-                    failure,
+                    CommandQuarantine {
+                        quarantined_at: now,
+                        retain_until: now + self.retention_policy.quarantined_command_for,
+                        reason,
+                        failure,
+                    },
                 )
                 .map(|()| ConsumeOutcome::Quarantined { command_id, reason })
                 .or_else(|error| match error {

--- a/apps/backend/crates/orchestration/src/store.rs
+++ b/apps/backend/crates/orchestration/src/store.rs
@@ -6,8 +6,9 @@ use uuid::Uuid;
 use crate::{
     ArchivedCommandInboxEntry, ArchivedOutboxMessage, AuthoritativeChange, ClaimedOutboxMessage,
     CommandBeginOutcome, CommandCompletion, CommandEnvelope, CommandInboxEntry, CommandInboxStatus,
-    CommandKey, DeliveryReceipt, NewOutboxMessage, OrchestrationError, OutboxAttempt,
-    OutboxDeliveryStatus, OutboxMessage, ProcessingFailure, PruneOutcome, QuarantineReason,
+    CommandKey, CommandQuarantine, DeliveryReceipt, NewOutboxMessage, OrchestrationError,
+    OutboxAttempt, OutboxDeliveryStatus, OutboxMessage, ProcessingFailure, PruneOutcome,
+    QuarantineReason,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -91,10 +92,7 @@ pub trait OrchestrationStore {
         consumer_name: &str,
         command_id: Uuid,
         expected_claimed_until: DateTime<Utc>,
-        quarantined_at: DateTime<Utc>,
-        retain_until: DateTime<Utc>,
-        reason: QuarantineReason,
-        failure: ProcessingFailure,
+        quarantine: CommandQuarantine,
     ) -> Result<(), OrchestrationError>;
 
     fn prune_coordination(
@@ -552,10 +550,7 @@ impl OrchestrationStore for InMemoryOrchestrationStore {
         consumer_name: &str,
         command_id: Uuid,
         expected_claimed_until: DateTime<Utc>,
-        quarantined_at: DateTime<Utc>,
-        retain_until: DateTime<Utc>,
-        reason: QuarantineReason,
-        failure: ProcessingFailure,
+        quarantine: CommandQuarantine,
     ) -> Result<(), OrchestrationError> {
         let key = Self::command_key(consumer_name, command_id);
         let entry = self.command_inbox.get_mut(&key).ok_or_else(|| {
@@ -576,12 +571,12 @@ impl OrchestrationStore for InMemoryOrchestrationStore {
         entry.attempt_count += 1;
         entry.claimed_by = None;
         entry.claimed_until = None;
-        entry.last_error_class = Some(failure.class);
-        entry.last_error_code = Some(failure.code);
-        entry.last_error_detail = Some(failure.detail);
-        entry.quarantined_at = Some(quarantined_at);
-        entry.quarantine_reason = Some(reason);
-        entry.retain_until = Some(retain_until);
+        entry.last_error_class = Some(quarantine.failure.class);
+        entry.last_error_code = Some(quarantine.failure.code);
+        entry.last_error_detail = Some(quarantine.failure.detail);
+        entry.quarantined_at = Some(quarantine.quarantined_at);
+        entry.quarantine_reason = Some(quarantine.reason);
+        entry.retain_until = Some(quarantine.retain_until);
 
         Ok(())
     }

--- a/apps/backend/crates/orchestration/tests/postgres_contract.rs
+++ b/apps/backend/crates/orchestration/tests/postgres_contract.rs
@@ -4,8 +4,8 @@ use tokio_postgres::NoTls;
 use uuid::Uuid;
 
 use musubi_orchestration::{
-    CommandBeginOutcome, CommandEnvelope, NewOutboxMessage, OrchestrationError,
-    PostgresOrchestrationStore,
+    AuthoritativeSqlCommand, CommandBeginOutcome, CommandEnvelope, NewOutboxMessage,
+    NewOutboxMessageSpec, OrchestrationError, PostgresOrchestrationStore, SqlParam,
 };
 
 fn ts(seconds: i64) -> chrono::DateTime<Utc> {
@@ -53,33 +53,31 @@ async fn postgres_helpers_keep_truth_and_outbox_in_same_transaction() {
     let fact_id = Uuid::from_u128(0x700);
     let event_id = Uuid::from_u128(0x701);
     let command_id = Uuid::from_u128(0x702);
-    let message = NewOutboxMessage::new(
+    let message = NewOutboxMessage::new(NewOutboxMessageSpec {
         event_id,
-        Uuid::from_u128(0x703),
-        "settlement_case:700",
-        "settlement_case",
-        fact_id,
-        "settlement.receipt_recorded",
-        1,
-        json!({ "fact_id": fact_id }),
-        ts(0),
-        ts(0),
-    )
+        idempotency_key: Uuid::from_u128(0x703),
+        stream_key: "settlement_case:700".to_owned(),
+        aggregate_type: "settlement_case".to_owned(),
+        aggregate_id: fact_id,
+        event_type: "settlement.receipt_recorded".to_owned(),
+        schema_version: 1,
+        payload_json: json!({ "fact_id": fact_id }),
+        available_at: ts(0),
+        created_at: ts(0),
+    })
     .unwrap();
 
-    PostgresOrchestrationStore::record_authoritative_write(&tx, &message, |tx| {
-        Box::pin(async move {
-            tx.execute(
-                "INSERT INTO authoritative_facts (fact_id, fact_kind) VALUES ($1, $2)",
-                &[&fact_id, &"receipt_recorded"],
-            )
-            .await
-            .map_err(|error| OrchestrationError::Database(error.to_string()))?;
-            Ok(())
-        })
-    })
-    .await
-    .expect("same-tx authoritative write + outbox insert should succeed");
+    let authoritative_commands = [AuthoritativeSqlCommand {
+        statement: "INSERT INTO authoritative_facts (fact_id, fact_kind) VALUES ($1, $2)",
+        params: vec![
+            &fact_id as SqlParam<'_>,
+            &"receipt_recorded" as SqlParam<'_>,
+        ],
+    }];
+
+    PostgresOrchestrationStore::record_authoritative_write(&tx, &authoritative_commands, &message)
+        .await
+        .expect("same-tx authoritative write + outbox insert should succeed");
 
     let fact_count: i64 = tx
         .query_one("SELECT COUNT(*) AS count FROM authoritative_facts", &[])
@@ -154,6 +152,59 @@ async fn postgres_helpers_keep_truth_and_outbox_in_same_transaction() {
             command_id,
         })
     );
+
+    tx.rollback()
+        .await
+        .expect("rollback should clean up transactional test state");
+}
+
+#[tokio::test]
+async fn postgres_helper_rejects_empty_authoritative_write_batch() {
+    let Ok(database_url) = std::env::var("MUSUBI_TEST_DATABASE_URL") else {
+        return;
+    };
+
+    let (mut client, connection) = tokio_postgres::connect(&database_url, NoTls)
+        .await
+        .expect("failed to connect to MUSUBI_TEST_DATABASE_URL");
+    tokio::spawn(async move {
+        let _ = connection.await;
+    });
+
+    let tx = client
+        .transaction()
+        .await
+        .expect("failed to open transaction");
+    tx.batch_execute(include_str!(
+        "../../../migrations/0004_create_outbox_schema.sql"
+    ))
+    .await
+    .expect("failed to apply outbox schema");
+    tx.batch_execute(include_str!(
+        "../../../migrations/0006_orchestration_runtime_baseline.sql"
+    ))
+    .await
+    .expect("failed to apply orchestration baseline migration");
+
+    let message = NewOutboxMessage::new(NewOutboxMessageSpec {
+        event_id: Uuid::from_u128(0x706),
+        idempotency_key: Uuid::from_u128(0x707),
+        stream_key: "settlement_case:706".to_owned(),
+        aggregate_type: "settlement_case".to_owned(),
+        aggregate_id: Uuid::from_u128(0x708),
+        event_type: "settlement.receipt_recorded".to_owned(),
+        schema_version: 1,
+        payload_json: json!({ "fact_id": "empty-batch" }),
+        available_at: ts(0),
+        created_at: ts(0),
+    })
+    .unwrap();
+
+    let error = PostgresOrchestrationStore::record_authoritative_write(&tx, &[], &message)
+        .await
+        .unwrap_err();
+
+    assert_eq!(error, OrchestrationError::EmptyAuthoritativeWriteBatch);
 
     tx.rollback()
         .await

--- a/apps/backend/crates/orchestration/tests/runtime_contract.rs
+++ b/apps/backend/crates/orchestration/tests/runtime_contract.rs
@@ -1,16 +1,18 @@
 use chrono::{TimeDelta, TimeZone, Utc};
 use serde_json::json;
 use std::sync::{
-    Arc,
+    Arc, Mutex,
     atomic::{AtomicUsize, Ordering},
 };
 use uuid::Uuid;
 
 use musubi_orchestration::{
-    AuthoritativeChange, CommandCompletion, CommandEnvelope, ConsumeOutcome, DeliveryOutcome,
-    DeliveryReceipt, ExternalIdempotencyKey, InMemoryOrchestrationStore, NewOutboxMessage,
-    OrchestrationError, OrchestrationRuntime, OrchestrationStore, OutboxAttempt,
-    OutboxDeliveryStatus, ProcessingFailure, QuarantineReason, RetentionPolicy, RetryPolicy,
+    AuthoritativeChange, ClaimedOutboxMessage, CommandBeginOutcome, CommandCompletion,
+    CommandEnvelope, CommandInboxEntry, CommandInboxStatus, CommandKey, CommandQuarantine,
+    ConsumeOutcome, DeliveryOutcome, DeliveryReceipt, ExternalIdempotencyKey,
+    InMemoryOrchestrationStore, NewOutboxMessage, NewOutboxMessageSpec, OrchestrationError,
+    OrchestrationRuntime, OrchestrationStore, OutboxAttempt, OutboxDeliveryStatus, OutboxMessage,
+    ProcessingFailure, PruneOutcome, QuarantineReason, RetentionPolicy, RetryPolicy,
     SchemaCompatibilityPolicy, WriterReadSource,
 };
 
@@ -41,6 +43,150 @@ fn ts(seconds: i64) -> chrono::DateTime<Utc> {
     Utc.timestamp_opt(1_700_000_000 + seconds, 0).unwrap()
 }
 
+struct PhaseTracingStore {
+    phases: Arc<Mutex<Vec<&'static str>>>,
+    claimed_outbox: Option<ClaimedOutboxMessage>,
+    command_begin_outcome: Option<CommandBeginOutcome>,
+}
+
+impl PhaseTracingStore {
+    fn for_outbox(
+        phases: Arc<Mutex<Vec<&'static str>>>,
+        claimed_outbox: ClaimedOutboxMessage,
+    ) -> Self {
+        Self {
+            phases,
+            claimed_outbox: Some(claimed_outbox),
+            command_begin_outcome: None,
+        }
+    }
+
+    fn for_command(
+        phases: Arc<Mutex<Vec<&'static str>>>,
+        command_begin_outcome: CommandBeginOutcome,
+    ) -> Self {
+        Self {
+            phases,
+            claimed_outbox: None,
+            command_begin_outcome: Some(command_begin_outcome),
+        }
+    }
+
+    fn record(&self, phase: &'static str) {
+        self.phases.lock().unwrap().push(phase);
+    }
+}
+
+impl OrchestrationStore for PhaseTracingStore {
+    fn commit_authoritative_write(
+        &mut self,
+        _source: WriterReadSource,
+        _change: AuthoritativeChange,
+        _message: NewOutboxMessage,
+    ) -> Result<(), OrchestrationError> {
+        unreachable!("phase tracing store is only used for async boundary tests")
+    }
+
+    fn claim_ready_outbox(
+        &mut self,
+        _source: WriterReadSource,
+        _relay_name: &str,
+        _now: chrono::DateTime<Utc>,
+        _claimed_until: chrono::DateTime<Utc>,
+    ) -> Result<Option<ClaimedOutboxMessage>, OrchestrationError> {
+        self.record("claim_ready_outbox");
+        Ok(self.claimed_outbox.take())
+    }
+
+    fn mark_outbox_published(
+        &mut self,
+        _event_id: Uuid,
+        _retain_until: chrono::DateTime<Utc>,
+        _receipt: DeliveryReceipt,
+        _attempt: OutboxAttempt,
+    ) -> Result<(), OrchestrationError> {
+        self.record("mark_outbox_published");
+        Ok(())
+    }
+
+    fn schedule_outbox_retry(
+        &mut self,
+        _event_id: Uuid,
+        _retry_at: chrono::DateTime<Utc>,
+        _failure: ProcessingFailure,
+        _attempt: OutboxAttempt,
+    ) -> Result<(), OrchestrationError> {
+        unreachable!("phase tracing store is only used for successful async boundary tests")
+    }
+
+    fn quarantine_outbox(
+        &mut self,
+        _event_id: Uuid,
+        _quarantined_at: chrono::DateTime<Utc>,
+        _retain_until: chrono::DateTime<Utc>,
+        _reason: QuarantineReason,
+        _failure: ProcessingFailure,
+        _attempt: OutboxAttempt,
+    ) -> Result<(), OrchestrationError> {
+        unreachable!("phase tracing store is only used for successful async boundary tests")
+    }
+
+    fn begin_command(
+        &mut self,
+        _source: WriterReadSource,
+        _consumer_name: &str,
+        _command: CommandEnvelope,
+        _now: chrono::DateTime<Utc>,
+        _claimed_until: chrono::DateTime<Utc>,
+    ) -> Result<CommandBeginOutcome, OrchestrationError> {
+        self.record("begin_command");
+        self.command_begin_outcome
+            .take()
+            .ok_or_else(|| OrchestrationError::Database("missing command begin outcome".to_owned()))
+    }
+
+    fn complete_command(
+        &mut self,
+        _consumer_name: &str,
+        _command_id: Uuid,
+        _expected_claimed_until: chrono::DateTime<Utc>,
+        _completed_at: chrono::DateTime<Utc>,
+        _retain_until: chrono::DateTime<Utc>,
+        _completion: CommandCompletion,
+    ) -> Result<(), OrchestrationError> {
+        self.record("complete_command");
+        Ok(())
+    }
+
+    fn schedule_command_retry(
+        &mut self,
+        _consumer_name: &str,
+        _command_id: Uuid,
+        _expected_claimed_until: chrono::DateTime<Utc>,
+        _retry_at: chrono::DateTime<Utc>,
+        _failure: ProcessingFailure,
+    ) -> Result<(), OrchestrationError> {
+        unreachable!("phase tracing store is only used for successful async boundary tests")
+    }
+
+    fn quarantine_command(
+        &mut self,
+        _consumer_name: &str,
+        _command_id: Uuid,
+        _expected_claimed_until: chrono::DateTime<Utc>,
+        _quarantine: CommandQuarantine,
+    ) -> Result<(), OrchestrationError> {
+        unreachable!("phase tracing store is only used for successful async boundary tests")
+    }
+
+    fn prune_coordination(
+        &mut self,
+        _now: chrono::DateTime<Utc>,
+    ) -> Result<PruneOutcome, OrchestrationError> {
+        unreachable!("phase tracing store is only used for async boundary tests")
+    }
+}
+
 #[tokio::test]
 async fn producer_truth_and_outbox_commit_together() {
     let mut runtime = runtime();
@@ -56,18 +202,18 @@ async fn producer_truth_and_outbox_commit_together() {
                 change_type: "receipt_recorded".to_owned(),
                 payload_json: json!({ "receipt_id": "receipt-1" }),
             },
-            NewOutboxMessage::new(
+            NewOutboxMessage::new(NewOutboxMessageSpec {
                 event_id,
                 idempotency_key,
-                "settlement_case:10",
-                "settlement_case",
+                stream_key: "settlement_case:10".to_owned(),
+                aggregate_type: "settlement_case".to_owned(),
                 aggregate_id,
-                "settlement.receipt_recorded",
-                1,
-                json!({ "receipt_id": "receipt-1" }),
-                ts(0),
-                ts(0),
-            )
+                event_type: "settlement.receipt_recorded".to_owned(),
+                schema_version: 1,
+                payload_json: json!({ "receipt_id": "receipt-1" }),
+                available_at: ts(0),
+                created_at: ts(0),
+            })
             .unwrap(),
         )
         .unwrap();
@@ -78,26 +224,361 @@ async fn producer_truth_and_outbox_commit_together() {
     assert_eq!(message.aggregate_id, aggregate_id);
 }
 
+#[tokio::test]
+async fn outbox_publish_callback_runs_between_writer_phases() {
+    let phases = Arc::new(Mutex::new(Vec::new()));
+    let event_id = Uuid::from_u128(0x22);
+    let aggregate_id = Uuid::from_u128(0x23);
+    let store = PhaseTracingStore::for_outbox(
+        phases.clone(),
+        ClaimedOutboxMessage {
+            message: OutboxMessage {
+                event_id,
+                idempotency_key: Uuid::from_u128(0x24),
+                stream_key: "settlement_case:23".to_owned(),
+                aggregate_type: "settlement_case".to_owned(),
+                aggregate_id,
+                event_type: "settlement.submit_action".to_owned(),
+                schema_version: 1,
+                payload_json: json!({ "intent_id": "intent-phase" }),
+                payload_hash: "phase-hash".to_owned(),
+                delivery_status: OutboxDeliveryStatus::Processing,
+                attempt_count: 0,
+                available_at: ts(0),
+                created_at: ts(0),
+                published_at: None,
+                last_attempt_at: None,
+                last_error_class: None,
+                last_error_code: None,
+                last_error_detail: None,
+                claimed_by: Some("settlement-relay".to_owned()),
+                claimed_until: Some(ts(300)),
+                quarantined_at: None,
+                quarantine_reason: None,
+                retain_until: None,
+                causal_order: 1,
+                published_external_idempotency_key: None,
+            },
+            relay_name: "settlement-relay".to_owned(),
+            claimed_at: ts(0),
+            claimed_until: ts(300),
+        },
+    );
+    let mut runtime = OrchestrationRuntime::new(
+        store,
+        RetryPolicy {
+            max_attempts: 3,
+            base_delay: TimeDelta::seconds(30),
+            max_delay: TimeDelta::minutes(5),
+            max_jitter: TimeDelta::seconds(10),
+        },
+        RetentionPolicy {
+            published_outbox_for: TimeDelta::hours(1),
+            quarantined_outbox_for: TimeDelta::hours(12),
+            completed_command_for: TimeDelta::hours(1),
+            quarantined_command_for: TimeDelta::hours(12),
+        },
+        SchemaCompatibilityPolicy {
+            max_supported_schema_version: 1,
+            compatibility_window: TimeDelta::minutes(15),
+        },
+        TimeDelta::minutes(5),
+    );
+    let phases_for_publish = phases.clone();
+
+    let outcome = runtime
+        .deliver_ready_outbox("settlement-relay", ts(0), move |_| {
+            let phases = phases_for_publish.clone();
+            async move {
+                phases.lock().unwrap().push("publish_started");
+                tokio::task::yield_now().await;
+                phases.lock().unwrap().push("publish_finished");
+                Ok(DeliveryReceipt {
+                    external_idempotency_key: ExternalIdempotencyKey::new("provider-key-phase")
+                        .unwrap(),
+                })
+            }
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(outcome, DeliveryOutcome::Published { event_id });
+    assert_eq!(
+        phases.lock().unwrap().clone(),
+        vec![
+            "claim_ready_outbox",
+            "publish_started",
+            "publish_finished",
+            "mark_outbox_published",
+        ]
+    );
+}
+
+#[tokio::test]
+async fn command_handler_runs_between_writer_phases() {
+    let phases = Arc::new(Mutex::new(Vec::new()));
+    let command_id = Uuid::from_u128(0x25);
+    let store = PhaseTracingStore::for_command(
+        phases.clone(),
+        CommandBeginOutcome::FirstSeen(CommandInboxEntry {
+            key: CommandKey {
+                consumer_name: "projection-builder".to_owned(),
+                command_id,
+            },
+            source_event_id: Uuid::from_u128(0x26),
+            command_type: "projection.refresh".to_owned(),
+            schema_version: 1,
+            payload_hash: "command-phase-hash".to_owned(),
+            status: CommandInboxStatus::Processing,
+            attempt_count: 0,
+            first_seen_at: ts(0),
+            available_at: ts(0),
+            completed_at: None,
+            claimed_by: Some("projection-builder".to_owned()),
+            claimed_until: Some(ts(300)),
+            last_error_class: None,
+            last_error_code: None,
+            last_error_detail: None,
+            quarantined_at: None,
+            quarantine_reason: None,
+            result_type: None,
+            result_json: None,
+            retain_until: None,
+        }),
+    );
+    let mut runtime = OrchestrationRuntime::new(
+        store,
+        RetryPolicy {
+            max_attempts: 3,
+            base_delay: TimeDelta::seconds(30),
+            max_delay: TimeDelta::minutes(5),
+            max_jitter: TimeDelta::seconds(10),
+        },
+        RetentionPolicy {
+            published_outbox_for: TimeDelta::hours(1),
+            quarantined_outbox_for: TimeDelta::hours(12),
+            completed_command_for: TimeDelta::hours(1),
+            quarantined_command_for: TimeDelta::hours(12),
+        },
+        SchemaCompatibilityPolicy {
+            max_supported_schema_version: 1,
+            compatibility_window: TimeDelta::minutes(15),
+        },
+        TimeDelta::minutes(5),
+    );
+    let phases_for_handler = phases.clone();
+
+    let outcome = runtime
+        .consume_command(
+            "projection-builder",
+            CommandEnvelope::new(
+                command_id,
+                Uuid::from_u128(0x26),
+                "projection.refresh",
+                1,
+                json!({ "case_id": "case-phase" }),
+            )
+            .unwrap(),
+            ts(0),
+            move |_| {
+                let phases = phases_for_handler.clone();
+                async move {
+                    phases.lock().unwrap().push("handle_started");
+                    tokio::task::yield_now().await;
+                    phases.lock().unwrap().push("handle_finished");
+                    Ok(CommandCompletion {
+                        result_type: "projected".to_owned(),
+                        result_json: json!({ "projection_id": "phase-read" }),
+                    })
+                }
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(outcome, ConsumeOutcome::Completed { command_id });
+    assert_eq!(
+        phases.lock().unwrap().clone(),
+        vec![
+            "begin_command",
+            "handle_started",
+            "handle_finished",
+            "complete_command",
+        ]
+    );
+}
+
 #[test]
 fn payload_hash_matches_postgres_jsonb_text_canonicalization() {
-    let message = NewOutboxMessage::new(
-        Uuid::from_u128(0x31),
-        Uuid::from_u128(0x32),
-        "settlement_case:canonical",
-        "settlement_case",
-        Uuid::from_u128(0x33),
-        "settlement.receipt_recorded",
-        1,
-        json!({ "b": 1, "a": 2 }),
-        ts(0),
-        ts(0),
-    )
+    let message = NewOutboxMessage::new(NewOutboxMessageSpec {
+        event_id: Uuid::from_u128(0x31),
+        idempotency_key: Uuid::from_u128(0x32),
+        stream_key: "settlement_case:canonical".to_owned(),
+        aggregate_type: "settlement_case".to_owned(),
+        aggregate_id: Uuid::from_u128(0x33),
+        event_type: "settlement.receipt_recorded".to_owned(),
+        schema_version: 1,
+        payload_json: json!({ "b": 1, "a": 2 }),
+        available_at: ts(0),
+        created_at: ts(0),
+    })
     .unwrap();
 
     assert_eq!(
         message.payload_hash,
         "21501dbaf73f5223934d22283f01caff4132bc1de4a9550c1ed0dffeb397a323"
     );
+}
+
+#[test]
+fn authoritative_progression_rejects_read_replica_sources() {
+    let mut store = InMemoryOrchestrationStore::default();
+    let aggregate_id = Uuid::from_u128(0x34);
+    let event_id = Uuid::from_u128(0x35);
+
+    let write_from_replica = store.commit_authoritative_write(
+        WriterReadSource::ReadReplica,
+        AuthoritativeChange {
+            aggregate_type: "settlement_case".to_owned(),
+            aggregate_id,
+            change_type: "receipt_recorded".to_owned(),
+            payload_json: json!({ "receipt_id": "replica-write" }),
+        },
+        NewOutboxMessage::new(NewOutboxMessageSpec {
+            event_id,
+            idempotency_key: Uuid::from_u128(0x36),
+            stream_key: "settlement_case:34".to_owned(),
+            aggregate_type: "settlement_case".to_owned(),
+            aggregate_id,
+            event_type: "settlement.receipt_recorded".to_owned(),
+            schema_version: 1,
+            payload_json: json!({ "receipt_id": "replica-write" }),
+            available_at: ts(0),
+            created_at: ts(0),
+        })
+        .unwrap(),
+    );
+
+    assert_eq!(
+        write_from_replica,
+        Err(OrchestrationError::ReplicaReadForbidden)
+    );
+
+    store
+        .commit_authoritative_write(
+            WriterReadSource::PrimaryWriter,
+            AuthoritativeChange {
+                aggregate_type: "settlement_case".to_owned(),
+                aggregate_id,
+                change_type: "receipt_recorded".to_owned(),
+                payload_json: json!({ "receipt_id": "writer-only" }),
+            },
+            NewOutboxMessage::new(NewOutboxMessageSpec {
+                event_id,
+                idempotency_key: Uuid::from_u128(0x37),
+                stream_key: "settlement_case:34".to_owned(),
+                aggregate_type: "settlement_case".to_owned(),
+                aggregate_id,
+                event_type: "settlement.receipt_recorded".to_owned(),
+                schema_version: 1,
+                payload_json: json!({ "receipt_id": "writer-only" }),
+                available_at: ts(0),
+                created_at: ts(0),
+            })
+            .unwrap(),
+        )
+        .unwrap();
+
+    let claim_from_replica =
+        store.claim_ready_outbox(WriterReadSource::ReadReplica, "relay-a", ts(1), ts(301));
+    let begin_from_replica = store.begin_command(
+        WriterReadSource::ReadReplica,
+        "projection-builder",
+        CommandEnvelope::new(
+            Uuid::from_u128(0x38),
+            event_id,
+            "projection.refresh",
+            1,
+            json!({ "case_id": "replica-command" }),
+        )
+        .unwrap(),
+        ts(1),
+        ts(301),
+    );
+
+    assert_eq!(
+        claim_from_replica,
+        Err(OrchestrationError::ReplicaReadForbidden)
+    );
+    assert_eq!(
+        begin_from_replica,
+        Err(OrchestrationError::ReplicaReadForbidden)
+    );
+}
+
+#[test]
+fn duplicate_outbox_idempotency_key_does_not_duplicate_truth() {
+    let mut store = InMemoryOrchestrationStore::default();
+    let aggregate_id = Uuid::from_u128(0x39);
+    let first_event_id = Uuid::from_u128(0x3A);
+    let duplicate_event_id = Uuid::from_u128(0x3B);
+    let idempotency_key = Uuid::from_u128(0x3C);
+
+    store
+        .commit_authoritative_write(
+            WriterReadSource::PrimaryWriter,
+            AuthoritativeChange {
+                aggregate_type: "settlement_case".to_owned(),
+                aggregate_id,
+                change_type: "receipt_recorded".to_owned(),
+                payload_json: json!({ "receipt_id": "first" }),
+            },
+            NewOutboxMessage::new(NewOutboxMessageSpec {
+                event_id: first_event_id,
+                idempotency_key,
+                stream_key: "settlement_case:39".to_owned(),
+                aggregate_type: "settlement_case".to_owned(),
+                aggregate_id,
+                event_type: "settlement.receipt_recorded".to_owned(),
+                schema_version: 1,
+                payload_json: json!({ "receipt_id": "first" }),
+                available_at: ts(0),
+                created_at: ts(0),
+            })
+            .unwrap(),
+        )
+        .unwrap();
+
+    let duplicate = store.commit_authoritative_write(
+        WriterReadSource::PrimaryWriter,
+        AuthoritativeChange {
+            aggregate_type: "settlement_case".to_owned(),
+            aggregate_id,
+            change_type: "receipt_recorded".to_owned(),
+            payload_json: json!({ "receipt_id": "duplicate" }),
+        },
+        NewOutboxMessage::new(NewOutboxMessageSpec {
+            event_id: duplicate_event_id,
+            idempotency_key,
+            stream_key: "settlement_case:39".to_owned(),
+            aggregate_type: "settlement_case".to_owned(),
+            aggregate_id,
+            event_type: "settlement.receipt_recorded".to_owned(),
+            schema_version: 1,
+            payload_json: json!({ "receipt_id": "duplicate" }),
+            available_at: ts(1),
+            created_at: ts(1),
+        })
+        .unwrap(),
+    );
+
+    assert_eq!(
+        duplicate,
+        Err(OrchestrationError::IdempotencyKeyAlreadyExists { idempotency_key })
+    );
+    assert_eq!(store.authoritative_changes().len(), 1);
+    assert!(store.outbox_message(first_event_id).is_some());
+    assert!(store.outbox_message(duplicate_event_id).is_none());
 }
 
 #[tokio::test]
@@ -247,18 +728,18 @@ async fn transient_outbox_failure_schedules_retry() {
                 change_type: "submission_requested".to_owned(),
                 payload_json: json!({ "intent_id": "intent-1" }),
             },
-            NewOutboxMessage::new(
+            NewOutboxMessage::new(NewOutboxMessageSpec {
                 event_id,
-                Uuid::from_u128(0x52),
-                "settlement_case:50",
-                "settlement_case",
+                idempotency_key: Uuid::from_u128(0x52),
+                stream_key: "settlement_case:50".to_owned(),
+                aggregate_type: "settlement_case".to_owned(),
                 aggregate_id,
-                "settlement.submit_action",
-                1,
-                json!({ "intent_id": "intent-1" }),
-                ts(0),
-                ts(0),
-            )
+                event_type: "settlement.submit_action".to_owned(),
+                schema_version: 1,
+                payload_json: json!({ "intent_id": "intent-1" }),
+                available_at: ts(0),
+                created_at: ts(0),
+            })
             .unwrap(),
         )
         .unwrap();
@@ -300,18 +781,18 @@ async fn transient_outbox_budget_counts_total_attempts() {
                 change_type: "submission_requested".to_owned(),
                 payload_json: json!({ "intent_id": "budgeted-outbox" }),
             },
-            NewOutboxMessage::new(
+            NewOutboxMessage::new(NewOutboxMessageSpec {
                 event_id,
-                Uuid::from_u128(0x55),
-                "settlement_case:53",
-                "settlement_case",
+                idempotency_key: Uuid::from_u128(0x55),
+                stream_key: "settlement_case:53".to_owned(),
+                aggregate_type: "settlement_case".to_owned(),
                 aggregate_id,
-                "settlement.submit_action",
-                1,
-                json!({ "intent_id": "budgeted-outbox" }),
-                ts(0),
-                ts(0),
-            )
+                event_type: "settlement.submit_action".to_owned(),
+                schema_version: 1,
+                payload_json: json!({ "intent_id": "budgeted-outbox" }),
+                available_at: ts(0),
+                created_at: ts(0),
+            })
             .unwrap(),
         )
         .unwrap();
@@ -562,18 +1043,18 @@ async fn deferred_outbox_ignores_attempt_budget_until_window_expires() {
                 change_type: "submission_requested".to_owned(),
                 payload_json: json!({ "intent_id": "future-schema" }),
             },
-            NewOutboxMessage::new(
+            NewOutboxMessage::new(NewOutboxMessageSpec {
                 event_id,
-                Uuid::from_u128(0x68),
-                "settlement_case:66",
-                "settlement_case",
+                idempotency_key: Uuid::from_u128(0x68),
+                stream_key: "settlement_case:66".to_owned(),
+                aggregate_type: "settlement_case".to_owned(),
                 aggregate_id,
-                "settlement.submit_action",
-                99,
-                json!({ "intent_id": "future-schema" }),
-                ts(0),
-                ts(0),
-            )
+                event_type: "settlement.submit_action".to_owned(),
+                schema_version: 99,
+                payload_json: json!({ "intent_id": "future-schema" }),
+                available_at: ts(0),
+                created_at: ts(0),
+            })
             .unwrap(),
         )
         .unwrap();
@@ -614,18 +1095,18 @@ async fn pruning_archives_terminal_coordination_rows() {
                 change_type: "submission_requested".to_owned(),
                 payload_json: json!({ "intent_id": "intent-2" }),
             },
-            NewOutboxMessage::new(
+            NewOutboxMessage::new(NewOutboxMessageSpec {
                 event_id,
-                Uuid::from_u128(0x73),
-                "settlement_case:70",
-                "settlement_case",
+                idempotency_key: Uuid::from_u128(0x73),
+                stream_key: "settlement_case:70".to_owned(),
+                aggregate_type: "settlement_case".to_owned(),
                 aggregate_id,
-                "settlement.submit_action",
-                1,
-                json!({ "intent_id": "intent-2" }),
-                ts(0),
-                ts(0),
-            )
+                event_type: "settlement.submit_action".to_owned(),
+                schema_version: 1,
+                payload_json: json!({ "intent_id": "intent-2" }),
+                available_at: ts(0),
+                created_at: ts(0),
+            })
             .unwrap(),
         )
         .unwrap();
@@ -691,18 +1172,18 @@ fn stale_outbox_retry_cannot_reopen_published_message() {
                 change_type: "submission_requested".to_owned(),
                 payload_json: json!({ "intent_id": "stale-outbox" }),
             },
-            NewOutboxMessage::new(
+            NewOutboxMessage::new(NewOutboxMessageSpec {
                 event_id,
-                Uuid::from_u128(0x82),
-                "settlement_case:80",
-                "settlement_case",
+                idempotency_key: Uuid::from_u128(0x82),
+                stream_key: "settlement_case:80".to_owned(),
+                aggregate_type: "settlement_case".to_owned(),
                 aggregate_id,
-                "settlement.submit_action",
-                1,
-                json!({ "intent_id": "stale-outbox" }),
-                ts(0),
-                ts(0),
-            )
+                event_type: "settlement.submit_action".to_owned(),
+                schema_version: 1,
+                payload_json: json!({ "intent_id": "stale-outbox" }),
+                available_at: ts(0),
+                created_at: ts(0),
+            })
             .unwrap(),
         )
         .unwrap();

--- a/apps/backend/docs/guardrails.md
+++ b/apps/backend/docs/guardrails.md
@@ -1,0 +1,113 @@
+# Backend Guardrails
+
+This note records the executable guardrails introduced for M1 Issue #6.
+
+The goal is not fake perfection.
+The goal is to make the most failure-prone MUSUBI laws mechanically harder to violate while being honest about what still depends on human review.
+
+## Mechanically enforced now
+
+### 1. Writer-first state-changing reads
+
+The orchestration boundary encodes writer-only progression through `WriterReadSource`.
+
+Current executable guards:
+- `InMemoryOrchestrationStore` rejects `WriterReadSource::ReadReplica` for:
+  - `commit_authoritative_write(...)`
+  - `claim_ready_outbox(...)`
+  - `begin_command(...)`
+- `OrchestrationRuntime` does not expose a replica option for those progression paths. It always uses `WriterReadSource::PrimaryWriter`.
+- `apps/backend/crates/orchestration/tests/runtime_contract.rs` includes `authoritative_progression_rejects_read_replica_sources`.
+
+Why this matters:
+- settlement progression
+- retry/claim progression
+- command dedupe progression
+
+These are the places where replica lag would create duplicate execution or stale settlement truth.
+
+### 2. Idempotency behavior
+
+Current executable guards:
+- producer-side duplicate outbox idempotency keys are rejected before a second authoritative change is recorded
+- consumer-side duplicate command delivery is treated as normal and returns `ConsumeOutcome::Duplicate`
+- command payload drift for the same `(consumer_name, command_id)` is rejected
+
+Current executable tests:
+- `duplicate_outbox_idempotency_key_does_not_duplicate_truth`
+- `duplicate_consumer_delivery_is_a_no_op`
+- `postgres_helpers_keep_truth_and_outbox_in_same_transaction`
+
+This is intentionally database-shaped logic, not in-memory optimism.
+
+### 3. Drop-Tx-Before-Await at the runtime seam
+
+Current executable guards:
+- `OrchestrationRuntime::deliver_ready_outbox(...)` claims work first, then awaits publish, then records the result in a fresh store call
+- `OrchestrationRuntime::consume_command(...)` begins inbox processing first, then awaits the handler, then records completion/retry/quarantine in a fresh store call
+- `apps/backend/crates/orchestration/tests/runtime_contract.rs` includes:
+  - `outbox_publish_callback_runs_between_writer_phases`
+  - `command_handler_runs_between_writer_phases`
+
+What those tests prove:
+- the async callback runs after the writer-side claim/begin step
+- the completion write happens only after the callback future resolves
+- later refactors cannot silently move the completion write ahead of the external await without breaking tests
+
+## Still review-only for now
+
+### 1. Raw transaction code outside orchestration/runtime seams
+
+`PostgresOrchestrationStore::record_authoritative_write(...)` no longer accepts an arbitrary async closure.
+It now accepts only declarative SQL commands plus the outbox message, and it rejects an empty command batch.
+That removes the easiest place to smuggle remote `await` into a live authoritative transaction and also prevents "outbox only" use through that helper.
+
+What still remains review-sensitive:
+- code that takes a raw `tokio_postgres::Transaction<'_>` directly
+- future service or adapter code that bypasses orchestration helpers entirely
+
+So the rule is still:
+- keep authoritative transaction code database-only
+- perform provider/network I/O only after that transaction is committed or dropped
+
+### 2. Code outside the orchestration crate
+
+The current tests guard the orchestration boundary.
+They do not automatically police every future Axum handler, service, or provider adapter that may open its own transaction.
+
+If later code bypasses orchestration and performs:
+- authoritative DB write
+- remote await
+- same-tx follow-up mutation
+
+that would still be a bug even if these tests stay green.
+
+## Why static enforcement is limited today
+
+The backend is still on a small Day 1 skeleton:
+- no custom lint crate
+- no MIR/static analysis pass
+- no provider adapters yet
+
+Because of that, the most honest posture is:
+- encode the invariant at the runtime seam with executable sequencing tests
+- narrow the PostgreSQL helper so it cannot accept arbitrary async callback logic
+- encode writer-first via interface and tests
+- encode idempotency via durable uniqueness and duplicate-delivery tests
+- explicitly document the places where review is still required
+
+## Expected next improvements
+
+The next meaningful upgrades would be:
+- add integration tests around real PostgreSQL writer/claim/persist flows as the happy route grows
+- add CI review hooks or linting that flag suspicious `Transaction` + remote client usage patterns
+- keep new settlement/provider code inside orchestration and settlement boundaries rather than ad hoc service methods
+
+## Bottom line
+
+Today the repo has real guardrails for:
+- writer-first progression
+- duplicate-delivery / duplicate-submission behavior
+- async boundary ordering around outbox and inbox work
+
+And it is still honest that some no-Tx-across-await violations remain review-detectable rather than fully statically impossible.


### PR DESCRIPTION
## Summary
- add executable guardrails for drop-tx-before-await ordering at the orchestration runtime seam
- enforce writer-first progression and producer/consumer idempotency through focused orchestration tests
- narrow the PostgreSQL authoritative-write helper so it only accepts declarative SQL command batches, and document the remaining review-only limits
- clean up orchestration API shapes so the backend workspace passes strict `clippy` warning checks

## Why
Issue #6 is about turning MUSUBI architectural law into executable guardrails so later implementation cannot silently drift back toward replica-based decisioning, duplicate truth mutation, or transaction-held external await.

## Validation
- `cargo check`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`

## Notes
- adds `apps/backend/docs/guardrails.md`
- keeps behavior focused on guardrails and does not expand happy-route product scope
- refs #6