### PR TITLE
feat(proof): add safer venue proof primitives

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -22,3 +22,4 @@ PROVIDER_BASE_URL=https://sandbox.minepi.com/v2
 PROVIDER_API_KEY=your_provider_api_key_here
 PROVIDER_WEBHOOK_SECRET=your_provider_webhook_secret_here
 PROVIDER_TIMEOUT_MS=3000
+PROOF_MASTER_SECRET=local_dev_replace_with_random_secret

--- a/apps/backend/Cargo.lock
+++ b/apps/backend/Cargo.lock
@@ -254,7 +254,6 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common 0.1.7",
- "subtle",
 ]
 
 [[package]]
@@ -421,15 +420,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest 0.10.7",
-]
 
 [[package]]
 name = "hmac"
@@ -682,12 +672,12 @@ dependencies = [
  "axum",
  "chrono",
  "dotenvy",
- "hmac 0.12.1",
+ "hmac",
  "musubi_db_runtime",
  "musubi_settlement_domain",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "tokio",
  "tower",
  "tower-http",
@@ -821,7 +811,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "fallible-iterator",
- "hmac 0.13.0",
+ "hmac",
  "md-5",
  "memchr",
  "rand 0.10.0",
@@ -1121,12 +1111,6 @@ dependencies = [
  "unicode-normalization",
  "unicode-properties",
 ]
-
-[[package]]
-name = "subtle"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"

--- a/apps/backend/Cargo.lock
+++ b/apps/backend/Cargo.lock
@@ -254,6 +254,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common 0.1.7",
+ "subtle",
 ]
 
 [[package]]
