### PR TITLE
feat(ops): add operator review, appeal, and evidence workflow baseline

### DIFF
--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -119,7 +119,7 @@ Issue #8 adds the runtime migration runner and backend startup schema check.
 See `docs/db_runtime.md` for the current DB bootstrap and local reset flow.
 Issue #21 wires the happy-route writer truth to PostgreSQL while preserving the existing HTTP surface and settlement-view response contract.
 Issue #22 adds derived Promise, expanded settlement, and bounded trust read models with rebuild and freshness metadata.
-Design source: ISSUE-12-operator-review-appeal-evidence.md adds the operator review / appeal / evidence workflow baseline. Operator decisions are append-only facts, original writer truth is not overwritten, and user-facing review state is projected with bounded status and reason codes. See `docs/operator_review_workflow.md`.
+Design source: ISSUE-12-operator-review-appeal-evidence.md adds the operator review / appeal / evidence workflow baseline. Operator decisions are append-only facts, original writer truth is not overwritten, concurrent idempotent replays return the preserved case or fact instead of surfacing a duplicate-write error, and user-facing review state is projected with bounded status and reason codes. See `docs/operator_review_workflow.md`.
 Issue #17 adds the first sandbox Pi provider adapter boundary for happy-route hold submission and callback intake.
 ISSUE-10 adds Day 1 safer venue proof primitives.
 The public HTTP surface supports the normal venue-code path only.

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -10,6 +10,15 @@ Current local HTTP surface:
 - `POST /api/proof/submissions`
 - `POST /api/internal/orchestration/drain` in debug builds, or in release only when `MUSUBI_ENABLE_INTERNAL_ORCHESTRATION_DRAIN=true` and the request includes `Authorization: Bearer $MUSUBI_INTERNAL_API_TOKEN`
 - `POST /api/internal/projection/rebuild` under the same internal/debug gate and release-time internal bearer-token requirement
+- `POST /api/internal/operator/review-cases` under the same internal/debug gate; requires `x-musubi-operator-id` with a durable operator role grant
+- `GET /api/internal/operator/review-cases` under the same internal/debug gate; requires `x-musubi-operator-id` with a durable operator role grant
+- `GET /api/internal/operator/review-cases/{review_case_id}` under the same internal/debug gate; returns bounded operator case detail without raw evidence locators or internal notes
+- `POST /api/internal/operator/review-cases/{review_case_id}/evidence-bundles` under the same internal/debug gate
+- `POST /api/internal/operator/review-cases/{review_case_id}/evidence-access-grants` under the same internal/debug gate
+- `POST /api/internal/operator/review-cases/{review_case_id}/decisions` under the same internal/debug gate; appends operator decision facts instead of rewriting source truth
+- `POST /api/review-cases/{review_case_id}/appeals` for the authenticated review subject
+- `GET /api/review-cases/{review_case_id}/appeals` for the authenticated review subject
+- `GET /api/review-cases/{review_case_id}/status` for the authenticated review subject
 - `GET /api/projection/settlement-views/{settlement_case_id}` for authenticated participants only
 - `GET /api/projection/settlement-views/{settlement_case_id}/expanded` for authenticated participants only
 - `GET /api/projection/promise-views/{promise_intent_id}` for authenticated participants only
@@ -110,6 +119,7 @@ Issue #8 adds the runtime migration runner and backend startup schema check.
 See `docs/db_runtime.md` for the current DB bootstrap and local reset flow.
 Issue #21 wires the happy-route writer truth to PostgreSQL while preserving the existing HTTP surface and settlement-view response contract.
 Issue #22 adds derived Promise, expanded settlement, and bounded trust read models with rebuild and freshness metadata.
+Design source: ISSUE-12-operator-review-appeal-evidence.md adds the operator review / appeal / evidence workflow baseline. Operator decisions are append-only facts, original writer truth is not overwritten, and user-facing review state is projected with bounded status and reason codes. See `docs/operator_review_workflow.md`.
 Issue #17 adds the first sandbox Pi provider adapter boundary for happy-route hold submission and callback intake.
 ISSUE-10 adds Day 1 safer venue proof primitives.
 The public HTTP surface supports the normal venue-code path only.
@@ -126,6 +136,7 @@ These proof records are input facts only; they are not settlement truth or final
 - `docs/settlement_domain_types.md`: settlement-domain contract
 - `docs/orchestration_runtime.md`: outbox/inbox runtime rules
 - `docs/projection_read_models.md`: derived read-side contracts, rebuild path, and bounded trust boundary
+- `docs/operator_review_workflow.md`: ISSUE-12 operator review, appeal, evidence, and append-only decision boundary
 - `docs/guardrails.md`: executable architectural guardrails
 - `docs/proof_primitives.md`: Day 1 safer venue proof input boundary
 - `docs/happy_route_walkthrough.md`: current Issue #7 end-to-end path

--- a/apps/backend/docs/operator_review_workflow.md
+++ b/apps/backend/docs/operator_review_workflow.md
@@ -1,0 +1,56 @@
+# Operator Review Workflow
+
+Design source: ISSUE-12-operator-review-appeal-evidence.md
+
+The GitHub issue number is intentionally not hardcoded. The design source number is a product/design reference, not a repository issue identifier.
+
+ISSUE-12 adds the baseline operator review, appeal, and evidence workflow. It is a human review foundation for later safety and product surfaces, including ISSUE-13 room progression and ISSUE-14 Promise UI fallback states. Those later surfaces are consumers of this workflow and are not implemented here.
+
+## Boundary
+
+Operator decisions are append-only facts in `dao.operator_decision_facts`.
+
+An operator decision must not overwrite the original writer-owned truth row that opened the review. Review cases reference source facts through `source_fact_kind`, `source_fact_id`, and an optional source snapshot, while the source tables remain unchanged. User-facing state is derived into `projection.review_status_views`.
+
+This keeps the workflow auditable:
+- `dao.review_cases` tracks the case envelope and source linkage.
+- `dao.evidence_bundles` stores evidence summaries and raw evidence locators separately.
+- `dao.evidence_access_grants` records scoped, expiring evidence access approvals.
+- `dao.operator_decision_facts` records decisions as append-only facts.
+- `dao.appeal_cases` links appeals back to the original review case or decision fact.
+- `projection.review_status_views` exposes bounded, calm user-facing status and reason codes.
+
+## Evidence Access
+
+Evidence access is separate from case visibility. A case may exist without granting an operator raw evidence access.
+
+Access scopes are intentionally boring and bounded:
+- `summary_only`
+- `redacted_raw`
+- `full_raw`
+
+Granting access requires an approver role. The grantee must also have a role allowed for the requested scope. Expired or revoked grants are not a reusable permission source.
+
+Raw evidence locators stay out of handler responses and user-facing projections. Internal operator notes also stay out of the user-facing read model.
+
+## User-Facing Projection
+
+`projection.review_status_views` is derived and rebuildable. It exposes only stable user-facing states such as:
+- `pending_review`
+- `under_review`
+- `evidence_requested`
+- `sealed_or_restricted`
+- `appeal_available`
+- `appeal_submitted`
+- `decided`
+- `closed`
+
+User-facing reason codes are constrained by the database and service validation. They must not expose raw accusations, private claims, operator identities, internal evidence details, or safety-sensitive classifications.
+
+## Deferred Scope
+
+ISSUE-13 and ISSUE-14 integration points are intentionally left as consumers:
+- room progression may read review status later, but no room progression state machine is implemented here.
+- Promise UI may link to proof missing fallback and appeal surfaces later, but no Promise creation, completion, reflection, or dispute-center UI is implemented here.
+
+Proof persistence, full dispute-center UI, settlement UI, and broad operator console product work remain outside this baseline.

--- a/apps/backend/docs/operator_review_workflow.md
+++ b/apps/backend/docs/operator_review_workflow.md
@@ -20,6 +20,8 @@ This keeps the workflow auditable:
 - `dao.appeal_cases` links appeals back to the original review case or decision fact.
 - `projection.review_status_views` exposes bounded, calm user-facing status and reason codes.
 
+Idempotent create / decision / appeal requests must be durable under concurrent replay. Reusing the same idempotency key with a different payload is rejected instead of being silently treated as a replay.
+
 ## Evidence Access
 
 Evidence access is separate from case visibility. A case may exist without granting an operator raw evidence access.
@@ -46,6 +48,8 @@ Raw evidence locators stay out of handler responses and user-facing projections.
 - `closed`
 
 User-facing reason codes are constrained by the database and service validation. They must not expose raw accusations, private claims, operator identities, internal evidence details, or safety-sensitive classifications.
+
+The projection must derive appeal availability and evidence-needed posture from the latest preserved facts, not from a stale mutable case row alone.
 
 ## Deferred Scope
 

--- a/apps/backend/docs/schema_skeleton.md
+++ b/apps/backend/docs/schema_skeleton.md
@@ -29,6 +29,7 @@ Owns:
 - Promise coordination facts
 - settlement coordination facts
 - realm-scoped, pseudonymous references used to coordinate state progression
+- operator review cases, evidence bundles, appeal cases, and append-only operator decision facts that reference writer-owned source facts without overwriting them
 
 Must not own:
 - immutable financial postings
@@ -66,6 +67,7 @@ Owns:
 - rebuildable Promise read models
 - rebuildable settlement read models
 - rebuildable bounded trust read models
+- rebuildable user-facing review status models derived from operator review and appeal facts
 - freshness, lag, watermark, and rebuild metadata for projections
 
 Must not own:
@@ -73,6 +75,7 @@ Must not own:
 - raw PII
 - append-only ledger truth
 - raw callback payloads
+- raw evidence locators or internal operator notes
 - ranking, leaderboard, popularity, or recommendation truth
 
 ## Foundation alignment
@@ -106,3 +109,22 @@ Issue #3 did not implement:
 
 That incompleteness is deliberate.
 Issue #3 only establishes the physical ownership boundaries so later issues can build without collapsing core, dao, ledger, outbox, and projection into convenience tables.
+
+## ISSUE-12 operator review additions
+
+Design source: ISSUE-12-operator-review-appeal-evidence.md
+
+The GitHub issue number is intentionally not hardcoded.
+
+Migration `0014_operator_review_appeal_evidence.sql` adds the baseline operator review workflow:
+- `core.operator_role_assignments`
+- `dao.review_cases`
+- `dao.evidence_bundles`
+- `dao.evidence_access_grants`
+- `dao.operator_decision_facts`
+- `dao.appeal_cases`
+- `projection.review_status_views`
+
+The architectural boundary is strict: operator decisions are append-only facts and do not rewrite the original Promise, settlement, proof, or source writer truth. User-facing review status is projected from review, decision, evidence, and appeal facts using bounded status and reason codes.
+
+ISSUE-13 room progression and ISSUE-14 Promise UI are future consumers of this boundary. They are not implemented by this schema addition.

--- a/apps/backend/migrations/0014_operator_review_appeal_evidence.sql
+++ b/apps/backend/migrations/0014_operator_review_appeal_evidence.sql
@@ -8,7 +8,7 @@ CREATE TABLE IF NOT EXISTS core.operator_role_assignments (
         operator_role IN ('reviewer', 'approver', 'steward', 'auditor', 'support')
     ),
     grant_reason TEXT NOT NULL CHECK (char_length(trim(grant_reason)) > 0),
-    granted_by_operator_id UUID,
+    granted_by_operator_id UUID REFERENCES core.accounts(account_id),
     created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
     revoked_at TIMESTAMPTZ
 );
@@ -70,14 +70,14 @@ CREATE TABLE IF NOT EXISTS dao.review_cases (
     source_fact_kind TEXT NOT NULL CHECK (char_length(trim(source_fact_kind)) > 0),
     source_fact_id TEXT NOT NULL CHECK (char_length(trim(source_fact_id)) > 0),
     source_snapshot_json JSONB NOT NULL DEFAULT '{}'::jsonb,
-    assigned_operator_id UUID,
+    assigned_operator_id UUID REFERENCES core.accounts(account_id),
     opened_by_operator_id UUID REFERENCES core.accounts(account_id),
     request_idempotency_key TEXT,
     opened_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS review_cases_open_idempotency_unique
+CREATE UNIQUE INDEX IF NOT EXISTS review_cases_idempotency_unique
     ON dao.review_cases (opened_by_operator_id, request_idempotency_key)
     WHERE request_idempotency_key IS NOT NULL;
 

--- a/apps/backend/migrations/0014_operator_review_appeal_evidence.sql
+++ b/apps/backend/migrations/0014_operator_review_appeal_evidence.sql
@@ -1,0 +1,277 @@
+-- Design source: ISSUE-12-operator-review-appeal-evidence.md
+-- GitHub issue number is intentionally not hardcoded.
+
+CREATE TABLE IF NOT EXISTS core.operator_role_assignments (
+    operator_role_assignment_id UUID PRIMARY KEY,
+    operator_account_id UUID NOT NULL REFERENCES core.accounts(account_id),
+    operator_role TEXT NOT NULL CHECK (
+        operator_role IN ('reviewer', 'approver', 'steward', 'auditor', 'support')
+    ),
+    grant_reason TEXT NOT NULL CHECK (char_length(trim(grant_reason)) > 0),
+    granted_by_operator_id UUID,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    revoked_at TIMESTAMPTZ
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS operator_role_assignments_active_unique
+    ON core.operator_role_assignments (operator_account_id, operator_role)
+    WHERE revoked_at IS NULL;
+
+COMMENT ON TABLE core.operator_role_assignments IS
+'Controlled operator role grants for ISSUE-12 review/evidence workflows. Roles are separated even when one Day 1 human holds multiple responsibilities.';
+
+CREATE TABLE IF NOT EXISTS dao.review_cases (
+    review_case_id UUID PRIMARY KEY,
+    case_type TEXT NOT NULL CHECK (
+        case_type IN (
+            'proof_anomaly',
+            'promise_dispute',
+            'settlement_conflict',
+            'safety_escalation',
+            'realm_admission_review',
+            'operator_manual_hold',
+            'sealed_room_fallback',
+            'appeal'
+        )
+    ),
+    severity TEXT NOT NULL CHECK (severity IN ('sev0', 'sev1', 'sev2', 'sev3')),
+    review_status TEXT NOT NULL CHECK (
+        review_status IN (
+            'open',
+            'triaged',
+            'under_review',
+            'awaiting_evidence',
+            'decided',
+            'appealed',
+            'closed'
+        )
+    ),
+    subject_account_id UUID REFERENCES core.accounts(account_id),
+    related_promise_intent_id UUID REFERENCES dao.promise_intents(promise_intent_id),
+    related_settlement_case_id UUID REFERENCES dao.settlement_cases(settlement_case_id),
+    related_realm_id TEXT,
+    opened_reason_code TEXT NOT NULL CHECK (
+        opened_reason_code IN (
+            'verification_pending_review',
+            'proof_rejected_expired',
+            'promise_completion_under_review',
+            'manual_hold_safety_review',
+            'appeal_received',
+            'proof_missing',
+            'proof_inconclusive',
+            'safety_review',
+            'policy_review',
+            'duplicate_or_invalid',
+            'resolved_no_action',
+            'restricted_after_review',
+            'restored_after_review'
+        )
+    ),
+    source_fact_kind TEXT NOT NULL CHECK (char_length(trim(source_fact_kind)) > 0),
+    source_fact_id TEXT NOT NULL CHECK (char_length(trim(source_fact_id)) > 0),
+    source_snapshot_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+    assigned_operator_id UUID,
+    opened_by_operator_id UUID REFERENCES core.accounts(account_id),
+    request_idempotency_key TEXT,
+    opened_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS review_cases_open_idempotency_unique
+    ON dao.review_cases (opened_by_operator_id, request_idempotency_key)
+    WHERE request_idempotency_key IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS review_cases_queue_idx
+    ON dao.review_cases (review_status, severity, opened_at);
+
+COMMENT ON TABLE dao.review_cases IS
+'ISSUE-12 review cases. They reference source facts but do not overwrite Promise, settlement, proof, or other authoritative writer truth.';
+
+CREATE TABLE IF NOT EXISTS dao.evidence_bundles (
+    evidence_bundle_id UUID PRIMARY KEY,
+    review_case_id UUID NOT NULL REFERENCES dao.review_cases(review_case_id),
+    evidence_visibility TEXT NOT NULL CHECK (
+        evidence_visibility IN ('summary_only', 'redacted_raw', 'full_raw')
+    ),
+    summary_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+    raw_locator_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+    retention_class TEXT NOT NULL CHECK (retention_class IN ('R4', 'R6', 'R7')),
+    created_by_operator_id UUID REFERENCES core.accounts(account_id),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS evidence_bundles_review_case_idx
+    ON dao.evidence_bundles (review_case_id, created_at);
+
+COMMENT ON TABLE dao.evidence_bundles IS
+'Logical evidence containers for ISSUE-12. User-facing read models must not expose raw_locator_json.';
+
+CREATE TABLE IF NOT EXISTS dao.evidence_access_grants (
+    access_grant_id UUID PRIMARY KEY,
+    review_case_id UUID NOT NULL REFERENCES dao.review_cases(review_case_id),
+    evidence_bundle_id UUID REFERENCES dao.evidence_bundles(evidence_bundle_id),
+    grantee_operator_id UUID NOT NULL REFERENCES core.accounts(account_id),
+    access_scope TEXT NOT NULL CHECK (
+        access_scope IN ('summary_only', 'redacted_raw', 'full_raw')
+    ),
+    grant_reason TEXT NOT NULL CHECK (char_length(trim(grant_reason)) > 0),
+    approved_by_operator_id UUID NOT NULL REFERENCES core.accounts(account_id),
+    expires_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    revoked_at TIMESTAMPTZ,
+    CHECK (expires_at > created_at)
+);
+
+CREATE INDEX IF NOT EXISTS evidence_access_grants_grantee_idx
+    ON dao.evidence_access_grants (grantee_operator_id, review_case_id, expires_at)
+    WHERE revoked_at IS NULL;
+
+COMMENT ON TABLE dao.evidence_access_grants IS
+'Scoped and auditable evidence access grants. Grants are separate from case existence and expire by design.';
+
+CREATE TABLE IF NOT EXISTS dao.operator_decision_facts (
+    operator_decision_fact_id UUID PRIMARY KEY,
+    review_case_id UUID NOT NULL REFERENCES dao.review_cases(review_case_id),
+    appeal_case_id UUID,
+    decision_kind TEXT NOT NULL CHECK (
+        decision_kind IN (
+            'no_action',
+            'uphold',
+            'restrict',
+            'restore',
+            'request_more_evidence',
+            'escalate'
+        )
+    ),
+    user_facing_reason_code TEXT NOT NULL CHECK (
+        user_facing_reason_code IN (
+            'verification_pending_review',
+            'proof_rejected_expired',
+            'promise_completion_under_review',
+            'manual_hold_safety_review',
+            'appeal_received',
+            'proof_missing',
+            'proof_inconclusive',
+            'safety_review',
+            'policy_review',
+            'duplicate_or_invalid',
+            'resolved_no_action',
+            'restricted_after_review',
+            'restored_after_review'
+        )
+    ),
+    operator_note_internal TEXT,
+    decision_payload_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+    decided_by_operator_id UUID NOT NULL REFERENCES core.accounts(account_id),
+    decision_idempotency_key TEXT,
+    recorded_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS operator_decision_facts_idempotency_unique
+    ON dao.operator_decision_facts (review_case_id, decided_by_operator_id, decision_idempotency_key)
+    WHERE decision_idempotency_key IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS operator_decision_facts_case_idx
+    ON dao.operator_decision_facts (review_case_id, recorded_at);
+
+COMMENT ON TABLE dao.operator_decision_facts IS
+'Append-only ISSUE-12 operator decision facts. Operator actions must add facts rather than rewrite original writer truth.';
+
+CREATE TABLE IF NOT EXISTS dao.appeal_cases (
+    appeal_case_id UUID PRIMARY KEY,
+    source_review_case_id UUID NOT NULL REFERENCES dao.review_cases(review_case_id),
+    source_decision_fact_id UUID REFERENCES dao.operator_decision_facts(operator_decision_fact_id),
+    appeal_status TEXT NOT NULL CHECK (
+        appeal_status IN ('submitted', 'accepted', 'under_review', 'decided', 'closed')
+    ),
+    submitted_by_account_id UUID NOT NULL REFERENCES core.accounts(account_id),
+    submitted_reason_code TEXT NOT NULL CHECK (
+        submitted_reason_code IN (
+            'verification_pending_review',
+            'proof_rejected_expired',
+            'promise_completion_under_review',
+            'manual_hold_safety_review',
+            'appeal_received',
+            'proof_missing',
+            'proof_inconclusive',
+            'safety_review',
+            'policy_review',
+            'duplicate_or_invalid',
+            'resolved_no_action',
+            'restricted_after_review',
+            'restored_after_review'
+        )
+    ),
+    appellant_statement TEXT,
+    new_evidence_summary_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+    appeal_idempotency_key TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+ALTER TABLE dao.operator_decision_facts
+    ADD CONSTRAINT operator_decision_facts_appeal_fk
+    FOREIGN KEY (appeal_case_id) REFERENCES dao.appeal_cases(appeal_case_id)
+    DEFERRABLE INITIALLY DEFERRED;
+
+CREATE UNIQUE INDEX IF NOT EXISTS appeal_cases_idempotency_unique
+    ON dao.appeal_cases (source_review_case_id, submitted_by_account_id, appeal_idempotency_key)
+    WHERE appeal_idempotency_key IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS appeal_cases_source_case_idx
+    ON dao.appeal_cases (source_review_case_id, created_at);
+
+COMMENT ON TABLE dao.appeal_cases IS
+'ISSUE-12 appeal cases linked to the original review case or decision fact. Appeals do not destroy preserved evidence.';
+
+CREATE TABLE IF NOT EXISTS projection.review_status_views (
+    review_case_id UUID PRIMARY KEY,
+    subject_account_id UUID,
+    related_promise_intent_id UUID,
+    related_settlement_case_id UUID,
+    related_realm_id TEXT,
+    user_facing_status TEXT NOT NULL CHECK (
+        user_facing_status IN (
+            'pending_review',
+            'under_review',
+            'decided',
+            'appeal_available',
+            'appeal_submitted',
+            'evidence_requested',
+            'sealed_or_restricted',
+            'closed'
+        )
+    ),
+    user_facing_reason_code TEXT NOT NULL CHECK (
+        user_facing_reason_code IN (
+            'verification_pending_review',
+            'proof_rejected_expired',
+            'promise_completion_under_review',
+            'manual_hold_safety_review',
+            'appeal_received',
+            'proof_missing',
+            'proof_inconclusive',
+            'safety_review',
+            'policy_review',
+            'duplicate_or_invalid',
+            'resolved_no_action',
+            'restricted_after_review',
+            'restored_after_review'
+        )
+    ),
+    appeal_status TEXT NOT NULL CHECK (
+        appeal_status IN ('none', 'appeal_available', 'submitted', 'under_review', 'decided', 'closed')
+    ),
+    latest_decision_fact_id UUID,
+    evidence_requested BOOLEAN NOT NULL DEFAULT FALSE,
+    appeal_available BOOLEAN NOT NULL DEFAULT FALSE,
+    source_watermark_at TIMESTAMPTZ NOT NULL,
+    source_fact_count BIGINT NOT NULL CHECK (source_fact_count >= 0),
+    last_projected_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS review_status_views_subject_idx
+    ON projection.review_status_views (subject_account_id, last_projected_at);
+
+COMMENT ON TABLE projection.review_status_views IS
+'User-facing ISSUE-12 review status projection. It exposes bounded status and reason codes only; internal notes and raw evidence stay out of this read model.';

--- a/apps/backend/src/handlers/mod.rs
+++ b/apps/backend/src/handlers/mod.rs
@@ -7,6 +7,7 @@ use serde::Serialize;
 use crate::services::happy_route::{HappyRouteError, ProviderErrorClass};
 
 pub mod auth;
+pub mod operator_review;
 pub mod orchestration;
 pub mod payments;
 pub mod projection;
@@ -113,13 +114,17 @@ fn require_internal_bearer_token_with_config(
         .map(str::trim)
         .filter(|token| !token.is_empty())
     else {
-        return Err(unauthorized("internal authorization bearer token is required"));
+        return Err(unauthorized(
+            "internal authorization bearer token is required",
+        ));
     };
 
     let token = require_bearer_token(headers)
         .map_err(|_| unauthorized("internal authorization bearer token is required"))?;
     if token != configured_token {
-        return Err(unauthorized("internal authorization bearer token is required"));
+        return Err(unauthorized(
+            "internal authorization bearer token is required",
+        ));
     }
 
     Ok(())
@@ -166,7 +171,7 @@ pub fn map_happy_route_error(error: HappyRouteError) -> ApiError {
 mod tests {
     use axum::http::{HeaderValue, header::AUTHORIZATION};
 
-    use super::{require_internal_bearer_token_with_config, HeaderMap};
+    use super::{HeaderMap, require_internal_bearer_token_with_config};
 
     #[test]
     fn debug_build_internal_requests_do_not_require_token() {
@@ -177,7 +182,10 @@ mod tests {
     #[test]
     fn release_build_internal_requests_require_matching_bearer_token() {
         let mut headers = HeaderMap::new();
-        headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer musubi-internal"));
+        headers.insert(
+            AUTHORIZATION,
+            HeaderValue::from_static("Bearer musubi-internal"),
+        );
 
         assert!(
             require_internal_bearer_token_with_config(&headers, false, Some("musubi-internal"))
@@ -188,7 +196,10 @@ mod tests {
     #[test]
     fn release_build_internal_requests_reject_wrong_bearer_token() {
         let mut headers = HeaderMap::new();
-        headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer wrong-token"));
+        headers.insert(
+            AUTHORIZATION,
+            HeaderValue::from_static("Bearer wrong-token"),
+        );
 
         assert!(
             require_internal_bearer_token_with_config(&headers, false, Some("musubi-internal"))

--- a/apps/backend/src/handlers/operator_review.rs
+++ b/apps/backend/src/handlers/operator_review.rs
@@ -1,0 +1,547 @@
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::HeaderMap,
+};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{
+    SharedState,
+    handlers::{
+        ApiError, ApiResult, bad_request, internal_server_error, map_happy_route_error, not_found,
+        require_bearer_token, require_internal_bearer_token, service_unavailable, unauthorized,
+    },
+    services::{
+        happy_route::authorize_account,
+        operator_review::{
+            AppealCaseSnapshot, AttachEvidenceBundleInput, CreateAppealCaseInput,
+            CreateReviewCaseInput, EvidenceAccessGrantSnapshot, EvidenceBundleSnapshot,
+            GrantEvidenceAccessInput, OperatorDecisionFactSnapshot, OperatorReviewError,
+            ReadReviewCaseSnapshot, RecordOperatorDecisionInput, ReviewCaseSnapshot,
+            ReviewStatusReadModelSnapshot,
+        },
+    },
+};
+
+#[derive(Debug, Deserialize)]
+pub struct CreateReviewCaseRequest {
+    pub case_type: String,
+    pub severity: String,
+    pub subject_account_id: Option<String>,
+    pub related_promise_intent_id: Option<String>,
+    pub related_settlement_case_id: Option<String>,
+    pub related_realm_id: Option<String>,
+    pub opened_reason_code: String,
+    pub source_fact_kind: String,
+    pub source_fact_id: String,
+    pub source_snapshot_json: Option<Value>,
+    pub assigned_operator_id: Option<String>,
+    pub request_idempotency_key: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AttachEvidenceBundleRequest {
+    pub evidence_visibility: String,
+    pub summary_json: Option<Value>,
+    pub raw_locator_json: Option<Value>,
+    pub retention_class: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GrantEvidenceAccessRequest {
+    pub evidence_bundle_id: Option<String>,
+    pub grantee_operator_id: String,
+    pub access_scope: String,
+    pub grant_reason: String,
+    pub expires_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RecordOperatorDecisionRequest {
+    pub decision_kind: String,
+    pub user_facing_reason_code: String,
+    pub operator_note_internal: Option<String>,
+    pub decision_payload_json: Option<Value>,
+    pub decision_idempotency_key: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateAppealCaseRequest {
+    pub source_decision_fact_id: Option<String>,
+    pub submitted_reason_code: String,
+    pub appellant_statement: Option<String>,
+    pub new_evidence_summary_json: Option<Value>,
+    pub appeal_idempotency_key: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ReviewCaseResponse {
+    pub review_case_id: String,
+    pub case_type: String,
+    pub severity: String,
+    pub review_status: String,
+    pub subject_account_id: Option<String>,
+    pub related_promise_intent_id: Option<String>,
+    pub related_settlement_case_id: Option<String>,
+    pub related_realm_id: Option<String>,
+    pub opened_reason_code: String,
+    pub source_fact_kind: String,
+    pub source_fact_id: String,
+    pub assigned_operator_id: Option<String>,
+    pub opened_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct EvidenceBundleResponse {
+    pub evidence_bundle_id: String,
+    pub review_case_id: String,
+    pub evidence_visibility: String,
+    pub summary_json: Value,
+    pub retention_class: String,
+    pub created_by_operator_id: Option<String>,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct EvidenceAccessGrantResponse {
+    pub access_grant_id: String,
+    pub review_case_id: String,
+    pub evidence_bundle_id: Option<String>,
+    pub grantee_operator_id: String,
+    pub access_scope: String,
+    pub grant_reason: String,
+    pub approved_by_operator_id: String,
+    pub expires_at: DateTime<Utc>,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct OperatorDecisionFactResponse {
+    pub operator_decision_fact_id: String,
+    pub review_case_id: String,
+    pub appeal_case_id: Option<String>,
+    pub decision_kind: String,
+    pub user_facing_reason_code: String,
+    pub decided_by_operator_id: String,
+    pub recorded_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AppealCaseResponse {
+    pub appeal_case_id: String,
+    pub source_review_case_id: String,
+    pub source_decision_fact_id: Option<String>,
+    pub appeal_status: String,
+    pub submitted_by_account_id: String,
+    pub submitted_reason_code: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ReadReviewCaseResponse {
+    pub review_case: ReviewCaseResponse,
+    pub evidence_bundles: Vec<EvidenceBundleResponse>,
+    pub evidence_access_grants: Vec<EvidenceAccessGrantResponse>,
+    pub operator_decision_facts: Vec<OperatorDecisionFactResponse>,
+    pub appeal_cases: Vec<AppealCaseResponse>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ReviewStatusReadModelResponse {
+    pub review_case_id: String,
+    pub subject_account_id: Option<String>,
+    pub related_promise_intent_id: Option<String>,
+    pub related_settlement_case_id: Option<String>,
+    pub related_realm_id: Option<String>,
+    pub user_facing_status: String,
+    pub user_facing_reason_code: String,
+    pub appeal_status: String,
+    pub evidence_requested: bool,
+    pub appeal_available: bool,
+    pub latest_decision_fact_id: Option<String>,
+    pub source_watermark_at: DateTime<Utc>,
+    pub source_fact_count: i64,
+    pub last_projected_at: DateTime<Utc>,
+}
+
+pub async fn create_review_case(
+    State(state): State<SharedState>,
+    headers: HeaderMap,
+    Json(payload): Json<CreateReviewCaseRequest>,
+) -> ApiResult<ReviewCaseResponse> {
+    require_internal_bearer_token(&headers)?;
+    let operator_id = require_operator_id(&headers)?;
+    let snapshot = state
+        .operator_review
+        .create_review_case(
+            &operator_id,
+            CreateReviewCaseInput {
+                case_type: payload.case_type,
+                severity: payload.severity,
+                subject_account_id: payload.subject_account_id,
+                related_promise_intent_id: payload.related_promise_intent_id,
+                related_settlement_case_id: payload.related_settlement_case_id,
+                related_realm_id: payload.related_realm_id,
+                opened_reason_code: payload.opened_reason_code,
+                source_fact_kind: payload.source_fact_kind,
+                source_fact_id: payload.source_fact_id,
+                source_snapshot_json: payload.source_snapshot_json.unwrap_or_else(|| {
+                    serde_json::json!({
+                        "source": "operator_review",
+                        "note": "no source snapshot supplied"
+                    })
+                }),
+                assigned_operator_id: payload.assigned_operator_id,
+                request_idempotency_key: payload.request_idempotency_key,
+            },
+        )
+        .await
+        .map_err(map_operator_review_error)?;
+
+    Ok(Json(review_case_response(snapshot)))
+}
+
+pub async fn list_review_cases(
+    State(state): State<SharedState>,
+    headers: HeaderMap,
+) -> ApiResult<Vec<ReviewCaseResponse>> {
+    require_internal_bearer_token(&headers)?;
+    let operator_id = require_operator_id(&headers)?;
+    let snapshots = state
+        .operator_review
+        .list_review_cases(&operator_id)
+        .await
+        .map_err(map_operator_review_error)?;
+
+    Ok(Json(
+        snapshots.into_iter().map(review_case_response).collect(),
+    ))
+}
+
+pub async fn read_review_case(
+    State(state): State<SharedState>,
+    headers: HeaderMap,
+    Path(review_case_id): Path<String>,
+) -> ApiResult<ReadReviewCaseResponse> {
+    require_internal_bearer_token(&headers)?;
+    let operator_id = require_operator_id(&headers)?;
+    let snapshot = state
+        .operator_review
+        .read_review_case(&operator_id, review_case_id.trim())
+        .await
+        .map_err(map_operator_review_error)?;
+
+    Ok(Json(read_review_case_response(snapshot)))
+}
+
+pub async fn attach_evidence_bundle(
+    State(state): State<SharedState>,
+    headers: HeaderMap,
+    Path(review_case_id): Path<String>,
+    Json(payload): Json<AttachEvidenceBundleRequest>,
+) -> ApiResult<EvidenceBundleResponse> {
+    require_internal_bearer_token(&headers)?;
+    let operator_id = require_operator_id(&headers)?;
+    let snapshot = state
+        .operator_review
+        .attach_evidence_bundle(
+            &operator_id,
+            review_case_id.trim(),
+            AttachEvidenceBundleInput {
+                evidence_visibility: payload.evidence_visibility,
+                summary_json: payload
+                    .summary_json
+                    .unwrap_or_else(|| serde_json::json!({})),
+                raw_locator_json: payload
+                    .raw_locator_json
+                    .unwrap_or_else(|| serde_json::json!({})),
+                retention_class: payload.retention_class,
+            },
+        )
+        .await
+        .map_err(map_operator_review_error)?;
+
+    Ok(Json(evidence_bundle_response(snapshot)))
+}
+
+pub async fn grant_evidence_access(
+    State(state): State<SharedState>,
+    headers: HeaderMap,
+    Path(review_case_id): Path<String>,
+    Json(payload): Json<GrantEvidenceAccessRequest>,
+) -> ApiResult<EvidenceAccessGrantResponse> {
+    require_internal_bearer_token(&headers)?;
+    let operator_id = require_operator_id(&headers)?;
+    let snapshot = state
+        .operator_review
+        .grant_evidence_access(
+            &operator_id,
+            review_case_id.trim(),
+            GrantEvidenceAccessInput {
+                evidence_bundle_id: payload.evidence_bundle_id,
+                grantee_operator_id: payload.grantee_operator_id,
+                access_scope: payload.access_scope,
+                grant_reason: payload.grant_reason,
+                expires_at: payload.expires_at,
+            },
+        )
+        .await
+        .map_err(map_operator_review_error)?;
+
+    Ok(Json(evidence_access_grant_response(snapshot)))
+}
+
+pub async fn record_operator_decision(
+    State(state): State<SharedState>,
+    headers: HeaderMap,
+    Path(review_case_id): Path<String>,
+    Json(payload): Json<RecordOperatorDecisionRequest>,
+) -> ApiResult<OperatorDecisionFactResponse> {
+    require_internal_bearer_token(&headers)?;
+    let operator_id = require_operator_id(&headers)?;
+    let snapshot = state
+        .operator_review
+        .record_operator_decision(
+            &operator_id,
+            review_case_id.trim(),
+            RecordOperatorDecisionInput {
+                decision_kind: payload.decision_kind,
+                user_facing_reason_code: payload.user_facing_reason_code,
+                operator_note_internal: payload.operator_note_internal,
+                decision_payload_json: payload
+                    .decision_payload_json
+                    .unwrap_or_else(|| serde_json::json!({})),
+                decision_idempotency_key: payload.decision_idempotency_key,
+            },
+        )
+        .await
+        .map_err(map_operator_review_error)?;
+
+    Ok(Json(operator_decision_fact_response(snapshot)))
+}
+
+pub async fn create_appeal_case(
+    State(state): State<SharedState>,
+    headers: HeaderMap,
+    Path(review_case_id): Path<String>,
+    Json(payload): Json<CreateAppealCaseRequest>,
+) -> ApiResult<AppealCaseResponse> {
+    let bearer_token = require_bearer_token(&headers)?;
+    let authenticated_account = authorize_account(&state, &bearer_token)
+        .await
+        .map_err(map_happy_route_error)?;
+    let snapshot = state
+        .operator_review
+        .create_appeal_case(
+            &authenticated_account.account_id,
+            review_case_id.trim(),
+            CreateAppealCaseInput {
+                source_decision_fact_id: payload.source_decision_fact_id,
+                submitted_reason_code: payload.submitted_reason_code,
+                appellant_statement: payload.appellant_statement,
+                new_evidence_summary_json: payload
+                    .new_evidence_summary_json
+                    .unwrap_or_else(|| serde_json::json!({})),
+                appeal_idempotency_key: payload.appeal_idempotency_key,
+            },
+        )
+        .await
+        .map_err(map_operator_review_error)?;
+
+    Ok(Json(appeal_case_response(snapshot)))
+}
+
+pub async fn list_appeal_cases(
+    State(state): State<SharedState>,
+    headers: HeaderMap,
+    Path(review_case_id): Path<String>,
+) -> ApiResult<Vec<AppealCaseResponse>> {
+    let bearer_token = require_bearer_token(&headers)?;
+    let authenticated_account = authorize_account(&state, &bearer_token)
+        .await
+        .map_err(map_happy_route_error)?;
+    let snapshots = state
+        .operator_review
+        .list_appeal_cases_for_subject(&authenticated_account.account_id, review_case_id.trim())
+        .await
+        .map_err(map_operator_review_error)?;
+
+    Ok(Json(
+        snapshots.into_iter().map(appeal_case_response).collect(),
+    ))
+}
+
+pub async fn get_review_status(
+    State(state): State<SharedState>,
+    headers: HeaderMap,
+    Path(review_case_id): Path<String>,
+) -> ApiResult<ReviewStatusReadModelResponse> {
+    let bearer_token = require_bearer_token(&headers)?;
+    let authenticated_account = authorize_account(&state, &bearer_token)
+        .await
+        .map_err(map_happy_route_error)?;
+    let snapshot = state
+        .operator_review
+        .get_review_status_for_subject(&authenticated_account.account_id, review_case_id.trim())
+        .await
+        .map_err(map_operator_review_error)?;
+
+    Ok(Json(review_status_read_model_response(snapshot)))
+}
+
+fn require_operator_id(headers: &HeaderMap) -> Result<String, ApiError> {
+    headers
+        .get("x-musubi-operator-id")
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+        .ok_or_else(|| bad_request("x-musubi-operator-id header is required"))
+}
+
+fn map_operator_review_error(error: OperatorReviewError) -> ApiError {
+    match error {
+        OperatorReviewError::BadRequest(message) => bad_request(message),
+        OperatorReviewError::Unauthorized(message) => unauthorized(message),
+        OperatorReviewError::NotFound(message) => not_found(message),
+        OperatorReviewError::Database {
+            message, retryable, ..
+        } => {
+            eprintln!("database operator review error: {message}");
+            if retryable {
+                service_unavailable("temporarily unavailable")
+            } else {
+                internal_server_error("internal server error")
+            }
+        }
+        OperatorReviewError::Internal(message) => {
+            eprintln!("internal operator review error: {message}");
+            internal_server_error("internal server error")
+        }
+    }
+}
+
+fn read_review_case_response(snapshot: ReadReviewCaseSnapshot) -> ReadReviewCaseResponse {
+    ReadReviewCaseResponse {
+        review_case: review_case_response(snapshot.review_case),
+        evidence_bundles: snapshot
+            .evidence_bundles
+            .into_iter()
+            .map(evidence_bundle_response)
+            .collect(),
+        evidence_access_grants: snapshot
+            .evidence_access_grants
+            .into_iter()
+            .map(evidence_access_grant_response)
+            .collect(),
+        operator_decision_facts: snapshot
+            .operator_decision_facts
+            .into_iter()
+            .map(operator_decision_fact_response)
+            .collect(),
+        appeal_cases: snapshot
+            .appeal_cases
+            .into_iter()
+            .map(appeal_case_response)
+            .collect(),
+    }
+}
+
+fn review_case_response(snapshot: ReviewCaseSnapshot) -> ReviewCaseResponse {
+    ReviewCaseResponse {
+        review_case_id: snapshot.review_case_id,
+        case_type: snapshot.case_type,
+        severity: snapshot.severity,
+        review_status: snapshot.review_status,
+        subject_account_id: snapshot.subject_account_id,
+        related_promise_intent_id: snapshot.related_promise_intent_id,
+        related_settlement_case_id: snapshot.related_settlement_case_id,
+        related_realm_id: snapshot.related_realm_id,
+        opened_reason_code: snapshot.opened_reason_code,
+        source_fact_kind: snapshot.source_fact_kind,
+        source_fact_id: snapshot.source_fact_id,
+        assigned_operator_id: snapshot.assigned_operator_id,
+        opened_at: snapshot.opened_at,
+        updated_at: snapshot.updated_at,
+    }
+}
+
+fn evidence_bundle_response(snapshot: EvidenceBundleSnapshot) -> EvidenceBundleResponse {
+    EvidenceBundleResponse {
+        evidence_bundle_id: snapshot.evidence_bundle_id,
+        review_case_id: snapshot.review_case_id,
+        evidence_visibility: snapshot.evidence_visibility,
+        summary_json: snapshot.summary_json,
+        retention_class: snapshot.retention_class,
+        created_by_operator_id: snapshot.created_by_operator_id,
+        created_at: snapshot.created_at,
+    }
+}
+
+fn evidence_access_grant_response(
+    snapshot: EvidenceAccessGrantSnapshot,
+) -> EvidenceAccessGrantResponse {
+    EvidenceAccessGrantResponse {
+        access_grant_id: snapshot.access_grant_id,
+        review_case_id: snapshot.review_case_id,
+        evidence_bundle_id: snapshot.evidence_bundle_id,
+        grantee_operator_id: snapshot.grantee_operator_id,
+        access_scope: snapshot.access_scope,
+        grant_reason: snapshot.grant_reason,
+        approved_by_operator_id: snapshot.approved_by_operator_id,
+        expires_at: snapshot.expires_at,
+        created_at: snapshot.created_at,
+    }
+}
+
+fn operator_decision_fact_response(
+    snapshot: OperatorDecisionFactSnapshot,
+) -> OperatorDecisionFactResponse {
+    OperatorDecisionFactResponse {
+        operator_decision_fact_id: snapshot.operator_decision_fact_id,
+        review_case_id: snapshot.review_case_id,
+        appeal_case_id: snapshot.appeal_case_id,
+        decision_kind: snapshot.decision_kind,
+        user_facing_reason_code: snapshot.user_facing_reason_code,
+        decided_by_operator_id: snapshot.decided_by_operator_id,
+        recorded_at: snapshot.recorded_at,
+    }
+}
+
+fn appeal_case_response(snapshot: AppealCaseSnapshot) -> AppealCaseResponse {
+    AppealCaseResponse {
+        appeal_case_id: snapshot.appeal_case_id,
+        source_review_case_id: snapshot.source_review_case_id,
+        source_decision_fact_id: snapshot.source_decision_fact_id,
+        appeal_status: snapshot.appeal_status,
+        submitted_by_account_id: snapshot.submitted_by_account_id,
+        submitted_reason_code: snapshot.submitted_reason_code,
+        created_at: snapshot.created_at,
+        updated_at: snapshot.updated_at,
+    }
+}
+
+fn review_status_read_model_response(
+    snapshot: ReviewStatusReadModelSnapshot,
+) -> ReviewStatusReadModelResponse {
+    ReviewStatusReadModelResponse {
+        review_case_id: snapshot.review_case_id,
+        subject_account_id: snapshot.subject_account_id,
+        related_promise_intent_id: snapshot.related_promise_intent_id,
+        related_settlement_case_id: snapshot.related_settlement_case_id,
+        related_realm_id: snapshot.related_realm_id,
+        user_facing_status: snapshot.user_facing_status,
+        user_facing_reason_code: snapshot.user_facing_reason_code,
+        appeal_status: snapshot.appeal_status,
+        evidence_requested: snapshot.evidence_requested,
+        appeal_available: snapshot.appeal_available,
+        latest_decision_fact_id: snapshot.latest_decision_fact_id,
+        source_watermark_at: snapshot.source_watermark_at,
+        source_fact_count: snapshot.source_fact_count,
+        last_projected_at: snapshot.last_projected_at,
+    }
+}

--- a/apps/backend/src/lib.rs
+++ b/apps/backend/src/lib.rs
@@ -23,6 +23,7 @@ pub type SharedState = Arc<AppState>;
 
 pub struct AppState {
     pub happy_route: services::happy_route::HappyRouteStore,
+    pub operator_review: services::operator_review::OperatorReviewStore,
     pub proof: RwLock<services::proof::ProofState>,
 }
 
@@ -41,6 +42,7 @@ pub async fn new_state() -> musubi_db_runtime::Result<SharedState> {
 pub async fn new_state_from_config(config: &DbConfig) -> musubi_db_runtime::Result<SharedState> {
     Ok(Arc::new(AppState {
         happy_route: services::happy_route::HappyRouteStore::connect(config).await?,
+        operator_review: services::operator_review::OperatorReviewStore::connect(config).await?,
         proof: RwLock::new(services::proof::ProofState::default()),
     }))
 }
@@ -84,6 +86,11 @@ pub async fn new_test_state() -> Result<TestState, String> {
         .map_err(|error| error.to_string())?;
     state
         .happy_route
+        .reset_for_test()
+        .await
+        .map_err(|error| error.message().to_owned())?;
+    state
+        .operator_review
         .reset_for_test()
         .await
         .map_err(|error| error.message().to_owned())?;
@@ -133,6 +140,15 @@ pub fn build_app(state: SharedState) -> Router {
         .route(
             "/api/projection/realm-trust-snapshots/{realm_id}/{account_id}",
             get(handlers::projection::get_realm_trust_snapshot),
+        )
+        .route(
+            "/api/review-cases/{review_case_id}/appeals",
+            post(handlers::operator_review::create_appeal_case)
+                .get(handlers::operator_review::list_appeal_cases),
+        )
+        .route(
+            "/api/review-cases/{review_case_id}/status",
+            get(handlers::operator_review::get_review_status),
         );
     let app = if unauthenticated_pi_callback_enabled() {
         app.route(
@@ -150,6 +166,27 @@ pub fn build_app(state: SharedState) -> Router {
         .route(
             "/api/internal/projection/rebuild",
             post(handlers::projection::rebuild_projection_read_models),
+        )
+        .route(
+            "/api/internal/operator/review-cases",
+            post(handlers::operator_review::create_review_case)
+                .get(handlers::operator_review::list_review_cases),
+        )
+        .route(
+            "/api/internal/operator/review-cases/{review_case_id}",
+            get(handlers::operator_review::read_review_case),
+        )
+        .route(
+            "/api/internal/operator/review-cases/{review_case_id}/evidence-bundles",
+            post(handlers::operator_review::attach_evidence_bundle),
+        )
+        .route(
+            "/api/internal/operator/review-cases/{review_case_id}/evidence-access-grants",
+            post(handlers::operator_review::grant_evidence_access),
+        )
+        .route(
+            "/api/internal/operator/review-cases/{review_case_id}/decisions",
+            post(handlers::operator_review::record_operator_decision),
         )
     } else {
         app

--- a/apps/backend/src/services/mod.rs
+++ b/apps/backend/src/services/mod.rs
@@ -1,3 +1,4 @@
 #[path = "happy_route/mod.rs"]
 pub mod happy_route;
+pub mod operator_review;
 pub mod proof;

--- a/apps/backend/src/services/operator_review/mod.rs
+++ b/apps/backend/src/services/operator_review/mod.rs
@@ -1,0 +1,10 @@
+mod repository;
+mod types;
+
+pub use repository::OperatorReviewStore;
+pub use types::{
+    AppealCaseSnapshot, AttachEvidenceBundleInput, CreateAppealCaseInput, CreateReviewCaseInput,
+    EvidenceAccessGrantSnapshot, EvidenceBundleSnapshot, GrantEvidenceAccessInput,
+    OperatorDecisionFactSnapshot, OperatorReviewError, OperatorRole, ReadReviewCaseSnapshot,
+    RecordOperatorDecisionInput, ReviewCaseSnapshot, ReviewStatusReadModelSnapshot,
+};

--- a/apps/backend/src/services/operator_review/repository.rs
+++ b/apps/backend/src/services/operator_review/repository.rs
@@ -367,12 +367,14 @@ impl OperatorReviewStore {
         review_case_id: &str,
         input: GrantEvidenceAccessInput,
     ) -> Result<EvidenceAccessGrantSnapshot, OperatorReviewError> {
+        const ACCESS_SCOPES: &[&str] = &["private", "case", "public"];
+
         let operator_id = parse_uuid(operator_id, "operator id")?;
         let review_case_id = parse_uuid(review_case_id, "review case id")?;
         let evidence_bundle_id =
             parse_optional_uuid(&input.evidence_bundle_id, "evidence bundle id")?;
         let grantee_operator_id = parse_uuid(&input.grantee_operator_id, "grantee operator id")?;
-        validate_allowed("access_scope", &input.access_scope, EVIDENCE_VISIBILITIES)?;
+        validate_allowed("access_scope", &input.access_scope, ACCESS_SCOPES)?;
         require_non_empty("grant_reason", &input.grant_reason)?;
 
         let mut client = self.client.lock().await;

--- a/apps/backend/src/services/operator_review/repository.rs
+++ b/apps/backend/src/services/operator_review/repository.rs
@@ -1,0 +1,1250 @@
+use std::sync::Arc;
+
+use chrono::Utc;
+use musubi_db_runtime::{DbConfig, connect_writer};
+use tokio::sync::Mutex;
+use tokio_postgres::{Client, GenericClient, Row, Transaction, error::SqlState};
+use uuid::Uuid;
+
+use super::types::{
+    AppealCaseSnapshot, AttachEvidenceBundleInput, CreateAppealCaseInput, CreateReviewCaseInput,
+    EvidenceAccessGrantSnapshot, EvidenceBundleSnapshot, GrantEvidenceAccessInput,
+    OperatorDecisionFactSnapshot, OperatorReviewError, OperatorRole, ReadReviewCaseSnapshot,
+    RecordOperatorDecisionInput, ReviewCaseSnapshot, ReviewStatusReadModelSnapshot,
+};
+
+const READ_ROLES: &[OperatorRole] = &[
+    OperatorRole::Reviewer,
+    OperatorRole::Approver,
+    OperatorRole::Steward,
+    OperatorRole::Auditor,
+    OperatorRole::Support,
+];
+const WRITE_REVIEW_ROLES: &[OperatorRole] = &[
+    OperatorRole::Reviewer,
+    OperatorRole::Approver,
+    OperatorRole::Steward,
+];
+
+const CASE_TYPES: &[&str] = &[
+    "proof_anomaly",
+    "promise_dispute",
+    "settlement_conflict",
+    "safety_escalation",
+    "realm_admission_review",
+    "operator_manual_hold",
+    "sealed_room_fallback",
+    "appeal",
+];
+const SEVERITIES: &[&str] = &["sev0", "sev1", "sev2", "sev3"];
+const EVIDENCE_VISIBILITIES: &[&str] = &["summary_only", "redacted_raw", "full_raw"];
+const RETENTION_CLASSES: &[&str] = &["R4", "R6", "R7"];
+const DECISION_KINDS: &[&str] = &[
+    "no_action",
+    "uphold",
+    "restrict",
+    "restore",
+    "request_more_evidence",
+    "escalate",
+];
+const USER_FACING_REASON_CODES: &[&str] = &[
+    "verification_pending_review",
+    "proof_rejected_expired",
+    "promise_completion_under_review",
+    "manual_hold_safety_review",
+    "appeal_received",
+    "proof_missing",
+    "proof_inconclusive",
+    "safety_review",
+    "policy_review",
+    "duplicate_or_invalid",
+    "resolved_no_action",
+    "restricted_after_review",
+    "restored_after_review",
+];
+
+#[derive(Clone)]
+pub struct OperatorReviewStore {
+    client: Arc<Mutex<Client>>,
+}
+
+impl OperatorReviewStore {
+    pub(crate) async fn connect(config: &DbConfig) -> musubi_db_runtime::Result<Self> {
+        let client = connect_writer(config, "musubi-backend operator-review").await?;
+        Ok(Self {
+            client: Arc::new(Mutex::new(client)),
+        })
+    }
+
+    pub(crate) async fn reset_for_test(&self) -> Result<(), OperatorReviewError> {
+        let client = self.client.lock().await;
+        client
+            .batch_execute(
+                "
+                TRUNCATE
+                    projection.review_status_views,
+                    dao.operator_decision_facts,
+                    dao.appeal_cases,
+                    dao.evidence_access_grants,
+                    dao.evidence_bundles,
+                    dao.review_cases,
+                    core.operator_role_assignments
+                RESTART IDENTITY CASCADE
+                ",
+            )
+            .await
+            .map_err(db_error)?;
+        Ok(())
+    }
+
+    pub async fn create_review_case(
+        &self,
+        operator_id: &str,
+        input: CreateReviewCaseInput,
+    ) -> Result<ReviewCaseSnapshot, OperatorReviewError> {
+        let operator_id = parse_uuid(operator_id, "operator id")?;
+        validate_allowed("case_type", &input.case_type, CASE_TYPES)?;
+        validate_allowed("severity", &input.severity, SEVERITIES)?;
+        validate_allowed(
+            "opened_reason_code",
+            &input.opened_reason_code,
+            USER_FACING_REASON_CODES,
+        )?;
+        require_non_empty("source_fact_kind", &input.source_fact_kind)?;
+        require_non_empty("source_fact_id", &input.source_fact_id)?;
+        let subject_account_id =
+            parse_optional_uuid(&input.subject_account_id, "subject account id")?;
+        let related_promise_intent_id = parse_optional_uuid(
+            &input.related_promise_intent_id,
+            "related promise intent id",
+        )?;
+        let related_settlement_case_id = parse_optional_uuid(
+            &input.related_settlement_case_id,
+            "related settlement case id",
+        )?;
+        let assigned_operator_id =
+            parse_optional_uuid(&input.assigned_operator_id, "assigned operator id")?;
+        let request_idempotency_key = normalize_optional(&input.request_idempotency_key);
+
+        let mut client = self.client.lock().await;
+        let tx = client.transaction().await.map_err(db_error)?;
+        ensure_operator_has_any_role(&tx, &operator_id, WRITE_REVIEW_ROLES).await?;
+
+        if let Some(existing) =
+            find_existing_review_case_by_idempotency(&tx, &operator_id, &request_idempotency_key)
+                .await?
+        {
+            tx.commit().await.map_err(db_error)?;
+            return Ok(existing);
+        }
+
+        let review_case_id = Uuid::new_v4();
+        tx.execute(
+            "
+            INSERT INTO dao.review_cases (
+                review_case_id,
+                case_type,
+                severity,
+                review_status,
+                subject_account_id,
+                related_promise_intent_id,
+                related_settlement_case_id,
+                related_realm_id,
+                opened_reason_code,
+                source_fact_kind,
+                source_fact_id,
+                source_snapshot_json,
+                assigned_operator_id,
+                opened_by_operator_id,
+                request_idempotency_key
+            )
+            VALUES ($1, $2, $3, 'open', $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+            ",
+            &[
+                &review_case_id,
+                &input.case_type,
+                &input.severity,
+                &subject_account_id,
+                &related_promise_intent_id,
+                &related_settlement_case_id,
+                &input.related_realm_id,
+                &input.opened_reason_code,
+                &input.source_fact_kind,
+                &input.source_fact_id,
+                &input.source_snapshot_json,
+                &assigned_operator_id,
+                &operator_id,
+                &request_idempotency_key,
+            ],
+        )
+        .await
+        .map_err(db_error)?;
+        refresh_review_status_view_tx(&tx, &review_case_id).await?;
+        let snapshot = select_review_case_tx(&tx, &review_case_id).await?;
+        tx.commit().await.map_err(db_error)?;
+        Ok(snapshot)
+    }
+
+    pub async fn list_review_cases(
+        &self,
+        operator_id: &str,
+    ) -> Result<Vec<ReviewCaseSnapshot>, OperatorReviewError> {
+        let operator_id = parse_uuid(operator_id, "operator id")?;
+        let client = self.client.lock().await;
+        ensure_operator_has_any_role(&*client, &operator_id, READ_ROLES).await?;
+        let rows = client
+            .query(
+                "
+                SELECT *
+                FROM dao.review_cases
+                ORDER BY opened_at DESC
+                LIMIT 100
+                ",
+                &[],
+            )
+            .await
+            .map_err(db_error)?;
+        Ok(rows.iter().map(review_case_from_row).collect())
+    }
+
+    pub async fn read_review_case(
+        &self,
+        operator_id: &str,
+        review_case_id: &str,
+    ) -> Result<ReadReviewCaseSnapshot, OperatorReviewError> {
+        let operator_id = parse_uuid(operator_id, "operator id")?;
+        let review_case_id = parse_uuid(review_case_id, "review case id")?;
+        let client = self.client.lock().await;
+        ensure_operator_has_any_role(&*client, &operator_id, READ_ROLES).await?;
+        read_review_case_tx(&*client, &review_case_id).await
+    }
+
+    pub async fn attach_evidence_bundle(
+        &self,
+        operator_id: &str,
+        review_case_id: &str,
+        input: AttachEvidenceBundleInput,
+    ) -> Result<EvidenceBundleSnapshot, OperatorReviewError> {
+        let operator_id = parse_uuid(operator_id, "operator id")?;
+        let review_case_id = parse_uuid(review_case_id, "review case id")?;
+        validate_allowed(
+            "evidence_visibility",
+            &input.evidence_visibility,
+            EVIDENCE_VISIBILITIES,
+        )?;
+        validate_allowed("retention_class", &input.retention_class, RETENTION_CLASSES)?;
+
+        let mut client = self.client.lock().await;
+        let tx = client.transaction().await.map_err(db_error)?;
+        ensure_operator_has_any_role(&tx, &operator_id, WRITE_REVIEW_ROLES).await?;
+        ensure_review_case_exists_tx(&tx, &review_case_id).await?;
+        let evidence_bundle_id = Uuid::new_v4();
+        let row = tx
+            .query_one(
+                "
+                INSERT INTO dao.evidence_bundles (
+                    evidence_bundle_id,
+                    review_case_id,
+                    evidence_visibility,
+                    summary_json,
+                    raw_locator_json,
+                    retention_class,
+                    created_by_operator_id
+                )
+                VALUES ($1, $2, $3, $4, $5, $6, $7)
+                RETURNING *
+                ",
+                &[
+                    &evidence_bundle_id,
+                    &review_case_id,
+                    &input.evidence_visibility,
+                    &input.summary_json,
+                    &input.raw_locator_json,
+                    &input.retention_class,
+                    &operator_id,
+                ],
+            )
+            .await
+            .map_err(db_error)?;
+        refresh_review_status_view_tx(&tx, &review_case_id).await?;
+        tx.commit().await.map_err(db_error)?;
+        Ok(evidence_bundle_from_row(&row))
+    }
+
+    pub async fn grant_evidence_access(
+        &self,
+        operator_id: &str,
+        review_case_id: &str,
+        input: GrantEvidenceAccessInput,
+    ) -> Result<EvidenceAccessGrantSnapshot, OperatorReviewError> {
+        let operator_id = parse_uuid(operator_id, "operator id")?;
+        let review_case_id = parse_uuid(review_case_id, "review case id")?;
+        let evidence_bundle_id =
+            parse_optional_uuid(&input.evidence_bundle_id, "evidence bundle id")?;
+        let grantee_operator_id = parse_uuid(&input.grantee_operator_id, "grantee operator id")?;
+        validate_allowed("access_scope", &input.access_scope, EVIDENCE_VISIBILITIES)?;
+        require_non_empty("grant_reason", &input.grant_reason)?;
+        if input.expires_at <= Utc::now() {
+            return Err(OperatorReviewError::BadRequest(
+                "expires_at must be in the future".to_owned(),
+            ));
+        }
+
+        let mut client = self.client.lock().await;
+        let tx = client.transaction().await.map_err(db_error)?;
+        ensure_operator_has_role(&tx, &operator_id, OperatorRole::Approver).await?;
+        ensure_review_case_exists_tx(&tx, &review_case_id).await?;
+        if let Some(bundle_id) = evidence_bundle_id.as_ref() {
+            ensure_evidence_bundle_belongs_to_case_tx(&tx, &bundle_id, &review_case_id).await?;
+        }
+        ensure_grantee_allowed_for_scope(&tx, &grantee_operator_id, &input.access_scope).await?;
+
+        let access_grant_id = Uuid::new_v4();
+        let row = tx
+            .query_one(
+                "
+                INSERT INTO dao.evidence_access_grants (
+                    access_grant_id,
+                    review_case_id,
+                    evidence_bundle_id,
+                    grantee_operator_id,
+                    access_scope,
+                    grant_reason,
+                    approved_by_operator_id,
+                    expires_at
+                )
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+                RETURNING *
+                ",
+                &[
+                    &access_grant_id,
+                    &review_case_id,
+                    &evidence_bundle_id,
+                    &grantee_operator_id,
+                    &input.access_scope,
+                    &input.grant_reason,
+                    &operator_id,
+                    &input.expires_at,
+                ],
+            )
+            .await
+            .map_err(db_error)?;
+        refresh_review_status_view_tx(&tx, &review_case_id).await?;
+        tx.commit().await.map_err(db_error)?;
+        Ok(evidence_access_grant_from_row(&row))
+    }
+
+    pub async fn record_operator_decision(
+        &self,
+        operator_id: &str,
+        review_case_id: &str,
+        input: RecordOperatorDecisionInput,
+    ) -> Result<OperatorDecisionFactSnapshot, OperatorReviewError> {
+        let operator_id = parse_uuid(operator_id, "operator id")?;
+        let review_case_id = parse_uuid(review_case_id, "review case id")?;
+        validate_allowed("decision_kind", &input.decision_kind, DECISION_KINDS)?;
+        validate_allowed(
+            "user_facing_reason_code",
+            &input.user_facing_reason_code,
+            USER_FACING_REASON_CODES,
+        )?;
+        let decision_idempotency_key = normalize_optional(&input.decision_idempotency_key);
+
+        let mut client = self.client.lock().await;
+        let tx = client.transaction().await.map_err(db_error)?;
+        ensure_operator_has_role(&tx, &operator_id, OperatorRole::Approver).await?;
+        ensure_review_case_exists_tx(&tx, &review_case_id).await?;
+        if let Some(existing) = find_existing_decision_by_idempotency(
+            &tx,
+            &review_case_id,
+            &operator_id,
+            &decision_idempotency_key,
+        )
+        .await?
+        {
+            tx.commit().await.map_err(db_error)?;
+            return Ok(existing);
+        }
+
+        let operator_decision_fact_id = Uuid::new_v4();
+        let row = tx
+            .query_one(
+                "
+                INSERT INTO dao.operator_decision_facts (
+                    operator_decision_fact_id,
+                    review_case_id,
+                    decision_kind,
+                    user_facing_reason_code,
+                    operator_note_internal,
+                    decision_payload_json,
+                    decided_by_operator_id,
+                    decision_idempotency_key
+                )
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+                RETURNING *
+                ",
+                &[
+                    &operator_decision_fact_id,
+                    &review_case_id,
+                    &input.decision_kind,
+                    &input.user_facing_reason_code,
+                    &input.operator_note_internal,
+                    &input.decision_payload_json,
+                    &operator_id,
+                    &decision_idempotency_key,
+                ],
+            )
+            .await
+            .map_err(db_error)?;
+        let next_status = if input.decision_kind == "request_more_evidence" {
+            "awaiting_evidence"
+        } else {
+            "decided"
+        };
+        tx.execute(
+            "
+            UPDATE dao.review_cases
+            SET review_status = $2,
+                updated_at = CURRENT_TIMESTAMP
+            WHERE review_case_id = $1
+            ",
+            &[&review_case_id, &next_status],
+        )
+        .await
+        .map_err(db_error)?;
+        refresh_review_status_view_tx(&tx, &review_case_id).await?;
+        tx.commit().await.map_err(db_error)?;
+        Ok(operator_decision_fact_from_row(&row))
+    }
+
+    pub async fn create_appeal_case(
+        &self,
+        submitted_by_account_id: &str,
+        review_case_id: &str,
+        input: CreateAppealCaseInput,
+    ) -> Result<AppealCaseSnapshot, OperatorReviewError> {
+        let submitted_by_account_id =
+            parse_uuid(submitted_by_account_id, "submitted by account id")?;
+        let review_case_id = parse_uuid(review_case_id, "review case id")?;
+        let source_decision_fact_id =
+            parse_optional_uuid(&input.source_decision_fact_id, "source decision fact id")?;
+        validate_allowed(
+            "submitted_reason_code",
+            &input.submitted_reason_code,
+            USER_FACING_REASON_CODES,
+        )?;
+        let appeal_idempotency_key = normalize_optional(&input.appeal_idempotency_key);
+
+        let mut client = self.client.lock().await;
+        let tx = client.transaction().await.map_err(db_error)?;
+        ensure_subject_can_access_case_tx(&tx, &review_case_id, &submitted_by_account_id).await?;
+        if let Some(existing) = find_existing_appeal_by_idempotency(
+            &tx,
+            &review_case_id,
+            &submitted_by_account_id,
+            &appeal_idempotency_key,
+        )
+        .await?
+        {
+            tx.commit().await.map_err(db_error)?;
+            return Ok(existing);
+        }
+        ensure_appeal_source_tx(&tx, &review_case_id, source_decision_fact_id.as_ref()).await?;
+
+        let appeal_case_id = Uuid::new_v4();
+        let row = tx
+            .query_one(
+                "
+                INSERT INTO dao.appeal_cases (
+                    appeal_case_id,
+                    source_review_case_id,
+                    source_decision_fact_id,
+                    appeal_status,
+                    submitted_by_account_id,
+                    submitted_reason_code,
+                    appellant_statement,
+                    new_evidence_summary_json,
+                    appeal_idempotency_key
+                )
+                VALUES ($1, $2, $3, 'submitted', $4, $5, $6, $7, $8)
+                RETURNING *
+                ",
+                &[
+                    &appeal_case_id,
+                    &review_case_id,
+                    &source_decision_fact_id,
+                    &submitted_by_account_id,
+                    &input.submitted_reason_code,
+                    &input.appellant_statement,
+                    &input.new_evidence_summary_json,
+                    &appeal_idempotency_key,
+                ],
+            )
+            .await
+            .map_err(db_error)?;
+        tx.execute(
+            "
+            UPDATE dao.review_cases
+            SET review_status = 'appealed',
+                updated_at = CURRENT_TIMESTAMP
+            WHERE review_case_id = $1
+            ",
+            &[&review_case_id],
+        )
+        .await
+        .map_err(db_error)?;
+        refresh_review_status_view_tx(&tx, &review_case_id).await?;
+        tx.commit().await.map_err(db_error)?;
+        Ok(appeal_case_from_row(&row))
+    }
+
+    pub async fn list_appeal_cases_for_subject(
+        &self,
+        subject_account_id: &str,
+        review_case_id: &str,
+    ) -> Result<Vec<AppealCaseSnapshot>, OperatorReviewError> {
+        let subject_account_id = parse_uuid(subject_account_id, "subject account id")?;
+        let review_case_id = parse_uuid(review_case_id, "review case id")?;
+        let client = self.client.lock().await;
+        ensure_subject_can_access_case_tx(&*client, &review_case_id, &subject_account_id).await?;
+        let rows = client
+            .query(
+                "
+                SELECT *
+                FROM dao.appeal_cases
+                WHERE source_review_case_id = $1
+                ORDER BY created_at ASC
+                ",
+                &[&review_case_id],
+            )
+            .await
+            .map_err(db_error)?;
+        Ok(rows.iter().map(appeal_case_from_row).collect())
+    }
+
+    pub async fn get_review_status_for_subject(
+        &self,
+        subject_account_id: &str,
+        review_case_id: &str,
+    ) -> Result<ReviewStatusReadModelSnapshot, OperatorReviewError> {
+        let subject_account_id = parse_uuid(subject_account_id, "subject account id")?;
+        let review_case_id = parse_uuid(review_case_id, "review case id")?;
+        let client = self.client.lock().await;
+        let row = client
+            .query_opt(
+                "
+                SELECT *
+                FROM projection.review_status_views
+                WHERE review_case_id = $1
+                  AND subject_account_id = $2
+                ",
+                &[&review_case_id, &subject_account_id],
+            )
+            .await
+            .map_err(db_error)?
+            .ok_or_else(|| {
+                OperatorReviewError::NotFound("review status was not found".to_owned())
+            })?;
+        Ok(review_status_read_model_from_row(&row))
+    }
+}
+
+async fn read_review_case_tx<C: GenericClient + Sync>(
+    client: &C,
+    review_case_id: &Uuid,
+) -> Result<ReadReviewCaseSnapshot, OperatorReviewError> {
+    let review_case = select_review_case_tx(client, review_case_id).await?;
+    let evidence_bundles = client
+        .query(
+            "
+            SELECT *
+            FROM dao.evidence_bundles
+            WHERE review_case_id = $1
+            ORDER BY created_at ASC
+            ",
+            &[review_case_id],
+        )
+        .await
+        .map_err(db_error)?
+        .iter()
+        .map(evidence_bundle_from_row)
+        .collect();
+    let evidence_access_grants = client
+        .query(
+            "
+            SELECT *
+            FROM dao.evidence_access_grants
+            WHERE review_case_id = $1
+            ORDER BY created_at ASC
+            ",
+            &[review_case_id],
+        )
+        .await
+        .map_err(db_error)?
+        .iter()
+        .map(evidence_access_grant_from_row)
+        .collect();
+    let operator_decision_facts = client
+        .query(
+            "
+            SELECT *
+            FROM dao.operator_decision_facts
+            WHERE review_case_id = $1
+            ORDER BY recorded_at ASC
+            ",
+            &[review_case_id],
+        )
+        .await
+        .map_err(db_error)?
+        .iter()
+        .map(operator_decision_fact_from_row)
+        .collect();
+    let appeal_cases = client
+        .query(
+            "
+            SELECT *
+            FROM dao.appeal_cases
+            WHERE source_review_case_id = $1
+            ORDER BY created_at ASC
+            ",
+            &[review_case_id],
+        )
+        .await
+        .map_err(db_error)?
+        .iter()
+        .map(appeal_case_from_row)
+        .collect();
+
+    Ok(ReadReviewCaseSnapshot {
+        review_case,
+        evidence_bundles,
+        evidence_access_grants,
+        operator_decision_facts,
+        appeal_cases,
+    })
+}
+
+async fn find_existing_review_case_by_idempotency<C: GenericClient + Sync>(
+    client: &C,
+    operator_id: &Uuid,
+    request_idempotency_key: &Option<String>,
+) -> Result<Option<ReviewCaseSnapshot>, OperatorReviewError> {
+    let Some(request_idempotency_key) = request_idempotency_key else {
+        return Ok(None);
+    };
+    let row = client
+        .query_opt(
+            "
+            SELECT *
+            FROM dao.review_cases
+            WHERE opened_by_operator_id = $1
+              AND request_idempotency_key = $2
+            ",
+            &[operator_id, request_idempotency_key],
+        )
+        .await
+        .map_err(db_error)?;
+    Ok(row.as_ref().map(review_case_from_row))
+}
+
+async fn find_existing_decision_by_idempotency<C: GenericClient + Sync>(
+    client: &C,
+    review_case_id: &Uuid,
+    operator_id: &Uuid,
+    decision_idempotency_key: &Option<String>,
+) -> Result<Option<OperatorDecisionFactSnapshot>, OperatorReviewError> {
+    let Some(decision_idempotency_key) = decision_idempotency_key else {
+        return Ok(None);
+    };
+    let row = client
+        .query_opt(
+            "
+            SELECT *
+            FROM dao.operator_decision_facts
+            WHERE review_case_id = $1
+              AND decided_by_operator_id = $2
+              AND decision_idempotency_key = $3
+            ",
+            &[review_case_id, operator_id, decision_idempotency_key],
+        )
+        .await
+        .map_err(db_error)?;
+    Ok(row.as_ref().map(operator_decision_fact_from_row))
+}
+
+async fn find_existing_appeal_by_idempotency<C: GenericClient + Sync>(
+    client: &C,
+    review_case_id: &Uuid,
+    submitted_by_account_id: &Uuid,
+    appeal_idempotency_key: &Option<String>,
+) -> Result<Option<AppealCaseSnapshot>, OperatorReviewError> {
+    let Some(appeal_idempotency_key) = appeal_idempotency_key else {
+        return Ok(None);
+    };
+    let row = client
+        .query_opt(
+            "
+            SELECT *
+            FROM dao.appeal_cases
+            WHERE source_review_case_id = $1
+              AND submitted_by_account_id = $2
+              AND appeal_idempotency_key = $3
+            ",
+            &[
+                review_case_id,
+                submitted_by_account_id,
+                appeal_idempotency_key,
+            ],
+        )
+        .await
+        .map_err(db_error)?;
+    Ok(row.as_ref().map(appeal_case_from_row))
+}
+
+async fn ensure_operator_has_any_role<C: GenericClient + Sync>(
+    client: &C,
+    operator_id: &Uuid,
+    roles: &[OperatorRole],
+) -> Result<(), OperatorReviewError> {
+    for role in roles {
+        if operator_has_role(client, operator_id, *role).await? {
+            return Ok(());
+        }
+    }
+    Err(OperatorReviewError::Unauthorized(
+        "operator role is not allowed for this action".to_owned(),
+    ))
+}
+
+async fn ensure_operator_has_role<C: GenericClient + Sync>(
+    client: &C,
+    operator_id: &Uuid,
+    role: OperatorRole,
+) -> Result<(), OperatorReviewError> {
+    if operator_has_role(client, operator_id, role).await? {
+        return Ok(());
+    }
+    Err(OperatorReviewError::Unauthorized(
+        "operator role is not allowed for this action".to_owned(),
+    ))
+}
+
+async fn operator_has_role<C: GenericClient + Sync>(
+    client: &C,
+    operator_id: &Uuid,
+    role: OperatorRole,
+) -> Result<bool, OperatorReviewError> {
+    let row = client
+        .query_one(
+            "
+            SELECT EXISTS (
+                SELECT 1
+                FROM core.operator_role_assignments
+                JOIN core.accounts
+                  ON core.accounts.account_id = core.operator_role_assignments.operator_account_id
+                WHERE operator_account_id = $1
+                  AND operator_role = $2
+                  AND revoked_at IS NULL
+                  AND core.accounts.account_class = 'Controlled Exceptional Account'
+                  AND core.accounts.account_state = 'active'
+            ) AS has_role
+            ",
+            &[operator_id, &role.as_str()],
+        )
+        .await
+        .map_err(db_error)?;
+    Ok(row.get("has_role"))
+}
+
+async fn ensure_grantee_allowed_for_scope(
+    tx: &Transaction<'_>,
+    grantee_operator_id: &Uuid,
+    access_scope: &str,
+) -> Result<(), OperatorReviewError> {
+    let allowed_roles: &[OperatorRole] = match access_scope {
+        "summary_only" => READ_ROLES,
+        "redacted_raw" => &[
+            OperatorRole::Reviewer,
+            OperatorRole::Approver,
+            OperatorRole::Steward,
+            OperatorRole::Auditor,
+        ],
+        "full_raw" => &[OperatorRole::Approver, OperatorRole::Auditor],
+        _ => {
+            return Err(OperatorReviewError::BadRequest(
+                "unsupported access_scope".to_owned(),
+            ));
+        }
+    };
+    ensure_operator_has_any_role(tx, grantee_operator_id, allowed_roles).await
+}
+
+async fn ensure_review_case_exists_tx<C: GenericClient + Sync>(
+    client: &C,
+    review_case_id: &Uuid,
+) -> Result<(), OperatorReviewError> {
+    let exists: bool = client
+        .query_one(
+            "SELECT EXISTS (SELECT 1 FROM dao.review_cases WHERE review_case_id = $1) AS exists",
+            &[review_case_id],
+        )
+        .await
+        .map_err(db_error)?
+        .get("exists");
+    if exists {
+        Ok(())
+    } else {
+        Err(OperatorReviewError::NotFound(
+            "review case was not found".to_owned(),
+        ))
+    }
+}
+
+async fn ensure_evidence_bundle_belongs_to_case_tx<C: GenericClient + Sync>(
+    client: &C,
+    evidence_bundle_id: &Uuid,
+    review_case_id: &Uuid,
+) -> Result<(), OperatorReviewError> {
+    let exists: bool = client
+        .query_one(
+            "
+            SELECT EXISTS (
+                SELECT 1
+                FROM dao.evidence_bundles
+                WHERE evidence_bundle_id = $1
+                  AND review_case_id = $2
+            ) AS exists
+            ",
+            &[evidence_bundle_id, review_case_id],
+        )
+        .await
+        .map_err(db_error)?
+        .get("exists");
+    if exists {
+        Ok(())
+    } else {
+        Err(OperatorReviewError::BadRequest(
+            "evidence_bundle_id must belong to the review case".to_owned(),
+        ))
+    }
+}
+
+async fn ensure_subject_can_access_case_tx<C: GenericClient + Sync>(
+    client: &C,
+    review_case_id: &Uuid,
+    subject_account_id: &Uuid,
+) -> Result<(), OperatorReviewError> {
+    let exists: bool = client
+        .query_one(
+            "
+            SELECT EXISTS (
+                SELECT 1
+                FROM dao.review_cases
+                WHERE review_case_id = $1
+                  AND subject_account_id = $2
+            ) AS exists
+            ",
+            &[review_case_id, subject_account_id],
+        )
+        .await
+        .map_err(db_error)?
+        .get("exists");
+    if exists {
+        Ok(())
+    } else {
+        Err(OperatorReviewError::NotFound(
+            "review case was not found".to_owned(),
+        ))
+    }
+}
+
+async fn ensure_appeal_source_tx<C: GenericClient + Sync>(
+    client: &C,
+    review_case_id: &Uuid,
+    source_decision_fact_id: Option<&Uuid>,
+) -> Result<(), OperatorReviewError> {
+    if let Some(source_decision_fact_id) = source_decision_fact_id {
+        let exists: bool = client
+            .query_one(
+                "
+                SELECT EXISTS (
+                    SELECT 1
+                    FROM dao.operator_decision_facts
+                    WHERE operator_decision_fact_id = $1
+                      AND review_case_id = $2
+                ) AS exists
+                ",
+                &[source_decision_fact_id, review_case_id],
+            )
+            .await
+            .map_err(db_error)?
+            .get("exists");
+        if exists {
+            return Ok(());
+        }
+        return Err(OperatorReviewError::BadRequest(
+            "source_decision_fact_id must belong to the review case".to_owned(),
+        ));
+    }
+
+    let status: String = client
+        .query_one(
+            "
+            SELECT review_status
+            FROM dao.review_cases
+            WHERE review_case_id = $1
+            ",
+            &[review_case_id],
+        )
+        .await
+        .map_err(db_error)?
+        .get("review_status");
+    if matches!(status.as_str(), "decided" | "appealed" | "closed") {
+        Ok(())
+    } else {
+        Err(OperatorReviewError::BadRequest(
+            "appeal must reference an original review decision or a decided review case".to_owned(),
+        ))
+    }
+}
+
+async fn select_review_case_tx<C: GenericClient + Sync>(
+    client: &C,
+    review_case_id: &Uuid,
+) -> Result<ReviewCaseSnapshot, OperatorReviewError> {
+    let row = client
+        .query_opt(
+            "SELECT * FROM dao.review_cases WHERE review_case_id = $1",
+            &[review_case_id],
+        )
+        .await
+        .map_err(db_error)?
+        .ok_or_else(|| OperatorReviewError::NotFound("review case was not found".to_owned()))?;
+    Ok(review_case_from_row(&row))
+}
+
+async fn refresh_review_status_view_tx<C: GenericClient + Sync>(
+    client: &C,
+    review_case_id: &Uuid,
+) -> Result<(), OperatorReviewError> {
+    client
+        .execute(
+            "
+            INSERT INTO projection.review_status_views (
+                review_case_id,
+                subject_account_id,
+                related_promise_intent_id,
+                related_settlement_case_id,
+                related_realm_id,
+                user_facing_status,
+                user_facing_reason_code,
+                appeal_status,
+                latest_decision_fact_id,
+                evidence_requested,
+                appeal_available,
+                source_watermark_at,
+                source_fact_count,
+                last_projected_at
+            )
+            WITH latest_decision AS (
+                SELECT *
+                FROM dao.operator_decision_facts
+                WHERE review_case_id = $1
+                ORDER BY recorded_at DESC, operator_decision_fact_id DESC
+                LIMIT 1
+            ),
+            latest_appeal AS (
+                SELECT *
+                FROM dao.appeal_cases
+                WHERE source_review_case_id = $1
+                ORDER BY updated_at DESC, appeal_case_id DESC
+                LIMIT 1
+            ),
+            latest_evidence AS (
+                SELECT created_at
+                FROM dao.evidence_bundles
+                WHERE review_case_id = $1
+                ORDER BY created_at DESC, evidence_bundle_id DESC
+                LIMIT 1
+            ),
+            latest_grant AS (
+                SELECT created_at
+                FROM dao.evidence_access_grants
+                WHERE review_case_id = $1
+                ORDER BY created_at DESC, access_grant_id DESC
+                LIMIT 1
+            ),
+            fact_counts AS (
+                SELECT
+                    (1
+                     + (SELECT count(*) FROM dao.operator_decision_facts WHERE review_case_id = $1)
+                     + (SELECT count(*) FROM dao.appeal_cases WHERE source_review_case_id = $1)
+                     + (SELECT count(*) FROM dao.evidence_bundles WHERE review_case_id = $1)
+                     + (SELECT count(*) FROM dao.evidence_access_grants WHERE review_case_id = $1)
+                    )::bigint AS source_fact_count
+            ),
+            shaped AS (
+                SELECT
+                    review.review_case_id,
+                    review.subject_account_id,
+                    review.related_promise_intent_id,
+                    review.related_settlement_case_id,
+                    review.related_realm_id,
+                    latest_decision.operator_decision_fact_id,
+                    CASE
+                        WHEN review.review_status = 'closed' THEN 'closed'
+                        WHEN latest_appeal.appeal_status IN ('submitted', 'accepted', 'under_review')
+                            OR review.review_status = 'appealed'
+                            THEN 'appeal_submitted'
+                        WHEN latest_decision.decision_kind IN ('restrict', 'escalate')
+                            THEN 'sealed_or_restricted'
+                        WHEN review.review_status = 'awaiting_evidence'
+                            OR latest_decision.decision_kind = 'request_more_evidence'
+                            THEN 'evidence_requested'
+                        WHEN review.review_status IN ('open', 'triaged') THEN 'pending_review'
+                        WHEN review.review_status = 'under_review' THEN 'under_review'
+                        WHEN review.review_status = 'decided'
+                            AND latest_decision.operator_decision_fact_id IS NOT NULL
+                            AND latest_appeal.appeal_case_id IS NULL
+                            THEN 'appeal_available'
+                        WHEN review.review_status = 'decided' THEN 'decided'
+                        ELSE 'pending_review'
+                    END AS user_facing_status,
+                    COALESCE(
+                        latest_appeal.submitted_reason_code,
+                        latest_decision.user_facing_reason_code,
+                        review.opened_reason_code
+                    ) AS user_facing_reason_code,
+                    CASE
+                        WHEN latest_appeal.appeal_status = 'submitted' THEN 'submitted'
+                        WHEN latest_appeal.appeal_status = 'accepted' THEN 'under_review'
+                        WHEN latest_appeal.appeal_status = 'under_review' THEN 'under_review'
+                        WHEN latest_appeal.appeal_status = 'decided' THEN 'decided'
+                        WHEN latest_appeal.appeal_status = 'closed' THEN 'closed'
+                        WHEN review.review_status = 'decided'
+                            AND latest_decision.operator_decision_fact_id IS NOT NULL
+                            THEN 'appeal_available'
+                        ELSE 'none'
+                    END AS appeal_status,
+                    (
+                        review.review_status = 'awaiting_evidence'
+                        OR COALESCE(latest_decision.decision_kind = 'request_more_evidence', FALSE)
+                    ) AS evidence_requested,
+                    (
+                        review.review_status = 'decided'
+                        AND latest_decision.operator_decision_fact_id IS NOT NULL
+                        AND latest_appeal.appeal_case_id IS NULL
+                    ) AS appeal_available,
+                    GREATEST(
+                        review.updated_at,
+                        COALESCE(latest_decision.recorded_at, review.updated_at),
+                        COALESCE(latest_appeal.updated_at, review.updated_at),
+                        COALESCE(latest_evidence.created_at, review.updated_at),
+                        COALESCE(latest_grant.created_at, review.updated_at)
+                    ) AS source_watermark_at,
+                    fact_counts.source_fact_count
+                FROM dao.review_cases review
+                LEFT JOIN latest_decision ON TRUE
+                LEFT JOIN latest_appeal ON TRUE
+                LEFT JOIN latest_evidence ON TRUE
+                LEFT JOIN latest_grant ON TRUE
+                CROSS JOIN fact_counts
+                WHERE review.review_case_id = $1
+            )
+            SELECT
+                review_case_id,
+                subject_account_id,
+                related_promise_intent_id,
+                related_settlement_case_id,
+                related_realm_id,
+                user_facing_status,
+                user_facing_reason_code,
+                appeal_status,
+                operator_decision_fact_id,
+                evidence_requested,
+                appeal_available,
+                source_watermark_at,
+                source_fact_count,
+                CURRENT_TIMESTAMP
+            FROM shaped
+            ON CONFLICT (review_case_id) DO UPDATE
+            SET subject_account_id = EXCLUDED.subject_account_id,
+                related_promise_intent_id = EXCLUDED.related_promise_intent_id,
+                related_settlement_case_id = EXCLUDED.related_settlement_case_id,
+                related_realm_id = EXCLUDED.related_realm_id,
+                user_facing_status = EXCLUDED.user_facing_status,
+                user_facing_reason_code = EXCLUDED.user_facing_reason_code,
+                appeal_status = EXCLUDED.appeal_status,
+                latest_decision_fact_id = EXCLUDED.latest_decision_fact_id,
+                evidence_requested = EXCLUDED.evidence_requested,
+                appeal_available = EXCLUDED.appeal_available,
+                source_watermark_at = EXCLUDED.source_watermark_at,
+                source_fact_count = EXCLUDED.source_fact_count,
+                last_projected_at = EXCLUDED.last_projected_at
+            ",
+            &[review_case_id],
+        )
+        .await
+        .map_err(db_error)?;
+    Ok(())
+}
+
+fn review_case_from_row(row: &Row) -> ReviewCaseSnapshot {
+    ReviewCaseSnapshot {
+        review_case_id: row.get::<_, Uuid>("review_case_id").to_string(),
+        case_type: row.get("case_type"),
+        severity: row.get("severity"),
+        review_status: row.get("review_status"),
+        subject_account_id: optional_uuid_to_string(row.get("subject_account_id")),
+        related_promise_intent_id: optional_uuid_to_string(row.get("related_promise_intent_id")),
+        related_settlement_case_id: optional_uuid_to_string(row.get("related_settlement_case_id")),
+        related_realm_id: row.get("related_realm_id"),
+        opened_reason_code: row.get("opened_reason_code"),
+        source_fact_kind: row.get("source_fact_kind"),
+        source_fact_id: row.get("source_fact_id"),
+        assigned_operator_id: optional_uuid_to_string(row.get("assigned_operator_id")),
+        opened_at: row.get("opened_at"),
+        updated_at: row.get("updated_at"),
+    }
+}
+
+fn evidence_bundle_from_row(row: &Row) -> EvidenceBundleSnapshot {
+    EvidenceBundleSnapshot {
+        evidence_bundle_id: row.get::<_, Uuid>("evidence_bundle_id").to_string(),
+        review_case_id: row.get::<_, Uuid>("review_case_id").to_string(),
+        evidence_visibility: row.get("evidence_visibility"),
+        summary_json: row.get("summary_json"),
+        retention_class: row.get("retention_class"),
+        created_by_operator_id: optional_uuid_to_string(row.get("created_by_operator_id")),
+        created_at: row.get("created_at"),
+    }
+}
+
+fn evidence_access_grant_from_row(row: &Row) -> EvidenceAccessGrantSnapshot {
+    EvidenceAccessGrantSnapshot {
+        access_grant_id: row.get::<_, Uuid>("access_grant_id").to_string(),
+        review_case_id: row.get::<_, Uuid>("review_case_id").to_string(),
+        evidence_bundle_id: optional_uuid_to_string(row.get("evidence_bundle_id")),
+        grantee_operator_id: row.get::<_, Uuid>("grantee_operator_id").to_string(),
+        access_scope: row.get("access_scope"),
+        grant_reason: row.get("grant_reason"),
+        approved_by_operator_id: row.get::<_, Uuid>("approved_by_operator_id").to_string(),
+        expires_at: row.get("expires_at"),
+        created_at: row.get("created_at"),
+    }
+}
+
+fn operator_decision_fact_from_row(row: &Row) -> OperatorDecisionFactSnapshot {
+    OperatorDecisionFactSnapshot {
+        operator_decision_fact_id: row.get::<_, Uuid>("operator_decision_fact_id").to_string(),
+        review_case_id: row.get::<_, Uuid>("review_case_id").to_string(),
+        appeal_case_id: optional_uuid_to_string(row.get("appeal_case_id")),
+        decision_kind: row.get("decision_kind"),
+        user_facing_reason_code: row.get("user_facing_reason_code"),
+        decided_by_operator_id: row.get::<_, Uuid>("decided_by_operator_id").to_string(),
+        recorded_at: row.get("recorded_at"),
+    }
+}
+
+fn appeal_case_from_row(row: &Row) -> AppealCaseSnapshot {
+    AppealCaseSnapshot {
+        appeal_case_id: row.get::<_, Uuid>("appeal_case_id").to_string(),
+        source_review_case_id: row.get::<_, Uuid>("source_review_case_id").to_string(),
+        source_decision_fact_id: optional_uuid_to_string(row.get("source_decision_fact_id")),
+        appeal_status: row.get("appeal_status"),
+        submitted_by_account_id: row.get::<_, Uuid>("submitted_by_account_id").to_string(),
+        submitted_reason_code: row.get("submitted_reason_code"),
+        created_at: row.get("created_at"),
+        updated_at: row.get("updated_at"),
+    }
+}
+
+fn review_status_read_model_from_row(row: &Row) -> ReviewStatusReadModelSnapshot {
+    ReviewStatusReadModelSnapshot {
+        review_case_id: row.get::<_, Uuid>("review_case_id").to_string(),
+        subject_account_id: optional_uuid_to_string(row.get("subject_account_id")),
+        related_promise_intent_id: optional_uuid_to_string(row.get("related_promise_intent_id")),
+        related_settlement_case_id: optional_uuid_to_string(row.get("related_settlement_case_id")),
+        related_realm_id: row.get("related_realm_id"),
+        user_facing_status: row.get("user_facing_status"),
+        user_facing_reason_code: row.get("user_facing_reason_code"),
+        appeal_status: row.get("appeal_status"),
+        evidence_requested: row.get("evidence_requested"),
+        appeal_available: row.get("appeal_available"),
+        latest_decision_fact_id: optional_uuid_to_string(row.get("latest_decision_fact_id")),
+        source_watermark_at: row.get("source_watermark_at"),
+        source_fact_count: row.get("source_fact_count"),
+        last_projected_at: row.get("last_projected_at"),
+    }
+}
+
+fn parse_uuid(value: &str, label: &str) -> Result<Uuid, OperatorReviewError> {
+    Uuid::parse_str(value.trim())
+        .map_err(|_| OperatorReviewError::BadRequest(format!("{label} must be a valid UUID")))
+}
+
+fn parse_optional_uuid(
+    value: &Option<String>,
+    label: &str,
+) -> Result<Option<Uuid>, OperatorReviewError> {
+    value
+        .as_ref()
+        .map(|value| parse_uuid(value, label))
+        .transpose()
+}
+
+fn optional_uuid_to_string(value: Option<Uuid>) -> Option<String> {
+    value.map(|value| value.to_string())
+}
+
+fn validate_allowed(label: &str, value: &str, allowed: &[&str]) -> Result<(), OperatorReviewError> {
+    if allowed.contains(&value) {
+        Ok(())
+    } else {
+        Err(OperatorReviewError::BadRequest(format!(
+            "{label} is not supported"
+        )))
+    }
+}
+
+fn require_non_empty(label: &str, value: &str) -> Result<(), OperatorReviewError> {
+    if value.trim().is_empty() {
+        Err(OperatorReviewError::BadRequest(format!(
+            "{label} is required"
+        )))
+    } else {
+        Ok(())
+    }
+}
+
+fn normalize_optional(value: &Option<String>) -> Option<String> {
+    value
+        .as_ref()
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
+}
+
+fn db_error(error: tokio_postgres::Error) -> OperatorReviewError {
+    let code = error.code().map(SqlState::code).map(str::to_owned);
+    let retryable = matches!(
+        error.code(),
+        Some(&SqlState::T_R_SERIALIZATION_FAILURE)
+            | Some(&SqlState::T_R_DEADLOCK_DETECTED)
+            | Some(&SqlState::CONNECTION_EXCEPTION)
+            | Some(&SqlState::CONNECTION_DOES_NOT_EXIST)
+            | Some(&SqlState::CONNECTION_FAILURE)
+            | Some(&SqlState::SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION)
+            | Some(&SqlState::SQLSERVER_REJECTED_ESTABLISHMENT_OF_SQLCONNECTION)
+            | Some(&SqlState::TRANSACTION_RESOLUTION_UNKNOWN)
+            | Some(&SqlState::PROTOCOL_VIOLATION)
+    );
+    OperatorReviewError::Database {
+        message: error.to_string(),
+        code,
+        constraint: error
+            .as_db_error()
+            .and_then(|db_error| db_error.constraint())
+            .map(str::to_owned),
+        retryable,
+    }
+}

--- a/apps/backend/src/services/operator_review/repository.rs
+++ b/apps/backend/src/services/operator_review/repository.rs
@@ -39,6 +39,7 @@ const CASE_TYPES: &[&str] = &[
 ];
 const SEVERITIES: &[&str] = &["sev0", "sev1", "sev2", "sev3"];
 const EVIDENCE_VISIBILITIES: &[&str] = &["summary_only", "redacted_raw", "full_raw"];
+const EVIDENCE_ACCESS_SCOPES: &[&str] = &["summary_only", "redacted_raw", "full_raw"];
 const RETENTION_CLASSES: &[&str] = &["R4", "R6", "R7"];
 const DECISION_KINDS: &[&str] = &[
     "no_action",
@@ -367,14 +368,12 @@ impl OperatorReviewStore {
         review_case_id: &str,
         input: GrantEvidenceAccessInput,
     ) -> Result<EvidenceAccessGrantSnapshot, OperatorReviewError> {
-        const ACCESS_SCOPES: &[&str] = &["private", "case", "public"];
-
         let operator_id = parse_uuid(operator_id, "operator id")?;
         let review_case_id = parse_uuid(review_case_id, "review case id")?;
         let evidence_bundle_id =
             parse_optional_uuid(&input.evidence_bundle_id, "evidence bundle id")?;
         let grantee_operator_id = parse_uuid(&input.grantee_operator_id, "grantee operator id")?;
-        validate_allowed("access_scope", &input.access_scope, ACCESS_SCOPES)?;
+        validate_allowed("access_scope", &input.access_scope, EVIDENCE_ACCESS_SCOPES)?;
         require_non_empty("grant_reason", &input.grant_reason)?;
 
         let mut client = self.client.lock().await;

--- a/apps/backend/src/services/operator_review/repository.rs
+++ b/apps/backend/src/services/operator_review/repository.rs
@@ -1102,27 +1102,30 @@ async fn ensure_appeal_source_tx<C: GenericClient + Sync>(
     source_decision_fact_id: Option<&Uuid>,
 ) -> Result<(), OperatorReviewError> {
     if let Some(source_decision_fact_id) = source_decision_fact_id {
-        let exists: bool = client
-            .query_one(
+        let source_decision = client
+            .query_opt(
                 "
-                SELECT EXISTS (
-                    SELECT 1
-                    FROM dao.operator_decision_facts
-                    WHERE operator_decision_fact_id = $1
-                      AND review_case_id = $2
-                ) AS exists
+                SELECT decision_kind
+                FROM dao.operator_decision_facts
+                WHERE operator_decision_fact_id = $1
+                  AND review_case_id = $2
                 ",
                 &[source_decision_fact_id, review_case_id],
             )
             .await
-            .map_err(db_error)?
-            .get("exists");
-        if exists {
-            return Ok(());
+            .map_err(db_error)?;
+        let Some(source_decision) = source_decision else {
+            return Err(OperatorReviewError::BadRequest(
+                "source_decision_fact_id must belong to the review case".to_owned(),
+            ));
+        };
+        let decision_kind: String = source_decision.get("decision_kind");
+        if decision_kind == "request_more_evidence" {
+            return Err(OperatorReviewError::BadRequest(
+                "appeal cannot reference a non-final decision".to_owned(),
+            ));
         }
-        return Err(OperatorReviewError::BadRequest(
-            "source_decision_fact_id must belong to the review case".to_owned(),
-        ));
+        return Ok(());
     }
 
     let status: String = client

--- a/apps/backend/src/services/operator_review/repository.rs
+++ b/apps/backend/src/services/operator_review/repository.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use chrono::Utc;
 use musubi_db_runtime::{DbConfig, connect_writer};
+use serde_json::Value;
 use tokio::sync::Mutex;
 use tokio_postgres::{Client, GenericClient, Row, Transaction, error::SqlState};
 use uuid::Uuid;
@@ -129,58 +130,125 @@ impl OperatorReviewStore {
         let mut client = self.client.lock().await;
         let tx = client.transaction().await.map_err(db_error)?;
         ensure_operator_has_any_role(&tx, &operator_id, WRITE_REVIEW_ROLES).await?;
-
-        if let Some(existing) =
-            find_existing_review_case_by_idempotency(&tx, &operator_id, &request_idempotency_key)
-                .await?
-        {
-            tx.commit().await.map_err(db_error)?;
-            return Ok(existing);
-        }
-
         let review_case_id = Uuid::new_v4();
-        tx.execute(
-            "
-            INSERT INTO dao.review_cases (
-                review_case_id,
-                case_type,
-                severity,
-                review_status,
-                subject_account_id,
-                related_promise_intent_id,
-                related_settlement_case_id,
-                related_realm_id,
-                opened_reason_code,
-                source_fact_kind,
-                source_fact_id,
-                source_snapshot_json,
-                assigned_operator_id,
-                opened_by_operator_id,
-                request_idempotency_key
-            )
-            VALUES ($1, $2, $3, 'open', $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
-            ",
-            &[
-                &review_case_id,
-                &input.case_type,
-                &input.severity,
-                &subject_account_id,
-                &related_promise_intent_id,
-                &related_settlement_case_id,
-                &input.related_realm_id,
-                &input.opened_reason_code,
-                &input.source_fact_kind,
-                &input.source_fact_id,
-                &input.source_snapshot_json,
-                &assigned_operator_id,
-                &operator_id,
-                &request_idempotency_key,
-            ],
-        )
-        .await
-        .map_err(db_error)?;
-        refresh_review_status_view_tx(&tx, &review_case_id).await?;
-        let snapshot = select_review_case_tx(&tx, &review_case_id).await?;
+        let row = if request_idempotency_key.is_some() {
+            if let Some(row) = tx
+                .query_opt(
+                    "
+                    INSERT INTO dao.review_cases (
+                        review_case_id,
+                        case_type,
+                        severity,
+                        review_status,
+                        subject_account_id,
+                        related_promise_intent_id,
+                        related_settlement_case_id,
+                        related_realm_id,
+                        opened_reason_code,
+                        source_fact_kind,
+                        source_fact_id,
+                        source_snapshot_json,
+                        assigned_operator_id,
+                        opened_by_operator_id,
+                        request_idempotency_key
+                    )
+                    VALUES ($1, $2, $3, 'open', $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+                    ON CONFLICT (opened_by_operator_id, request_idempotency_key)
+                    WHERE request_idempotency_key IS NOT NULL
+                    DO NOTHING
+                    RETURNING *
+                    ",
+                    &[
+                        &review_case_id,
+                        &input.case_type,
+                        &input.severity,
+                        &subject_account_id,
+                        &related_promise_intent_id,
+                        &related_settlement_case_id,
+                        &input.related_realm_id,
+                        &input.opened_reason_code,
+                        &input.source_fact_kind,
+                        &input.source_fact_id,
+                        &input.source_snapshot_json,
+                        &assigned_operator_id,
+                        &operator_id,
+                        &request_idempotency_key,
+                    ],
+                )
+                .await
+                .map_err(db_error)?
+            {
+                refresh_review_status_view_tx(&tx, &review_case_id).await?;
+                row
+            } else {
+                let row = find_existing_review_case_by_idempotency(
+                    &tx,
+                    &operator_id,
+                    &request_idempotency_key,
+                )
+                .await?
+                .ok_or_else(|| {
+                    OperatorReviewError::Internal(
+                        "review case idempotency row disappeared after conflict".to_owned(),
+                    )
+                })?;
+                ensure_review_case_matches_input(
+                    &row,
+                    &input,
+                    &subject_account_id,
+                    &related_promise_intent_id,
+                    &related_settlement_case_id,
+                    &assigned_operator_id,
+                )?;
+                row
+            }
+        } else {
+            let row = tx
+                .query_one(
+                    "
+                    INSERT INTO dao.review_cases (
+                        review_case_id,
+                        case_type,
+                        severity,
+                        review_status,
+                        subject_account_id,
+                        related_promise_intent_id,
+                        related_settlement_case_id,
+                        related_realm_id,
+                        opened_reason_code,
+                        source_fact_kind,
+                        source_fact_id,
+                        source_snapshot_json,
+                        assigned_operator_id,
+                        opened_by_operator_id,
+                        request_idempotency_key
+                    )
+                    VALUES ($1, $2, $3, 'open', $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+                    RETURNING *
+                    ",
+                    &[
+                        &review_case_id,
+                        &input.case_type,
+                        &input.severity,
+                        &subject_account_id,
+                        &related_promise_intent_id,
+                        &related_settlement_case_id,
+                        &input.related_realm_id,
+                        &input.opened_reason_code,
+                        &input.source_fact_kind,
+                        &input.source_fact_id,
+                        &input.source_snapshot_json,
+                        &assigned_operator_id,
+                        &operator_id,
+                        &request_idempotency_key,
+                    ],
+                )
+                .await
+                .map_err(db_error)?;
+            refresh_review_status_view_tx(&tx, &review_case_id).await?;
+            row
+        };
+        let snapshot = review_case_from_row(&row);
         tx.commit().await.map_err(db_error)?;
         Ok(snapshot)
     }
@@ -195,7 +263,21 @@ impl OperatorReviewStore {
         let rows = client
             .query(
                 "
-                SELECT *
+                SELECT
+                    review_case_id,
+                    case_type,
+                    severity,
+                    review_status,
+                    subject_account_id,
+                    related_promise_intent_id,
+                    related_settlement_case_id,
+                    related_realm_id,
+                    opened_reason_code,
+                    source_fact_kind,
+                    source_fact_id,
+                    assigned_operator_id,
+                    opened_at,
+                    updated_at
                 FROM dao.review_cases
                 ORDER BY opened_at DESC
                 LIMIT 100
@@ -252,7 +334,14 @@ impl OperatorReviewStore {
                     created_by_operator_id
                 )
                 VALUES ($1, $2, $3, $4, $5, $6, $7)
-                RETURNING *
+                RETURNING
+                    evidence_bundle_id,
+                    review_case_id,
+                    evidence_visibility,
+                    summary_json,
+                    retention_class,
+                    created_by_operator_id,
+                    created_at
                 ",
                 &[
                     &evidence_bundle_id,
@@ -266,6 +355,7 @@ impl OperatorReviewStore {
             )
             .await
             .map_err(db_error)?;
+        sync_review_case_status_tx(&tx, &review_case_id).await?;
         refresh_review_status_view_tx(&tx, &review_case_id).await?;
         tx.commit().await.map_err(db_error)?;
         Ok(evidence_bundle_from_row(&row))
@@ -284,14 +374,19 @@ impl OperatorReviewStore {
         let grantee_operator_id = parse_uuid(&input.grantee_operator_id, "grantee operator id")?;
         validate_allowed("access_scope", &input.access_scope, EVIDENCE_VISIBILITIES)?;
         require_non_empty("grant_reason", &input.grant_reason)?;
-        if input.expires_at <= Utc::now() {
+
+        let mut client = self.client.lock().await;
+        let tx = client.transaction().await.map_err(db_error)?;
+        let db_now: chrono::DateTime<Utc> = tx
+            .query_one("SELECT CURRENT_TIMESTAMP AS current_timestamp", &[])
+            .await
+            .map_err(db_error)?
+            .get("current_timestamp");
+        if input.expires_at <= db_now {
             return Err(OperatorReviewError::BadRequest(
                 "expires_at must be in the future".to_owned(),
             ));
         }
-
-        let mut client = self.client.lock().await;
-        let tx = client.transaction().await.map_err(db_error)?;
         ensure_operator_has_role(&tx, &operator_id, OperatorRole::Approver).await?;
         ensure_review_case_exists_tx(&tx, &review_case_id).await?;
         if let Some(bundle_id) = evidence_bundle_id.as_ref() {
@@ -329,6 +424,7 @@ impl OperatorReviewStore {
             )
             .await
             .map_err(db_error)?;
+        sync_review_case_status_tx(&tx, &review_case_id).await?;
         refresh_review_status_view_tx(&tx, &review_case_id).await?;
         tx.commit().await.map_err(db_error)?;
         Ok(evidence_access_grant_from_row(&row))
@@ -354,21 +450,68 @@ impl OperatorReviewStore {
         let tx = client.transaction().await.map_err(db_error)?;
         ensure_operator_has_role(&tx, &operator_id, OperatorRole::Approver).await?;
         ensure_review_case_exists_tx(&tx, &review_case_id).await?;
-        if let Some(existing) = find_existing_decision_by_idempotency(
-            &tx,
-            &review_case_id,
-            &operator_id,
-            &decision_idempotency_key,
-        )
-        .await?
-        {
-            tx.commit().await.map_err(db_error)?;
-            return Ok(existing);
-        }
 
         let operator_decision_fact_id = Uuid::new_v4();
-        let row = tx
-            .query_one(
+        let row = if decision_idempotency_key.is_some() {
+            if let Some(row) = tx
+                .query_opt(
+                    "
+                    INSERT INTO dao.operator_decision_facts (
+                        operator_decision_fact_id,
+                        review_case_id,
+                        decision_kind,
+                        user_facing_reason_code,
+                        operator_note_internal,
+                        decision_payload_json,
+                        decided_by_operator_id,
+                        decision_idempotency_key
+                    )
+                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+                    ON CONFLICT (review_case_id, decided_by_operator_id, decision_idempotency_key)
+                    WHERE decision_idempotency_key IS NOT NULL
+                    DO NOTHING
+                    RETURNING
+                        operator_decision_fact_id,
+                        review_case_id,
+                        appeal_case_id,
+                        decision_kind,
+                        user_facing_reason_code,
+                        decided_by_operator_id,
+                        recorded_at
+                    ",
+                    &[
+                        &operator_decision_fact_id,
+                        &review_case_id,
+                        &input.decision_kind,
+                        &input.user_facing_reason_code,
+                        &input.operator_note_internal,
+                        &input.decision_payload_json,
+                        &operator_id,
+                        &decision_idempotency_key,
+                    ],
+                )
+                .await
+                .map_err(db_error)?
+            {
+                row
+            } else {
+                let row = find_existing_decision_by_idempotency(
+                    &tx,
+                    &review_case_id,
+                    &operator_id,
+                    &decision_idempotency_key,
+                )
+                .await?
+                .ok_or_else(|| {
+                    OperatorReviewError::Internal(
+                        "operator decision idempotency row disappeared after conflict".to_owned(),
+                    )
+                })?;
+                ensure_operator_decision_matches_input(&row, &input)?;
+                row
+            }
+        } else {
+            tx.query_one(
                 "
                 INSERT INTO dao.operator_decision_facts (
                     operator_decision_fact_id,
@@ -381,7 +524,14 @@ impl OperatorReviewStore {
                     decision_idempotency_key
                 )
                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-                RETURNING *
+                RETURNING
+                    operator_decision_fact_id,
+                    review_case_id,
+                    appeal_case_id,
+                    decision_kind,
+                    user_facing_reason_code,
+                    decided_by_operator_id,
+                    recorded_at
                 ",
                 &[
                     &operator_decision_fact_id,
@@ -395,23 +545,9 @@ impl OperatorReviewStore {
                 ],
             )
             .await
-            .map_err(db_error)?;
-        let next_status = if input.decision_kind == "request_more_evidence" {
-            "awaiting_evidence"
-        } else {
-            "decided"
+            .map_err(db_error)?
         };
-        tx.execute(
-            "
-            UPDATE dao.review_cases
-            SET review_status = $2,
-                updated_at = CURRENT_TIMESTAMP
-            WHERE review_case_id = $1
-            ",
-            &[&review_case_id, &next_status],
-        )
-        .await
-        .map_err(db_error)?;
+        sync_review_case_status_tx(&tx, &review_case_id).await?;
         refresh_review_status_view_tx(&tx, &review_case_id).await?;
         tx.commit().await.map_err(db_error)?;
         Ok(operator_decision_fact_from_row(&row))
@@ -438,22 +574,75 @@ impl OperatorReviewStore {
         let mut client = self.client.lock().await;
         let tx = client.transaction().await.map_err(db_error)?;
         ensure_subject_can_access_case_tx(&tx, &review_case_id, &submitted_by_account_id).await?;
-        if let Some(existing) = find_existing_appeal_by_idempotency(
-            &tx,
-            &review_case_id,
-            &submitted_by_account_id,
-            &appeal_idempotency_key,
-        )
-        .await?
-        {
-            tx.commit().await.map_err(db_error)?;
-            return Ok(existing);
-        }
         ensure_appeal_source_tx(&tx, &review_case_id, source_decision_fact_id.as_ref()).await?;
 
         let appeal_case_id = Uuid::new_v4();
-        let row = tx
-            .query_one(
+        let row = if appeal_idempotency_key.is_some() {
+            if let Some(row) = tx
+                .query_opt(
+                    "
+                    INSERT INTO dao.appeal_cases (
+                        appeal_case_id,
+                        source_review_case_id,
+                        source_decision_fact_id,
+                        appeal_status,
+                        submitted_by_account_id,
+                        submitted_reason_code,
+                        appellant_statement,
+                        new_evidence_summary_json,
+                        appeal_idempotency_key
+                    )
+                    VALUES ($1, $2, $3, 'submitted', $4, $5, $6, $7, $8)
+                    ON CONFLICT (
+                        source_review_case_id,
+                        submitted_by_account_id,
+                        appeal_idempotency_key
+                    )
+                    WHERE appeal_idempotency_key IS NOT NULL
+                    DO NOTHING
+                    RETURNING
+                        appeal_case_id,
+                        source_review_case_id,
+                        source_decision_fact_id,
+                        appeal_status,
+                        submitted_by_account_id,
+                        submitted_reason_code,
+                        created_at,
+                        updated_at
+                    ",
+                    &[
+                        &appeal_case_id,
+                        &review_case_id,
+                        &source_decision_fact_id,
+                        &submitted_by_account_id,
+                        &input.submitted_reason_code,
+                        &input.appellant_statement,
+                        &input.new_evidence_summary_json,
+                        &appeal_idempotency_key,
+                    ],
+                )
+                .await
+                .map_err(db_error)?
+            {
+                row
+            } else {
+                let row = find_existing_appeal_by_idempotency(
+                    &tx,
+                    &review_case_id,
+                    &submitted_by_account_id,
+                    &appeal_idempotency_key,
+                )
+                .await?
+                .ok_or_else(|| {
+                    OperatorReviewError::Internal(
+                        "appeal idempotency row disappeared after conflict".to_owned(),
+                    )
+                })?;
+                ensure_appeal_matches_input(&row, &input, source_decision_fact_id.as_ref())?;
+                row
+            }
+        } else {
+            tx.query_one(
                 "
                 INSERT INTO dao.appeal_cases (
                     appeal_case_id,
@@ -467,7 +656,15 @@ impl OperatorReviewStore {
                     appeal_idempotency_key
                 )
                 VALUES ($1, $2, $3, 'submitted', $4, $5, $6, $7, $8)
-                RETURNING *
+                RETURNING
+                    appeal_case_id,
+                    source_review_case_id,
+                    source_decision_fact_id,
+                    appeal_status,
+                    submitted_by_account_id,
+                    submitted_reason_code,
+                    created_at,
+                    updated_at
                 ",
                 &[
                     &appeal_case_id,
@@ -481,18 +678,9 @@ impl OperatorReviewStore {
                 ],
             )
             .await
-            .map_err(db_error)?;
-        tx.execute(
-            "
-            UPDATE dao.review_cases
-            SET review_status = 'appealed',
-                updated_at = CURRENT_TIMESTAMP
-            WHERE review_case_id = $1
-            ",
-            &[&review_case_id],
-        )
-        .await
-        .map_err(db_error)?;
+            .map_err(db_error)?
+        };
+        sync_review_case_status_tx(&tx, &review_case_id).await?;
         refresh_review_status_view_tx(&tx, &review_case_id).await?;
         tx.commit().await.map_err(db_error)?;
         Ok(appeal_case_from_row(&row))
@@ -510,7 +698,15 @@ impl OperatorReviewStore {
         let rows = client
             .query(
                 "
-                SELECT *
+                SELECT
+                    appeal_case_id,
+                    source_review_case_id,
+                    source_decision_fact_id,
+                    appeal_status,
+                    submitted_by_account_id,
+                    submitted_reason_code,
+                    created_at,
+                    updated_at
                 FROM dao.appeal_cases
                 WHERE source_review_case_id = $1
                 ORDER BY created_at ASC
@@ -557,7 +753,14 @@ async fn read_review_case_tx<C: GenericClient + Sync>(
     let evidence_bundles = client
         .query(
             "
-            SELECT *
+            SELECT
+                evidence_bundle_id,
+                review_case_id,
+                evidence_visibility,
+                summary_json,
+                retention_class,
+                created_by_operator_id,
+                created_at
             FROM dao.evidence_bundles
             WHERE review_case_id = $1
             ORDER BY created_at ASC
@@ -587,7 +790,14 @@ async fn read_review_case_tx<C: GenericClient + Sync>(
     let operator_decision_facts = client
         .query(
             "
-            SELECT *
+            SELECT
+                operator_decision_fact_id,
+                review_case_id,
+                appeal_case_id,
+                decision_kind,
+                user_facing_reason_code,
+                decided_by_operator_id,
+                recorded_at
             FROM dao.operator_decision_facts
             WHERE review_case_id = $1
             ORDER BY recorded_at ASC
@@ -602,7 +812,15 @@ async fn read_review_case_tx<C: GenericClient + Sync>(
     let appeal_cases = client
         .query(
             "
-            SELECT *
+            SELECT
+                appeal_case_id,
+                source_review_case_id,
+                source_decision_fact_id,
+                appeal_status,
+                submitted_by_account_id,
+                submitted_reason_code,
+                created_at,
+                updated_at
             FROM dao.appeal_cases
             WHERE source_review_case_id = $1
             ORDER BY created_at ASC
@@ -628,11 +846,11 @@ async fn find_existing_review_case_by_idempotency<C: GenericClient + Sync>(
     client: &C,
     operator_id: &Uuid,
     request_idempotency_key: &Option<String>,
-) -> Result<Option<ReviewCaseSnapshot>, OperatorReviewError> {
+) -> Result<Option<Row>, OperatorReviewError> {
     let Some(request_idempotency_key) = request_idempotency_key else {
         return Ok(None);
     };
-    let row = client
+    client
         .query_opt(
             "
             SELECT *
@@ -643,8 +861,7 @@ async fn find_existing_review_case_by_idempotency<C: GenericClient + Sync>(
             &[operator_id, request_idempotency_key],
         )
         .await
-        .map_err(db_error)?;
-    Ok(row.as_ref().map(review_case_from_row))
+        .map_err(db_error)
 }
 
 async fn find_existing_decision_by_idempotency<C: GenericClient + Sync>(
@@ -652,11 +869,11 @@ async fn find_existing_decision_by_idempotency<C: GenericClient + Sync>(
     review_case_id: &Uuid,
     operator_id: &Uuid,
     decision_idempotency_key: &Option<String>,
-) -> Result<Option<OperatorDecisionFactSnapshot>, OperatorReviewError> {
+) -> Result<Option<Row>, OperatorReviewError> {
     let Some(decision_idempotency_key) = decision_idempotency_key else {
         return Ok(None);
     };
-    let row = client
+    client
         .query_opt(
             "
             SELECT *
@@ -668,8 +885,7 @@ async fn find_existing_decision_by_idempotency<C: GenericClient + Sync>(
             &[review_case_id, operator_id, decision_idempotency_key],
         )
         .await
-        .map_err(db_error)?;
-    Ok(row.as_ref().map(operator_decision_fact_from_row))
+        .map_err(db_error)
 }
 
 async fn find_existing_appeal_by_idempotency<C: GenericClient + Sync>(
@@ -677,11 +893,11 @@ async fn find_existing_appeal_by_idempotency<C: GenericClient + Sync>(
     review_case_id: &Uuid,
     submitted_by_account_id: &Uuid,
     appeal_idempotency_key: &Option<String>,
-) -> Result<Option<AppealCaseSnapshot>, OperatorReviewError> {
+) -> Result<Option<Row>, OperatorReviewError> {
     let Some(appeal_idempotency_key) = appeal_idempotency_key else {
         return Ok(None);
     };
-    let row = client
+    client
         .query_opt(
             "
             SELECT *
@@ -697,8 +913,7 @@ async fn find_existing_appeal_by_idempotency<C: GenericClient + Sync>(
             ],
         )
         .await
-        .map_err(db_error)?;
-    Ok(row.as_ref().map(appeal_case_from_row))
+        .map_err(db_error)
 }
 
 async fn ensure_operator_has_any_role<C: GenericClient + Sync>(
@@ -706,10 +921,33 @@ async fn ensure_operator_has_any_role<C: GenericClient + Sync>(
     operator_id: &Uuid,
     roles: &[OperatorRole],
 ) -> Result<(), OperatorReviewError> {
-    for role in roles {
-        if operator_has_role(client, operator_id, *role).await? {
-            return Ok(());
-        }
+    if roles.is_empty() {
+        return Err(OperatorReviewError::Unauthorized(
+            "operator role is not allowed for this action".to_owned(),
+        ));
+    }
+    let role_names = roles.iter().map(|role| role.as_str()).collect::<Vec<_>>();
+    let row = client
+        .query_one(
+            "
+            SELECT EXISTS (
+                SELECT 1
+                FROM core.operator_role_assignments
+                JOIN core.accounts
+                  ON core.accounts.account_id = core.operator_role_assignments.operator_account_id
+                WHERE operator_account_id = $1
+                  AND operator_role = ANY($2::text[])
+                  AND revoked_at IS NULL
+                  AND core.accounts.account_class = 'Controlled Exceptional Account'
+                  AND core.accounts.account_state = 'active'
+            ) AS has_role
+            ",
+            &[operator_id, &role_names],
+        )
+        .await
+        .map_err(db_error)?;
+    if row.get("has_role") {
+        return Ok(());
     }
     Err(OperatorReviewError::Unauthorized(
         "operator role is not allowed for this action".to_owned(),
@@ -914,7 +1152,25 @@ async fn select_review_case_tx<C: GenericClient + Sync>(
 ) -> Result<ReviewCaseSnapshot, OperatorReviewError> {
     let row = client
         .query_opt(
-            "SELECT * FROM dao.review_cases WHERE review_case_id = $1",
+            "
+            SELECT
+                review_case_id,
+                case_type,
+                severity,
+                review_status,
+                subject_account_id,
+                related_promise_intent_id,
+                related_settlement_case_id,
+                related_realm_id,
+                opened_reason_code,
+                source_fact_kind,
+                source_fact_id,
+                assigned_operator_id,
+                opened_at,
+                updated_at
+            FROM dao.review_cases
+            WHERE review_case_id = $1
+            ",
             &[review_case_id],
         )
         .await
@@ -947,14 +1203,22 @@ async fn refresh_review_status_view_tx<C: GenericClient + Sync>(
                 last_projected_at
             )
             WITH latest_decision AS (
-                SELECT *
+                SELECT
+                    operator_decision_fact_id,
+                    decision_kind,
+                    user_facing_reason_code,
+                    recorded_at
                 FROM dao.operator_decision_facts
                 WHERE review_case_id = $1
                 ORDER BY recorded_at DESC, operator_decision_fact_id DESC
                 LIMIT 1
             ),
             latest_appeal AS (
-                SELECT *
+                SELECT
+                    appeal_case_id,
+                    appeal_status,
+                    submitted_reason_code,
+                    updated_at
                 FROM dao.appeal_cases
                 WHERE source_review_case_id = $1
                 ORDER BY updated_at DESC, appeal_case_id DESC
@@ -990,7 +1254,7 @@ async fn refresh_review_status_view_tx<C: GenericClient + Sync>(
                     review.related_promise_intent_id,
                     review.related_settlement_case_id,
                     review.related_realm_id,
-                    latest_decision.operator_decision_fact_id,
+                    latest_decision.operator_decision_fact_id AS latest_decision_fact_id,
                     CASE
                         WHEN review.review_status = 'closed' THEN 'closed'
                         WHEN latest_appeal.appeal_status IN ('submitted', 'accepted', 'under_review')
@@ -998,13 +1262,16 @@ async fn refresh_review_status_view_tx<C: GenericClient + Sync>(
                             THEN 'appeal_submitted'
                         WHEN latest_decision.decision_kind IN ('restrict', 'escalate')
                             THEN 'sealed_or_restricted'
-                        WHEN review.review_status = 'awaiting_evidence'
-                            OR latest_decision.decision_kind = 'request_more_evidence'
+                        WHEN latest_decision.decision_kind = 'request_more_evidence'
+                            OR (
+                                review.review_status = 'awaiting_evidence'
+                                AND latest_decision.operator_decision_fact_id IS NULL
+                            )
                             THEN 'evidence_requested'
                         WHEN review.review_status IN ('open', 'triaged') THEN 'pending_review'
                         WHEN review.review_status = 'under_review' THEN 'under_review'
-                        WHEN review.review_status = 'decided'
-                            AND latest_decision.operator_decision_fact_id IS NOT NULL
+                        WHEN latest_decision.operator_decision_fact_id IS NOT NULL
+                            AND latest_decision.decision_kind <> 'request_more_evidence'
                             AND latest_appeal.appeal_case_id IS NULL
                             THEN 'appeal_available'
                         WHEN review.review_status = 'decided' THEN 'decided'
@@ -1021,18 +1288,23 @@ async fn refresh_review_status_view_tx<C: GenericClient + Sync>(
                         WHEN latest_appeal.appeal_status = 'under_review' THEN 'under_review'
                         WHEN latest_appeal.appeal_status = 'decided' THEN 'decided'
                         WHEN latest_appeal.appeal_status = 'closed' THEN 'closed'
-                        WHEN review.review_status = 'decided'
-                            AND latest_decision.operator_decision_fact_id IS NOT NULL
+                        WHEN latest_decision.operator_decision_fact_id IS NOT NULL
+                            AND latest_decision.decision_kind <> 'request_more_evidence'
+                            AND latest_appeal.appeal_case_id IS NULL
                             THEN 'appeal_available'
                         ELSE 'none'
                     END AS appeal_status,
                     (
-                        review.review_status = 'awaiting_evidence'
-                        OR COALESCE(latest_decision.decision_kind = 'request_more_evidence', FALSE)
+                        COALESCE(latest_decision.decision_kind = 'request_more_evidence', FALSE)
+                        OR (
+                            review.review_status = 'awaiting_evidence'
+                            AND latest_decision.operator_decision_fact_id IS NULL
+                        )
                     ) AS evidence_requested,
                     (
-                        review.review_status = 'decided'
+                        review.review_status <> 'closed'
                         AND latest_decision.operator_decision_fact_id IS NOT NULL
+                        AND latest_decision.decision_kind <> 'request_more_evidence'
                         AND latest_appeal.appeal_case_id IS NULL
                     ) AS appeal_available,
                     GREATEST(
@@ -1060,7 +1332,7 @@ async fn refresh_review_status_view_tx<C: GenericClient + Sync>(
                 user_facing_status,
                 user_facing_reason_code,
                 appeal_status,
-                operator_decision_fact_id,
+                latest_decision_fact_id,
                 evidence_requested,
                 appeal_available,
                 source_watermark_at,
@@ -1086,6 +1358,127 @@ async fn refresh_review_status_view_tx<C: GenericClient + Sync>(
         )
         .await
         .map_err(db_error)?;
+    Ok(())
+}
+
+async fn sync_review_case_status_tx<C: GenericClient + Sync>(
+    client: &C,
+    review_case_id: &Uuid,
+) -> Result<(), OperatorReviewError> {
+    client
+        .execute(
+            "
+            WITH latest_decision AS (
+                SELECT decision_kind
+                FROM dao.operator_decision_facts
+                WHERE review_case_id = $1
+                ORDER BY recorded_at DESC, operator_decision_fact_id DESC
+                LIMIT 1
+            ),
+            latest_appeal AS (
+                SELECT appeal_status
+                FROM dao.appeal_cases
+                WHERE source_review_case_id = $1
+                ORDER BY updated_at DESC, appeal_case_id DESC
+                LIMIT 1
+            ),
+            next_status AS (
+                SELECT
+                    CASE
+                        WHEN review.review_status = 'closed' THEN 'closed'
+                        WHEN EXISTS (
+                            SELECT 1
+                            FROM latest_appeal
+                            WHERE appeal_status IN ('submitted', 'accepted', 'under_review')
+                        ) THEN 'appealed'
+                        WHEN (SELECT decision_kind FROM latest_decision) = 'request_more_evidence'
+                            THEN 'awaiting_evidence'
+                        WHEN EXISTS (SELECT 1 FROM latest_decision) THEN 'decided'
+                        ELSE review.review_status
+                    END AS review_status
+                FROM dao.review_cases review
+                WHERE review.review_case_id = $1
+            )
+            UPDATE dao.review_cases review
+            SET review_status = next_status.review_status,
+                updated_at = CASE
+                    WHEN review.review_status IS DISTINCT FROM next_status.review_status
+                        THEN CURRENT_TIMESTAMP
+                    ELSE review.updated_at
+                END
+            FROM next_status
+            WHERE review.review_case_id = $1
+            ",
+            &[review_case_id],
+        )
+        .await
+        .map_err(db_error)?;
+    Ok(())
+}
+
+fn ensure_review_case_matches_input(
+    row: &Row,
+    input: &CreateReviewCaseInput,
+    subject_account_id: &Option<Uuid>,
+    related_promise_intent_id: &Option<Uuid>,
+    related_settlement_case_id: &Option<Uuid>,
+    assigned_operator_id: &Option<Uuid>,
+) -> Result<(), OperatorReviewError> {
+    let existing_related_realm_id = row
+        .get::<_, Option<String>>("related_realm_id")
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty());
+    if row.get::<_, String>("case_type") != input.case_type
+        || row.get::<_, String>("severity") != input.severity
+        || row.get::<_, Option<Uuid>>("subject_account_id") != *subject_account_id
+        || row.get::<_, Option<Uuid>>("related_promise_intent_id") != *related_promise_intent_id
+        || row.get::<_, Option<Uuid>>("related_settlement_case_id") != *related_settlement_case_id
+        || existing_related_realm_id != normalize_optional(&input.related_realm_id)
+        || row.get::<_, String>("opened_reason_code") != input.opened_reason_code
+        || row.get::<_, String>("source_fact_kind") != input.source_fact_kind
+        || row.get::<_, String>("source_fact_id") != input.source_fact_id
+        || row.get::<_, Value>("source_snapshot_json") != input.source_snapshot_json
+        || row.get::<_, Option<Uuid>>("assigned_operator_id") != *assigned_operator_id
+    {
+        return Err(OperatorReviewError::BadRequest(
+            "request_idempotency_key was already used with a different review case payload"
+                .to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn ensure_operator_decision_matches_input(
+    row: &Row,
+    input: &RecordOperatorDecisionInput,
+) -> Result<(), OperatorReviewError> {
+    if row.get::<_, String>("decision_kind") != input.decision_kind
+        || row.get::<_, String>("user_facing_reason_code") != input.user_facing_reason_code
+        || row.get::<_, Option<String>>("operator_note_internal") != input.operator_note_internal
+        || row.get::<_, Value>("decision_payload_json") != input.decision_payload_json
+    {
+        return Err(OperatorReviewError::BadRequest(
+            "decision_idempotency_key was already used with a different operator decision payload"
+                .to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn ensure_appeal_matches_input(
+    row: &Row,
+    input: &CreateAppealCaseInput,
+    source_decision_fact_id: Option<&Uuid>,
+) -> Result<(), OperatorReviewError> {
+    if row.get::<_, Option<Uuid>>("source_decision_fact_id") != source_decision_fact_id.copied()
+        || row.get::<_, String>("submitted_reason_code") != input.submitted_reason_code
+        || row.get::<_, Option<String>>("appellant_statement") != input.appellant_statement
+        || row.get::<_, Value>("new_evidence_summary_json") != input.new_evidence_summary_json
+    {
+        return Err(OperatorReviewError::BadRequest(
+            "appeal_idempotency_key was already used with a different appeal payload".to_owned(),
+        ));
+    }
     Ok(())
 }
 

--- a/apps/backend/src/services/operator_review/types.rs
+++ b/apps/backend/src/services/operator_review/types.rs
@@ -1,0 +1,192 @@
+use chrono::{DateTime, Utc};
+use serde_json::Value;
+
+#[derive(Debug)]
+pub enum OperatorReviewError {
+    BadRequest(String),
+    Unauthorized(String),
+    NotFound(String),
+    Database {
+        message: String,
+        code: Option<String>,
+        constraint: Option<String>,
+        retryable: bool,
+    },
+    Internal(String),
+}
+
+impl OperatorReviewError {
+    pub fn message(&self) -> &str {
+        match self {
+            Self::BadRequest(message)
+            | Self::Unauthorized(message)
+            | Self::NotFound(message)
+            | Self::Database { message, .. }
+            | Self::Internal(message) => message,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OperatorRole {
+    Reviewer,
+    Approver,
+    Steward,
+    Auditor,
+    Support,
+}
+
+impl OperatorRole {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Reviewer => "reviewer",
+            Self::Approver => "approver",
+            Self::Steward => "steward",
+            Self::Auditor => "auditor",
+            Self::Support => "support",
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct CreateReviewCaseInput {
+    pub case_type: String,
+    pub severity: String,
+    pub subject_account_id: Option<String>,
+    pub related_promise_intent_id: Option<String>,
+    pub related_settlement_case_id: Option<String>,
+    pub related_realm_id: Option<String>,
+    pub opened_reason_code: String,
+    pub source_fact_kind: String,
+    pub source_fact_id: String,
+    pub source_snapshot_json: Value,
+    pub assigned_operator_id: Option<String>,
+    pub request_idempotency_key: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct AttachEvidenceBundleInput {
+    pub evidence_visibility: String,
+    pub summary_json: Value,
+    pub raw_locator_json: Value,
+    pub retention_class: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct GrantEvidenceAccessInput {
+    pub evidence_bundle_id: Option<String>,
+    pub grantee_operator_id: String,
+    pub access_scope: String,
+    pub grant_reason: String,
+    pub expires_at: DateTime<Utc>,
+}
+
+#[derive(Clone, Debug)]
+pub struct RecordOperatorDecisionInput {
+    pub decision_kind: String,
+    pub user_facing_reason_code: String,
+    pub operator_note_internal: Option<String>,
+    pub decision_payload_json: Value,
+    pub decision_idempotency_key: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct CreateAppealCaseInput {
+    pub source_decision_fact_id: Option<String>,
+    pub submitted_reason_code: String,
+    pub appellant_statement: Option<String>,
+    pub new_evidence_summary_json: Value,
+    pub appeal_idempotency_key: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct ReviewCaseSnapshot {
+    pub review_case_id: String,
+    pub case_type: String,
+    pub severity: String,
+    pub review_status: String,
+    pub subject_account_id: Option<String>,
+    pub related_promise_intent_id: Option<String>,
+    pub related_settlement_case_id: Option<String>,
+    pub related_realm_id: Option<String>,
+    pub opened_reason_code: String,
+    pub source_fact_kind: String,
+    pub source_fact_id: String,
+    pub assigned_operator_id: Option<String>,
+    pub opened_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Clone, Debug)]
+pub struct EvidenceBundleSnapshot {
+    pub evidence_bundle_id: String,
+    pub review_case_id: String,
+    pub evidence_visibility: String,
+    pub summary_json: Value,
+    pub retention_class: String,
+    pub created_by_operator_id: Option<String>,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Clone, Debug)]
+pub struct EvidenceAccessGrantSnapshot {
+    pub access_grant_id: String,
+    pub review_case_id: String,
+    pub evidence_bundle_id: Option<String>,
+    pub grantee_operator_id: String,
+    pub access_scope: String,
+    pub grant_reason: String,
+    pub approved_by_operator_id: String,
+    pub expires_at: DateTime<Utc>,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Clone, Debug)]
+pub struct OperatorDecisionFactSnapshot {
+    pub operator_decision_fact_id: String,
+    pub review_case_id: String,
+    pub appeal_case_id: Option<String>,
+    pub decision_kind: String,
+    pub user_facing_reason_code: String,
+    pub decided_by_operator_id: String,
+    pub recorded_at: DateTime<Utc>,
+}
+
+#[derive(Clone, Debug)]
+pub struct AppealCaseSnapshot {
+    pub appeal_case_id: String,
+    pub source_review_case_id: String,
+    pub source_decision_fact_id: Option<String>,
+    pub appeal_status: String,
+    pub submitted_by_account_id: String,
+    pub submitted_reason_code: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Clone, Debug)]
+pub struct ReadReviewCaseSnapshot {
+    pub review_case: ReviewCaseSnapshot,
+    pub evidence_bundles: Vec<EvidenceBundleSnapshot>,
+    pub evidence_access_grants: Vec<EvidenceAccessGrantSnapshot>,
+    pub operator_decision_facts: Vec<OperatorDecisionFactSnapshot>,
+    pub appeal_cases: Vec<AppealCaseSnapshot>,
+}
+
+#[derive(Clone, Debug)]
+pub struct ReviewStatusReadModelSnapshot {
+    pub review_case_id: String,
+    pub subject_account_id: Option<String>,
+    pub related_promise_intent_id: Option<String>,
+    pub related_settlement_case_id: Option<String>,
+    pub related_realm_id: Option<String>,
+    pub user_facing_status: String,
+    pub user_facing_reason_code: String,
+    pub appeal_status: String,
+    pub evidence_requested: bool,
+    pub appeal_available: bool,
+    pub latest_decision_fact_id: Option<String>,
+    pub source_watermark_at: DateTime<Utc>,
+    pub source_fact_count: i64,
+    pub last_projected_at: DateTime<Utc>,
+}

--- a/apps/backend/tests/operator_review.rs
+++ b/apps/backend/tests/operator_review.rs
@@ -1,0 +1,679 @@
+use axum::{
+    Router,
+    body::{Body, to_bytes},
+    http::{Request, StatusCode},
+};
+use musubi_backend::{build_app, new_test_state};
+use serde_json::{Value, json};
+use tower::ServiceExt;
+use uuid::Uuid;
+
+#[tokio::test]
+async fn operator_review_flow_preserves_writer_truth_and_projects_safe_status() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let subject = sign_in(&app, "pi-user-review-subject", "review-subject").await;
+    let counterparty = sign_in(&app, "pi-user-review-counterparty", "review-counterparty").await;
+    let client = test_db_client().await;
+    let reviewer_id = insert_operator_account(&client, "reviewer").await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+    let support_id = insert_operator_account(&client, "support").await;
+
+    let create_promise = post_json(
+        &app,
+        "/api/promise/intents",
+        Some(subject.token.as_str()),
+        json!({
+            "internal_idempotency_key": "operator-review-promise",
+            "realm_id": "realm-operator-review",
+            "counterparty_account_id": counterparty.account_id,
+            "deposit_amount_minor_units": 10000,
+            "currency_code": "PI"
+        }),
+    )
+    .await;
+    assert_eq!(create_promise.status, StatusCode::OK);
+    let promise_intent_id = create_promise.body["promise_intent_id"]
+        .as_str()
+        .expect("promise_intent_id must exist")
+        .to_owned();
+    let settlement_case_id = create_promise.body["settlement_case_id"]
+        .as_str()
+        .expect("settlement_case_id must exist")
+        .to_owned();
+    let original_settlement_status = settlement_status(&client, &settlement_case_id).await;
+
+    let create_case = operator_post_json(
+        &app,
+        "/api/internal/operator/review-cases",
+        &reviewer_id,
+        json!({
+            "case_type": "promise_dispute",
+            "severity": "sev2",
+            "subject_account_id": subject.account_id,
+            "related_promise_intent_id": promise_intent_id,
+            "related_settlement_case_id": settlement_case_id,
+            "related_realm_id": "realm-operator-review",
+            "opened_reason_code": "promise_completion_under_review",
+            "source_fact_kind": "settlement_case",
+            "source_fact_id": settlement_case_id,
+            "source_snapshot_json": {
+                "case_status": original_settlement_status
+            },
+            "request_idempotency_key": "review-case-001"
+        }),
+    )
+    .await;
+    assert_eq!(create_case.status, StatusCode::OK);
+    assert_eq!(create_case.body["review_status"], "open");
+    let review_case_id = create_case.body["review_case_id"]
+        .as_str()
+        .expect("review_case_id must exist")
+        .to_owned();
+
+    let initial_status = get_json(
+        &app,
+        &format!("/api/review-cases/{review_case_id}/status"),
+        Some(subject.token.as_str()),
+    )
+    .await;
+    assert_eq!(initial_status.status, StatusCode::OK);
+    assert_eq!(initial_status.body["user_facing_status"], "pending_review");
+    assert_eq!(
+        initial_status.body["user_facing_reason_code"],
+        "promise_completion_under_review"
+    );
+    assert_eq!(initial_status.body["source_fact_count"], 1);
+
+    let attach_evidence = operator_post_json(
+        &app,
+        &format!("/api/internal/operator/review-cases/{review_case_id}/evidence-bundles"),
+        &reviewer_id,
+        json!({
+            "evidence_visibility": "redacted_raw",
+            "summary_json": {
+                "badge": "timeline_ready",
+                "safe_summary": "Promise timeline and proof summary are ready for review."
+            },
+            "raw_locator_json": {
+                "raw_callback_locator": "private-raw-callback-uri"
+            },
+            "retention_class": "R6"
+        }),
+    )
+    .await;
+    assert_eq!(attach_evidence.status, StatusCode::OK);
+    assert!(attach_evidence.body.get("raw_locator_json").is_none());
+    assert!(
+        !attach_evidence
+            .body
+            .to_string()
+            .contains("private-raw-callback-uri")
+    );
+    let evidence_bundle_id = attach_evidence.body["evidence_bundle_id"]
+        .as_str()
+        .expect("evidence_bundle_id must exist")
+        .to_owned();
+
+    let after_evidence_status = get_json(
+        &app,
+        &format!("/api/review-cases/{review_case_id}/status"),
+        Some(subject.token.as_str()),
+    )
+    .await;
+    assert_eq!(after_evidence_status.status, StatusCode::OK);
+    assert_eq!(after_evidence_status.body["source_fact_count"], 2);
+
+    let reviewer_grant_attempt = operator_post_json(
+        &app,
+        &format!("/api/internal/operator/review-cases/{review_case_id}/evidence-access-grants"),
+        &reviewer_id,
+        json!({
+            "evidence_bundle_id": evidence_bundle_id,
+            "grantee_operator_id": reviewer_id,
+            "access_scope": "summary_only",
+            "grant_reason": "reviewer needs the bounded case summary",
+            "expires_at": future_timestamp()
+        }),
+    )
+    .await;
+    assert_eq!(reviewer_grant_attempt.status, StatusCode::UNAUTHORIZED);
+
+    let summary_grant = operator_post_json(
+        &app,
+        &format!("/api/internal/operator/review-cases/{review_case_id}/evidence-access-grants"),
+        &approver_id,
+        json!({
+            "evidence_bundle_id": evidence_bundle_id,
+            "grantee_operator_id": reviewer_id,
+            "access_scope": "summary_only",
+            "grant_reason": "reviewer needs the bounded case summary",
+            "expires_at": future_timestamp()
+        }),
+    )
+    .await;
+    assert_eq!(summary_grant.status, StatusCode::OK);
+    assert_eq!(summary_grant.body["access_scope"], "summary_only");
+
+    let after_grant_status = get_json(
+        &app,
+        &format!("/api/review-cases/{review_case_id}/status"),
+        Some(subject.token.as_str()),
+    )
+    .await;
+    assert_eq!(after_grant_status.status, StatusCode::OK);
+    assert_eq!(after_grant_status.body["source_fact_count"], 3);
+
+    let support_raw_grant = operator_post_json(
+        &app,
+        &format!("/api/internal/operator/review-cases/{review_case_id}/evidence-access-grants"),
+        &approver_id,
+        json!({
+            "evidence_bundle_id": evidence_bundle_id,
+            "grantee_operator_id": support_id,
+            "access_scope": "full_raw",
+            "grant_reason": "support should not get full raw access",
+            "expires_at": future_timestamp()
+        }),
+    )
+    .await;
+    assert_eq!(support_raw_grant.status, StatusCode::UNAUTHORIZED);
+
+    let invalid_reason_decision = operator_post_json(
+        &app,
+        &format!("/api/internal/operator/review-cases/{review_case_id}/decisions"),
+        &approver_id,
+        json!({
+            "decision_kind": "restrict",
+            "user_facing_reason_code": "internal_abuse_label",
+            "operator_note_internal": "private operator note must not leak",
+            "decision_payload_json": {
+                "internal": "not user facing"
+            },
+            "decision_idempotency_key": "decision-invalid"
+        }),
+    )
+    .await;
+    assert_eq!(invalid_reason_decision.status, StatusCode::BAD_REQUEST);
+
+    let reviewer_decision_attempt = operator_post_json(
+        &app,
+        &format!("/api/internal/operator/review-cases/{review_case_id}/decisions"),
+        &reviewer_id,
+        json!({
+            "decision_kind": "restrict",
+            "user_facing_reason_code": "restricted_after_review",
+            "operator_note_internal": "private operator note must not leak",
+            "decision_payload_json": {
+                "internal": "not user facing"
+            },
+            "decision_idempotency_key": "decision-unauthorized"
+        }),
+    )
+    .await;
+    assert_eq!(reviewer_decision_attempt.status, StatusCode::UNAUTHORIZED);
+
+    let decision = operator_post_json(
+        &app,
+        &format!("/api/internal/operator/review-cases/{review_case_id}/decisions"),
+        &approver_id,
+        json!({
+            "decision_kind": "restrict",
+            "user_facing_reason_code": "restricted_after_review",
+            "operator_note_internal": "private operator note must not leak",
+            "decision_payload_json": {
+                "internal": "not user facing"
+            },
+            "decision_idempotency_key": "decision-001"
+        }),
+    )
+    .await;
+    assert_eq!(decision.status, StatusCode::OK);
+    let decision_fact_id = decision.body["operator_decision_fact_id"]
+        .as_str()
+        .expect("decision fact id must exist")
+        .to_owned();
+
+    let replayed_decision = operator_post_json(
+        &app,
+        &format!("/api/internal/operator/review-cases/{review_case_id}/decisions"),
+        &approver_id,
+        json!({
+            "decision_kind": "restrict",
+            "user_facing_reason_code": "restricted_after_review",
+            "operator_note_internal": "private operator note must not leak",
+            "decision_payload_json": {
+                "internal": "not user facing"
+            },
+            "decision_idempotency_key": "decision-001"
+        }),
+    )
+    .await;
+    assert_eq!(replayed_decision.status, StatusCode::OK);
+    assert_eq!(
+        replayed_decision.body["operator_decision_fact_id"],
+        decision_fact_id
+    );
+    assert_eq!(
+        decision_count(&client, &review_case_id).await,
+        1,
+        "idempotent replay must not append a second decision fact"
+    );
+    assert_eq!(
+        settlement_status(&client, &settlement_case_id).await,
+        original_settlement_status,
+        "operator decision must not mutate settlement writer truth"
+    );
+
+    let decided_status = get_json(
+        &app,
+        &format!("/api/review-cases/{review_case_id}/status"),
+        Some(subject.token.as_str()),
+    )
+    .await;
+    assert_eq!(decided_status.status, StatusCode::OK);
+    assert_eq!(
+        decided_status.body["user_facing_status"],
+        "sealed_or_restricted"
+    );
+    assert_eq!(
+        decided_status.body["user_facing_reason_code"],
+        "restricted_after_review"
+    );
+    assert!(decided_status.body.get("operator_note_internal").is_none());
+    assert!(
+        !decided_status
+            .body
+            .to_string()
+            .contains("private operator note")
+    );
+
+    let review_detail = operator_get_json(
+        &app,
+        &format!("/api/internal/operator/review-cases/{review_case_id}"),
+        &approver_id,
+    )
+    .await;
+    assert_eq!(review_detail.status, StatusCode::OK);
+    assert!(review_detail.body.get("operator_note_internal").is_none());
+    assert!(
+        !review_detail
+            .body
+            .to_string()
+            .contains("private operator note")
+    );
+    assert!(
+        !review_detail
+            .body
+            .to_string()
+            .contains("private-raw-callback-uri")
+    );
+    assert_eq!(
+        review_detail.body["operator_decision_facts"]
+            .as_array()
+            .expect("decision facts must be an array")
+            .len(),
+        1
+    );
+
+    let appeal = post_json(
+        &app,
+        &format!("/api/review-cases/{review_case_id}/appeals"),
+        Some(subject.token.as_str()),
+        json!({
+            "source_decision_fact_id": decision_fact_id,
+            "submitted_reason_code": "appeal_received",
+            "appellant_statement": "I have additional context.",
+            "new_evidence_summary_json": {
+                "safe_summary": "Additional user-provided context is available."
+            },
+            "appeal_idempotency_key": "appeal-001"
+        }),
+    )
+    .await;
+    assert_eq!(appeal.status, StatusCode::OK);
+    assert_eq!(appeal.body["source_review_case_id"], review_case_id);
+    assert_eq!(appeal.body["source_decision_fact_id"], decision_fact_id);
+    assert_eq!(appeal.body["appeal_status"], "submitted");
+
+    let appeals = get_json(
+        &app,
+        &format!("/api/review-cases/{review_case_id}/appeals"),
+        Some(subject.token.as_str()),
+    )
+    .await;
+    assert_eq!(appeals.status, StatusCode::OK);
+    assert_eq!(
+        appeals
+            .body
+            .as_array()
+            .expect("appeals must be an array")
+            .len(),
+        1
+    );
+
+    let appealed_status = get_json(
+        &app,
+        &format!("/api/review-cases/{review_case_id}/status"),
+        Some(subject.token.as_str()),
+    )
+    .await;
+    assert_eq!(appealed_status.status, StatusCode::OK);
+    assert_eq!(
+        appealed_status.body["user_facing_status"],
+        "appeal_submitted"
+    );
+    assert_eq!(appealed_status.body["appeal_status"], "submitted");
+    assert_eq!(
+        appealed_status.body["user_facing_reason_code"],
+        "appeal_received"
+    );
+
+    let cross_user_status = get_json(
+        &app,
+        &format!("/api/review-cases/{review_case_id}/status"),
+        Some(counterparty.token.as_str()),
+    )
+    .await;
+    assert_eq!(cross_user_status.status, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn distinct_operator_decisions_append_new_facts_without_rewriting_source_truth() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let subject = sign_in(&app, "pi-user-review-append", "review-append").await;
+    let counterparty = sign_in(&app, "pi-user-review-append-b", "review-append-b").await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let create_promise = post_json(
+        &app,
+        "/api/promise/intents",
+        Some(subject.token.as_str()),
+        json!({
+            "internal_idempotency_key": "operator-review-append-promise",
+            "realm_id": "realm-operator-review-append",
+            "counterparty_account_id": counterparty.account_id,
+            "deposit_amount_minor_units": 10000,
+            "currency_code": "PI"
+        }),
+    )
+    .await;
+    assert_eq!(create_promise.status, StatusCode::OK);
+    let settlement_case_id = create_promise.body["settlement_case_id"]
+        .as_str()
+        .expect("settlement_case_id must exist")
+        .to_owned();
+    let original_settlement_status = settlement_status(&client, &settlement_case_id).await;
+
+    let create_case = operator_post_json(
+        &app,
+        "/api/internal/operator/review-cases",
+        &approver_id,
+        json!({
+            "case_type": "settlement_conflict",
+            "severity": "sev1",
+            "subject_account_id": subject.account_id,
+            "related_settlement_case_id": settlement_case_id,
+            "related_realm_id": "realm-operator-review-append",
+            "opened_reason_code": "policy_review",
+            "source_fact_kind": "settlement_case",
+            "source_fact_id": settlement_case_id,
+            "source_snapshot_json": {
+                "case_status": original_settlement_status
+            },
+            "request_idempotency_key": "review-case-append"
+        }),
+    )
+    .await;
+    assert_eq!(create_case.status, StatusCode::OK);
+    let review_case_id = create_case.body["review_case_id"]
+        .as_str()
+        .expect("review_case_id must exist")
+        .to_owned();
+
+    let request_more_evidence = operator_post_json(
+        &app,
+        &format!("/api/internal/operator/review-cases/{review_case_id}/decisions"),
+        &approver_id,
+        json!({
+            "decision_kind": "request_more_evidence",
+            "user_facing_reason_code": "proof_inconclusive",
+            "operator_note_internal": "requesting private details for internal review",
+            "decision_payload_json": {
+                "requested": "bounded evidence summary"
+            },
+            "decision_idempotency_key": "append-decision-001"
+        }),
+    )
+    .await;
+    assert_eq!(request_more_evidence.status, StatusCode::OK);
+
+    let restore = operator_post_json(
+        &app,
+        &format!("/api/internal/operator/review-cases/{review_case_id}/decisions"),
+        &approver_id,
+        json!({
+            "decision_kind": "restore",
+            "user_facing_reason_code": "restored_after_review",
+            "operator_note_internal": "restoration rationale is internal",
+            "decision_payload_json": {
+                "resolution": "restore"
+            },
+            "decision_idempotency_key": "append-decision-002"
+        }),
+    )
+    .await;
+    assert_eq!(restore.status, StatusCode::OK);
+    assert_ne!(
+        request_more_evidence.body["operator_decision_fact_id"],
+        restore.body["operator_decision_fact_id"]
+    );
+    assert_eq!(decision_count(&client, &review_case_id).await, 2);
+    assert_eq!(
+        settlement_status(&client, &settlement_case_id).await,
+        original_settlement_status
+    );
+
+    let status = get_json(
+        &app,
+        &format!("/api/review-cases/{review_case_id}/status"),
+        Some(subject.token.as_str()),
+    )
+    .await;
+    assert_eq!(status.status, StatusCode::OK);
+    assert_eq!(status.body["user_facing_status"], "appeal_available");
+    assert_eq!(
+        status.body["user_facing_reason_code"],
+        "restored_after_review"
+    );
+    assert_eq!(
+        status.body["latest_decision_fact_id"],
+        restore.body["operator_decision_fact_id"]
+    );
+}
+
+struct SignedInUser {
+    token: String,
+    account_id: String,
+}
+
+struct JsonResponse {
+    status: StatusCode,
+    body: Value,
+}
+
+async fn sign_in(app: &Router, pi_uid: &str, username: &str) -> SignedInUser {
+    let response = post_json(
+        app,
+        "/api/auth/pi",
+        None,
+        json!({
+            "pi_uid": pi_uid,
+            "username": username,
+            "wallet_address": format!("wallet-{pi_uid}"),
+            "access_token": format!("access-token-{pi_uid}")
+        }),
+    )
+    .await;
+    assert_eq!(response.status, StatusCode::OK);
+
+    SignedInUser {
+        token: response.body["token"]
+            .as_str()
+            .expect("token must exist")
+            .to_owned(),
+        account_id: response.body["user"]["id"]
+            .as_str()
+            .expect("user id must exist")
+            .to_owned(),
+    }
+}
+
+async fn insert_operator_account(client: &tokio_postgres::Client, role: &str) -> String {
+    let account_id = Uuid::new_v4();
+    client
+        .execute(
+            "
+            INSERT INTO core.accounts (account_id, account_class, account_state)
+            VALUES ($1, 'Controlled Exceptional Account', 'active')
+            ",
+            &[&account_id],
+        )
+        .await
+        .expect("operator account must insert");
+    client
+        .execute(
+            "
+            INSERT INTO core.operator_role_assignments (
+                operator_role_assignment_id,
+                operator_account_id,
+                operator_role,
+                grant_reason
+            )
+            VALUES ($1, $2, $3, 'operator review test role')
+            ",
+            &[&Uuid::new_v4(), &account_id, &role],
+        )
+        .await
+        .expect("operator role assignment must insert");
+    account_id.to_string()
+}
+
+async fn settlement_status(client: &tokio_postgres::Client, settlement_case_id: &str) -> String {
+    client
+        .query_one(
+            "
+            SELECT case_status
+            FROM dao.settlement_cases
+            WHERE settlement_case_id::text = $1
+            ",
+            &[&settlement_case_id],
+        )
+        .await
+        .expect("settlement case must exist")
+        .get("case_status")
+}
+
+async fn decision_count(client: &tokio_postgres::Client, review_case_id: &str) -> i64 {
+    client
+        .query_one(
+            "
+            SELECT count(*) AS count
+            FROM dao.operator_decision_facts
+            WHERE review_case_id::text = $1
+            ",
+            &[&review_case_id],
+        )
+        .await
+        .expect("operator decision fact count must be queryable")
+        .get("count")
+}
+
+async fn test_db_client() -> tokio_postgres::Client {
+    let database_url = std::env::var("MUSUBI_TEST_DATABASE_URL")
+        .or_else(|_| std::env::var("DATABASE_URL"))
+        .expect("test database url must be present");
+    let (client, connection) = tokio_postgres::connect(&database_url, tokio_postgres::NoTls)
+        .await
+        .expect("test database must be reachable");
+    tokio::spawn(async move {
+        if let Err(error) = connection.await {
+            eprintln!("test database connection error: {error}");
+        }
+    });
+    client
+}
+
+fn future_timestamp() -> String {
+    (chrono::Utc::now() + chrono::Duration::hours(2)).to_rfc3339()
+}
+
+async fn operator_post_json(
+    app: &Router,
+    path: &str,
+    operator_id: &str,
+    body: Value,
+) -> JsonResponse {
+    request_json(app, "POST", path, None, Some(operator_id), Some(body)).await
+}
+
+async fn operator_get_json(app: &Router, path: &str, operator_id: &str) -> JsonResponse {
+    request_json(app, "GET", path, None, Some(operator_id), None).await
+}
+
+async fn post_json(
+    app: &Router,
+    path: &str,
+    bearer_token: Option<&str>,
+    body: Value,
+) -> JsonResponse {
+    request_json(app, "POST", path, bearer_token, None, Some(body)).await
+}
+
+async fn get_json(app: &Router, path: &str, bearer_token: Option<&str>) -> JsonResponse {
+    request_json(app, "GET", path, bearer_token, None, None).await
+}
+
+async fn request_json(
+    app: &Router,
+    method: &str,
+    path: &str,
+    bearer_token: Option<&str>,
+    operator_id: Option<&str>,
+    body: Option<Value>,
+) -> JsonResponse {
+    let mut builder = Request::builder().method(method).uri(path);
+    if let Some(token) = bearer_token {
+        builder = builder.header("authorization", format!("Bearer {token}"));
+    }
+    if let Some(operator_id) = operator_id {
+        builder = builder.header("x-musubi-operator-id", operator_id);
+    }
+
+    let request = builder
+        .header("content-type", "application/json")
+        .body(match body {
+            Some(body) => Body::from(body.to_string()),
+            None => Body::empty(),
+        })
+        .expect("request must build");
+
+    let response = app
+        .clone()
+        .oneshot(request)
+        .await
+        .expect("app should respond");
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body must be readable");
+    let body = if bytes.is_empty() {
+        json!({})
+    } else {
+        serde_json::from_slice(&bytes).expect("response body must be valid json")
+    };
+
+    JsonResponse { status, body }
+}

--- a/apps/backend/tests/operator_review.rs
+++ b/apps/backend/tests/operator_review.rs
@@ -738,6 +738,94 @@ async fn evidence_refresh_repairs_stale_case_status_from_latest_decision_fact() 
     );
 }
 
+#[tokio::test]
+async fn request_more_evidence_decision_is_not_appealable() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let subject = sign_in(
+        &app,
+        "pi-user-review-request-more-evidence",
+        "review-request-more-evidence",
+    )
+    .await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let create_case = operator_post_json(
+        &app,
+        "/api/internal/operator/review-cases",
+        &approver_id,
+        json!({
+            "case_type": "proof_anomaly",
+            "severity": "sev1",
+            "subject_account_id": subject.account_id,
+            "related_realm_id": "realm-review-request-more-evidence",
+            "opened_reason_code": "proof_inconclusive",
+            "source_fact_kind": "proof_submission",
+            "source_fact_id": "proof-source-request-more-evidence",
+            "source_snapshot_json": {
+                "source": "proof"
+            },
+            "request_idempotency_key": "review-case-request-more-evidence"
+        }),
+    )
+    .await;
+    assert_eq!(create_case.status, StatusCode::OK);
+    let review_case_id = create_case.body["review_case_id"]
+        .as_str()
+        .expect("review_case_id must exist")
+        .to_owned();
+
+    let request_more_evidence = operator_post_json(
+        &app,
+        &format!("/api/internal/operator/review-cases/{review_case_id}/decisions"),
+        &approver_id,
+        json!({
+            "decision_kind": "request_more_evidence",
+            "user_facing_reason_code": "proof_inconclusive",
+            "operator_note_internal": "need more proof context",
+            "decision_payload_json": {
+                "requested": "bounded evidence summary"
+            },
+            "decision_idempotency_key": "decision-request-more-evidence"
+        }),
+    )
+    .await;
+    assert_eq!(request_more_evidence.status, StatusCode::OK);
+    let decision_fact_id = request_more_evidence.body["operator_decision_fact_id"]
+        .as_str()
+        .expect("decision fact id must exist")
+        .to_owned();
+
+    let appeal = post_json(
+        &app,
+        &format!("/api/review-cases/{review_case_id}/appeals"),
+        Some(subject.token.as_str()),
+        json!({
+            "source_decision_fact_id": decision_fact_id,
+            "submitted_reason_code": "appeal_received",
+            "appellant_statement": "I want to appeal before sending more proof.",
+            "new_evidence_summary_json": {
+                "safe_summary": "appeal should be rejected for non-final decisions"
+            },
+            "appeal_idempotency_key": "appeal-request-more-evidence"
+        }),
+    )
+    .await;
+    assert_eq!(appeal.status, StatusCode::BAD_REQUEST);
+
+    let status = get_json(
+        &app,
+        &format!("/api/review-cases/{review_case_id}/status"),
+        Some(subject.token.as_str()),
+    )
+    .await;
+    assert_eq!(status.status, StatusCode::OK);
+    assert_eq!(status.body["user_facing_status"], "evidence_requested");
+    assert_eq!(status.body["appeal_status"], "none");
+    assert_eq!(status.body["appeal_available"], false);
+}
+
 struct SignedInUser {
     token: String,
     account_id: String,

--- a/apps/backend/tests/operator_review.rs
+++ b/apps/backend/tests/operator_review.rs
@@ -3,7 +3,8 @@ use axum::{
     body::{Body, to_bytes},
     http::{Request, StatusCode},
 };
-use musubi_backend::{build_app, new_test_state};
+use musubi_backend::{build_app, new_state_from_config, new_test_state};
+use musubi_db_runtime::DbConfig;
 use serde_json::{Value, json};
 use tower::ServiceExt;
 use uuid::Uuid;
@@ -491,6 +492,249 @@ async fn distinct_operator_decisions_append_new_facts_without_rewriting_source_t
     assert_eq!(
         status.body["latest_decision_fact_id"],
         restore.body["operator_decision_fact_id"]
+    );
+}
+
+#[tokio::test]
+async fn reused_decision_idempotency_key_rejects_mismatched_payload() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let subject = sign_in(&app, "pi-user-review-mismatch", "review-mismatch").await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let create_case = operator_post_json(
+        &app,
+        "/api/internal/operator/review-cases",
+        &approver_id,
+        json!({
+            "case_type": "proof_anomaly",
+            "severity": "sev1",
+            "subject_account_id": subject.account_id,
+            "related_realm_id": "realm-review-mismatch",
+            "opened_reason_code": "proof_inconclusive",
+            "source_fact_kind": "proof_submission",
+            "source_fact_id": "proof-source-mismatch",
+            "source_snapshot_json": {
+                "source": "proof"
+            },
+            "request_idempotency_key": "review-case-mismatch"
+        }),
+    )
+    .await;
+    assert_eq!(create_case.status, StatusCode::OK);
+    let review_case_id = create_case.body["review_case_id"]
+        .as_str()
+        .expect("review_case_id must exist")
+        .to_owned();
+
+    let first = operator_post_json(
+        &app,
+        &format!("/api/internal/operator/review-cases/{review_case_id}/decisions"),
+        &approver_id,
+        json!({
+            "decision_kind": "restrict",
+            "user_facing_reason_code": "restricted_after_review",
+            "operator_note_internal": "first decision",
+            "decision_payload_json": {
+                "resolution": "restrict"
+            },
+            "decision_idempotency_key": "decision-mismatch"
+        }),
+    )
+    .await;
+    assert_eq!(first.status, StatusCode::OK);
+
+    let second = operator_post_json(
+        &app,
+        &format!("/api/internal/operator/review-cases/{review_case_id}/decisions"),
+        &approver_id,
+        json!({
+            "decision_kind": "restore",
+            "user_facing_reason_code": "restored_after_review",
+            "operator_note_internal": "second decision should fail",
+            "decision_payload_json": {
+                "resolution": "restore"
+            },
+            "decision_idempotency_key": "decision-mismatch"
+        }),
+    )
+    .await;
+    assert_eq!(second.status, StatusCode::BAD_REQUEST);
+    assert_eq!(decision_count(&client, &review_case_id).await, 1);
+}
+
+#[tokio::test]
+async fn concurrent_decision_replay_returns_existing_fact_across_two_app_states() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let database_url = std::env::var("MUSUBI_TEST_DATABASE_URL")
+        .or_else(|_| std::env::var("DATABASE_URL"))
+        .expect("test database url must be present");
+    let config = DbConfig::from_lookup(|name| match name {
+        "APP_ENV" => Some("local".to_owned()),
+        "DATABASE_URL" => Some(database_url.clone()),
+        _ => std::env::var(name).ok(),
+    })
+    .expect("db config");
+    let second_state = new_state_from_config(&config).await.expect("second state");
+    let second_app = build_app(second_state.clone());
+    let subject = sign_in(&app, "pi-user-review-concurrent", "review-concurrent").await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let create_case = operator_post_json(
+        &app,
+        "/api/internal/operator/review-cases",
+        &approver_id,
+        json!({
+            "case_type": "proof_anomaly",
+            "severity": "sev1",
+            "subject_account_id": subject.account_id,
+            "related_realm_id": "realm-review-concurrent",
+            "opened_reason_code": "proof_inconclusive",
+            "source_fact_kind": "proof_submission",
+            "source_fact_id": "proof-source-concurrent",
+            "source_snapshot_json": {
+                "source": "proof"
+            },
+            "request_idempotency_key": "review-case-concurrent"
+        }),
+    )
+    .await;
+    assert_eq!(create_case.status, StatusCode::OK);
+    let review_case_id = create_case.body["review_case_id"]
+        .as_str()
+        .expect("review_case_id must exist")
+        .to_owned();
+
+    let path = format!("/api/internal/operator/review-cases/{review_case_id}/decisions");
+    let body = json!({
+        "decision_kind": "restrict",
+        "user_facing_reason_code": "restricted_after_review",
+        "operator_note_internal": "concurrent replay",
+        "decision_payload_json": {
+            "resolution": "restrict"
+        },
+        "decision_idempotency_key": "decision-concurrent"
+    });
+    let (first, second) = tokio::join!(
+        operator_post_json(&app, &path, &approver_id, body.clone()),
+        operator_post_json(&second_app, &path, &approver_id, body)
+    );
+    assert_eq!(first.status, StatusCode::OK);
+    assert_eq!(second.status, StatusCode::OK);
+    assert_eq!(
+        first.body["operator_decision_fact_id"],
+        second.body["operator_decision_fact_id"]
+    );
+    assert_eq!(decision_count(&client, &review_case_id).await, 1);
+}
+
+#[tokio::test]
+async fn evidence_refresh_repairs_stale_case_status_from_latest_decision_fact() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let subject = sign_in(&app, "pi-user-review-stale", "review-stale").await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let create_case = operator_post_json(
+        &app,
+        "/api/internal/operator/review-cases",
+        &approver_id,
+        json!({
+            "case_type": "proof_anomaly",
+            "severity": "sev1",
+            "subject_account_id": subject.account_id,
+            "related_realm_id": "realm-review-stale",
+            "opened_reason_code": "proof_inconclusive",
+            "source_fact_kind": "proof_submission",
+            "source_fact_id": "proof-source-stale",
+            "source_snapshot_json": {
+                "source": "proof"
+            },
+            "request_idempotency_key": "review-case-stale"
+        }),
+    )
+    .await;
+    assert_eq!(create_case.status, StatusCode::OK);
+    let review_case_id = create_case.body["review_case_id"]
+        .as_str()
+        .expect("review_case_id must exist")
+        .to_owned();
+
+    let decision = operator_post_json(
+        &app,
+        &format!("/api/internal/operator/review-cases/{review_case_id}/decisions"),
+        &approver_id,
+        json!({
+            "decision_kind": "restrict",
+            "user_facing_reason_code": "restricted_after_review",
+            "operator_note_internal": "final restriction",
+            "decision_payload_json": {
+                "resolution": "restrict"
+            },
+            "decision_idempotency_key": "decision-stale"
+        }),
+    )
+    .await;
+    assert_eq!(decision.status, StatusCode::OK);
+
+    client
+        .execute(
+            "
+            UPDATE dao.review_cases
+            SET review_status = 'awaiting_evidence',
+                updated_at = CURRENT_TIMESTAMP
+            WHERE review_case_id::text = $1
+            ",
+            &[&review_case_id],
+        )
+        .await
+        .expect("stale review status must update");
+
+    let attach_evidence = operator_post_json(
+        &app,
+        &format!("/api/internal/operator/review-cases/{review_case_id}/evidence-bundles"),
+        &approver_id,
+        json!({
+            "evidence_visibility": "summary_only",
+            "summary_json": {
+                "safe_summary": "bounded summary"
+            },
+            "raw_locator_json": {},
+            "retention_class": "R4"
+        }),
+    )
+    .await;
+    assert_eq!(attach_evidence.status, StatusCode::OK);
+
+    let status = get_json(
+        &app,
+        &format!("/api/review-cases/{review_case_id}/status"),
+        Some(subject.token.as_str()),
+    )
+    .await;
+    assert_eq!(status.status, StatusCode::OK);
+    assert_eq!(status.body["user_facing_status"], "sealed_or_restricted");
+    assert_eq!(status.body["appeal_status"], "appeal_available");
+    assert_eq!(status.body["appeal_available"], true);
+    assert_eq!(
+        status.body["latest_decision_fact_id"],
+        decision.body["operator_decision_fact_id"]
+    );
+
+    let review_detail = operator_get_json(
+        &app,
+        &format!("/api/internal/operator/review-cases/{review_case_id}"),
+        &approver_id,
+    )
+    .await;
+    assert_eq!(review_detail.status, StatusCode::OK);
+    assert_eq!(
+        review_detail.body["review_case"]["review_status"],
+        "decided"
     );
 }
 


### PR DESCRIPTION
## Design source

`ISSUE-12-operator-review-appeal-evidence.md`

This is design ISSUE-12, not a GitHub issue number. The GitHub issue number is intentionally not hardcoded.

## Summary

Adds the baseline operator review / appeal / evidence workflow required before the ISSUE-13 room progression surface and ISSUE-14 Promise UI fallback surfaces.

## What changed

- Added migration `0014_operator_review_appeal_evidence.sql`
- Added operator review domain/service layer
- Added review case, evidence bundle, evidence grant, decision, appeal, and user-facing status handlers
- Added bounded user-facing review status projection
- Added integration tests for append-only decisions, role restrictions, evidence access, appeal creation, and safe projection
- Added implementation docs and schema ownership notes

## Core behavior

- Operator decisions append `dao.operator_decision_facts`
- Operator decisions do not mutate original Promise / settlement writer truth
- User-facing review state is derived into `projection.review_status_views`
- User-facing reason codes are bounded
- Raw evidence locators and internal operator notes are not exposed through user-facing read models
- Evidence access grants are scoped, expiring, and auditable

## Validation

- `make ENV_FILE=.env.example db-bootstrap`
- `make ENV_FILE=.env.example db-migrate`
- `make ENV_FILE=.env.example db-status`
- `cargo check`
- `cargo test --test operator_review --no-fail-fast`
- `cargo test --no-fail-fast`
- `git diff --check`

Note: `cargo fmt --check` still reports a pre-existing formatting-only change in `apps/backend/src/handlers/orchestration.rs`. This PR leaves that unrelated file untouched.

## Deferred

- ISSUE-13 room progression state machine
- ISSUE-14 Promise UI / completion / proof-missing fallback UI
- full dispute center UI
- settlement UI
- proof persistence
- scoped raw evidence retrieval endpoint for authorized operators
- broad operator console product work