@@ -420,6 +421,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "hmac"
@@ -672,6 +682,7 @@ dependencies = [
  "axum",
  "chrono",
  "dotenvy",
+ "hmac 0.12.1",
  "musubi_db_runtime",
  "musubi_settlement_domain",
  "serde",
@@ -810,7 +821,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "fallible-iterator",
- "hmac",
+ "hmac 0.13.0",
  "md-5",
  "memchr",
  "rand 0.10.0",
@@ -1110,6 +1121,12 @@ dependencies = [
  "unicode-normalization",
  "unicode-properties",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"

--- a/apps/backend/Cargo.toml
+++ b/apps/backend/Cargo.toml
@@ -38,8 +38,8 @@ chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1", features = ["serde", "v4"] }
 tower-http = { version = "0.6.8", features = ["cors"] }
 async-trait = "0.1"
-hmac = "0.12"
-sha2 = "0.10"
+hmac = "0.13"
+sha2 = "0.11"
 musubi_db_runtime = { path = "crates/db-runtime" }
 musubi_settlement_domain = { path = "crates/settlement-domain" }
 

--- a/apps/backend/Cargo.toml
+++ b/apps/backend/Cargo.toml
@@ -38,6 +38,7 @@ chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1", features = ["serde", "v4"] }
 tower-http = { version = "0.6.8", features = ["cors"] }
 async-trait = "0.1"
+hmac = "0.12"
 sha2 = "0.10"
 musubi_db_runtime = { path = "crates/db-runtime" }
 musubi_settlement_domain = { path = "crates/settlement-domain" }

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -6,6 +6,8 @@ Current local HTTP surface:
 - `POST /api/auth/pi` with explicit `access_token`
 - `POST /api/promise/intents`
 - `POST /api/payment/callback`
+- `POST /api/proof/challenges`
+- `POST /api/proof/submissions`
 - `POST /api/internal/orchestration/drain` in debug builds, or in release only when `MUSUBI_ENABLE_INTERNAL_ORCHESTRATION_DRAIN=true`
 - `GET /api/projection/settlement-views/{settlement_case_id}` for authenticated participants only
 
@@ -103,6 +105,12 @@ See `docs/schema_skeleton.md` for ownership notes and deferred scope.
 Issue #8 adds the runtime migration runner and backend startup schema check.
 See `docs/db_runtime.md` for the current DB bootstrap and local reset flow.
 Issue #17 adds the first sandbox Pi provider adapter boundary for happy-route hold submission and callback intake.
+ISSUE-10 adds Day 1 safer venue proof primitives.
+The public HTTP surface supports the normal venue-code path only.
+Proof challenges are short-lived, proof envelopes are server-verified before acceptance, exact replays are rejected with server-keyed replay keys, and venue verification is realm-scoped, server-secret-backed, and bound to the challenge-issued key version.
+Operator PIN fallback remains an internal/deferred primitive until an authenticated operator surface exists; subject-facing requests for `operator_pin` are rejected before any operator audit or rate-limit state is touched.
+Location hints are sanitized before proof records are built, unsupported fallback modes are rejected before display-code verification, and malformed or cross-subject attempts do not burn another challenge's failed-attempt budget.
+These proof records are input facts only; they are not settlement truth or final anti-spoof guarantees.
 
 ## Local design notes
 
@@ -112,4 +120,5 @@ Issue #17 adds the first sandbox Pi provider adapter boundary for happy-route ho
 - `docs/settlement_domain_types.md`: settlement-domain contract
 - `docs/orchestration_runtime.md`: outbox/inbox runtime rules
 - `docs/guardrails.md`: executable architectural guardrails
+- `docs/proof_primitives.md`: Day 1 safer venue proof input boundary
 - `docs/happy_route_walkthrough.md`: current Issue #7 end-to-end path

--- a/apps/backend/docs/guardrails.md
+++ b/apps/backend/docs/guardrails.md
@@ -102,6 +102,16 @@ Provider errors now keep a retry class at the app boundary: transient provider f
 Payment callbacks now persist exact raw body bytes and redacted headers before mapping, amount, payer, normalization, or receipt verification logic runs.
 The HTTP callback endpoint does not advance settlement state, append ledger rows, or refresh projections; it schedules `INGEST_PROVIDER_CALLBACK` for outbox-driven orchestration.
 
+ISSUE-10 adds safer venue proof input primitives.
+Proof challenges are short-lived, near single-use, account-bound, realm/venue-bound, and verified against the challenge-issued, server-secret-backed, key-version-aware rotating code or a rate-limited operator fallback.
+The subject-facing proof challenge route only supports the normal venue-code flow; `operator_pin` is rejected before service-layer issuance so subject callers cannot self-assert operator identity, create operator audit rows, or burn operator fallback rate-limit budget.
+The proof service records only bounded proof-input evidence: sanitized coarse location hints, hashed device-session hints, server-keyed display-code hashes, canonical fallback modes, server-keyed replay keys, and redacted payload shape.
+Failed-attempt budget is charged only for bound secret-check failures after challenge, account, venue, nonce, and live-status binding.
+It does not write raw GPS, exact addresses, oversized location strings, arbitrary fallback-mode strings, clear display codes, clear operator PINs, or excessive device fingerprint material into the current in-memory truth stand-in.
+Venue display codes and operator PIN hashes are not derived from public identifiers alone.
+Verified proof remains an input fact, not authoritative business truth.
+Product and later domain flows must not describe this as complete anti-spoofing.
+
 ## Expected next improvements
 
 The next meaningful upgrades would be:

--- a/apps/backend/docs/proof_primitives.md
+++ b/apps/backend/docs/proof_primitives.md
@@ -135,6 +135,7 @@ PIN issuance is:
 - rate-limited per venue / operator
 
 Successful fallback adds an `operator_fallback` risk flag.
+An operator-pin-capable challenge still accepts the normal display-code path when a live venue code is available; `operator_fallback` is recorded only when the PIN path is actually used.
 The audit record keeps the PIN hash and issuance metadata, not the clear PIN.
 The clear PIN is not stored in proof state and is not part of the client-facing response.
 

--- a/apps/backend/docs/proof_primitives.md
+++ b/apps/backend/docs/proof_primitives.md
@@ -150,12 +150,13 @@ Proof submissions persist:
 - received timestamp
 - optional client observed timestamp
 - sanitized coarse location bucket only
-- hashed device session id
+- server-keyed device session hash
 - canonical fallback mode
 - redacted payload shape
 - verification status
 
 They do not store raw GPS coordinates, exact addresses, oversized location strings, arbitrary fallback-mode strings, exact device fingerprint material, clear display codes, clear operator PINs, or plain digests over low-entropy display-code / operator-PIN material.
+In-memory proof submissions, verifications, and replay material are pruned by TTL and max-entry caps so rejected-envelope evidence does not grow process memory without bound.
 
 ## Residual risk
 

--- a/apps/backend/docs/proof_primitives.md
+++ b/apps/backend/docs/proof_primitives.md
@@ -1,0 +1,173 @@
+# Safer Venue Proof Primitives
+
+ISSUE-10 adds Day 1 proof-input primitives for venue and real-world proof flows.
+
+This is not a final anti-spoofing system.
+It is a bounded input-fact boundary that makes naive static QR / raw GPS proof harder to accidentally treat as truth.
+
+## HTTP surface
+
+- `POST /api/proof/challenges`
+- `POST /api/proof/submissions`
+
+Both endpoints require the same bearer session used by the happy-route API.
+
+### Challenge request
+
+`POST /api/proof/challenges` creates a short-lived venue challenge for the authenticated account.
+
+Accepted fields:
+
+- `venue_id`
+- `realm_id`
+- `fallback_mode`
+
+The public subject-facing endpoint supports only the normal venue-code flow.
+`fallback_mode` may be omitted or set to `none`.
+`operator_pin` returns `400 Bad Request` because the request is asking the public subject route to perform an operator-only action.
+The public request body is never a source of truth for `operator_id`, audit identity, or fallback rate-limit accounting.
+The response deliberately reports `operator_pin_issued = false`; it does not expose an operator PIN or operator delivery object.
+
+The service still has an internal operator fallback primitive for the future authenticated operator surface.
+The clear PIN is generated from server-only entropy and returned only through a separate service-layer operator delivery object.
+That internal primitive must stay unreachable from subject-facing HTTP until an authenticated operator principal exists.
+
+### Proof submission request
+
+`POST /api/proof/submissions` records and verifies a proof envelope.
+
+Accepted fields:
+
+- `challenge_id`
+- `venue_id`
+- `display_code`
+- `key_version`
+- `client_nonce`
+- `observed_at_ms`
+- `coarse_location_bucket`
+- `device_session_id`
+- `fallback_mode`
+- `operator_pin`
+
+The handler denies unknown JSON fields.
+Raw latitude, longitude, advertising IDs, hardware fingerprints, and similar high-risk device facts are intentionally outside this Day 1 envelope.
+`fallback_mode` is parsed again at the service boundary.
+Only blank, `none`, and `operator_pin` are recognized; unsupported non-empty values are rejected before display-code verification and are stored only as the bounded sentinel `unsupported`.
+`coarse_location_bucket` is sanitized before any proof record is built.
+Only lowercase ASCII bucket labels like `tokyo-shibuya` are retained.
+Coordinates, exact-address-like values, oversized strings, and other invalid hints are dropped before persistence and represented only by the `invalid_coarse_location_hint` risk flag plus a bounded invalid marker in the redacted payload.
+
+## Verification boundary
+
+The server verifies:
+
+- challenge existence
+- challenge TTL
+- single-use consumption
+- account / venue binding
+- client nonce binding
+- challenge-issued venue key version and key status
+- rotating display-code validity for the current or immediately previous short window
+- coarse location hint shape
+- fallback mode canonical value
+- optional operator PIN fallback
+- replay of an identical server-keyed replay key
+- bounded failed attempts per challenge
+
+Outcomes are:
+
+- `verified`
+- `rejected`
+- `quarantined`
+
+These records are proof-input facts only.
+They are not settlement truth, ledger truth, Social Trust truth, or attendance truth by themselves.
+Later product flows must explicitly decide what a verified proof can unlock.
+
+## Key-version-aware verification
+
+Each `(realm_id, venue_id)` pair has an active key version in the Day 1 in-memory store.
+The display code is derived from:
+
+- venue secret material
+- realm id
+- venue id
+- key version
+- short server-time window
+
+Venue secret material is derived from the server-only `PROOF_MASTER_SECRET`.
+If `PROOF_MASTER_SECRET` is absent, the Day 1 in-memory stand-in generates a process-local random server secret.
+The rotating code uses an HMAC-style keyed function; realm id, venue id, and key version alone are not enough to compute it.
+The same `venue_id` in two different Realms therefore has separate active key state and separate valid display codes.
+
+Verification uses the key version issued with the challenge as the source of truth.
+The submitted `key_version`, when present, is only an echo check; a mismatch is rejected as `key_version_mismatch` and cannot select another key.
+Active, draining, and revoked semantics are evaluated against the challenge-issued key version only.
+This gives key rotation an explicit seam without claiming production key-management completeness.
+
+## Replay and TTL baseline
+
+Challenges expire after a short TTL and are consumed on successful verification.
+Exact proof-envelope replay is rejected using a deterministic server-keyed replay key.
+Replay keys include canonicalized envelope fields and are HMACed with the server secret so stored replay material cannot be used by itself to enumerate low-entropy display codes or operator PINs offline.
+Each issued challenge also has a small failed-attempt budget.
+Malformed envelopes, unsupported fallback modes, missing nonce, missing challenge, subject mismatch, venue mismatch, replay, expired challenges, risk quarantine, and key-version echo mismatch do not consume that budget.
+Only bound secret-check failures, such as a wrong display code or wrong operator PIN after challenge, subject, venue, nonce, and live-status binding, consume attempts.
+After the budget is exhausted through those real secret-check failures, the challenge is quarantined and the client must request a new challenge.
+
+This is a baseline, not a complete abuse-defense model.
+It is designed so the future PostgreSQL version has obvious uniqueness and retention boundaries.
+
+## Operator fallback
+
+`operator_pin` fallback is for degraded venue moments, not the normal path.
+It is internal/deferred in the current HTTP app.
+Subject-facing challenge creation cannot request it, cannot self-assert an operator identity, cannot create operator issuance audit rows, and cannot burn an operator fallback rate-limit budget.
+
+The internal primitive keeps the intended shape for a future authenticated operator route.
+PIN issuance is:
+
+- tied to a challenge
+- tied to an operator id
+- generated from server-only entropy
+- short-lived
+- audited
+- rate-limited per venue / operator
+
+Successful fallback adds an `operator_fallback` risk flag.
+The audit record keeps the PIN hash and issuance metadata, not the clear PIN.
+The clear PIN is not stored in proof state and is not part of the client-facing response.
+
+## Stored data
+
+Proof submissions persist:
+
+- proof submission id
+- challenge id
+- subject account id
+- server-keyed replay key
+- server-keyed display code hash
+- received timestamp
+- optional client observed timestamp
+- sanitized coarse location bucket only
+- hashed device session id
+- canonical fallback mode
+- redacted payload shape
+- verification status
+
+They do not store raw GPS coordinates, exact addresses, oversized location strings, arbitrary fallback-mode strings, exact device fingerprint material, clear display codes, clear operator PINs, or plain digests over low-entropy display-code / operator-PIN material.
+
+## Residual risk
+
+Residual risk remains explicit:
+
+- coarse location hints can still be spoofed
+- display-code observation can still be relayed by a colluding or compromised client
+- operator fallback depends on human operational discipline
+- in-memory Day 1 state must become PostgreSQL-backed before production use
+- deployments need explicit `PROOF_MASTER_SECRET` custody instead of process-local fallback
+- operator PIN delivery still needs a real authenticated operator channel
+- production venue key custody and rotation policy are still deferred
+
+Product wording must not claim complete anti-spoofing.
+The accurate claim is that the system records a bounded, server-verifiable proof input with visible residual risk.

--- a/apps/backend/docs/proof_primitives.md
+++ b/apps/backend/docs/proof_primitives.md
@@ -156,7 +156,7 @@ Proof submissions persist:
 - verification status
 
 They do not store raw GPS coordinates, exact addresses, oversized location strings, arbitrary fallback-mode strings, exact device fingerprint material, clear display codes, clear operator PINs, or plain digests over low-entropy display-code / operator-PIN material.
-In-memory proof submissions, verifications, and replay material are pruned by TTL and max-entry caps so rejected-envelope evidence does not grow process memory without bound.
+In-memory challenges, operator fallback audits, proof submissions, verifications, and replay material are pruned by TTL and max-entry caps so short-lived proof state does not grow process memory without bound.
 
 ## Residual risk
 

--- a/apps/backend/docs/proof_primitives.md
+++ b/apps/backend/docs/proof_primitives.md
@@ -24,7 +24,7 @@ Accepted fields:
 
 The public subject-facing endpoint supports only the normal venue-code flow.
 `fallback_mode` may be omitted or set to `none`.
-`operator_pin` returns `400 Bad Request` because the request is asking the public subject route to perform an operator-only action.
+`fallback_mode=operator_pin` returns `400 Bad Request` because the request is asking the public subject route to perform an operator-only action.
 The public request body is never a source of truth for `operator_id`, audit identity, or fallback rate-limit accounting.
 The response deliberately reports `operator_pin_issued = false`; it does not expose an operator PIN or operator delivery object.
 
@@ -109,7 +109,7 @@ This gives key rotation an explicit seam without claiming production key-managem
 
 Challenges expire after a short TTL and are consumed on successful verification.
 Exact proof-envelope replay is rejected using a deterministic server-keyed replay key.
-Replay keys include canonicalized envelope fields and are HMACed with the server secret so stored replay material cannot be used by itself to enumerate low-entropy display codes or operator PINs offline.
+Replay keys include the authenticated subject plus canonicalized envelope fields and are HMACed with the server secret so stored replay material cannot be used by itself to enumerate low-entropy display codes or operator PINs offline.
 Each issued challenge also has a small failed-attempt budget.
 Malformed envelopes, unsupported fallback modes, missing nonce, missing challenge, subject mismatch, venue mismatch, replay, expired challenges, risk quarantine, and key-version echo mismatch do not consume that budget.
 Only bound secret-check failures, such as a wrong display code or wrong operator PIN after challenge, subject, venue, nonce, and live-status binding, consume attempts.

--- a/apps/backend/docs/proof_primitives.md
+++ b/apps/backend/docs/proof_primitives.md
@@ -156,7 +156,7 @@ Proof submissions persist:
 - verification status
 
 They do not store raw GPS coordinates, exact addresses, oversized location strings, arbitrary fallback-mode strings, exact device fingerprint material, clear display codes, clear operator PINs, or plain digests over low-entropy display-code / operator-PIN material.
-In-memory challenges, operator fallback audits, proof submissions, verifications, and replay material are pruned by TTL and max-entry caps so short-lived proof state does not grow process memory without bound.
+In-memory venue key state, challenges, operator fallback audits, proof submissions, verifications, and replay material are pruned by TTL and max-entry caps so short-lived proof state does not grow process memory without bound.
 
 ## Residual risk
 

--- a/apps/backend/src/handlers/mod.rs
+++ b/apps/backend/src/handlers/mod.rs
@@ -11,6 +11,7 @@ pub mod orchestration;
 pub mod payments;
 pub mod projection;
 pub mod promise_intents;
+pub mod proof;
 
 #[derive(Debug, Serialize)]
 pub struct ErrorResponse {

--- a/apps/backend/src/handlers/proof.rs
+++ b/apps/backend/src/handlers/proof.rs
@@ -1,0 +1,142 @@
+use axum::{Json, extract::State, http::HeaderMap};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    SharedState,
+    handlers::{ApiResult, bad_request, map_happy_route_error, require_bearer_token},
+    services::{
+        happy_route::authorize_account,
+        proof::{
+            ProofEnvelopeInput, ProofSubmissionOutcome, StartProofChallengeInput,
+            start_proof_challenge as start_proof_challenge_service,
+            submit_proof_envelope as submit_proof_envelope_service,
+        },
+    },
+};
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct StartProofChallengeRequest {
+    pub venue_id: String,
+    pub realm_id: String,
+    pub fallback_mode: Option<String>,
+    pub operator_id: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct StartProofChallengeResponse {
+    pub challenge_id: String,
+    pub venue_id: String,
+    pub realm_id: String,
+    pub expires_at: DateTime<Utc>,
+    pub client_nonce: String,
+    pub allowed_fallback_mode: String,
+    pub venue_key_version: i32,
+    pub operator_pin_issued: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SubmitProofEnvelopeRequest {
+    pub challenge_id: Option<String>,
+    pub venue_id: Option<String>,
+    pub display_code: Option<String>,
+    pub key_version: Option<i32>,
+    pub client_nonce: Option<String>,
+    pub observed_at_ms: Option<i64>,
+    pub coarse_location_bucket: Option<String>,
+    pub device_session_id: Option<String>,
+    pub fallback_mode: Option<String>,
+    pub operator_pin: Option<String>,
+}
+
+pub async fn start_proof_challenge(
+    State(state): State<SharedState>,
+    headers: HeaderMap,
+    Json(payload): Json<StartProofChallengeRequest>,
+) -> ApiResult<StartProofChallengeResponse> {
+    let bearer_token = require_bearer_token(&headers)?;
+    let authenticated_account = authorize_account(&state, &bearer_token)
+        .await
+        .map_err(map_happy_route_error)?;
+    if public_fallback_mode(&payload.fallback_mode)? != "none" {
+        return Err(bad_request(
+            "operator_pin fallback is not available from the public proof challenge endpoint",
+        ));
+    }
+
+    let outcome = start_proof_challenge_service(
+        &state,
+        StartProofChallengeInput {
+            subject_account_id: authenticated_account.account_id,
+            venue_id: payload.venue_id,
+            realm_id: payload.realm_id,
+            fallback_mode: "none".to_owned(),
+            operator_id: None,
+        },
+    )
+    .await
+    .map_err(map_happy_route_error)?;
+    let client_outcome = outcome.client;
+
+    Ok(Json(StartProofChallengeResponse {
+        challenge_id: client_outcome.challenge_id,
+        venue_id: client_outcome.venue_id,
+        realm_id: client_outcome.realm_id,
+        expires_at: client_outcome.expires_at,
+        client_nonce: client_outcome.client_nonce,
+        allowed_fallback_mode: client_outcome.allowed_fallback_mode,
+        venue_key_version: client_outcome.venue_key_version,
+        operator_pin_issued: client_outcome.operator_pin_issued,
+    }))
+}
+
+pub async fn submit_proof_envelope(
+    State(state): State<SharedState>,
+    headers: HeaderMap,
+    Json(payload): Json<SubmitProofEnvelopeRequest>,
+) -> ApiResult<ProofSubmissionOutcome> {
+    let bearer_token = require_bearer_token(&headers)?;
+    let authenticated_account = authorize_account(&state, &bearer_token)
+        .await
+        .map_err(map_happy_route_error)?;
+
+    let outcome = submit_proof_envelope_service(
+        &state,
+        ProofEnvelopeInput {
+            subject_account_id: authenticated_account.account_id,
+            challenge_id: payload.challenge_id,
+            venue_id: payload.venue_id,
+            display_code: payload.display_code,
+            key_version: payload.key_version,
+            client_nonce: payload.client_nonce,
+            observed_at_ms: payload.observed_at_ms,
+            coarse_location_bucket: payload.coarse_location_bucket,
+            device_session_id: payload.device_session_id,
+            fallback_mode: payload.fallback_mode,
+            operator_pin: payload.operator_pin,
+        },
+    )
+    .await
+    .map_err(map_happy_route_error)?;
+
+    Ok(Json(outcome))
+}
+
+fn public_fallback_mode(value: &Option<String>) -> Result<&'static str, crate::handlers::ApiError> {
+    let normalized = value
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("none");
+    if normalized == "none" {
+        Ok("none")
+    } else if normalized == "operator_pin" {
+        Ok("operator_pin")
+    } else {
+        Err(bad_request(
+            "fallback_mode must be none for public proof challenges",
+        ))
+    }
+}

--- a/apps/backend/src/lib.rs
+++ b/apps/backend/src/lib.rs
@@ -19,6 +19,7 @@ pub type SharedState = Arc<AppState>;
 
 pub struct AppState {
     pub happy_route: RwLock<services::happy_route::HappyRouteState>,
+    pub proof: RwLock<services::proof::ProofState>,
 }
 
 #[derive(Serialize)]
@@ -30,6 +31,7 @@ struct HealthResponse {
 pub fn new_state() -> SharedState {
     Arc::new(AppState {
         happy_route: RwLock::new(services::happy_route::HappyRouteState::default()),
+        proof: RwLock::new(services::proof::ProofState::default()),
     })
 }
 
@@ -45,6 +47,14 @@ pub fn build_app(state: SharedState) -> Router {
         .route(
             "/api/promise/intents",
             post(handlers::promise_intents::create_promise_intent),
+        )
+        .route(
+            "/api/proof/challenges",
+            post(handlers::proof::start_proof_challenge).layer(DefaultBodyLimit::max(16 * 1024)),
+        )
+        .route(
+            "/api/proof/submissions",
+            post(handlers::proof::submit_proof_envelope).layer(DefaultBodyLimit::max(16 * 1024)),
         )
         .route(
             "/api/projection/settlement-views/{settlement_case_id}",

--- a/apps/backend/src/services/mod.rs
+++ b/apps/backend/src/services/mod.rs
@@ -1,2 +1,3 @@
 #[path = "happy_route/mod.rs"]
 pub mod happy_route;
+pub mod proof;

--- a/apps/backend/src/services/proof.rs
+++ b/apps/backend/src/services/proof.rs
@@ -1,0 +1,2447 @@
+use std::{collections::HashMap, fmt::Write as _};
+
+use chrono::{DateTime, Duration, Utc};
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+use crate::SharedState;
+
+use super::happy_route::HappyRouteError;
+
+const CHALLENGE_TTL_SECONDS: i64 = 90;
+const DISPLAY_CODE_WINDOW_SECONDS: i64 = 30;
+const OPERATOR_PIN_TTL_SECONDS: i64 = 60;
+const OPERATOR_PIN_RATE_LIMIT_PER_MINUTE: usize = 3;
+const MAX_CHALLENGE_FAILED_ATTEMPTS: u8 = 3;
+
+const KEY_STATUS_ACTIVE: &str = "active";
+const KEY_STATUS_DRAINING: &str = "draining";
+const KEY_STATUS_REVOKED: &str = "revoked";
+
+const CHALLENGE_STATUS_ISSUED: &str = "issued";
+const CHALLENGE_STATUS_CONSUMED: &str = "consumed";
+const CHALLENGE_STATUS_EXPIRED: &str = "expired";
+const CHALLENGE_STATUS_QUARANTINED: &str = "quarantined";
+
+const FALLBACK_NONE: &str = "none";
+const FALLBACK_OPERATOR_PIN: &str = "operator_pin";
+const FALLBACK_UNSUPPORTED: &str = "unsupported";
+
+const PROOF_STATUS_VERIFIED: &str = "verified";
+const PROOF_STATUS_REJECTED: &str = "rejected";
+const PROOF_STATUS_QUARANTINED: &str = "quarantined";
+
+const REASON_VERIFIED: &str = "verified";
+const REASON_MALFORMED: &str = "malformed";
+const REASON_CHALLENGE_NOT_FOUND: &str = "challenge_not_found";
+const REASON_EXPIRED: &str = "expired";
+const REASON_REPLAY: &str = "replay";
+const REASON_INVALID_CODE: &str = "invalid_code";
+const REASON_KEY_REVOKED: &str = "key_revoked";
+const REASON_VENUE_MISMATCH: &str = "venue_mismatch";
+const REASON_SUBJECT_MISMATCH: &str = "subject_mismatch";
+const REASON_OPERATOR_PIN_INVALID: &str = "operator_pin_invalid";
+const REASON_RISK_FLAGGED: &str = "risk_flagged";
+const REASON_ATTEMPT_LIMIT_EXCEEDED: &str = "attempt_limit_exceeded";
+const REASON_UNSUPPORTED_FALLBACK_MODE: &str = "unsupported_fallback_mode";
+const REASON_KEY_VERSION_MISMATCH: &str = "key_version_mismatch";
+
+const RISK_INVALID_COARSE_LOCATION_HINT: &str = "invalid_coarse_location_hint";
+
+pub struct ProofState {
+    server_secret: String,
+    venue_key_versions: HashMap<(String, String, i32), VenueKeyVersionRecord>,
+    active_key_version_by_venue: HashMap<(String, String), i32>,
+    venue_challenges_by_id: HashMap<String, VenueChallengeRecord>,
+    proof_submissions_by_id: HashMap<String, ProofSubmissionRecord>,
+    proof_submission_id_by_replay_key: HashMap<String, String>,
+    proof_verifications_by_id: HashMap<String, ProofVerificationRecord>,
+    operator_pin_audits: Vec<OperatorPinAuditRecord>,
+}
+
+impl Default for ProofState {
+    fn default() -> Self {
+        Self::with_server_secret(server_secret_from_env())
+    }
+}
+
+impl ProofState {
+    fn with_server_secret(server_secret: String) -> Self {
+        Self {
+            server_secret,
+            venue_key_versions: HashMap::new(),
+            active_key_version_by_venue: HashMap::new(),
+            venue_challenges_by_id: HashMap::new(),
+            proof_submissions_by_id: HashMap::new(),
+            proof_submission_id_by_replay_key: HashMap::new(),
+            proof_verifications_by_id: HashMap::new(),
+            operator_pin_audits: Vec::new(),
+        }
+    }
+
+    #[cfg(test)]
+    fn with_server_secret_for_test(server_secret: &str) -> Self {
+        Self::with_server_secret(server_secret.to_owned())
+    }
+}
+
+#[derive(Clone, Debug)]
+#[allow(dead_code)]
+struct VenueKeyVersionRecord {
+    realm_id: String,
+    venue_id: String,
+    key_version: i32,
+    secret_material: String,
+    status: String,
+    not_before: DateTime<Utc>,
+    not_after: Option<DateTime<Utc>>,
+    created_at: DateTime<Utc>,
+}
+
+#[derive(Clone, Debug)]
+#[allow(dead_code)]
+struct VenueChallengeRecord {
+    challenge_id: String,
+    subject_account_id: String,
+    venue_id: String,
+    realm_id: String,
+    client_nonce_hash: String,
+    issued_at: DateTime<Utc>,
+    expires_at: DateTime<Utc>,
+    consumed_at: Option<DateTime<Utc>>,
+    fallback_mode: String,
+    operator_pin_hash: Option<String>,
+    operator_pin_expires_at: Option<DateTime<Utc>>,
+    operator_id: Option<String>,
+    venue_key_version: i32,
+    failed_attempt_count: u8,
+    status: String,
+}
+
+#[derive(Clone, Debug)]
+#[allow(dead_code)]
+struct ProofSubmissionRecord {
+    proof_submission_id: String,
+    challenge_id: Option<String>,
+    subject_account_id: String,
+    replay_key: String,
+    display_code_hash: Option<String>,
+    received_at: DateTime<Utc>,
+    observed_at_client: Option<DateTime<Utc>>,
+    coarse_location_bucket: Option<String>,
+    device_session_id_hash: Option<String>,
+    fallback_mode: String,
+    raw_payload_json: serde_json::Value,
+    verification_status: String,
+}
+
+#[derive(Clone, Debug)]
+#[allow(dead_code)]
+struct ProofVerificationRecord {
+    proof_verification_id: String,
+    proof_submission_id: String,
+    result: String,
+    reason_code: String,
+    risk_flags: Vec<String>,
+    verified_at: DateTime<Utc>,
+    operator_override_case_id: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+#[allow(dead_code)]
+struct OperatorPinAuditRecord {
+    audit_id: String,
+    challenge_id: String,
+    operator_id: String,
+    venue_id: String,
+    realm_id: String,
+    issued_at: DateTime<Utc>,
+    expires_at: DateTime<Utc>,
+    pin_hash: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct StartProofChallengeInput {
+    pub subject_account_id: String,
+    pub venue_id: String,
+    pub realm_id: String,
+    pub fallback_mode: String,
+    pub operator_id: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct StartProofChallengeOutcome {
+    pub challenge_id: String,
+    pub venue_id: String,
+    pub realm_id: String,
+    pub expires_at: DateTime<Utc>,
+    pub client_nonce: String,
+    pub allowed_fallback_mode: String,
+    pub venue_key_version: i32,
+    pub operator_pin_issued: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct OperatorPinDelivery {
+    pub challenge_id: String,
+    pub operator_id: String,
+    pub venue_id: String,
+    pub realm_id: String,
+    pub pin: String,
+    pub expires_at: DateTime<Utc>,
+}
+
+#[derive(Clone, Debug)]
+pub struct StartProofChallengeServiceOutcome {
+    pub client: StartProofChallengeOutcome,
+    pub operator_delivery: Option<OperatorPinDelivery>,
+}
+
+#[derive(Clone, Debug)]
+pub struct ProofEnvelopeInput {
+    pub subject_account_id: String,
+    pub challenge_id: Option<String>,
+    pub venue_id: Option<String>,
+    pub display_code: Option<String>,
+    pub key_version: Option<i32>,
+    pub client_nonce: Option<String>,
+    pub observed_at_ms: Option<i64>,
+    pub coarse_location_bucket: Option<String>,
+    pub device_session_id: Option<String>,
+    pub fallback_mode: Option<String>,
+    pub operator_pin: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct ProofSubmissionOutcome {
+    pub proof_submission_id: String,
+    pub proof_verification_id: String,
+    pub accepted: bool,
+    pub verification_status: String,
+    pub reason_code: Option<String>,
+    pub risk_flags: Vec<String>,
+    pub next_action: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SubmissionFallbackMode {
+    None,
+    OperatorPin,
+}
+
+impl SubmissionFallbackMode {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::None => FALLBACK_NONE,
+            Self::OperatorPin => FALLBACK_OPERATOR_PIN,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct SanitizedCoarseLocationBucket {
+    stored_bucket: Option<String>,
+    invalid: bool,
+}
+
+pub async fn start_proof_challenge(
+    state: &SharedState,
+    input: StartProofChallengeInput,
+) -> Result<StartProofChallengeServiceOutcome, HappyRouteError> {
+    let now = Utc::now();
+    let venue_id = required_trimmed(input.venue_id, "venue_id is required")?;
+    let realm_id = required_trimmed(input.realm_id, "realm_id is required")?;
+    let subject_account_id =
+        required_trimmed(input.subject_account_id, "subject_account_id is required")?;
+    let fallback_mode = normalize_fallback_mode(input.fallback_mode.as_str())?;
+    let mut store = state.proof.write().await;
+    let key_version = ensure_active_venue_key(&mut store, &realm_id, &venue_id, now);
+    let challenge_id = Uuid::new_v4().to_string();
+    let client_nonce = Uuid::new_v4().to_string();
+    let expires_at = now + Duration::seconds(CHALLENGE_TTL_SECONDS);
+
+    let (operator_delivery, operator_pin_hash, operator_pin_expires_at, operator_id) =
+        if fallback_mode == FALLBACK_OPERATOR_PIN {
+            let operator_id = required_trimmed(
+                input.operator_id.unwrap_or_default(),
+                "operator_id is required for operator_pin fallback",
+            )?;
+            if operator_pin_issuance_count(&store, &realm_id, &venue_id, &operator_id, now)
+                >= OPERATOR_PIN_RATE_LIMIT_PER_MINUTE
+            {
+                return Err(HappyRouteError::BadRequest(
+                    "operator_pin fallback rate limit exceeded".to_owned(),
+                ));
+            }
+            let operator_pin = random_numeric_code();
+            let pin_hash = operator_pin_hash(&store.server_secret, &challenge_id, &operator_pin);
+            let pin_expires_at = now + Duration::seconds(OPERATOR_PIN_TTL_SECONDS);
+            store.operator_pin_audits.push(OperatorPinAuditRecord {
+                audit_id: Uuid::new_v4().to_string(),
+                challenge_id: challenge_id.clone(),
+                operator_id: operator_id.clone(),
+                venue_id: venue_id.clone(),
+                realm_id: realm_id.clone(),
+                issued_at: now,
+                expires_at: pin_expires_at,
+                pin_hash: pin_hash.clone(),
+            });
+            (
+                Some(OperatorPinDelivery {
+                    challenge_id: challenge_id.clone(),
+                    operator_id: operator_id.clone(),
+                    venue_id: venue_id.clone(),
+                    realm_id: realm_id.clone(),
+                    pin: operator_pin,
+                    expires_at: pin_expires_at,
+                }),
+                Some(pin_hash),
+                Some(pin_expires_at),
+                Some(operator_id),
+            )
+        } else {
+            (None, None, None, None)
+        };
+
+    store.venue_challenges_by_id.insert(
+        challenge_id.clone(),
+        VenueChallengeRecord {
+            challenge_id: challenge_id.clone(),
+            subject_account_id,
+            venue_id: venue_id.clone(),
+            realm_id: realm_id.clone(),
+            client_nonce_hash: digest_parts(&["client-nonce", &challenge_id, &client_nonce]),
+            issued_at: now,
+            expires_at,
+            consumed_at: None,
+            fallback_mode: fallback_mode.clone(),
+            operator_pin_hash,
+            operator_pin_expires_at,
+            operator_id,
+            venue_key_version: key_version,
+            failed_attempt_count: 0,
+            status: CHALLENGE_STATUS_ISSUED.to_owned(),
+        },
+    );
+
+    Ok(StartProofChallengeServiceOutcome {
+        client: StartProofChallengeOutcome {
+            challenge_id,
+            venue_id,
+            realm_id,
+            expires_at,
+            client_nonce,
+            allowed_fallback_mode: fallback_mode,
+            venue_key_version: key_version,
+            operator_pin_issued: operator_delivery.is_some(),
+        },
+        operator_delivery,
+    })
+}
+
+pub async fn submit_proof_envelope(
+    state: &SharedState,
+    input: ProofEnvelopeInput,
+) -> Result<ProofSubmissionOutcome, HappyRouteError> {
+    submit_proof_envelope_at(state, input, Utc::now()).await
+}
+
+async fn submit_proof_envelope_at(
+    state: &SharedState,
+    input: ProofEnvelopeInput,
+    received_at: DateTime<Utc>,
+) -> Result<ProofSubmissionOutcome, HappyRouteError> {
+    let mut store = state.proof.write().await;
+    let replay_key = replay_key(&store.server_secret, &input);
+    let replayed_submission_id = store
+        .proof_submission_id_by_replay_key
+        .get(&replay_key)
+        .cloned();
+    let display_code_hash = input
+        .display_code
+        .as_deref()
+        .map(|value| server_keyed_display_code_hash(&store.server_secret, value));
+    let observed_at_client = input
+        .observed_at_ms
+        .and_then(DateTime::<Utc>::from_timestamp_millis);
+    let sanitized_location =
+        sanitize_coarse_location_bucket(input.coarse_location_bucket.as_deref());
+    let device_session_id_hash = input
+        .device_session_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| digest_parts(&["device-session", value]));
+    let parsed_fallback_mode = parse_submission_fallback_mode(input.fallback_mode.as_deref());
+    let fallback_mode = parsed_fallback_mode
+        .map(SubmissionFallbackMode::as_str)
+        .unwrap_or(FALLBACK_UNSUPPORTED)
+        .to_owned();
+    let proof_submission_id = Uuid::new_v4().to_string();
+    let mut risk_flags = risk_flags(&input, &sanitized_location, received_at);
+
+    let verification = if let Some(fallback_mode) = parsed_fallback_mode {
+        verify_envelope(
+            &mut store,
+            &input,
+            fallback_mode,
+            received_at,
+            replayed_submission_id.as_deref(),
+            &mut risk_flags,
+        )
+    } else {
+        no_charge(rejected(REASON_UNSUPPORTED_FALLBACK_MODE))
+    };
+    let VerificationResult {
+        mut decision,
+        charge_attempt,
+    } = verification;
+    if charge_attempt && decision.status != PROOF_STATUS_VERIFIED {
+        decision = record_failed_attempt(&mut store, input.challenge_id.as_deref(), decision);
+    }
+    let raw_payload_json = redacted_payload(&input, &display_code_hash, &sanitized_location);
+    let submission = ProofSubmissionRecord {
+        proof_submission_id: proof_submission_id.clone(),
+        challenge_id: input
+            .challenge_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_owned),
+        subject_account_id: input.subject_account_id.clone(),
+        replay_key: replay_key.clone(),
+        display_code_hash,
+        received_at,
+        observed_at_client,
+        coarse_location_bucket: sanitized_location.stored_bucket,
+        device_session_id_hash,
+        fallback_mode,
+        raw_payload_json,
+        verification_status: decision.status.to_owned(),
+    };
+    store
+        .proof_submission_id_by_replay_key
+        .entry(replay_key)
+        .or_insert_with(|| proof_submission_id.clone());
+    store
+        .proof_submissions_by_id
+        .insert(proof_submission_id.clone(), submission);
+
+    if decision.status == PROOF_STATUS_VERIFIED
+        && let Some(challenge_id) = input.challenge_id.as_deref().map(str::trim)
+        && let Some(challenge) = store.venue_challenges_by_id.get_mut(challenge_id)
+    {
+        challenge.consumed_at = Some(received_at);
+        challenge.status = CHALLENGE_STATUS_CONSUMED.to_owned();
+    }
+
+    let proof_verification_id = Uuid::new_v4().to_string();
+    store.proof_verifications_by_id.insert(
+        proof_verification_id.clone(),
+        ProofVerificationRecord {
+            proof_verification_id: proof_verification_id.clone(),
+            proof_submission_id: proof_submission_id.clone(),
+            result: decision.status.to_owned(),
+            reason_code: decision.reason_code.to_owned(),
+            risk_flags: risk_flags.clone(),
+            verified_at: received_at,
+            operator_override_case_id: None,
+        },
+    );
+
+    Ok(ProofSubmissionOutcome {
+        proof_submission_id,
+        proof_verification_id,
+        accepted: decision.status == PROOF_STATUS_VERIFIED,
+        verification_status: decision.status.to_owned(),
+        reason_code: if decision.reason_code == REASON_VERIFIED {
+            None
+        } else {
+            Some(decision.reason_code.to_owned())
+        },
+        risk_flags,
+        next_action: decision.next_action.map(str::to_owned),
+    })
+}
+
+struct VerificationDecision {
+    status: &'static str,
+    reason_code: &'static str,
+    next_action: Option<&'static str>,
+}
+
+struct VerificationResult {
+    decision: VerificationDecision,
+    charge_attempt: bool,
+}
+
+fn verify_envelope(
+    store: &mut ProofState,
+    input: &ProofEnvelopeInput,
+    fallback_mode: SubmissionFallbackMode,
+    received_at: DateTime<Utc>,
+    replayed_submission_id: Option<&str>,
+    risk_flags: &mut Vec<String>,
+) -> VerificationResult {
+    if replayed_submission_id.is_some() {
+        return no_charge(rejected(REASON_REPLAY));
+    }
+
+    let Some(challenge_id) = trimmed_optional(input.challenge_id.as_deref()) else {
+        return no_charge(rejected(REASON_MALFORMED));
+    };
+    let Some(venue_id) = trimmed_optional(input.venue_id.as_deref()) else {
+        return no_charge(rejected(REASON_MALFORMED));
+    };
+    let Some(client_nonce) = trimmed_optional(input.client_nonce.as_deref()) else {
+        return no_charge(rejected(REASON_MALFORMED));
+    };
+    let Some(challenge) = store.venue_challenges_by_id.get(&challenge_id).cloned() else {
+        return no_charge(rejected(REASON_CHALLENGE_NOT_FOUND));
+    };
+    if challenge.subject_account_id != input.subject_account_id {
+        return no_charge(quarantined(REASON_SUBJECT_MISMATCH));
+    }
+    if challenge.venue_id != venue_id {
+        return no_charge(quarantined(REASON_VENUE_MISMATCH));
+    }
+    if challenge.consumed_at.is_some() {
+        return no_charge(rejected(REASON_REPLAY));
+    }
+    if challenge.status == CHALLENGE_STATUS_QUARANTINED
+        || challenge.failed_attempt_count >= MAX_CHALLENGE_FAILED_ATTEMPTS
+    {
+        return no_charge(quarantined(REASON_ATTEMPT_LIMIT_EXCEEDED));
+    }
+    if received_at > challenge.expires_at {
+        if let Some(existing) = store.venue_challenges_by_id.get_mut(&challenge_id) {
+            existing.status = CHALLENGE_STATUS_EXPIRED.to_owned();
+        }
+        return no_charge(rejected(REASON_EXPIRED));
+    }
+    if challenge.client_nonce_hash != digest_parts(&["client-nonce", &challenge_id, &client_nonce])
+    {
+        return no_charge(rejected(REASON_MALFORMED));
+    }
+    if risk_requires_quarantine(risk_flags) {
+        return no_charge(quarantined(REASON_RISK_FLAGGED));
+    }
+
+    if fallback_mode == SubmissionFallbackMode::OperatorPin {
+        return verify_operator_pin(
+            &store.server_secret,
+            &challenge,
+            input,
+            received_at,
+            risk_flags,
+        );
+    }
+
+    let Some(display_code) = trimmed_optional(input.display_code.as_deref()) else {
+        return no_charge(rejected(REASON_MALFORMED));
+    };
+    if input
+        .key_version
+        .is_some_and(|submitted| submitted != challenge.venue_key_version)
+    {
+        return no_charge(rejected(REASON_KEY_VERSION_MISMATCH));
+    }
+    let Some(key) = store
+        .venue_key_versions
+        .get(&(
+            challenge.realm_id.clone(),
+            venue_id.clone(),
+            challenge.venue_key_version,
+        ))
+        .cloned()
+    else {
+        return no_charge(rejected(REASON_INVALID_CODE));
+    };
+    if key.status == KEY_STATUS_REVOKED {
+        return no_charge(rejected(REASON_KEY_REVOKED));
+    }
+    if key.status != KEY_STATUS_ACTIVE && key.status != KEY_STATUS_DRAINING {
+        return no_charge(rejected(REASON_INVALID_CODE));
+    }
+    if key.not_before > received_at
+        || key
+            .not_after
+            .is_some_and(|not_after| received_at > not_after)
+    {
+        return no_charge(rejected(REASON_INVALID_CODE));
+    }
+    if !display_code_valid_for_key(&key, &display_code, received_at) {
+        return charge(rejected(REASON_INVALID_CODE));
+    }
+
+    no_charge(verified())
+}
+
+fn verify_operator_pin(
+    server_secret: &str,
+    challenge: &VenueChallengeRecord,
+    input: &ProofEnvelopeInput,
+    received_at: DateTime<Utc>,
+    risk_flags: &mut Vec<String>,
+) -> VerificationResult {
+    if challenge.fallback_mode != FALLBACK_OPERATOR_PIN {
+        return no_charge(rejected(REASON_OPERATOR_PIN_INVALID));
+    }
+    let Some(pin) = trimmed_optional(input.operator_pin.as_deref()) else {
+        return no_charge(rejected(REASON_OPERATOR_PIN_INVALID));
+    };
+    if challenge
+        .operator_pin_expires_at
+        .is_none_or(|expires_at| received_at > expires_at)
+    {
+        return no_charge(rejected(REASON_EXPIRED));
+    }
+    let submitted_pin_hash = operator_pin_hash(server_secret, &challenge.challenge_id, &pin);
+    if challenge.operator_pin_hash.as_deref() != Some(submitted_pin_hash.as_str()) {
+        return charge(rejected(REASON_OPERATOR_PIN_INVALID));
+    }
+    risk_flags.push("operator_fallback".to_owned());
+    no_charge(verified())
+}
+
+fn no_charge(decision: VerificationDecision) -> VerificationResult {
+    VerificationResult {
+        decision,
+        charge_attempt: false,
+    }
+}
+
+fn charge(decision: VerificationDecision) -> VerificationResult {
+    VerificationResult {
+        decision,
+        charge_attempt: true,
+    }
+}
+
+fn verified() -> VerificationDecision {
+    VerificationDecision {
+        status: PROOF_STATUS_VERIFIED,
+        reason_code: REASON_VERIFIED,
+        next_action: None,
+    }
+}
+
+fn rejected(reason_code: &'static str) -> VerificationDecision {
+    VerificationDecision {
+        status: PROOF_STATUS_REJECTED,
+        reason_code,
+        next_action: Some("retry_proof"),
+    }
+}
+
+fn quarantined(reason_code: &'static str) -> VerificationDecision {
+    VerificationDecision {
+        status: PROOF_STATUS_QUARANTINED,
+        reason_code,
+        next_action: Some("operator_review"),
+    }
+}
+
+fn record_failed_attempt(
+    store: &mut ProofState,
+    challenge_id: Option<&str>,
+    decision: VerificationDecision,
+) -> VerificationDecision {
+    let Some(challenge_id) = challenge_id
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return decision;
+    };
+    let Some(challenge) = store.venue_challenges_by_id.get_mut(challenge_id) else {
+        return decision;
+    };
+    if challenge.status != CHALLENGE_STATUS_ISSUED {
+        return decision;
+    }
+
+    challenge.failed_attempt_count = challenge.failed_attempt_count.saturating_add(1);
+    if challenge.failed_attempt_count >= MAX_CHALLENGE_FAILED_ATTEMPTS {
+        challenge.status = CHALLENGE_STATUS_QUARANTINED.to_owned();
+        quarantined(REASON_ATTEMPT_LIMIT_EXCEEDED)
+    } else {
+        decision
+    }
+}
+
+fn normalize_fallback_mode(value: &str) -> Result<String, HappyRouteError> {
+    let normalized = value.trim();
+    if normalized.is_empty() || normalized == FALLBACK_NONE {
+        Ok(FALLBACK_NONE.to_owned())
+    } else if normalized == FALLBACK_OPERATOR_PIN {
+        Ok(FALLBACK_OPERATOR_PIN.to_owned())
+    } else {
+        Err(HappyRouteError::BadRequest(
+            "fallback_mode must be none or operator_pin".to_owned(),
+        ))
+    }
+}
+
+fn parse_submission_fallback_mode(value: Option<&str>) -> Option<SubmissionFallbackMode> {
+    let normalized = value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(FALLBACK_NONE);
+    if normalized == FALLBACK_NONE {
+        Some(SubmissionFallbackMode::None)
+    } else if normalized == FALLBACK_OPERATOR_PIN {
+        Some(SubmissionFallbackMode::OperatorPin)
+    } else {
+        None
+    }
+}
+
+fn required_trimmed(value: String, message: &str) -> Result<String, HappyRouteError> {
+    let value = value.trim().to_owned();
+    if value.is_empty() {
+        Err(HappyRouteError::BadRequest(message.to_owned()))
+    } else {
+        Ok(value)
+    }
+}
+
+fn trimmed_optional(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+}
+
+fn server_secret_from_env() -> String {
+    std::env::var("PROOF_MASTER_SECRET")
+        .ok()
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(server_random_secret)
+}
+
+fn server_random_secret() -> String {
+    digest_parts(&[
+        "proof-server-secret",
+        &Uuid::new_v4().to_string(),
+        &Uuid::new_v4().to_string(),
+    ])
+}
+
+fn random_numeric_code() -> String {
+    let digest = Sha256::digest(format!("pin:{}:{}", Uuid::new_v4(), Uuid::new_v4()).as_bytes());
+    let mut bytes = [0_u8; 8];
+    bytes.copy_from_slice(&digest[..8]);
+    let value = u64::from_be_bytes(bytes) % 1_000_000;
+    format!("{value:06}")
+}
+
+fn operator_pin_hash(server_secret: &str, challenge_id: &str, pin: &str) -> String {
+    hmac_sha256_hex(server_secret, &["operator-pin", challenge_id, pin])
+}
+
+fn venue_secret_material(
+    server_secret: &str,
+    realm_id: &str,
+    venue_id: &str,
+    key_version: i32,
+) -> String {
+    hmac_sha256_hex(
+        server_secret,
+        &["venue-secret", realm_id, venue_id, &key_version.to_string()],
+    )
+}
+
+fn ensure_active_venue_key(
+    store: &mut ProofState,
+    realm_id: &str,
+    venue_id: &str,
+    now: DateTime<Utc>,
+) -> i32 {
+    let active_key = (realm_id.to_owned(), venue_id.to_owned());
+    if let Some(key_version) = store.active_key_version_by_venue.get(&active_key) {
+        return *key_version;
+    }
+    let key_version = 1;
+    store
+        .active_key_version_by_venue
+        .insert(active_key, key_version);
+    store.venue_key_versions.insert(
+        (realm_id.to_owned(), venue_id.to_owned(), key_version),
+        VenueKeyVersionRecord {
+            realm_id: realm_id.to_owned(),
+            venue_id: venue_id.to_owned(),
+            key_version,
+            secret_material: venue_secret_material(
+                &store.server_secret,
+                realm_id,
+                venue_id,
+                key_version,
+            ),
+            status: KEY_STATUS_ACTIVE.to_owned(),
+            not_before: now,
+            not_after: None,
+            created_at: now,
+        },
+    );
+    key_version
+}
+
+fn display_code_valid_for_key(
+    key: &VenueKeyVersionRecord,
+    display_code: &str,
+    received_at: DateTime<Utc>,
+) -> bool {
+    let normalized = display_code.trim().to_ascii_uppercase();
+    venue_display_code_for_window(key, received_at) == normalized
+        || venue_display_code_for_window(
+            key,
+            received_at - Duration::seconds(DISPLAY_CODE_WINDOW_SECONDS),
+        ) == normalized
+}
+
+fn venue_display_code_for_window(key: &VenueKeyVersionRecord, at: DateTime<Utc>) -> String {
+    let window = at.timestamp().div_euclid(DISPLAY_CODE_WINDOW_SECONDS);
+    short_code_from_bytes(&hmac_sha256(
+        key.secret_material.as_bytes(),
+        &[
+            "venue-display-code",
+            key.realm_id.as_str(),
+            key.venue_id.as_str(),
+            &key.key_version.to_string(),
+            &window.to_string(),
+        ],
+    ))
+}
+
+fn sanitize_coarse_location_bucket(value: Option<&str>) -> SanitizedCoarseLocationBucket {
+    let Some(value) = value.map(str::trim).filter(|value| !value.is_empty()) else {
+        return SanitizedCoarseLocationBucket {
+            stored_bucket: None,
+            invalid: false,
+        };
+    };
+    let canonical = value.to_ascii_lowercase();
+    let valid = canonical.len() <= 32
+        && canonical
+            .chars()
+            .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '-')
+        && canonical.contains('-')
+        && !canonical.contains("--")
+        && canonical
+            .split('-')
+            .all(|part| !part.is_empty() && !part.chars().all(|ch| ch.is_ascii_digit()));
+
+    SanitizedCoarseLocationBucket {
+        stored_bucket: valid.then_some(canonical),
+        invalid: !valid,
+    }
+}
+
+fn short_code_from_bytes(digest: &[u8]) -> String {
+    let mut encoded = String::with_capacity(8);
+    for byte in digest.iter().take(4) {
+        let _ = write!(&mut encoded, "{byte:02X}");
+    }
+    encoded.truncate(6);
+    encoded
+}
+
+fn server_keyed_display_code_hash(server_secret: &str, display_code: &str) -> String {
+    hmac_sha256_hex(
+        server_secret,
+        &[
+            "display-code",
+            display_code.trim().to_ascii_uppercase().as_str(),
+        ],
+    )
+}
+
+fn replay_key(server_secret: &str, input: &ProofEnvelopeInput) -> String {
+    let challenge_id = canonical_optional(input.challenge_id.as_deref());
+    let venue_id = canonical_optional(input.venue_id.as_deref());
+    let display_code = input
+        .display_code
+        .as_deref()
+        .map(str::trim)
+        .unwrap_or_default()
+        .to_ascii_uppercase();
+    let key_version = input
+        .key_version
+        .map(|value| value.to_string())
+        .unwrap_or_default();
+    let client_nonce = canonical_optional(input.client_nonce.as_deref());
+    let observed_at_ms = input
+        .observed_at_ms
+        .map(|value| value.to_string())
+        .unwrap_or_default();
+    let coarse_location_bucket = input
+        .coarse_location_bucket
+        .as_deref()
+        .map(str::trim)
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    let device_session_id = canonical_optional(input.device_session_id.as_deref());
+    let fallback_mode = canonical_optional(input.fallback_mode.as_deref());
+    let operator_pin = canonical_optional(input.operator_pin.as_deref());
+
+    hmac_sha256_hex(
+        server_secret,
+        &[
+            "proof-envelope",
+            challenge_id.as_str(),
+            venue_id.as_str(),
+            display_code.as_str(),
+            key_version.as_str(),
+            client_nonce.as_str(),
+            observed_at_ms.as_str(),
+            coarse_location_bucket.as_str(),
+            device_session_id.as_str(),
+            fallback_mode.as_str(),
+            operator_pin.as_str(),
+        ],
+    )
+}
+
+fn canonical_optional(value: Option<&str>) -> String {
+    value.map(str::trim).unwrap_or_default().to_owned()
+}
+
+fn redacted_payload(
+    input: &ProofEnvelopeInput,
+    display_code_hash: &Option<String>,
+    sanitized_location: &SanitizedCoarseLocationBucket,
+) -> serde_json::Value {
+    serde_json::json!({
+        "challenge_id": input.challenge_id.as_deref(),
+        "venue_id": input.venue_id.as_deref(),
+        "display_code_hash": display_code_hash.as_deref(),
+        "key_version": input.key_version,
+        "client_nonce_present": input.client_nonce.as_deref().is_some_and(|value| !value.trim().is_empty()),
+        "observed_at_ms": input.observed_at_ms,
+        "coarse_location_bucket": sanitized_location.stored_bucket.as_deref(),
+        "coarse_location_hint_invalid": sanitized_location.invalid,
+        "device_session_id_present": input.device_session_id.as_deref().is_some_and(|value| !value.trim().is_empty()),
+        "fallback_mode": parse_submission_fallback_mode(input.fallback_mode.as_deref())
+            .map(SubmissionFallbackMode::as_str)
+            .unwrap_or(FALLBACK_UNSUPPORTED),
+        "operator_pin_present": input.operator_pin.as_deref().is_some_and(|value| !value.trim().is_empty()),
+    })
+}
+
+fn risk_flags(
+    input: &ProofEnvelopeInput,
+    sanitized_location: &SanitizedCoarseLocationBucket,
+    received_at: DateTime<Utc>,
+) -> Vec<String> {
+    let mut flags = Vec::new();
+    if let Some(observed_at_ms) = input.observed_at_ms {
+        if let Some(observed_at) = DateTime::<Utc>::from_timestamp_millis(observed_at_ms) {
+            if (received_at - observed_at).num_seconds().abs() > 120 {
+                flags.push("client_clock_skew_high".to_owned());
+            }
+        } else {
+            flags.push("client_clock_invalid".to_owned());
+        }
+    }
+    if sanitized_location.invalid {
+        flags.push(RISK_INVALID_COARSE_LOCATION_HINT.to_owned());
+    }
+    if let Some(device_session_id) = input.device_session_id.as_deref()
+        && device_session_id.trim().len() > 128
+    {
+        flags.push("device_hint_oversized".to_owned());
+    }
+    flags
+}
+
+fn risk_requires_quarantine(risk_flags: &[String]) -> bool {
+    risk_flags.iter().any(|flag| {
+        flag == "client_clock_invalid"
+            || flag == "client_clock_skew_high"
+            || flag == "device_hint_oversized"
+            || flag == RISK_INVALID_COARSE_LOCATION_HINT
+    })
+}
+
+fn operator_pin_issuance_count(
+    store: &ProofState,
+    realm_id: &str,
+    venue_id: &str,
+    operator_id: &str,
+    now: DateTime<Utc>,
+) -> usize {
+    let since = now - Duration::seconds(60);
+    store
+        .operator_pin_audits
+        .iter()
+        .filter(|audit| {
+            audit.realm_id == realm_id
+                && audit.venue_id == venue_id
+                && audit.operator_id == operator_id
+                && audit.issued_at >= since
+                && audit.issued_at <= now
+        })
+        .count()
+}
+
+fn digest_parts(parts: &[&str]) -> String {
+    let mut hasher = Sha256::new();
+    update_hasher_with_parts(&mut hasher, parts);
+    hex_bytes(&hasher.finalize())
+}
+
+fn hmac_sha256_hex(key: &str, parts: &[&str]) -> String {
+    hex_bytes(&hmac_sha256(key.as_bytes(), parts))
+}
+
+fn hmac_sha256(key: &[u8], parts: &[&str]) -> [u8; 32] {
+    const SHA256_BLOCK_SIZE: usize = 64;
+    let mut normalized_key = if key.len() > SHA256_BLOCK_SIZE {
+        Sha256::digest(key).to_vec()
+    } else {
+        key.to_vec()
+    };
+    normalized_key.resize(SHA256_BLOCK_SIZE, 0);
+
+    let mut inner_pad = [0x36_u8; SHA256_BLOCK_SIZE];
+    let mut outer_pad = [0x5c_u8; SHA256_BLOCK_SIZE];
+    for (index, byte) in normalized_key.iter().enumerate() {
+        inner_pad[index] ^= byte;
+        outer_pad[index] ^= byte;
+    }
+
+    let mut inner = Sha256::new();
+    inner.update(inner_pad);
+    update_hasher_with_parts(&mut inner, parts);
+    let inner_digest = inner.finalize();
+
+    let mut outer = Sha256::new();
+    outer.update(outer_pad);
+    outer.update(inner_digest);
+    outer.finalize().into()
+}
+
+fn update_hasher_with_parts(hasher: &mut Sha256, parts: &[&str]) {
+    for part in parts {
+        hasher.update(part.len().to_string().as_bytes());
+        hasher.update(b":");
+        hasher.update(part.as_bytes());
+        hasher.update(b";");
+    }
+}
+
+fn hex_bytes(bytes: &[u8]) -> String {
+    let mut encoded = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        let _ = write!(&mut encoded, "{byte:02x}");
+    }
+    encoded
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn valid_dynamic_venue_code_verifies_without_raw_gps_persistence() {
+        let state = crate::new_state();
+        let challenge = start_test_challenge(&state, "venue-a", FALLBACK_NONE).await;
+        let code = display_code(&state, "venue-a", challenge.venue_key_version, Utc::now()).await;
+
+        let outcome = submit_proof_envelope(
+            &state,
+            valid_envelope(&challenge, code)
+                .coarse_location_bucket("tokyo-shibuya")
+                .device_session_id("ephemeral-device-session")
+                .into(),
+        )
+        .await
+        .expect("valid proof should verify");
+
+        assert!(outcome.accepted);
+        assert_eq!(outcome.verification_status, PROOF_STATUS_VERIFIED);
+        let store = state.proof.read().await;
+        let submission = store
+            .proof_submissions_by_id
+            .get(&outcome.proof_submission_id)
+            .expect("proof submission must be retained");
+        assert_eq!(
+            submission.coarse_location_bucket.as_deref(),
+            Some("tokyo-shibuya")
+        );
+        assert!(submission.device_session_id_hash.is_some());
+        assert!(submission.raw_payload_json.get("raw_latitude").is_none());
+        assert!(submission.raw_payload_json.get("raw_longitude").is_none());
+        assert!(
+            submission
+                .raw_payload_json
+                .get("display_code_hash")
+                .and_then(|value| value.as_str())
+                .is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn valid_coarse_location_bucket_is_canonicalized_before_recording() {
+        let state = crate::new_state();
+        let challenge =
+            start_test_challenge(&state, "venue-canonical-location", FALLBACK_NONE).await;
+        let code = display_code(
+            &state,
+            "venue-canonical-location",
+            challenge.venue_key_version,
+            Utc::now(),
+        )
+        .await;
+
+        let outcome = submit_proof_envelope(
+            &state,
+            valid_envelope(&challenge, code)
+                .coarse_location_bucket("Tokyo-Shibuya")
+                .into(),
+        )
+        .await
+        .expect("valid coarse location proof should produce a result");
+
+        assert!(outcome.accepted);
+        let store = state.proof.read().await;
+        let submission = store
+            .proof_submissions_by_id
+            .get(&outcome.proof_submission_id)
+            .expect("submission should be retained");
+        assert_eq!(
+            submission.coarse_location_bucket.as_deref(),
+            Some("tokyo-shibuya")
+        );
+        assert_eq!(
+            submission.raw_payload_json["coarse_location_bucket"],
+            "tokyo-shibuya"
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_coarse_location_hints_are_dropped_before_recording() {
+        let invalid_hints = [
+            "35.6812,139.7671",
+            "1-1-chiyoda-tokyo",
+            "tokyo-shibuya-proof-location-value-that-is-too-long",
+        ];
+
+        for (index, invalid_hint) in invalid_hints.iter().enumerate() {
+            let state = crate::new_state();
+            let venue_id = format!("venue-invalid-location-{index}");
+            let challenge = start_test_challenge(&state, &venue_id, FALLBACK_NONE).await;
+            let code =
+                display_code(&state, &venue_id, challenge.venue_key_version, Utc::now()).await;
+
+            let outcome = submit_proof_envelope(
+                &state,
+                valid_envelope(&challenge, code)
+                    .coarse_location_bucket(invalid_hint)
+                    .into(),
+            )
+            .await
+            .expect("invalid location proof should produce a result");
+
+            assert!(!outcome.accepted);
+            assert_eq!(outcome.verification_status, PROOF_STATUS_QUARANTINED);
+            assert!(
+                outcome
+                    .risk_flags
+                    .iter()
+                    .any(|flag| flag == RISK_INVALID_COARSE_LOCATION_HINT)
+            );
+            let store = state.proof.read().await;
+            let submission = store
+                .proof_submissions_by_id
+                .get(&outcome.proof_submission_id)
+                .expect("submission should be retained");
+            assert!(submission.coarse_location_bucket.is_none());
+            assert!(submission.raw_payload_json["coarse_location_bucket"].is_null());
+            assert_eq!(
+                submission.raw_payload_json["coarse_location_hint_invalid"],
+                true
+            );
+            assert!(
+                !submission
+                    .raw_payload_json
+                    .to_string()
+                    .contains(invalid_hint),
+                "invalid location hint must not remain in redacted payload"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn unsupported_submission_fallback_mode_is_rejected_before_verification() {
+        let state = crate::new_state();
+        let challenge =
+            start_test_challenge(&state, "venue-unsupported-fallback", FALLBACK_NONE).await;
+        let code = display_code(
+            &state,
+            "venue-unsupported-fallback",
+            challenge.venue_key_version,
+            Utc::now(),
+        )
+        .await;
+
+        let outcome = submit_proof_envelope(
+            &state,
+            valid_envelope(&challenge, code)
+                .fallback_mode("operator-pni")
+                .into(),
+        )
+        .await
+        .expect("unsupported fallback mode should produce a result");
+
+        assert!(!outcome.accepted);
+        assert_eq!(outcome.verification_status, PROOF_STATUS_REJECTED);
+        assert_eq!(
+            outcome.reason_code.as_deref(),
+            Some(REASON_UNSUPPORTED_FALLBACK_MODE)
+        );
+        let store = state.proof.read().await;
+        let submission = store
+            .proof_submissions_by_id
+            .get(&outcome.proof_submission_id)
+            .expect("submission should be retained");
+        assert_eq!(submission.fallback_mode, FALLBACK_UNSUPPORTED);
+        assert_eq!(submission.verification_status, PROOF_STATUS_REJECTED);
+        assert!(
+            !submission
+                .raw_payload_json
+                .to_string()
+                .contains("operator-pni")
+        );
+    }
+
+    #[tokio::test]
+    async fn blank_submission_fallback_mode_uses_normal_flow() {
+        let state = crate::new_state();
+        let challenge = start_test_challenge(&state, "venue-blank-fallback", FALLBACK_NONE).await;
+        let code = display_code(
+            &state,
+            "venue-blank-fallback",
+            challenge.venue_key_version,
+            Utc::now(),
+        )
+        .await;
+
+        let outcome = submit_proof_envelope(
+            &state,
+            valid_envelope(&challenge, code).fallback_mode("   ").into(),
+        )
+        .await
+        .expect("blank fallback mode should use normal proof flow");
+
+        assert!(outcome.accepted);
+        let store = state.proof.read().await;
+        let submission = store
+            .proof_submissions_by_id
+            .get(&outcome.proof_submission_id)
+            .expect("submission should be retained");
+        assert_eq!(submission.fallback_mode, FALLBACK_NONE);
+    }
+
+    #[tokio::test]
+    async fn expired_challenge_is_rejected_by_server_time() {
+        let state = crate::new_state();
+        let challenge = start_test_challenge(&state, "venue-expired", FALLBACK_NONE).await;
+        let code = display_code(
+            &state,
+            "venue-expired",
+            challenge.venue_key_version,
+            Utc::now(),
+        )
+        .await;
+        {
+            let mut store = state.proof.write().await;
+            let record = store
+                .venue_challenges_by_id
+                .get_mut(&challenge.challenge_id)
+                .expect("challenge should exist");
+            record.expires_at = Utc::now() - Duration::seconds(1);
+        }
+
+        let outcome = submit_proof_envelope(&state, valid_envelope(&challenge, code).into())
+            .await
+            .expect("expired proof should still produce a verification result");
+
+        assert!(!outcome.accepted);
+        assert_eq!(outcome.verification_status, PROOF_STATUS_REJECTED);
+        assert_eq!(outcome.reason_code.as_deref(), Some(REASON_EXPIRED));
+    }
+
+    #[tokio::test]
+    async fn replayed_envelope_is_rejected() {
+        let state = crate::new_state();
+        let challenge = start_test_challenge(&state, "venue-replay", FALLBACK_NONE).await;
+        let code = display_code(
+            &state,
+            "venue-replay",
+            challenge.venue_key_version,
+            Utc::now(),
+        )
+        .await;
+        let envelope: ProofEnvelopeInput = valid_envelope(&challenge, code).into();
+
+        let first = submit_proof_envelope(&state, envelope.clone())
+            .await
+            .expect("first proof should verify");
+        assert!(first.accepted);
+        let replay = submit_proof_envelope(&state, envelope)
+            .await
+            .expect("replay should produce a verification result");
+
+        assert!(!replay.accepted);
+        assert_eq!(replay.reason_code.as_deref(), Some(REASON_REPLAY));
+    }
+
+    #[test]
+    fn same_envelope_gets_same_replay_key_under_same_server_secret() {
+        let input = ProofEnvelopeInput {
+            subject_account_id: "account-replay-key".to_owned(),
+            challenge_id: Some("challenge-replay-key".to_owned()),
+            venue_id: Some("venue-replay-key".to_owned()),
+            display_code: Some("abc123".to_owned()),
+            key_version: Some(7),
+            client_nonce: Some("nonce-replay-key".to_owned()),
+            observed_at_ms: Some(123456789),
+            coarse_location_bucket: Some("Tokyo-Shibuya".to_owned()),
+            device_session_id: Some("device-replay-key".to_owned()),
+            fallback_mode: Some(FALLBACK_NONE.to_owned()),
+            operator_pin: None,
+        };
+
+        assert_eq!(
+            replay_key("server-secret-a", &input),
+            replay_key("server-secret-a", &input)
+        );
+    }
+
+    #[test]
+    fn different_server_secret_changes_replay_key() {
+        let input = ProofEnvelopeInput {
+            subject_account_id: "account-replay-key".to_owned(),
+            challenge_id: Some("challenge-replay-key".to_owned()),
+            venue_id: Some("venue-replay-key".to_owned()),
+            display_code: Some("123456".to_owned()),
+            key_version: Some(1),
+            client_nonce: Some("nonce-replay-key".to_owned()),
+            observed_at_ms: Some(123456789),
+            coarse_location_bucket: None,
+            device_session_id: None,
+            fallback_mode: Some(FALLBACK_NONE.to_owned()),
+            operator_pin: Some("654321".to_owned()),
+        };
+
+        assert_ne!(
+            replay_key("server-secret-a", &input),
+            replay_key("server-secret-b", &input)
+        );
+    }
+
+    #[tokio::test]
+    async fn persisted_replay_material_is_not_plain_digest_over_low_entropy_secrets() {
+        let state = crate::new_state();
+        let challenge = start_test_challenge(&state, "venue-hmac-persistence", FALLBACK_NONE).await;
+        let received_at = Utc::now();
+        let code = display_code(
+            &state,
+            "venue-hmac-persistence",
+            challenge.venue_key_version,
+            received_at,
+        )
+        .await;
+        let envelope: ProofEnvelopeInput = valid_envelope(&challenge, code.clone()).into();
+        let plain_display_code_digest = digest_parts(&["display-code", code.trim()]);
+        let plain_replay_digest = digest_parts(&[
+            "proof-envelope",
+            envelope.challenge_id.as_deref().unwrap_or_default(),
+            envelope.venue_id.as_deref().unwrap_or_default(),
+            code.as_str(),
+            &challenge.venue_key_version.to_string(),
+            envelope.client_nonce.as_deref().unwrap_or_default(),
+            &envelope
+                .observed_at_ms
+                .map(|value| value.to_string())
+                .unwrap_or_default(),
+            envelope
+                .coarse_location_bucket
+                .as_deref()
+                .unwrap_or_default(),
+            envelope.device_session_id.as_deref().unwrap_or_default(),
+            envelope.fallback_mode.as_deref().unwrap_or_default(),
+            envelope.operator_pin.as_deref().unwrap_or_default(),
+        ]);
+
+        let outcome = submit_proof_envelope_at(&state, envelope, received_at)
+            .await
+            .expect("valid proof should produce a result");
+
+        assert!(outcome.accepted);
+        let store = state.proof.read().await;
+        let submission = store
+            .proof_submissions_by_id
+            .get(&outcome.proof_submission_id)
+            .expect("submission should be retained");
+        assert_ne!(submission.replay_key, plain_replay_digest);
+        assert_ne!(
+            submission.display_code_hash.as_deref(),
+            Some(plain_display_code_digest.as_str())
+        );
+        assert!(submission.raw_payload_json["display_code_hash"].is_string());
+    }
+
+    #[tokio::test]
+    async fn previous_window_code_is_accepted_with_bounded_skew() {
+        let state = crate::new_state();
+        let challenge = start_test_challenge(&state, "venue-prev-window", FALLBACK_NONE).await;
+        let received_at = Utc::now();
+        let previous_code = display_code(
+            &state,
+            "venue-prev-window",
+            challenge.venue_key_version,
+            received_at - Duration::seconds(DISPLAY_CODE_WINDOW_SECONDS),
+        )
+        .await;
+
+        let outcome = submit_proof_envelope_at(
+            &state,
+            valid_envelope(&challenge, previous_code).into(),
+            received_at,
+        )
+        .await
+        .expect("previous window proof should produce a result");
+
+        assert!(outcome.accepted);
+    }
+
+    #[tokio::test]
+    async fn public_venue_inputs_do_not_reconstruct_display_code() {
+        let state = crate::new_state();
+        let challenge = start_test_challenge(&state, "venue-public-code", FALLBACK_NONE).await;
+        let received_at = Utc::now();
+        let public_secret = digest_parts(&[
+            "venue-secret",
+            "realm-proof",
+            "venue-public-code",
+            &challenge.venue_key_version.to_string(),
+        ]);
+        let public_key = VenueKeyVersionRecord {
+            realm_id: "realm-proof".to_owned(),
+            venue_id: "venue-public-code".to_owned(),
+            key_version: challenge.venue_key_version,
+            secret_material: public_secret,
+            status: KEY_STATUS_ACTIVE.to_owned(),
+            not_before: received_at,
+            not_after: None,
+            created_at: received_at,
+        };
+        let mut forged_code = venue_display_code_for_window(&public_key, received_at);
+        let real_code = display_code(
+            &state,
+            "venue-public-code",
+            challenge.venue_key_version,
+            received_at,
+        )
+        .await;
+        if forged_code == real_code {
+            forged_code = if real_code == "000000" {
+                "000001".to_owned()
+            } else {
+                "000000".to_owned()
+            };
+        }
+
+        let forged = submit_proof_envelope_at(
+            &state,
+            valid_envelope(&challenge, forged_code).into(),
+            received_at,
+        )
+        .await
+        .expect("forged proof should produce a result");
+
+        assert!(!forged.accepted);
+        assert_eq!(forged.reason_code.as_deref(), Some(REASON_INVALID_CODE));
+    }
+
+    #[test]
+    fn venue_display_code_depends_on_server_secret() {
+        let now = Utc::now();
+        let mut first = ProofState::with_server_secret_for_test("proof-master-secret-a");
+        let mut second = ProofState::with_server_secret_for_test("proof-master-secret-b");
+        let key_version =
+            ensure_active_venue_key(&mut first, "realm-proof", "venue-secret-test", now);
+        let second_key_version =
+            ensure_active_venue_key(&mut second, "realm-proof", "venue-secret-test", now);
+        assert_eq!(key_version, second_key_version);
+
+        let first_code = venue_display_code_for_window(
+            first
+                .venue_key_versions
+                .get(&(
+                    "realm-proof".to_owned(),
+                    "venue-secret-test".to_owned(),
+                    key_version,
+                ))
+                .expect("first key should exist"),
+            now,
+        );
+        let second_code = venue_display_code_for_window(
+            second
+                .venue_key_versions
+                .get(&(
+                    "realm-proof".to_owned(),
+                    "venue-secret-test".to_owned(),
+                    second_key_version,
+                ))
+                .expect("second key should exist"),
+            now,
+        );
+
+        assert_ne!(first_code, second_code);
+    }
+
+    #[tokio::test]
+    async fn same_venue_id_in_different_realms_gets_different_display_codes() {
+        let state = crate::new_state();
+        let realm_a =
+            start_test_challenge_in_realm(&state, "realm-a", "venue-shared", FALLBACK_NONE).await;
+        let realm_b =
+            start_test_challenge_in_realm(&state, "realm-b", "venue-shared", FALLBACK_NONE).await;
+        let received_at = Utc::now();
+
+        let realm_a_code = display_code_for_realm(
+            &state,
+            "realm-a",
+            "venue-shared",
+            realm_a.venue_key_version,
+            received_at,
+        )
+        .await;
+        let realm_b_code = display_code_for_realm(
+            &state,
+            "realm-b",
+            "venue-shared",
+            realm_b.venue_key_version,
+            received_at,
+        )
+        .await;
+
+        assert_ne!(realm_a_code, realm_b_code);
+
+        let realm_a_outcome = submit_proof_envelope_at(
+            &state,
+            valid_envelope(&realm_a, realm_a_code).into(),
+            received_at,
+        )
+        .await
+        .expect("realm A proof should verify");
+        let realm_b_outcome = submit_proof_envelope_at(
+            &state,
+            valid_envelope(&realm_b, realm_b_code).into(),
+            received_at,
+        )
+        .await
+        .expect("realm B proof should verify");
+
+        assert!(realm_a_outcome.accepted);
+        assert!(realm_b_outcome.accepted);
+    }
+
+    #[tokio::test]
+    async fn challenge_does_not_accept_display_code_from_another_realm() {
+        let state = crate::new_state();
+        let realm_a =
+            start_test_challenge_in_realm(&state, "realm-a", "venue-shared-proof", FALLBACK_NONE)
+                .await;
+        let realm_b =
+            start_test_challenge_in_realm(&state, "realm-b", "venue-shared-proof", FALLBACK_NONE)
+                .await;
+        let received_at = Utc::now();
+        let realm_b_code = display_code_for_realm(
+            &state,
+            "realm-b",
+            "venue-shared-proof",
+            realm_b.venue_key_version,
+            received_at,
+        )
+        .await;
+
+        let outcome = submit_proof_envelope_at(
+            &state,
+            valid_envelope(&realm_a, realm_b_code).into(),
+            received_at,
+        )
+        .await
+        .expect("cross-realm code proof should produce a result");
+
+        assert!(!outcome.accepted);
+        assert_eq!(outcome.reason_code.as_deref(), Some(REASON_INVALID_CODE));
+    }
+
+    #[tokio::test]
+    async fn failed_attempt_limit_quarantines_challenge() {
+        let state = crate::new_state();
+        let challenge = start_test_challenge(&state, "venue-attempt-limit", FALLBACK_NONE).await;
+        let received_at = Utc::now();
+
+        for attempt in 0..MAX_CHALLENGE_FAILED_ATTEMPTS {
+            let mut envelope: ProofEnvelopeInput =
+                valid_envelope(&challenge, format!("BAD{attempt:03}")).into();
+            envelope.observed_at_ms =
+                Some((received_at + Duration::seconds(attempt.into())).timestamp_millis());
+            let outcome = submit_proof_envelope_at(
+                &state,
+                envelope,
+                received_at + Duration::seconds(attempt.into()),
+            )
+            .await
+            .expect("failed attempt should produce a result");
+
+            if attempt + 1 < MAX_CHALLENGE_FAILED_ATTEMPTS {
+                assert_eq!(outcome.verification_status, PROOF_STATUS_REJECTED);
+                assert_eq!(outcome.reason_code.as_deref(), Some(REASON_INVALID_CODE));
+            } else {
+                assert_eq!(outcome.verification_status, PROOF_STATUS_QUARANTINED);
+                assert_eq!(
+                    outcome.reason_code.as_deref(),
+                    Some(REASON_ATTEMPT_LIMIT_EXCEEDED)
+                );
+            }
+        }
+
+        let valid_code = display_code(
+            &state,
+            "venue-attempt-limit",
+            challenge.venue_key_version,
+            received_at,
+        )
+        .await;
+        let valid_after_limit = submit_proof_envelope_at(
+            &state,
+            valid_envelope(&challenge, valid_code).into(),
+            received_at,
+        )
+        .await
+        .expect("proof after attempt limit should produce a result");
+
+        assert!(!valid_after_limit.accepted);
+        assert_eq!(
+            valid_after_limit.reason_code.as_deref(),
+            Some(REASON_ATTEMPT_LIMIT_EXCEEDED)
+        );
+    }
+
+    #[tokio::test]
+    async fn malformed_or_mismatched_requests_do_not_consume_attempt_budget() {
+        let state = crate::new_state();
+        let challenge = start_test_challenge(&state, "venue-malformed-budget", FALLBACK_NONE).await;
+        let received_at = Utc::now();
+
+        for index in 0..5 {
+            let outcome = submit_proof_envelope_at(
+                &state,
+                ProofEnvelopeInput {
+                    subject_account_id: "account-proof-a".to_owned(),
+                    challenge_id: Some(challenge.challenge_id.clone()),
+                    venue_id: None,
+                    display_code: Some(format!("BAD{index:03}")),
+                    key_version: Some(challenge.venue_key_version),
+                    client_nonce: None,
+                    observed_at_ms: Some(
+                        (received_at + Duration::seconds(index)).timestamp_millis(),
+                    ),
+                    coarse_location_bucket: None,
+                    device_session_id: Some(format!("malformed-device-{index}")),
+                    fallback_mode: Some(FALLBACK_NONE.to_owned()),
+                    operator_pin: None,
+                },
+                received_at + Duration::seconds(index),
+            )
+            .await
+            .expect("malformed proof should produce a result");
+            assert_eq!(outcome.reason_code.as_deref(), Some(REASON_MALFORMED));
+        }
+
+        for index in 0..5 {
+            let mut envelope: ProofEnvelopeInput =
+                valid_envelope(&challenge, format!("BAD-SUBJECT-{index}")).into();
+            envelope.subject_account_id = format!("other-account-{index}");
+            envelope.observed_at_ms =
+                Some((received_at + Duration::seconds(10 + index)).timestamp_millis());
+            let outcome = submit_proof_envelope_at(
+                &state,
+                envelope,
+                received_at + Duration::seconds(10 + index),
+            )
+            .await
+            .expect("subject mismatch proof should produce a result");
+            assert_eq!(
+                outcome.reason_code.as_deref(),
+                Some(REASON_SUBJECT_MISMATCH)
+            );
+        }
+
+        {
+            let store = state.proof.read().await;
+            let stored_challenge = store
+                .venue_challenges_by_id
+                .get(&challenge.challenge_id)
+                .expect("challenge should remain recorded");
+            assert_eq!(stored_challenge.failed_attempt_count, 0);
+            assert_eq!(stored_challenge.status, CHALLENGE_STATUS_ISSUED);
+        }
+
+        let valid_code = display_code(
+            &state,
+            "venue-malformed-budget",
+            challenge.venue_key_version,
+            received_at,
+        )
+        .await;
+        let valid_after_malformed = submit_proof_envelope_at(
+            &state,
+            valid_envelope(&challenge, valid_code).into(),
+            received_at,
+        )
+        .await
+        .expect("valid proof after malformed traffic should produce a result");
+
+        assert!(valid_after_malformed.accepted);
+    }
+
+    #[tokio::test]
+    async fn only_bound_secret_check_failures_consume_attempt_budget() {
+        let state = crate::new_state();
+        let challenge = start_test_challenge(&state, "venue-secret-budget", FALLBACK_NONE).await;
+        let received_at = Utc::now();
+        let mut missing_display_code: ProofEnvelopeInput =
+            valid_envelope(&challenge, "BAD000".to_owned()).into();
+        missing_display_code.display_code = None;
+
+        let missing = submit_proof_envelope_at(&state, missing_display_code, received_at)
+            .await
+            .expect("missing display code should produce a result");
+        assert_eq!(missing.reason_code.as_deref(), Some(REASON_MALFORMED));
+
+        let wrong_display_code = submit_proof_envelope_at(
+            &state,
+            valid_envelope(&challenge, "BAD001".to_owned()).into(),
+            received_at + Duration::seconds(1),
+        )
+        .await
+        .expect("wrong display code should produce a result");
+        assert_eq!(
+            wrong_display_code.reason_code.as_deref(),
+            Some(REASON_INVALID_CODE)
+        );
+
+        {
+            let store = state.proof.read().await;
+            let stored_challenge = store
+                .venue_challenges_by_id
+                .get(&challenge.challenge_id)
+                .expect("challenge should remain recorded");
+            assert_eq!(stored_challenge.failed_attempt_count, 1);
+        }
+
+        let operator_start = start_proof_challenge(
+            &state,
+            StartProofChallengeInput {
+                subject_account_id: "account-operator-budget".to_owned(),
+                venue_id: "venue-operator-secret-budget".to_owned(),
+                realm_id: "realm-proof".to_owned(),
+                fallback_mode: FALLBACK_OPERATOR_PIN.to_owned(),
+                operator_id: Some("operator-secret-budget".to_owned()),
+            },
+        )
+        .await
+        .expect("operator fallback challenge should issue");
+        let operator_challenge = operator_start.client;
+        let issued_pin = operator_start
+            .operator_delivery
+            .expect("operator delivery should exist")
+            .pin;
+        let invalid_pin = if issued_pin == "000000" {
+            "000001"
+        } else {
+            "000000"
+        };
+        let wrong_pin = submit_proof_envelope_at(
+            &state,
+            ProofEnvelopeInput {
+                subject_account_id: "account-operator-budget".to_owned(),
+                challenge_id: Some(operator_challenge.challenge_id.clone()),
+                venue_id: Some(operator_challenge.venue_id.clone()),
+                display_code: None,
+                key_version: None,
+                client_nonce: Some(operator_challenge.client_nonce.clone()),
+                observed_at_ms: Some(received_at.timestamp_millis()),
+                coarse_location_bucket: None,
+                device_session_id: None,
+                fallback_mode: Some(FALLBACK_OPERATOR_PIN.to_owned()),
+                operator_pin: Some(invalid_pin.to_owned()),
+            },
+            received_at,
+        )
+        .await
+        .expect("wrong operator PIN should produce a result");
+
+        assert_eq!(
+            wrong_pin.reason_code.as_deref(),
+            Some(REASON_OPERATOR_PIN_INVALID)
+        );
+        let store = state.proof.read().await;
+        let stored_operator_challenge = store
+            .venue_challenges_by_id
+            .get(&operator_challenge.challenge_id)
+            .expect("operator challenge should remain recorded");
+        assert_eq!(stored_operator_challenge.failed_attempt_count, 1);
+    }
+
+    #[tokio::test]
+    async fn attempt_limit_counts_only_real_secret_check_failures() {
+        let state = crate::new_state();
+        let challenge =
+            start_test_challenge(&state, "venue-attempt-limit-secret-only", FALLBACK_NONE).await;
+        let received_at = Utc::now();
+
+        for index in 0..MAX_CHALLENGE_FAILED_ATTEMPTS {
+            let malformed = ProofEnvelopeInput {
+                subject_account_id: "account-proof-a".to_owned(),
+                challenge_id: Some(challenge.challenge_id.clone()),
+                venue_id: Some(challenge.venue_id.clone()),
+                display_code: Some(format!("BAD-MALFORMED-{index}")),
+                key_version: Some(challenge.venue_key_version),
+                client_nonce: None,
+                observed_at_ms: Some(
+                    (received_at + Duration::seconds(index.into())).timestamp_millis(),
+                ),
+                coarse_location_bucket: None,
+                device_session_id: None,
+                fallback_mode: Some(FALLBACK_NONE.to_owned()),
+                operator_pin: None,
+            };
+            let outcome = submit_proof_envelope_at(
+                &state,
+                malformed,
+                received_at + Duration::seconds(index.into()),
+            )
+            .await
+            .expect("malformed proof should produce a result");
+            assert_eq!(outcome.reason_code.as_deref(), Some(REASON_MALFORMED));
+        }
+
+        for attempt in 0..MAX_CHALLENGE_FAILED_ATTEMPTS {
+            let mut envelope: ProofEnvelopeInput =
+                valid_envelope(&challenge, format!("BAD{attempt:03}")).into();
+            envelope.observed_at_ms =
+                Some((received_at + Duration::seconds(10 + i64::from(attempt))).timestamp_millis());
+            let outcome = submit_proof_envelope_at(
+                &state,
+                envelope,
+                received_at + Duration::seconds(10 + i64::from(attempt)),
+            )
+            .await
+            .expect("secret-check failure should produce a result");
+
+            if attempt + 1 < MAX_CHALLENGE_FAILED_ATTEMPTS {
+                assert_eq!(outcome.reason_code.as_deref(), Some(REASON_INVALID_CODE));
+            } else {
+                assert_eq!(
+                    outcome.reason_code.as_deref(),
+                    Some(REASON_ATTEMPT_LIMIT_EXCEEDED)
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn stale_client_observation_is_quarantined() {
+        let state = crate::new_state();
+        let challenge = start_test_challenge(&state, "venue-stale", FALLBACK_NONE).await;
+        let received_at = Utc::now();
+        let code = display_code(
+            &state,
+            "venue-stale",
+            challenge.venue_key_version,
+            received_at,
+        )
+        .await;
+        let mut envelope: ProofEnvelopeInput = valid_envelope(&challenge, code).into();
+        envelope.observed_at_ms = Some((received_at - Duration::seconds(121)).timestamp_millis());
+
+        let outcome = submit_proof_envelope_at(&state, envelope, received_at)
+            .await
+            .expect("stale proof should produce a result");
+
+        assert!(!outcome.accepted);
+        assert_eq!(outcome.verification_status, PROOF_STATUS_QUARANTINED);
+        assert_eq!(outcome.reason_code.as_deref(), Some(REASON_RISK_FLAGGED));
+        assert!(
+            outcome
+                .risk_flags
+                .iter()
+                .any(|flag| flag == "client_clock_skew_high")
+        );
+    }
+
+    #[tokio::test]
+    async fn revoked_key_version_is_rejected() {
+        let state = crate::new_state();
+        let challenge = start_test_challenge(&state, "venue-revoked", FALLBACK_NONE).await;
+        let code = display_code(
+            &state,
+            "venue-revoked",
+            challenge.venue_key_version,
+            Utc::now(),
+        )
+        .await;
+        {
+            let mut store = state.proof.write().await;
+            let key = store
+                .venue_key_versions
+                .get_mut(&(
+                    "realm-proof".to_owned(),
+                    "venue-revoked".to_owned(),
+                    challenge.venue_key_version,
+                ))
+                .expect("venue key should exist");
+            key.status = KEY_STATUS_REVOKED.to_owned();
+        }
+
+        let outcome = submit_proof_envelope(&state, valid_envelope(&challenge, code).into())
+            .await
+            .expect("revoked key proof should produce a result");
+
+        assert!(!outcome.accepted);
+        assert_eq!(outcome.reason_code.as_deref(), Some(REASON_KEY_REVOKED));
+    }
+
+    #[tokio::test]
+    async fn draining_key_version_accepts_existing_challenge_only() {
+        let state = crate::new_state();
+        let challenge = start_test_challenge(&state, "venue-draining", FALLBACK_NONE).await;
+        let received_at = Utc::now();
+        let code = display_code(
+            &state,
+            "venue-draining",
+            challenge.venue_key_version,
+            received_at,
+        )
+        .await;
+        {
+            let mut store = state.proof.write().await;
+            let old_key = store
+                .venue_key_versions
+                .get_mut(&(
+                    "realm-proof".to_owned(),
+                    "venue-draining".to_owned(),
+                    challenge.venue_key_version,
+                ))
+                .expect("old venue key should exist");
+            old_key.status = KEY_STATUS_DRAINING.to_owned();
+            let new_key_version = challenge.venue_key_version + 1;
+            store.active_key_version_by_venue.insert(
+                ("realm-proof".to_owned(), "venue-draining".to_owned()),
+                new_key_version,
+            );
+            let secret_material = venue_secret_material(
+                &store.server_secret,
+                "realm-proof",
+                "venue-draining",
+                new_key_version,
+            );
+            store.venue_key_versions.insert(
+                (
+                    "realm-proof".to_owned(),
+                    "venue-draining".to_owned(),
+                    new_key_version,
+                ),
+                VenueKeyVersionRecord {
+                    realm_id: "realm-proof".to_owned(),
+                    venue_id: "venue-draining".to_owned(),
+                    key_version: new_key_version,
+                    secret_material,
+                    status: KEY_STATUS_ACTIVE.to_owned(),
+                    not_before: received_at,
+                    not_after: None,
+                    created_at: received_at,
+                },
+            );
+        }
+
+        let outcome =
+            submit_proof_envelope_at(&state, valid_envelope(&challenge, code).into(), received_at)
+                .await
+                .expect("draining key proof should produce a result");
+
+        assert!(outcome.accepted);
+    }
+
+    #[tokio::test]
+    async fn old_challenge_rejects_submitted_key_version_override() {
+        let state = crate::new_state();
+        let challenge = start_test_challenge(&state, "venue-old-key-override", FALLBACK_NONE).await;
+        let received_at = Utc::now();
+        let new_key_version = challenge.venue_key_version + 1;
+        {
+            let mut store = state.proof.write().await;
+            store.active_key_version_by_venue.insert(
+                (
+                    "realm-proof".to_owned(),
+                    "venue-old-key-override".to_owned(),
+                ),
+                new_key_version,
+            );
+            let secret_material = venue_secret_material(
+                &store.server_secret,
+                "realm-proof",
+                "venue-old-key-override",
+                new_key_version,
+            );
+            store.venue_key_versions.insert(
+                (
+                    "realm-proof".to_owned(),
+                    "venue-old-key-override".to_owned(),
+                    new_key_version,
+                ),
+                VenueKeyVersionRecord {
+                    realm_id: "realm-proof".to_owned(),
+                    venue_id: "venue-old-key-override".to_owned(),
+                    key_version: new_key_version,
+                    secret_material,
+                    status: KEY_STATUS_ACTIVE.to_owned(),
+                    not_before: received_at,
+                    not_after: None,
+                    created_at: received_at,
+                },
+            );
+        }
+        let new_code = display_code(
+            &state,
+            "venue-old-key-override",
+            new_key_version,
+            received_at,
+        )
+        .await;
+        let mut envelope: ProofEnvelopeInput = valid_envelope(&challenge, new_code).into();
+        envelope.key_version = Some(new_key_version);
+
+        let outcome = submit_proof_envelope_at(&state, envelope, received_at)
+            .await
+            .expect("key-version override proof should produce a result");
+
+        assert!(!outcome.accepted);
+        assert_eq!(
+            outcome.reason_code.as_deref(),
+            Some(REASON_KEY_VERSION_MISMATCH)
+        );
+        let store = state.proof.read().await;
+        let stored_challenge = store
+            .venue_challenges_by_id
+            .get(&challenge.challenge_id)
+            .expect("challenge should remain recorded");
+        assert_eq!(stored_challenge.failed_attempt_count, 0);
+    }
+
+    #[tokio::test]
+    async fn new_challenge_rejects_old_draining_key_override() {
+        let state = crate::new_state();
+        let first = start_test_challenge(&state, "venue-new-key-override", FALLBACK_NONE).await;
+        let received_at = Utc::now();
+        let old_key_version = first.venue_key_version;
+        let new_key_version = old_key_version + 1;
+        {
+            let mut store = state.proof.write().await;
+            let old_key = store
+                .venue_key_versions
+                .get_mut(&(
+                    "realm-proof".to_owned(),
+                    "venue-new-key-override".to_owned(),
+                    old_key_version,
+                ))
+                .expect("old key should exist");
+            old_key.status = KEY_STATUS_DRAINING.to_owned();
+            store.active_key_version_by_venue.insert(
+                (
+                    "realm-proof".to_owned(),
+                    "venue-new-key-override".to_owned(),
+                ),
+                new_key_version,
+            );
+            let secret_material = venue_secret_material(
+                &store.server_secret,
+                "realm-proof",
+                "venue-new-key-override",
+                new_key_version,
+            );
+            store.venue_key_versions.insert(
+                (
+                    "realm-proof".to_owned(),
+                    "venue-new-key-override".to_owned(),
+                    new_key_version,
+                ),
+                VenueKeyVersionRecord {
+                    realm_id: "realm-proof".to_owned(),
+                    venue_id: "venue-new-key-override".to_owned(),
+                    key_version: new_key_version,
+                    secret_material,
+                    status: KEY_STATUS_ACTIVE.to_owned(),
+                    not_before: received_at,
+                    not_after: None,
+                    created_at: received_at,
+                },
+            );
+        }
+        let second = start_test_challenge(&state, "venue-new-key-override", FALLBACK_NONE).await;
+        assert_eq!(second.venue_key_version, new_key_version);
+        let old_code = display_code(
+            &state,
+            "venue-new-key-override",
+            old_key_version,
+            received_at,
+        )
+        .await;
+        let mut envelope: ProofEnvelopeInput = valid_envelope(&second, old_code).into();
+        envelope.key_version = Some(old_key_version);
+
+        let outcome = submit_proof_envelope_at(&state, envelope, received_at)
+            .await
+            .expect("old draining key override proof should produce a result");
+
+        assert!(!outcome.accepted);
+        assert_eq!(
+            outcome.reason_code.as_deref(),
+            Some(REASON_KEY_VERSION_MISMATCH)
+        );
+    }
+
+    #[tokio::test]
+    async fn operator_pin_flow_is_audited_and_rate_limited() {
+        let state = crate::new_state();
+        let first_start = start_proof_challenge(
+            &state,
+            StartProofChallengeInput {
+                subject_account_id: "account-operator-0".to_owned(),
+                venue_id: "venue-operator".to_owned(),
+                realm_id: "realm-proof".to_owned(),
+                fallback_mode: FALLBACK_OPERATOR_PIN.to_owned(),
+                operator_id: Some("operator-a".to_owned()),
+            },
+        )
+        .await
+        .expect("operator pin within rate limit should issue");
+        let first_challenge = first_start.client;
+        let first_delivery = first_start
+            .operator_delivery
+            .expect("operator delivery should be separated from client outcome");
+        assert!(first_challenge.operator_pin_issued);
+        assert_eq!(first_delivery.challenge_id, first_challenge.challenge_id);
+
+        let outcome = submit_proof_envelope(
+            &state,
+            ProofEnvelopeInput {
+                subject_account_id: "account-operator-0".to_owned(),
+                challenge_id: Some(first_challenge.challenge_id.clone()),
+                venue_id: Some(first_challenge.venue_id.clone()),
+                display_code: None,
+                key_version: None,
+                client_nonce: Some(first_challenge.client_nonce.clone()),
+                observed_at_ms: Some(Utc::now().timestamp_millis()),
+                coarse_location_bucket: None,
+                device_session_id: None,
+                fallback_mode: Some(FALLBACK_OPERATOR_PIN.to_owned()),
+                operator_pin: Some(first_delivery.pin.clone()),
+            },
+        )
+        .await
+        .expect("operator pin fallback should produce a result");
+        assert!(outcome.accepted);
+        assert!(
+            outcome
+                .risk_flags
+                .iter()
+                .any(|flag| flag == "operator_fallback")
+        );
+
+        for index in 1..OPERATOR_PIN_RATE_LIMIT_PER_MINUTE {
+            start_proof_challenge(
+                &state,
+                StartProofChallengeInput {
+                    subject_account_id: format!("account-{index}"),
+                    venue_id: "venue-operator".to_owned(),
+                    realm_id: "realm-proof".to_owned(),
+                    fallback_mode: FALLBACK_OPERATOR_PIN.to_owned(),
+                    operator_id: Some("operator-a".to_owned()),
+                },
+            )
+            .await
+            .expect("operator pin within rate limit should issue");
+        }
+
+        let blocked = start_proof_challenge(
+            &state,
+            StartProofChallengeInput {
+                subject_account_id: "account-blocked".to_owned(),
+                venue_id: "venue-operator".to_owned(),
+                realm_id: "realm-proof".to_owned(),
+                fallback_mode: FALLBACK_OPERATOR_PIN.to_owned(),
+                operator_id: Some("operator-a".to_owned()),
+            },
+        )
+        .await
+        .expect_err("operator pin overuse should be rate-limited");
+        assert_eq!(
+            blocked.message(),
+            "operator_pin fallback rate limit exceeded"
+        );
+
+        let store = state.proof.read().await;
+        assert_eq!(
+            store.operator_pin_audits.len(),
+            OPERATOR_PIN_RATE_LIMIT_PER_MINUTE
+        );
+        let first_audit = store
+            .operator_pin_audits
+            .iter()
+            .find(|audit| audit.challenge_id == first_challenge.challenge_id)
+            .expect("first operator PIN audit should exist");
+        assert_ne!(
+            first_audit.pin_hash,
+            digest_parts(&[
+                "operator-pin",
+                &first_challenge.challenge_id,
+                &first_delivery.pin
+            ])
+        );
+    }
+
+    #[tokio::test]
+    async fn public_operator_inputs_do_not_reconstruct_pin() {
+        let state = crate::new_state();
+        let start = start_proof_challenge(
+            &state,
+            StartProofChallengeInput {
+                subject_account_id: "account-public-pin".to_owned(),
+                venue_id: "venue-public-pin".to_owned(),
+                realm_id: "realm-proof".to_owned(),
+                fallback_mode: FALLBACK_OPERATOR_PIN.to_owned(),
+                operator_id: Some("operator-public".to_owned()),
+            },
+        )
+        .await
+        .expect("operator pin should issue");
+        let challenge = start.client;
+        let delivery = start
+            .operator_delivery
+            .expect("operator delivery should exist");
+        let old_pin_seed = format!(
+            "operator-pin:{}:{}",
+            challenge.challenge_id, delivery.operator_id
+        );
+        let mut old_publicly_derivable_pin =
+            short_code_from_bytes(&Sha256::digest(old_pin_seed.as_bytes()));
+        if old_publicly_derivable_pin == delivery.pin {
+            old_publicly_derivable_pin = if delivery.pin == "000000" {
+                "000001".to_owned()
+            } else {
+                "000000".to_owned()
+            };
+        }
+
+        let forged = submit_proof_envelope(
+            &state,
+            ProofEnvelopeInput {
+                subject_account_id: "account-public-pin".to_owned(),
+                challenge_id: Some(challenge.challenge_id.clone()),
+                venue_id: Some(challenge.venue_id.clone()),
+                display_code: None,
+                key_version: None,
+                client_nonce: Some(challenge.client_nonce.clone()),
+                observed_at_ms: Some(Utc::now().timestamp_millis()),
+                coarse_location_bucket: None,
+                device_session_id: None,
+                fallback_mode: Some(FALLBACK_OPERATOR_PIN.to_owned()),
+                operator_pin: Some(old_publicly_derivable_pin),
+            },
+        )
+        .await
+        .expect("forged operator pin should produce a result");
+
+        assert!(!forged.accepted);
+        assert_eq!(
+            forged.reason_code.as_deref(),
+            Some(REASON_OPERATOR_PIN_INVALID)
+        );
+    }
+
+    #[tokio::test]
+    async fn same_operator_and_venue_get_distinct_pins_per_challenge() {
+        let state = crate::new_state();
+        let first = start_proof_challenge(
+            &state,
+            StartProofChallengeInput {
+                subject_account_id: "account-random-pin-a".to_owned(),
+                venue_id: "venue-random-pin".to_owned(),
+                realm_id: "realm-proof".to_owned(),
+                fallback_mode: FALLBACK_OPERATOR_PIN.to_owned(),
+                operator_id: Some("operator-random".to_owned()),
+            },
+        )
+        .await
+        .expect("first operator pin should issue");
+        let second = start_proof_challenge(
+            &state,
+            StartProofChallengeInput {
+                subject_account_id: "account-random-pin-b".to_owned(),
+                venue_id: "venue-random-pin".to_owned(),
+                realm_id: "realm-proof".to_owned(),
+                fallback_mode: FALLBACK_OPERATOR_PIN.to_owned(),
+                operator_id: Some("operator-random".to_owned()),
+            },
+        )
+        .await
+        .expect("second operator pin should issue");
+
+        let first_pin = first.operator_delivery.expect("first delivery").pin;
+        let second_pin = second.operator_delivery.expect("second delivery").pin;
+        assert_ne!(first_pin, second_pin);
+    }
+
+    #[tokio::test]
+    async fn malformed_envelope_is_rejected_and_recorded() {
+        let state = crate::new_state();
+
+        let outcome = submit_proof_envelope(
+            &state,
+            ProofEnvelopeInput {
+                subject_account_id: "account-malformed".to_owned(),
+                challenge_id: None,
+                venue_id: Some("venue-malformed".to_owned()),
+                display_code: None,
+                key_version: None,
+                client_nonce: None,
+                observed_at_ms: None,
+                coarse_location_bucket: None,
+                device_session_id: Some("device-1".to_owned()),
+                fallback_mode: None,
+                operator_pin: None,
+            },
+        )
+        .await
+        .expect("malformed proof should produce a verification result");
+
+        assert!(!outcome.accepted);
+        assert_eq!(outcome.reason_code.as_deref(), Some(REASON_MALFORMED));
+        let store = state.proof.read().await;
+        assert!(
+            store
+                .proof_submissions_by_id
+                .contains_key(&outcome.proof_submission_id)
+        );
+    }
+
+    async fn start_test_challenge(
+        state: &SharedState,
+        venue_id: &str,
+        fallback_mode: &str,
+    ) -> StartProofChallengeOutcome {
+        start_test_challenge_in_realm(state, "realm-proof", venue_id, fallback_mode).await
+    }
+
+    async fn start_test_challenge_in_realm(
+        state: &SharedState,
+        realm_id: &str,
+        venue_id: &str,
+        fallback_mode: &str,
+    ) -> StartProofChallengeOutcome {
+        start_proof_challenge(
+            state,
+            StartProofChallengeInput {
+                subject_account_id: "account-proof-a".to_owned(),
+                venue_id: venue_id.to_owned(),
+                realm_id: realm_id.to_owned(),
+                fallback_mode: fallback_mode.to_owned(),
+                operator_id: if fallback_mode == FALLBACK_OPERATOR_PIN {
+                    Some("operator-a".to_owned())
+                } else {
+                    None
+                },
+            },
+        )
+        .await
+        .expect("challenge should issue")
+        .client
+    }
+
+    async fn display_code(
+        state: &SharedState,
+        venue_id: &str,
+        key_version: i32,
+        at: DateTime<Utc>,
+    ) -> String {
+        display_code_for_realm(state, "realm-proof", venue_id, key_version, at).await
+    }
+
+    async fn display_code_for_realm(
+        state: &SharedState,
+        realm_id: &str,
+        venue_id: &str,
+        key_version: i32,
+        at: DateTime<Utc>,
+    ) -> String {
+        let store = state.proof.read().await;
+        let key = store
+            .venue_key_versions
+            .get(&(realm_id.to_owned(), venue_id.to_owned(), key_version))
+            .expect("venue key should exist");
+        venue_display_code_for_window(key, at)
+    }
+
+    fn valid_envelope(challenge: &StartProofChallengeOutcome, code: String) -> TestEnvelopeBuilder {
+        TestEnvelopeBuilder(ProofEnvelopeInput {
+            subject_account_id: "account-proof-a".to_owned(),
+            challenge_id: Some(challenge.challenge_id.clone()),
+            venue_id: Some(challenge.venue_id.clone()),
+            display_code: Some(code),
+            key_version: Some(challenge.venue_key_version),
+            client_nonce: Some(challenge.client_nonce.clone()),
+            observed_at_ms: Some(Utc::now().timestamp_millis()),
+            coarse_location_bucket: None,
+            device_session_id: None,
+            fallback_mode: Some(FALLBACK_NONE.to_owned()),
+            operator_pin: None,
+        })
+    }
+
+    #[derive(Clone)]
+    struct TestEnvelopeBuilder(ProofEnvelopeInput);
+
+    impl TestEnvelopeBuilder {
+        fn coarse_location_bucket(mut self, value: &str) -> Self {
+            self.0.coarse_location_bucket = Some(value.to_owned());
+            self
+        }
+
+        fn device_session_id(mut self, value: &str) -> Self {
+            self.0.device_session_id = Some(value.to_owned());
+            self
+        }
+
+        fn fallback_mode(mut self, value: &str) -> Self {
+            self.0.fallback_mode = Some(value.to_owned());
+            self
+        }
+    }
+
+    impl From<TestEnvelopeBuilder> for ProofEnvelopeInput {
+        fn from(value: TestEnvelopeBuilder) -> Self {
+            value.0
+        }
+    }
+}

--- a/apps/backend/src/services/proof.rs
+++ b/apps/backend/src/services/proof.rs
@@ -16,10 +16,14 @@ use super::happy_route::HappyRouteError;
 const CHALLENGE_TTL_SECONDS: i64 = 90;
 const DISPLAY_CODE_WINDOW_SECONDS: i64 = 30;
 const OPERATOR_PIN_TTL_SECONDS: i64 = 60;
+const OPERATOR_PIN_RATE_LIMIT_WINDOW_SECONDS: i64 = 60;
 const OPERATOR_PIN_RATE_LIMIT_PER_MINUTE: usize = 3;
 const MAX_CHALLENGE_FAILED_ATTEMPTS: u8 = 3;
+const PROOF_CHALLENGE_RETENTION_SECONDS: i64 = PROOF_SUBMISSION_RETENTION_SECONDS;
 const PROOF_SUBMISSION_RETENTION_SECONDS: i64 = 15 * 60;
+const MAX_RETAINED_PROOF_CHALLENGES: usize = MAX_RETAINED_PROOF_SUBMISSIONS;
 const MAX_RETAINED_PROOF_SUBMISSIONS: usize = 1024;
+const MAX_RETAINED_OPERATOR_PIN_AUDITS: usize = MAX_RETAINED_PROOF_CHALLENGES;
 
 const KEY_STATUS_ACTIVE: &str = "active";
 const KEY_STATUS_DRAINING: &str = "draining";
@@ -264,6 +268,7 @@ pub async fn start_proof_challenge(
         required_trimmed(input.subject_account_id, "subject_account_id is required")?;
     let fallback_mode = normalize_fallback_mode(input.fallback_mode.as_str())?;
     let mut store = state.proof.write().await;
+    prune_ephemeral_proof_state(&mut store, now);
     let key_version = ensure_active_venue_key(&mut store, &realm_id, &venue_id, now);
     let challenge_id = Uuid::new_v4().to_string();
     let client_nonce = Uuid::new_v4().to_string();
@@ -332,6 +337,7 @@ pub async fn start_proof_challenge(
             status: CHALLENGE_STATUS_ISSUED.to_owned(),
         },
     );
+    prune_ephemeral_proof_state(&mut store, now);
 
     Ok(StartProofChallengeServiceOutcome {
         client: StartProofChallengeOutcome {
@@ -361,7 +367,7 @@ async fn submit_proof_envelope_at(
     received_at: DateTime<Utc>,
 ) -> Result<ProofSubmissionOutcome, HappyRouteError> {
     let mut store = state.proof.write().await;
-    prune_proof_submission_state(&mut store, received_at);
+    prune_ephemeral_proof_state(&mut store, received_at);
     let replay_key = replay_key(&store.server_secret, &input);
     let replayed_submission_id = store
         .proof_submission_id_by_replay_key
@@ -431,8 +437,7 @@ async fn submit_proof_envelope_at(
     };
     store
         .proof_submission_id_by_replay_key
-        .entry(replay_key)
-        .or_insert_with(|| proof_submission_id.clone());
+        .insert(replay_key, proof_submission_id.clone());
     store
         .proof_submissions_by_id
         .insert(proof_submission_id.clone(), submission);
@@ -458,7 +463,7 @@ async fn submit_proof_envelope_at(
             operator_override_case_id: None,
         },
     );
-    prune_proof_submission_state(&mut store, received_at);
+    prune_ephemeral_proof_state(&mut store, received_at);
 
     Ok(ProofSubmissionOutcome {
         proof_submission_id,
@@ -962,6 +967,88 @@ fn redacted_payload(
     })
 }
 
+fn prune_ephemeral_proof_state(store: &mut ProofState, now: DateTime<Utc>) {
+    prune_venue_challenge_state(store, now);
+    prune_operator_pin_audit_state(store, now);
+    prune_proof_submission_state(store, now);
+}
+
+fn prune_venue_challenge_state(store: &mut ProofState, now: DateTime<Utc>) {
+    let cutoff = now - Duration::seconds(PROOF_CHALLENGE_RETENTION_SECONDS);
+    let mut expired_challenge_ids: HashSet<String> = store
+        .venue_challenges_by_id
+        .iter()
+        .filter_map(|(challenge_id, challenge)| {
+            (challenge_retention_anchor(challenge) < cutoff).then(|| challenge_id.clone())
+        })
+        .collect();
+
+    let mut retained_challenges: Vec<(String, DateTime<Utc>)> = store
+        .venue_challenges_by_id
+        .iter()
+        .filter(|(_, challenge)| challenge_retention_anchor(challenge) >= cutoff)
+        .map(|(challenge_id, challenge)| (challenge_id.clone(), challenge.issued_at))
+        .collect();
+    retained_challenges.sort_by(|(left_id, left_issued_at), (right_id, right_issued_at)| {
+        left_issued_at
+            .cmp(right_issued_at)
+            .then_with(|| left_id.cmp(right_id))
+    });
+
+    let overflow = retained_challenges
+        .len()
+        .saturating_sub(MAX_RETAINED_PROOF_CHALLENGES);
+    expired_challenge_ids.extend(
+        retained_challenges
+            .into_iter()
+            .take(overflow)
+            .map(|(challenge_id, _)| challenge_id),
+    );
+
+    if expired_challenge_ids.is_empty() {
+        return;
+    }
+
+    store
+        .venue_challenges_by_id
+        .retain(|challenge_id, _| !expired_challenge_ids.contains(challenge_id));
+}
+
+fn challenge_retention_anchor(challenge: &VenueChallengeRecord) -> DateTime<Utc> {
+    let mut anchor = challenge.expires_at;
+    if let Some(consumed_at) = challenge.consumed_at
+        && consumed_at > anchor
+    {
+        anchor = consumed_at;
+    }
+    if let Some(operator_pin_expires_at) = challenge.operator_pin_expires_at
+        && operator_pin_expires_at > anchor
+    {
+        anchor = operator_pin_expires_at;
+    }
+    anchor
+}
+
+fn prune_operator_pin_audit_state(store: &mut ProofState, now: DateTime<Utc>) {
+    let cutoff = now - Duration::seconds(OPERATOR_PIN_RATE_LIMIT_WINDOW_SECONDS);
+    store
+        .operator_pin_audits
+        .retain(|audit| audit.issued_at >= cutoff && audit.issued_at <= now);
+    store.operator_pin_audits.sort_by(|left, right| {
+        left.issued_at
+            .cmp(&right.issued_at)
+            .then_with(|| left.audit_id.cmp(&right.audit_id))
+    });
+
+    let overflow = store
+        .operator_pin_audits
+        .len()
+        .saturating_sub(MAX_RETAINED_OPERATOR_PIN_AUDITS);
+    if overflow > 0 {
+        store.operator_pin_audits.drain(0..overflow);
+    }
+}
+
 fn prune_proof_submission_state(store: &mut ProofState, now: DateTime<Utc>) {
     let cutoff = now - Duration::seconds(PROOF_SUBMISSION_RETENTION_SECONDS);
     let mut expired_submission_ids: HashSet<String> = store
@@ -1003,12 +1090,24 @@ fn prune_proof_submission_state(store: &mut ProofState, now: DateTime<Utc>) {
     store
         .proof_submissions_by_id
         .retain(|submission_id, _| !expired_submission_ids.contains(submission_id));
-    store
-        .proof_submission_id_by_replay_key
-        .retain(|_, submission_id| !expired_submission_ids.contains(submission_id));
     store.proof_verifications_by_id.retain(|_, verification| {
         !expired_submission_ids.contains(&verification.proof_submission_id)
     });
+
+    let mut retained_submissions: Vec<(&String, &ProofSubmissionRecord)> =
+        store.proof_submissions_by_id.iter().collect();
+    retained_submissions.sort_by(|(left_id, left_submission), (right_id, right_submission)| {
+        left_submission
+            .received_at
+            .cmp(&right_submission.received_at)
+            .then_with(|| left_id.cmp(right_id))
+    });
+
+    let mut replay_index = HashMap::new();
+    for (submission_id, submission) in retained_submissions {
+        replay_index.insert(submission.replay_key.clone(), submission_id.clone());
+    }
+    store.proof_submission_id_by_replay_key = replay_index;
 }
 
 fn risk_flags(
@@ -1053,7 +1152,7 @@ fn operator_pin_issuance_count(
     operator_id: &str,
     now: DateTime<Utc>,
 ) -> usize {
-    let since = now - Duration::seconds(60);
+    let since = now - Duration::seconds(OPERATOR_PIN_RATE_LIMIT_WINDOW_SECONDS);
     store
         .operator_pin_audits
         .iter()
@@ -2599,6 +2698,54 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn replay_index_tracks_latest_retained_duplicate_submission() {
+        let state = crate::new_state();
+        let base = Utc::now();
+        let input = ProofEnvelopeInput {
+            subject_account_id: "account-replay-prune".to_owned(),
+            challenge_id: Some("challenge-replay-prune".to_owned()),
+            venue_id: Some("venue-replay-prune".to_owned()),
+            display_code: None,
+            key_version: None,
+            client_nonce: None,
+            observed_at_ms: None,
+            coarse_location_bucket: None,
+            device_session_id: None,
+            fallback_mode: None,
+            operator_pin: None,
+        };
+
+        let first = submit_proof_envelope_at(&state, input.clone(), base)
+            .await
+            .expect("first malformed proof should be recorded");
+        let second = submit_proof_envelope_at(&state, input.clone(), base + Duration::seconds(2))
+            .await
+            .expect("duplicate malformed proof should be recorded as replay");
+        assert_eq!(second.reason_code.as_deref(), Some(REASON_REPLAY));
+
+        let third = submit_proof_envelope_at(
+            &state,
+            input.clone(),
+            base + Duration::seconds(PROOF_SUBMISSION_RETENTION_SECONDS + 1),
+        )
+        .await
+        .expect("retained duplicate should still be treated as replay");
+        assert_eq!(third.reason_code.as_deref(), Some(REASON_REPLAY));
+
+        let store = state.proof.read().await;
+        let replay_key = replay_key(&store.server_secret, &input);
+        assert_eq!(
+            store.proof_submission_id_by_replay_key.get(&replay_key),
+            Some(&third.proof_submission_id)
+        );
+        assert!(
+            !store
+                .proof_submissions_by_id
+                .contains_key(&first.proof_submission_id)
+        );
+    }
+
+    #[tokio::test]
     async fn proof_submission_state_caps_unique_rejected_evidence() {
         let state = crate::new_state();
         let base = Utc::now();
@@ -2652,6 +2799,106 @@ mod tests {
             store
                 .proof_submissions_by_id
                 .contains_key(&last_submission_id.expect("last submission id"))
+        );
+    }
+
+    #[tokio::test]
+    async fn challenge_state_prunes_expired_challenges_and_stale_operator_audits() {
+        let state = crate::new_state();
+        let first = start_proof_challenge(
+            &state,
+            StartProofChallengeInput {
+                subject_account_id: "account-prune-challenge-0".to_owned(),
+                venue_id: "venue-prune-challenge".to_owned(),
+                realm_id: "realm-proof".to_owned(),
+                fallback_mode: FALLBACK_OPERATOR_PIN.to_owned(),
+                operator_id: Some("operator-prune".to_owned()),
+            },
+        )
+        .await
+        .expect("operator fallback challenge should issue")
+        .client;
+
+        {
+            let mut store = state.proof.write().await;
+            let challenge = store
+                .venue_challenges_by_id
+                .get_mut(&first.challenge_id)
+                .expect("first challenge should be retained before pruning");
+            let stale_at = Utc::now() - Duration::seconds(PROOF_CHALLENGE_RETENTION_SECONDS + 1);
+            challenge.expires_at = stale_at;
+            challenge.operator_pin_expires_at = Some(stale_at);
+
+            let audit = store
+                .operator_pin_audits
+                .iter_mut()
+                .find(|audit| audit.challenge_id == first.challenge_id)
+                .expect("operator audit should exist");
+            let stale_audit_at =
+                Utc::now() - Duration::seconds(OPERATOR_PIN_RATE_LIMIT_WINDOW_SECONDS + 1);
+            audit.issued_at = stale_audit_at;
+            audit.expires_at = stale_audit_at;
+        }
+
+        let second = start_test_challenge(&state, "venue-prune-challenge", FALLBACK_NONE).await;
+
+        let store = state.proof.read().await;
+        assert!(
+            !store
+                .venue_challenges_by_id
+                .contains_key(&first.challenge_id)
+        );
+        assert!(
+            store
+                .venue_challenges_by_id
+                .contains_key(&second.challenge_id)
+        );
+        assert!(store.operator_pin_audits.is_empty());
+    }
+
+    #[tokio::test]
+    async fn challenge_state_caps_retained_challenges() {
+        let state = crate::new_state();
+        let mut first_challenge_id = None;
+        let mut last_challenge_id = None;
+
+        for index in 0..=MAX_RETAINED_PROOF_CHALLENGES {
+            let challenge = start_proof_challenge(
+                &state,
+                StartProofChallengeInput {
+                    subject_account_id: format!("account-challenge-cap-{index}"),
+                    venue_id: "venue-challenge-cap".to_owned(),
+                    realm_id: "realm-proof".to_owned(),
+                    fallback_mode: FALLBACK_NONE.to_owned(),
+                    operator_id: None,
+                },
+            )
+            .await
+            .expect("challenge within retained cap should issue")
+            .client;
+
+            if index == 0 {
+                first_challenge_id = Some(challenge.challenge_id.clone());
+            }
+            if index == MAX_RETAINED_PROOF_CHALLENGES {
+                last_challenge_id = Some(challenge.challenge_id.clone());
+            }
+        }
+
+        let store = state.proof.read().await;
+        assert_eq!(
+            store.venue_challenges_by_id.len(),
+            MAX_RETAINED_PROOF_CHALLENGES
+        );
+        assert!(
+            !store
+                .venue_challenges_by_id
+                .contains_key(&first_challenge_id.expect("first challenge id"))
+        );
+        assert!(
+            store
+                .venue_challenges_by_id
+                .contains_key(&last_challenge_id.expect("last challenge id"))
         );
     }
 

--- a/apps/backend/src/services/proof.rs
+++ b/apps/backend/src/services/proof.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, fmt::Write as _};
 
 use chrono::{DateTime, Duration, Utc};
+use hmac::{Hmac, Mac};
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
@@ -48,6 +49,8 @@ const REASON_UNSUPPORTED_FALLBACK_MODE: &str = "unsupported_fallback_mode";
 const REASON_KEY_VERSION_MISMATCH: &str = "key_version_mismatch";
 
 const RISK_INVALID_COARSE_LOCATION_HINT: &str = "invalid_coarse_location_hint";
+
+type HmacSha256 = Hmac<Sha256>;
 
 pub struct ProofState {
     server_secret: String,
@@ -111,7 +114,7 @@ struct VenueChallengeRecord {
     expires_at: DateTime<Utc>,
     consumed_at: Option<DateTime<Utc>>,
     fallback_mode: String,
-    operator_pin_hash: Option<String>,
+    operator_pin_hash: Option<[u8; 32]>,
     operator_pin_expires_at: Option<DateTime<Utc>>,
     operator_id: Option<String>,
     venue_key_version: i32,
@@ -158,7 +161,7 @@ struct OperatorPinAuditRecord {
     realm_id: String,
     issued_at: DateTime<Utc>,
     expires_at: DateTime<Utc>,
-    pin_hash: String,
+    pin_hash: [u8; 32],
 }
 
 #[derive(Clone, Debug)]
@@ -597,8 +600,14 @@ fn verify_operator_pin(
     {
         return no_charge(rejected(REASON_EXPIRED));
     }
-    let submitted_pin_hash = operator_pin_hash(server_secret, &challenge.challenge_id, &pin);
-    if challenge.operator_pin_hash.as_deref() != Some(submitted_pin_hash.as_str()) {
+    let Some(expected_pin_hash) = challenge.operator_pin_hash.as_ref() else {
+        return no_charge(rejected(REASON_OPERATOR_PIN_INVALID));
+    };
+    if !hmac_sha256_matches(
+        server_secret.as_bytes(),
+        &["operator-pin", &challenge.challenge_id, &pin],
+        expected_pin_hash,
+    ) {
         return charge(rejected(REASON_OPERATOR_PIN_INVALID));
     }
     risk_flags.push("operator_fallback".to_owned());
@@ -737,8 +746,11 @@ fn random_numeric_code() -> String {
     format!("{value:06}")
 }
 
-fn operator_pin_hash(server_secret: &str, challenge_id: &str, pin: &str) -> String {
-    hmac_sha256_hex(server_secret, &["operator-pin", challenge_id, pin])
+fn operator_pin_hash(server_secret: &str, challenge_id: &str, pin: &str) -> [u8; 32] {
+    hmac_sha256(
+        server_secret.as_bytes(),
+        &["operator-pin", challenge_id, pin],
+    )
 }
 
 fn venue_secret_material(
@@ -859,6 +871,7 @@ fn server_keyed_display_code_hash(server_secret: &str, display_code: &str) -> St
 }
 
 fn replay_key(server_secret: &str, input: &ProofEnvelopeInput) -> String {
+    let subject_account_id = input.subject_account_id.trim().to_owned();
     let challenge_id = canonical_optional(input.challenge_id.as_deref());
     let venue_id = canonical_optional(input.venue_id.as_deref());
     let display_code = input
@@ -890,6 +903,7 @@ fn replay_key(server_secret: &str, input: &ProofEnvelopeInput) -> String {
         server_secret,
         &[
             "proof-envelope",
+            subject_account_id.as_str(),
             challenge_id.as_str(),
             venue_id.as_str(),
             display_code.as_str(),
@@ -997,30 +1011,28 @@ fn hmac_sha256_hex(key: &str, parts: &[&str]) -> String {
 }
 
 fn hmac_sha256(key: &[u8], parts: &[&str]) -> [u8; 32] {
-    const SHA256_BLOCK_SIZE: usize = 64;
-    let mut normalized_key = if key.len() > SHA256_BLOCK_SIZE {
-        Sha256::digest(key).to_vec()
-    } else {
-        key.to_vec()
-    };
-    normalized_key.resize(SHA256_BLOCK_SIZE, 0);
+    let mut mac = new_hmac_sha256(key);
+    update_hmac_with_parts(&mut mac, parts);
+    mac.finalize().into_bytes().into()
+}
 
-    let mut inner_pad = [0x36_u8; SHA256_BLOCK_SIZE];
-    let mut outer_pad = [0x5c_u8; SHA256_BLOCK_SIZE];
-    for (index, byte) in normalized_key.iter().enumerate() {
-        inner_pad[index] ^= byte;
-        outer_pad[index] ^= byte;
+fn hmac_sha256_matches(key: &[u8], parts: &[&str], expected: &[u8]) -> bool {
+    let mut mac = new_hmac_sha256(key);
+    update_hmac_with_parts(&mut mac, parts);
+    mac.verify_slice(expected).is_ok()
+}
+
+fn new_hmac_sha256(key: &[u8]) -> HmacSha256 {
+    HmacSha256::new_from_slice(key).expect("HMAC-SHA256 accepts arbitrary key length")
+}
+
+fn update_hmac_with_parts(mac: &mut HmacSha256, parts: &[&str]) {
+    for part in parts {
+        mac.update(part.len().to_string().as_bytes());
+        mac.update(b":");
+        mac.update(part.as_bytes());
+        mac.update(b";");
     }
-
-    let mut inner = Sha256::new();
-    inner.update(inner_pad);
-    update_hasher_with_parts(&mut inner, parts);
-    let inner_digest = inner.finalize();
-
-    let mut outer = Sha256::new();
-    outer.update(outer_pad);
-    outer.update(inner_digest);
-    outer.finalize().into()
 }
 
 fn update_hasher_with_parts(hasher: &mut Sha256, parts: &[&str]) {
@@ -1343,6 +1355,32 @@ mod tests {
         );
     }
 
+    #[test]
+    fn different_subject_changes_replay_key() {
+        let first = ProofEnvelopeInput {
+            subject_account_id: "account-replay-key-a".to_owned(),
+            challenge_id: Some("challenge-replay-key".to_owned()),
+            venue_id: Some("venue-replay-key".to_owned()),
+            display_code: Some("ABC123".to_owned()),
+            key_version: Some(7),
+            client_nonce: Some("nonce-replay-key".to_owned()),
+            observed_at_ms: Some(123456789),
+            coarse_location_bucket: Some("tokyo-shibuya".to_owned()),
+            device_session_id: Some("device-replay-key".to_owned()),
+            fallback_mode: Some(FALLBACK_NONE.to_owned()),
+            operator_pin: None,
+        };
+        let second = ProofEnvelopeInput {
+            subject_account_id: "account-replay-key-b".to_owned(),
+            ..first.clone()
+        };
+
+        assert_ne!(
+            replay_key("server-secret-a", &first),
+            replay_key("server-secret-a", &second)
+        );
+    }
+
     #[tokio::test]
     async fn persisted_replay_material_is_not_plain_digest_over_low_entropy_secrets() {
         let state = crate::new_state();
@@ -1417,6 +1455,40 @@ mod tests {
         .expect("previous window proof should produce a result");
 
         assert!(outcome.accepted);
+    }
+
+    #[tokio::test]
+    async fn subject_mismatch_submission_does_not_poison_valid_subject_submission() {
+        let state = crate::new_state();
+        let challenge = start_test_challenge(&state, "venue-replay-subject", FALLBACK_NONE).await;
+        let received_at = Utc::now();
+        let code = display_code(
+            &state,
+            "venue-replay-subject",
+            challenge.venue_key_version,
+            received_at,
+        )
+        .await;
+
+        let mut mismatched: ProofEnvelopeInput = valid_envelope(&challenge, code.clone()).into();
+        mismatched.subject_account_id = "other-account".to_owned();
+        let mismatched_outcome = submit_proof_envelope_at(&state, mismatched, received_at)
+            .await
+            .expect("subject mismatch should still return a verification result");
+        assert_eq!(
+            mismatched_outcome.reason_code.as_deref(),
+            Some(REASON_SUBJECT_MISMATCH)
+        );
+
+        let valid_outcome = submit_proof_envelope_at(
+            &state,
+            valid_envelope(&challenge, code).into(),
+            received_at + Duration::seconds(1),
+        )
+        .await
+        .expect("valid subject should not be blocked by another account");
+
+        assert!(valid_outcome.accepted);
     }
 
     #[tokio::test]
@@ -2212,7 +2284,7 @@ mod tests {
             .find(|audit| audit.challenge_id == first_challenge.challenge_id)
             .expect("first operator PIN audit should exist");
         assert_ne!(
-            first_audit.pin_hash,
+            hex_bytes(&first_audit.pin_hash),
             digest_parts(&[
                 "operator-pin",
                 &first_challenge.challenge_id,

--- a/apps/backend/src/services/proof.rs
+++ b/apps/backend/src/services/proof.rs
@@ -1,7 +1,10 @@
-use std::{collections::HashMap, fmt::Write as _};
+use std::{
+    collections::{HashMap, HashSet},
+    fmt::Write as _,
+};
 
 use chrono::{DateTime, Duration, Utc};
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
@@ -15,6 +18,8 @@ const DISPLAY_CODE_WINDOW_SECONDS: i64 = 30;
 const OPERATOR_PIN_TTL_SECONDS: i64 = 60;
 const OPERATOR_PIN_RATE_LIMIT_PER_MINUTE: usize = 3;
 const MAX_CHALLENGE_FAILED_ATTEMPTS: u8 = 3;
+const PROOF_SUBMISSION_RETENTION_SECONDS: i64 = 15 * 60;
+const MAX_RETAINED_PROOF_SUBMISSIONS: usize = 1024;
 
 const KEY_STATUS_ACTIVE: &str = "active";
 const KEY_STATUS_DRAINING: &str = "draining";
@@ -356,6 +361,7 @@ async fn submit_proof_envelope_at(
     received_at: DateTime<Utc>,
 ) -> Result<ProofSubmissionOutcome, HappyRouteError> {
     let mut store = state.proof.write().await;
+    prune_proof_submission_state(&mut store, received_at);
     let replay_key = replay_key(&store.server_secret, &input);
     let replayed_submission_id = store
         .proof_submission_id_by_replay_key
@@ -375,7 +381,7 @@ async fn submit_proof_envelope_at(
         .as_deref()
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .map(|value| digest_parts(&["device-session", value]));
+        .map(|value| server_keyed_device_session_id_hash(&store.server_secret, value));
     let parsed_fallback_mode = parse_submission_fallback_mode(input.fallback_mode.as_deref());
     let fallback_mode = parsed_fallback_mode
         .map(SubmissionFallbackMode::as_str)
@@ -452,6 +458,7 @@ async fn submit_proof_envelope_at(
             operator_override_case_id: None,
         },
     );
+    prune_proof_submission_state(&mut store, received_at);
 
     Ok(ProofSubmissionOutcome {
         proof_submission_id,
@@ -870,6 +877,10 @@ fn server_keyed_display_code_hash(server_secret: &str, display_code: &str) -> St
     )
 }
 
+fn server_keyed_device_session_id_hash(server_secret: &str, device_session_id: &str) -> String {
+    hmac_sha256_hex(server_secret, &["device-session", device_session_id.trim()])
+}
+
 fn replay_key(server_secret: &str, input: &ProofEnvelopeInput) -> String {
     let subject_account_id = input.subject_account_id.trim().to_owned();
     let challenge_id = canonical_optional(input.challenge_id.as_deref());
@@ -922,14 +933,21 @@ fn canonical_optional(value: Option<&str>) -> String {
     value.map(str::trim).unwrap_or_default().to_owned()
 }
 
+fn canonical_optional_json(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+}
+
 fn redacted_payload(
     input: &ProofEnvelopeInput,
     display_code_hash: &Option<String>,
     sanitized_location: &SanitizedCoarseLocationBucket,
 ) -> serde_json::Value {
     serde_json::json!({
-        "challenge_id": input.challenge_id.as_deref(),
-        "venue_id": input.venue_id.as_deref(),
+        "challenge_id": canonical_optional_json(input.challenge_id.as_deref()),
+        "venue_id": canonical_optional_json(input.venue_id.as_deref()),
         "display_code_hash": display_code_hash.as_deref(),
         "key_version": input.key_version,
         "client_nonce_present": input.client_nonce.as_deref().is_some_and(|value| !value.trim().is_empty()),
@@ -942,6 +960,55 @@ fn redacted_payload(
             .unwrap_or(FALLBACK_UNSUPPORTED),
         "operator_pin_present": input.operator_pin.as_deref().is_some_and(|value| !value.trim().is_empty()),
     })
+}
+
+fn prune_proof_submission_state(store: &mut ProofState, now: DateTime<Utc>) {
+    let cutoff = now - Duration::seconds(PROOF_SUBMISSION_RETENTION_SECONDS);
+    let mut expired_submission_ids: HashSet<String> = store
+        .proof_submissions_by_id
+        .iter()
+        .filter_map(|(submission_id, submission)| {
+            (submission.received_at < cutoff).then(|| submission_id.clone())
+        })
+        .collect();
+
+    let mut retained_submissions: Vec<(String, DateTime<Utc>)> = store
+        .proof_submissions_by_id
+        .iter()
+        .filter(|(_, submission)| submission.received_at >= cutoff)
+        .map(|(submission_id, submission)| (submission_id.clone(), submission.received_at))
+        .collect();
+    retained_submissions.sort_by(
+        |(left_id, left_received_at), (right_id, right_received_at)| {
+            left_received_at
+                .cmp(right_received_at)
+                .then_with(|| left_id.cmp(right_id))
+        },
+    );
+
+    let overflow = retained_submissions
+        .len()
+        .saturating_sub(MAX_RETAINED_PROOF_SUBMISSIONS);
+    expired_submission_ids.extend(
+        retained_submissions
+            .into_iter()
+            .take(overflow)
+            .map(|(submission_id, _)| submission_id),
+    );
+
+    if expired_submission_ids.is_empty() {
+        return;
+    }
+
+    store
+        .proof_submissions_by_id
+        .retain(|submission_id, _| !expired_submission_ids.contains(submission_id));
+    store
+        .proof_submission_id_by_replay_key
+        .retain(|_, submission_id| !expired_submission_ids.contains(submission_id));
+    store.proof_verifications_by_id.retain(|_, verification| {
+        !expired_submission_ids.contains(&verification.proof_submission_id)
+    });
 }
 
 fn risk_flags(
@@ -1393,10 +1460,14 @@ mod tests {
             received_at,
         )
         .await;
-        let envelope: ProofEnvelopeInput = valid_envelope(&challenge, code.clone()).into();
+        let envelope: ProofEnvelopeInput = valid_envelope(&challenge, code.clone())
+            .device_session_id("device-replay")
+            .into();
         let plain_display_code_digest = digest_parts(&["display-code", code.trim()]);
+        let plain_device_session_digest = digest_parts(&["device-session", "device-replay"]);
         let plain_replay_digest = digest_parts(&[
             "proof-envelope",
+            envelope.subject_account_id.as_str(),
             envelope.challenge_id.as_deref().unwrap_or_default(),
             envelope.venue_id.as_deref().unwrap_or_default(),
             code.as_str(),
@@ -1429,6 +1500,10 @@ mod tests {
         assert_ne!(
             submission.display_code_hash.as_deref(),
             Some(plain_display_code_digest.as_str())
+        );
+        assert_ne!(
+            submission.device_session_id_hash.as_deref(),
+            Some(plain_device_session_digest.as_str())
         );
         assert!(submission.raw_payload_json["display_code_hash"].is_string());
     }
@@ -2415,6 +2490,168 @@ mod tests {
             store
                 .proof_submissions_by_id
                 .contains_key(&outcome.proof_submission_id)
+        );
+    }
+
+    #[tokio::test]
+    async fn redacted_payload_canonicalizes_request_identifiers() {
+        let state = crate::new_state();
+        let outcome = submit_proof_envelope(
+            &state,
+            ProofEnvelopeInput {
+                subject_account_id: "account-redacted".to_owned(),
+                challenge_id: Some("  challenge-redacted  ".to_owned()),
+                venue_id: Some("  venue-redacted  ".to_owned()),
+                display_code: None,
+                key_version: None,
+                client_nonce: None,
+                observed_at_ms: None,
+                coarse_location_bucket: None,
+                device_session_id: None,
+                fallback_mode: None,
+                operator_pin: None,
+            },
+        )
+        .await
+        .expect("malformed proof should still be recorded");
+
+        let store = state.proof.read().await;
+        let submission = store
+            .proof_submissions_by_id
+            .get(&outcome.proof_submission_id)
+            .expect("submission should be retained");
+        assert_eq!(
+            submission.raw_payload_json["challenge_id"].as_str(),
+            Some("challenge-redacted")
+        );
+        assert_eq!(
+            submission.raw_payload_json["venue_id"].as_str(),
+            Some("venue-redacted")
+        );
+    }
+
+    #[tokio::test]
+    async fn proof_submission_state_prunes_expired_rejected_evidence() {
+        let state = crate::new_state();
+        let base = Utc::now();
+        let old_input = ProofEnvelopeInput {
+            subject_account_id: "account-prune-old".to_owned(),
+            challenge_id: Some("challenge-prune-old".to_owned()),
+            venue_id: Some("venue-prune".to_owned()),
+            display_code: None,
+            key_version: None,
+            client_nonce: None,
+            observed_at_ms: None,
+            coarse_location_bucket: None,
+            device_session_id: None,
+            fallback_mode: None,
+            operator_pin: None,
+        };
+        let old_outcome = submit_proof_envelope_at(&state, old_input.clone(), base)
+            .await
+            .expect("old malformed proof should be recorded");
+
+        let new_input = ProofEnvelopeInput {
+            subject_account_id: "account-prune-new".to_owned(),
+            challenge_id: Some("challenge-prune-new".to_owned()),
+            venue_id: Some("venue-prune".to_owned()),
+            display_code: None,
+            key_version: None,
+            client_nonce: None,
+            observed_at_ms: None,
+            coarse_location_bucket: None,
+            device_session_id: None,
+            fallback_mode: None,
+            operator_pin: None,
+        };
+        let new_outcome = submit_proof_envelope_at(
+            &state,
+            new_input.clone(),
+            base + Duration::seconds(PROOF_SUBMISSION_RETENTION_SECONDS + 1),
+        )
+        .await
+        .expect("new malformed proof should be recorded");
+
+        let store = state.proof.read().await;
+        assert!(
+            !store
+                .proof_submissions_by_id
+                .contains_key(&old_outcome.proof_submission_id)
+        );
+        assert!(
+            store
+                .proof_submissions_by_id
+                .contains_key(&new_outcome.proof_submission_id)
+        );
+        assert_eq!(
+            store
+                .proof_submission_id_by_replay_key
+                .get(&replay_key(&store.server_secret, &old_input)),
+            None
+        );
+        assert!(
+            store
+                .proof_verifications_by_id
+                .values()
+                .all(|verification| verification.proof_submission_id
+                    != old_outcome.proof_submission_id)
+        );
+    }
+
+    #[tokio::test]
+    async fn proof_submission_state_caps_unique_rejected_evidence() {
+        let state = crate::new_state();
+        let base = Utc::now();
+        let mut first_submission_id = None;
+        let mut last_submission_id = None;
+
+        for index in 0..=MAX_RETAINED_PROOF_SUBMISSIONS {
+            let outcome = submit_proof_envelope_at(
+                &state,
+                ProofEnvelopeInput {
+                    subject_account_id: format!("account-cap-{index}"),
+                    challenge_id: Some(format!("challenge-cap-{index}")),
+                    venue_id: Some("venue-cap".to_owned()),
+                    display_code: None,
+                    key_version: None,
+                    client_nonce: None,
+                    observed_at_ms: None,
+                    coarse_location_bucket: None,
+                    device_session_id: None,
+                    fallback_mode: None,
+                    operator_pin: None,
+                },
+                base + Duration::milliseconds(index as i64),
+            )
+            .await
+            .expect("malformed proof should be recorded");
+
+            if index == 0 {
+                first_submission_id = Some(outcome.proof_submission_id.clone());
+            }
+            if index == MAX_RETAINED_PROOF_SUBMISSIONS {
+                last_submission_id = Some(outcome.proof_submission_id.clone());
+            }
+        }
+
+        let store = state.proof.read().await;
+        assert_eq!(
+            store.proof_submissions_by_id.len(),
+            MAX_RETAINED_PROOF_SUBMISSIONS
+        );
+        assert_eq!(
+            store.proof_verifications_by_id.len(),
+            MAX_RETAINED_PROOF_SUBMISSIONS
+        );
+        assert!(
+            !store
+                .proof_submissions_by_id
+                .contains_key(&first_submission_id.expect("first submission id"))
+        );
+        assert!(
+            store
+                .proof_submissions_by_id
+                .contains_key(&last_submission_id.expect("last submission id"))
         );
     }
 

--- a/apps/backend/src/services/proof.rs
+++ b/apps/backend/src/services/proof.rs
@@ -19,10 +19,12 @@ const OPERATOR_PIN_TTL_SECONDS: i64 = 60;
 const OPERATOR_PIN_RATE_LIMIT_WINDOW_SECONDS: i64 = 60;
 const OPERATOR_PIN_RATE_LIMIT_PER_MINUTE: usize = 3;
 const MAX_CHALLENGE_FAILED_ATTEMPTS: u8 = 3;
-const PROOF_CHALLENGE_RETENTION_SECONDS: i64 = PROOF_SUBMISSION_RETENTION_SECONDS;
+const PROOF_CHALLENGE_RETENTION_SECONDS: i64 = CHALLENGE_TTL_SECONDS * 2;
 const PROOF_SUBMISSION_RETENTION_SECONDS: i64 = 15 * 60;
+const MAX_ACTIVE_PROOF_CHALLENGES_PER_SUBJECT: usize = 4;
 const MAX_RETAINED_PROOF_CHALLENGES: usize = MAX_RETAINED_PROOF_SUBMISSIONS;
 const MAX_RETAINED_PROOF_SUBMISSIONS: usize = 1024;
+const MAX_ACTIVE_PROOF_CHALLENGES: usize = MAX_RETAINED_PROOF_CHALLENGES;
 const MAX_RETAINED_OPERATOR_PIN_AUDITS: usize = MAX_RETAINED_PROOF_CHALLENGES;
 
 const KEY_STATUS_ACTIVE: &str = "active";
@@ -269,6 +271,18 @@ pub async fn start_proof_challenge(
     let fallback_mode = normalize_fallback_mode(input.fallback_mode.as_str())?;
     let mut store = state.proof.write().await;
     prune_ephemeral_proof_state(&mut store, now);
+    if active_challenge_count_for_subject(&store, &subject_account_id, now)
+        >= MAX_ACTIVE_PROOF_CHALLENGES_PER_SUBJECT
+    {
+        return Err(HappyRouteError::BadRequest(
+            "active proof challenge limit exceeded".to_owned(),
+        ));
+    }
+    if active_challenge_count(&store, now) >= MAX_ACTIVE_PROOF_CHALLENGES {
+        return Err(HappyRouteError::BadRequest(
+            "proof challenge capacity exceeded".to_owned(),
+        ));
+    }
     let key_version = ensure_active_venue_key(&mut store, &realm_id, &venue_id, now);
     let challenge_id = Uuid::new_v4().to_string();
     let client_nonce = Uuid::new_v4().to_string();
@@ -990,15 +1004,20 @@ fn prune_venue_challenge_state(store: &mut ProofState, now: DateTime<Utc>) {
         .filter(|(_, challenge)| challenge_retention_anchor(challenge) >= cutoff)
         .map(|(challenge_id, challenge)| (challenge_id.clone(), challenge.issued_at))
         .collect();
+    let total_retained = retained_challenges.len();
+    retained_challenges.retain(|(challenge_id, _)| {
+        store
+            .venue_challenges_by_id
+            .get(challenge_id)
+            .is_some_and(|challenge| !is_challenge_active(challenge, now))
+    });
     retained_challenges.sort_by(|(left_id, left_issued_at), (right_id, right_issued_at)| {
         left_issued_at
             .cmp(right_issued_at)
             .then_with(|| left_id.cmp(right_id))
     });
 
-    let overflow = retained_challenges
-        .len()
-        .saturating_sub(MAX_RETAINED_PROOF_CHALLENGES);
+    let overflow = total_retained.saturating_sub(MAX_RETAINED_PROOF_CHALLENGES);
     expired_challenge_ids.extend(
         retained_challenges
             .into_iter()
@@ -1028,6 +1047,35 @@ fn challenge_retention_anchor(challenge: &VenueChallengeRecord) -> DateTime<Utc>
         anchor = operator_pin_expires_at;
     }
     anchor
+}
+
+fn is_challenge_active(challenge: &VenueChallengeRecord, now: DateTime<Utc>) -> bool {
+    challenge.status == CHALLENGE_STATUS_ISSUED
+        && challenge.consumed_at.is_none()
+        && now <= challenge.expires_at
+}
+
+fn active_challenge_count(store: &ProofState, now: DateTime<Utc>) -> usize {
+    store
+        .venue_challenges_by_id
+        .values()
+        .filter(|challenge| is_challenge_active(challenge, now))
+        .count()
+}
+
+fn active_challenge_count_for_subject(
+    store: &ProofState,
+    subject_account_id: &str,
+    now: DateTime<Utc>,
+) -> usize {
+    store
+        .venue_challenges_by_id
+        .values()
+        .filter(|challenge| {
+            challenge.subject_account_id == subject_account_id
+                && is_challenge_active(challenge, now)
+        })
+        .count()
 }
 
 fn prune_venue_key_state(store: &mut ProofState) {
@@ -1895,7 +1943,7 @@ mod tests {
 
         for attempt in 0..MAX_CHALLENGE_FAILED_ATTEMPTS {
             let mut envelope: ProofEnvelopeInput =
-                valid_envelope(&challenge, format!("BAD{attempt:03}")).into();
+                valid_envelope(&challenge, impossible_display_code(attempt.into())).into();
             envelope.observed_at_ms =
                 Some((received_at + Duration::seconds(attempt.into())).timestamp_millis());
             let outcome = submit_proof_envelope_at(
@@ -1953,7 +2001,7 @@ mod tests {
                     subject_account_id: "account-proof-a".to_owned(),
                     challenge_id: Some(challenge.challenge_id.clone()),
                     venue_id: None,
-                    display_code: Some(format!("BAD{index:03}")),
+                    display_code: Some(impossible_display_code(index as usize)),
                     key_version: Some(challenge.venue_key_version),
                     client_nonce: None,
                     observed_at_ms: Some(
@@ -2024,7 +2072,7 @@ mod tests {
         let challenge = start_test_challenge(&state, "venue-secret-budget", FALLBACK_NONE).await;
         let received_at = Utc::now();
         let mut missing_display_code: ProofEnvelopeInput =
-            valid_envelope(&challenge, "BAD000".to_owned()).into();
+            valid_envelope(&challenge, impossible_display_code(0)).into();
         missing_display_code.display_code = None;
 
         let missing = submit_proof_envelope_at(&state, missing_display_code, received_at)
@@ -2034,7 +2082,7 @@ mod tests {
 
         let wrong_display_code = submit_proof_envelope_at(
             &state,
-            valid_envelope(&challenge, "BAD001".to_owned()).into(),
+            valid_envelope(&challenge, impossible_display_code(1)).into(),
             received_at + Duration::seconds(1),
         )
         .await
@@ -2142,7 +2190,7 @@ mod tests {
 
         for attempt in 0..MAX_CHALLENGE_FAILED_ATTEMPTS {
             let mut envelope: ProofEnvelopeInput =
-                valid_envelope(&challenge, format!("BAD{attempt:03}")).into();
+                valid_envelope(&challenge, impossible_display_code(attempt.into())).into();
             envelope.observed_at_ms =
                 Some((received_at + Duration::seconds(10 + i64::from(attempt))).timestamp_millis());
             let outcome = submit_proof_envelope_at(
@@ -2522,6 +2570,44 @@ mod tests {
                 &first_challenge.challenge_id,
                 &first_delivery.pin
             ])
+        );
+    }
+
+    #[tokio::test]
+    async fn operator_pin_capable_challenge_accepts_normal_display_code_flow() {
+        let state = crate::new_state();
+        let start = start_proof_challenge(
+            &state,
+            StartProofChallengeInput {
+                subject_account_id: "account-proof-a".to_owned(),
+                venue_id: "venue-operator-display-code".to_owned(),
+                realm_id: "realm-proof".to_owned(),
+                fallback_mode: FALLBACK_OPERATOR_PIN.to_owned(),
+                operator_id: Some("operator-display-code".to_owned()),
+            },
+        )
+        .await
+        .expect("operator fallback challenge should issue");
+        let challenge = start.client;
+        let code = display_code_for_realm(
+            &state,
+            &challenge.realm_id,
+            &challenge.venue_id,
+            challenge.venue_key_version,
+            Utc::now(),
+        )
+        .await;
+
+        let outcome = submit_proof_envelope(&state, valid_envelope(&challenge, code).into())
+            .await
+            .expect("normal display-code flow should remain valid");
+
+        assert!(outcome.accepted);
+        assert!(
+            !outcome
+                .risk_flags
+                .iter()
+                .any(|flag| flag == "operator_fallback")
         );
     }
 
@@ -2915,48 +3001,96 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn challenge_state_caps_retained_challenges() {
+    async fn active_challenge_limit_is_enforced_per_subject() {
         let state = crate::new_state();
-        let mut first_challenge_id = None;
-        let mut last_challenge_id = None;
 
-        for index in 0..=MAX_RETAINED_PROOF_CHALLENGES {
-            let challenge = start_proof_challenge(
+        for index in 0..MAX_ACTIVE_PROOF_CHALLENGES_PER_SUBJECT {
+            start_proof_challenge(
                 &state,
                 StartProofChallengeInput {
-                    subject_account_id: format!("account-challenge-cap-{index}"),
-                    venue_id: "venue-challenge-cap".to_owned(),
+                    subject_account_id: "account-challenge-cap".to_owned(),
+                    venue_id: format!("venue-challenge-cap-{index}"),
                     realm_id: "realm-proof".to_owned(),
                     fallback_mode: FALLBACK_NONE.to_owned(),
                     operator_id: None,
                 },
             )
             .await
-            .expect("challenge within retained cap should issue")
-            .client;
+            .expect("challenge within subject cap should issue");
+        }
 
-            if index == 0 {
-                first_challenge_id = Some(challenge.challenge_id.clone());
-            }
-            if index == MAX_RETAINED_PROOF_CHALLENGES {
-                last_challenge_id = Some(challenge.challenge_id.clone());
+        let blocked = start_proof_challenge(
+            &state,
+            StartProofChallengeInput {
+                subject_account_id: "account-challenge-cap".to_owned(),
+                venue_id: "venue-challenge-cap-blocked".to_owned(),
+                realm_id: "realm-proof".to_owned(),
+                fallback_mode: FALLBACK_NONE.to_owned(),
+                operator_id: None,
+            },
+        )
+        .await
+        .expect_err("subject beyond active challenge cap should be rejected");
+        assert_eq!(blocked.message(), "active proof challenge limit exceeded");
+    }
+
+    #[tokio::test]
+    async fn active_challenge_capacity_preserves_existing_active_challenges() {
+        let state = crate::new_state();
+        let first = start_test_challenge(&state, "venue-challenge-cap-first", FALLBACK_NONE).await;
+
+        {
+            let now = Utc::now();
+            let mut store = state.proof.write().await;
+            for index in 0..MAX_ACTIVE_PROOF_CHALLENGES - 1 {
+                let challenge_id = format!("manual-active-challenge-{index}");
+                let venue_id = format!("manual-active-venue-{index}");
+                store.venue_challenges_by_id.insert(
+                    challenge_id.clone(),
+                    VenueChallengeRecord {
+                        challenge_id: challenge_id.clone(),
+                        subject_account_id: format!("manual-subject-{index}"),
+                        venue_id,
+                        realm_id: "realm-proof".to_owned(),
+                        client_nonce_hash: digest_parts(&["client-nonce", &challenge_id, "manual"]),
+                        issued_at: now,
+                        expires_at: now + Duration::seconds(CHALLENGE_TTL_SECONDS),
+                        consumed_at: None,
+                        fallback_mode: FALLBACK_NONE.to_owned(),
+                        operator_pin_hash: None,
+                        operator_pin_expires_at: None,
+                        operator_id: None,
+                        venue_key_version: 1,
+                        failed_attempt_count: 0,
+                        status: CHALLENGE_STATUS_ISSUED.to_owned(),
+                    },
+                );
             }
         }
 
+        let blocked = start_proof_challenge(
+            &state,
+            StartProofChallengeInput {
+                subject_account_id: "account-capacity-blocked".to_owned(),
+                venue_id: "venue-capacity-blocked".to_owned(),
+                realm_id: "realm-proof".to_owned(),
+                fallback_mode: FALLBACK_NONE.to_owned(),
+                operator_id: None,
+            },
+        )
+        .await
+        .expect_err("global active challenge capacity should reject new issuance");
+        assert_eq!(blocked.message(), "proof challenge capacity exceeded");
+
         let store = state.proof.read().await;
         assert_eq!(
-            store.venue_challenges_by_id.len(),
-            MAX_RETAINED_PROOF_CHALLENGES
-        );
-        assert!(
-            !store
-                .venue_challenges_by_id
-                .contains_key(&first_challenge_id.expect("first challenge id"))
+            active_challenge_count(&store, Utc::now()),
+            MAX_ACTIVE_PROOF_CHALLENGES
         );
         assert!(
             store
                 .venue_challenges_by_id
-                .contains_key(&last_challenge_id.expect("last challenge id"))
+                .contains_key(&first.challenge_id)
         );
     }
 
@@ -3041,6 +3175,10 @@ mod tests {
 
         let second = start_test_challenge(&state, "venue-key-retain", FALLBACK_NONE).await;
         assert_eq!(second.venue_key_version, rotated_key_version);
+    }
+
+    fn impossible_display_code(index: usize) -> String {
+        format!("Z{index:05}")
     }
 
     async fn start_test_challenge(

--- a/apps/backend/src/services/proof.rs
+++ b/apps/backend/src/services/proof.rs
@@ -969,6 +969,7 @@ fn redacted_payload(
 
 fn prune_ephemeral_proof_state(store: &mut ProofState, now: DateTime<Utc>) {
     prune_venue_challenge_state(store, now);
+    prune_venue_key_state(store);
     prune_operator_pin_audit_state(store, now);
     prune_proof_submission_state(store, now);
 }
@@ -1027,6 +1028,63 @@ fn challenge_retention_anchor(challenge: &VenueChallengeRecord) -> DateTime<Utc>
         anchor = operator_pin_expires_at;
     }
     anchor
+}
+
+fn prune_venue_key_state(store: &mut ProofState) {
+    let retained_venues: HashSet<(String, String)> = store
+        .venue_challenges_by_id
+        .values()
+        .map(|challenge| (challenge.realm_id.clone(), challenge.venue_id.clone()))
+        .collect();
+
+    let mut retained_key_ids: HashSet<(String, String, i32)> = store
+        .venue_challenges_by_id
+        .values()
+        .map(|challenge| {
+            (
+                challenge.realm_id.clone(),
+                challenge.venue_id.clone(),
+                challenge.venue_key_version,
+            )
+        })
+        .collect();
+
+    for venue in &retained_venues {
+        if let Some(active_key_version) = store.active_key_version_by_venue.get(venue) {
+            retained_key_ids.insert((venue.0.clone(), venue.1.clone(), *active_key_version));
+        }
+    }
+
+    store
+        .venue_key_versions
+        .retain(|key_id, _| retained_key_ids.contains(key_id));
+
+    let previous_active = std::mem::take(&mut store.active_key_version_by_venue);
+    let mut rebuilt_active = HashMap::new();
+    for venue in retained_venues {
+        if let Some(active_key_version) = previous_active.get(&venue).copied()
+            && store.venue_key_versions.contains_key(&(
+                venue.0.clone(),
+                venue.1.clone(),
+                active_key_version,
+            ))
+        {
+            rebuilt_active.insert(venue, active_key_version);
+            continue;
+        }
+
+        if let Some(fallback_key_version) = store
+            .venue_key_versions
+            .keys()
+            .filter_map(|(realm_id, venue_id, key_version)| {
+                (realm_id == &venue.0 && venue_id == &venue.1).then_some(*key_version)
+            })
+            .max()
+        {
+            rebuilt_active.insert(venue, fallback_key_version);
+        }
+    }
+    store.active_key_version_by_venue = rebuilt_active;
 }
 
 fn prune_operator_pin_audit_state(store: &mut ProofState, now: DateTime<Utc>) {
@@ -2900,6 +2958,89 @@ mod tests {
                 .venue_challenges_by_id
                 .contains_key(&last_challenge_id.expect("last challenge id"))
         );
+    }
+
+    #[tokio::test]
+    async fn challenge_pruning_removes_unused_venue_key_state() {
+        let state = crate::new_state();
+        let first = start_test_challenge(&state, "venue-key-prune", FALLBACK_NONE).await;
+
+        {
+            let mut store = state.proof.write().await;
+            let stale_at = Utc::now() - Duration::seconds(PROOF_CHALLENGE_RETENTION_SECONDS + 1);
+            let challenge = store
+                .venue_challenges_by_id
+                .get_mut(&first.challenge_id)
+                .expect("challenge should exist before pruning");
+            challenge.expires_at = stale_at;
+        }
+
+        let second = start_test_challenge(&state, "venue-key-prune-next", FALLBACK_NONE).await;
+
+        let store = state.proof.read().await;
+        assert!(
+            !store
+                .venue_challenges_by_id
+                .contains_key(&first.challenge_id)
+        );
+        assert!(
+            !store
+                .active_key_version_by_venue
+                .contains_key(&("realm-proof".to_owned(), "venue-key-prune".to_owned()))
+        );
+        assert!(!store.venue_key_versions.contains_key(&(
+            "realm-proof".to_owned(),
+            "venue-key-prune".to_owned(),
+            first.venue_key_version
+        )));
+        assert!(
+            store
+                .active_key_version_by_venue
+                .contains_key(&("realm-proof".to_owned(), second.venue_id.clone()))
+        );
+    }
+
+    #[tokio::test]
+    async fn retained_challenge_keeps_active_rotated_venue_key_state() {
+        let state = crate::new_state();
+        let first = start_test_challenge(&state, "venue-key-retain", FALLBACK_NONE).await;
+        let rotated_key_version = first.venue_key_version + 1;
+        let now = Utc::now();
+
+        {
+            let mut store = state.proof.write().await;
+            store.active_key_version_by_venue.insert(
+                ("realm-proof".to_owned(), "venue-key-retain".to_owned()),
+                rotated_key_version,
+            );
+            let secret_material = venue_secret_material(
+                &store.server_secret,
+                "realm-proof",
+                "venue-key-retain",
+                rotated_key_version,
+            );
+            store.venue_key_versions.insert(
+                (
+                    "realm-proof".to_owned(),
+                    "venue-key-retain".to_owned(),
+                    rotated_key_version,
+                ),
+                VenueKeyVersionRecord {
+                    realm_id: "realm-proof".to_owned(),
+                    venue_id: "venue-key-retain".to_owned(),
+                    key_version: rotated_key_version,
+                    secret_material,
+                    status: KEY_STATUS_ACTIVE.to_owned(),
+                    not_before: now,
+                    not_after: None,
+                    created_at: now,
+                },
+            );
+            prune_ephemeral_proof_state(&mut store, now);
+        }
+
+        let second = start_test_challenge(&state, "venue-key-retain", FALLBACK_NONE).await;
+        assert_eq!(second.venue_key_version, rotated_key_version);
     }
 
     async fn start_test_challenge(

--- a/apps/backend/tests/proof_primitives.rs
+++ b/apps/backend/tests/proof_primitives.rs
@@ -131,7 +131,7 @@ async fn invalid_proof_envelope_is_recorded_as_rejected_evidence() {
         json!({
             "challenge_id": challenge.body["challenge_id"],
             "venue_id": "venue-proof-b",
-            "display_code": "BAD123",
+            "display_code": impossible_display_code(),
             "key_version": challenge.body["venue_key_version"],
             "client_nonce": challenge.body["client_nonce"],
             "observed_at_ms": chrono::Utc::now().timestamp_millis(),
@@ -180,6 +180,10 @@ async fn sign_in(app: &Router, pi_uid: &str, username: &str) -> SignedInUser {
 struct JsonResponse {
     status: StatusCode,
     body: Value,
+}
+
+fn impossible_display_code() -> &'static str {
+    "BAD12Z"
 }
 
 async fn post_json(

--- a/apps/backend/tests/proof_primitives.rs
+++ b/apps/backend/tests/proof_primitives.rs
@@ -10,6 +10,8 @@ use musubi_backend::{
 use serde_json::{Value, json};
 use tower::ServiceExt;
 
+const RESPONSE_BODY_LIMIT_BYTES: usize = 1024 * 1024;
+
 #[tokio::test]
 async fn public_proof_challenge_rejects_operator_pin_fallback() {
     let app = build_app(new_state());
@@ -202,7 +204,7 @@ async fn post_json(
         .await
         .expect("app should respond");
     let status = response.status();
-    let bytes = to_bytes(response.into_body(), usize::MAX)
+    let bytes = to_bytes(response.into_body(), RESPONSE_BODY_LIMIT_BYTES)
         .await
         .expect("body must be readable");
     let body = if bytes.is_empty() {

--- a/apps/backend/tests/proof_primitives.rs
+++ b/apps/backend/tests/proof_primitives.rs
@@ -1,0 +1,215 @@
+use axum::{
+    Router,
+    body::{Body, to_bytes},
+    http::{Request, StatusCode},
+};
+use musubi_backend::{
+    build_app, new_state,
+    services::proof::{StartProofChallengeInput, start_proof_challenge},
+};
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn public_proof_challenge_rejects_operator_pin_fallback() {
+    let app = build_app(new_state());
+    let user = sign_in(&app, "pi-user-proof-a", "proof-a").await;
+
+    let response = post_json(
+        &app,
+        "/api/proof/challenges",
+        Some(user.token.as_str()),
+        json!({
+            "venue_id": "venue-proof-a",
+            "realm_id": "realm-proof",
+            "fallback_mode": "operator_pin",
+            "operator_id": "operator-proof-a"
+        }),
+    )
+    .await;
+
+    assert_eq!(response.status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        response.body["error"],
+        "operator_pin fallback is not available from the public proof challenge endpoint"
+    );
+    assert!(response.body.get("operator_pin").is_none());
+    assert!(response.body.get("operator_delivery").is_none());
+}
+
+#[tokio::test]
+async fn public_operator_pin_rejections_do_not_consume_operator_budget() {
+    let state = new_state();
+    let app = build_app(state.clone());
+    let user = sign_in(&app, "pi-user-proof-budget", "proof-budget").await;
+
+    for _ in 0..3 {
+        let response = post_json(
+            &app,
+            "/api/proof/challenges",
+            Some(user.token.as_str()),
+            json!({
+                "venue_id": "venue-proof-budget",
+                "realm_id": "realm-proof",
+                "fallback_mode": "operator_pin",
+                "operator_id": "operator-budget-a"
+            }),
+        )
+        .await;
+        assert_eq!(response.status, StatusCode::BAD_REQUEST);
+    }
+
+    for index in 0..3 {
+        let internal = start_proof_challenge(
+            &state,
+            StartProofChallengeInput {
+                subject_account_id: format!("internal-proof-subject-{index}"),
+                venue_id: "venue-proof-budget".to_owned(),
+                realm_id: "realm-proof".to_owned(),
+                fallback_mode: "operator_pin".to_owned(),
+                operator_id: Some("operator-budget-a".to_owned()),
+            },
+        )
+        .await
+        .expect("public rejections must not burn internal operator fallback budget");
+        assert!(internal.client.operator_pin_issued);
+        assert!(internal.operator_delivery.is_some());
+    }
+}
+
+#[tokio::test]
+async fn public_challenge_ignores_operator_id_when_normal_flow_is_requested() {
+    let app = build_app(new_state());
+    let user = sign_in(&app, "pi-user-proof-normal", "proof-normal").await;
+
+    let response = post_json(
+        &app,
+        "/api/proof/challenges",
+        Some(user.token.as_str()),
+        json!({
+            "venue_id": "venue-proof-normal",
+            "realm_id": "realm-proof",
+            "fallback_mode": "none",
+            "operator_id": "operator-should-not-be-principal"
+        }),
+    )
+    .await;
+
+    assert_eq!(response.status, StatusCode::OK);
+    assert!(response.body["challenge_id"].is_string());
+    assert!(response.body["client_nonce"].is_string());
+    assert_eq!(response.body["allowed_fallback_mode"], "none");
+    assert_eq!(response.body["operator_pin_issued"], false);
+    assert!(response.body.get("operator_pin").is_none());
+    assert!(response.body.get("operator_delivery").is_none());
+}
+
+#[tokio::test]
+async fn invalid_proof_envelope_is_recorded_as_rejected_evidence() {
+    let app = build_app(new_state());
+    let user = sign_in(&app, "pi-user-proof-b", "proof-b").await;
+
+    let challenge = post_json(
+        &app,
+        "/api/proof/challenges",
+        Some(user.token.as_str()),
+        json!({
+            "venue_id": "venue-proof-b",
+            "realm_id": "realm-proof",
+            "fallback_mode": "none"
+        }),
+    )
+    .await;
+    assert_eq!(challenge.status, StatusCode::OK);
+
+    let submission = post_json(
+        &app,
+        "/api/proof/submissions",
+        Some(user.token.as_str()),
+        json!({
+            "challenge_id": challenge.body["challenge_id"],
+            "venue_id": "venue-proof-b",
+            "display_code": "BAD123",
+            "key_version": challenge.body["venue_key_version"],
+            "client_nonce": challenge.body["client_nonce"],
+            "observed_at_ms": chrono::Utc::now().timestamp_millis(),
+            "coarse_location_bucket": "tokyo-shibuya",
+            "device_session_id": "ephemeral-device-session",
+            "fallback_mode": "none"
+        }),
+    )
+    .await;
+
+    assert_eq!(submission.status, StatusCode::OK);
+    assert_eq!(submission.body["accepted"], false);
+    assert_eq!(submission.body["verification_status"], "rejected");
+    assert_eq!(submission.body["reason_code"], "invalid_code");
+    assert!(submission.body["proof_submission_id"].is_string());
+    assert!(submission.body["proof_verification_id"].is_string());
+}
+
+struct SignedInUser {
+    token: String,
+}
+
+async fn sign_in(app: &Router, pi_uid: &str, username: &str) -> SignedInUser {
+    let response = post_json(
+        app,
+        "/api/auth/pi",
+        None,
+        json!({
+            "pi_uid": pi_uid,
+            "username": username,
+            "wallet_address": format!("wallet-{pi_uid}"),
+            "access_token": format!("access-token-{pi_uid}")
+        }),
+    )
+    .await;
+    assert_eq!(response.status, StatusCode::OK);
+
+    SignedInUser {
+        token: response.body["token"]
+            .as_str()
+            .expect("token must exist")
+            .to_owned(),
+    }
+}
+
+struct JsonResponse {
+    status: StatusCode,
+    body: Value,
+}
+
+async fn post_json(
+    app: &Router,
+    path: &str,
+    bearer_token: Option<&str>,
+    body: Value,
+) -> JsonResponse {
+    let mut builder = Request::builder().method("POST").uri(path);
+    if let Some(token) = bearer_token {
+        builder = builder.header("authorization", format!("Bearer {token}"));
+    }
+
+    let request = builder
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_string()))
+        .expect("request must build");
+
+    let response = app
+        .clone()
+        .oneshot(request)
+        .await
+        .expect("app should respond");
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body must be readable");
+    let body = if bytes.is_empty() {
+        json!({})
+    } else {
+        serde_json::from_slice(&bytes).expect("response body must be valid json")
+    };
+
+    JsonResponse { status, body }
+}


### PR DESCRIPTION
## Summary

- Scope venue key state and display-code derivation by `(realm_id, venue_id)` so the same `venue_id` cannot share valid codes across Realms.
- Bind proof verification to the challenge-issued `venue_key_version`; submitted `key_version` is only an optional echo check and mismatches reject with `key_version_mismatch`.
- Charge failed-attempt budget only after real challenge binding reaches display-code or operator-PIN secret verification.
- Replace persisted low-entropy replay/display-code material with server-keyed HMAC material, while keeping replay detection deterministic within one server-secret regime.
- Update proof primitive docs and guardrails to match the hardened boundary.

## Validation

- `cargo fmt`
- `cargo check`
- `cargo test`
- `git diff --check`

## Non-blocking follow-up notes

- Proof state remains the Day 1 in-memory stand-in.
- Operator fallback remains internal/deferred until an authenticated operator surface exists.
- `PROOF_MASTER_SECRET` production custody/rotation is separate work.
- Making `clippy` a hard gate still requires existing `happy_route` cleanup outside this issue scope.