### PR TITLE
fix(ops): harden operator review idempotency

### DIFF
--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -119,7 +119,7 @@ Issue #8 adds the runtime migration runner and backend startup schema check.
 See `docs/db_runtime.md` for the current DB bootstrap and local reset flow.
 Issue #21 wires the happy-route writer truth to PostgreSQL while preserving the existing HTTP surface and settlement-view response contract.
 Issue #22 adds derived Promise, expanded settlement, and bounded trust read models with rebuild and freshness metadata.
-Design source: ISSUE-12-operator-review-appeal-evidence.md adds the operator review / appeal / evidence workflow baseline. Operator decisions are append-only facts, original writer truth is not overwritten, concurrent idempotent replays return the preserved case or fact instead of surfacing a duplicate-write error, replay mismatches are checked with payload hashes, and user-facing review state is projected with bounded status and reason codes. See `docs/operator_review_workflow.md`.
+Design source: ISSUE-12-operator-review-appeal-evidence.md adds the operator review / appeal / evidence workflow baseline. Operator decisions are append-only facts, original writer truth is not overwritten, concurrent idempotent replays return the preserved case or fact instead of surfacing a duplicate-write error, replay mismatches are checked with payload hashes, legacy rows backfill missing replay hashes on first retry, and user-facing review state is projected with bounded status and reason codes. See `docs/operator_review_workflow.md`.
 Issue #17 adds the first sandbox Pi provider adapter boundary for happy-route hold submission and callback intake.
 ISSUE-10 adds Day 1 safer venue proof primitives.
 The public HTTP surface supports the normal venue-code path only.

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -119,7 +119,7 @@ Issue #8 adds the runtime migration runner and backend startup schema check.
 See `docs/db_runtime.md` for the current DB bootstrap and local reset flow.
 Issue #21 wires the happy-route writer truth to PostgreSQL while preserving the existing HTTP surface and settlement-view response contract.
 Issue #22 adds derived Promise, expanded settlement, and bounded trust read models with rebuild and freshness metadata.
-Design source: ISSUE-12-operator-review-appeal-evidence.md adds the operator review / appeal / evidence workflow baseline. Operator decisions are append-only facts, original writer truth is not overwritten, concurrent idempotent replays return the preserved case or fact instead of surfacing a duplicate-write error, and user-facing review state is projected with bounded status and reason codes. See `docs/operator_review_workflow.md`.
+Design source: ISSUE-12-operator-review-appeal-evidence.md adds the operator review / appeal / evidence workflow baseline. Operator decisions are append-only facts, original writer truth is not overwritten, concurrent idempotent replays return the preserved case or fact instead of surfacing a duplicate-write error, replay mismatches are checked with payload hashes, and user-facing review state is projected with bounded status and reason codes. See `docs/operator_review_workflow.md`.
 Issue #17 adds the first sandbox Pi provider adapter boundary for happy-route hold submission and callback intake.
 ISSUE-10 adds Day 1 safer venue proof primitives.
 The public HTTP surface supports the normal venue-code path only.

--- a/apps/backend/docs/operator_review_workflow.md
+++ b/apps/backend/docs/operator_review_workflow.md
@@ -22,7 +22,7 @@ This keeps the workflow auditable:
 
 Idempotent create / decision / appeal requests must be durable under concurrent replay. Reusing the same idempotency key with a different payload is rejected instead of being silently treated as a replay.
 
-Replay mismatch checks use stored request payload hashes for review cases, operator decisions, and appeals. This keeps the replay boundary durable without requiring handlers to reload internal source snapshots, operator notes, decision payloads, appellant statements, or new evidence summaries when rejecting a mismatched replay. Rows without the expected replay hash are not treated as safe replays.
+Replay mismatch checks use stored request payload hashes for review cases, operator decisions, and appeals. This keeps the replay boundary durable without requiring handlers to reload internal source snapshots, operator notes, decision payloads, appellant statements, or new evidence summaries when rejecting a mismatched replay. If a legacy row is missing its replay hash, the handler recomputes the hash from the preserved row once, backfills the derived column, and then resumes the normal hash-only replay path.
 
 ## Evidence Access
 

--- a/apps/backend/docs/operator_review_workflow.md
+++ b/apps/backend/docs/operator_review_workflow.md
@@ -22,6 +22,8 @@ This keeps the workflow auditable:
 
 Idempotent create / decision / appeal requests must be durable under concurrent replay. Reusing the same idempotency key with a different payload is rejected instead of being silently treated as a replay.
 
+Replay mismatch checks use stored request payload hashes for review cases, operator decisions, and appeals. This keeps the replay boundary durable without requiring handlers to reload internal source snapshots, operator notes, decision payloads, appellant statements, or new evidence summaries when rejecting a mismatched replay. Rows without the expected replay hash are not treated as safe replays.
+
 ## Evidence Access
 
 Evidence access is separate from case visibility. A case may exist without granting an operator raw evidence access.

--- a/apps/backend/docs/schema_skeleton.md
+++ b/apps/backend/docs/schema_skeleton.md
@@ -125,6 +125,8 @@ Migration `0014_operator_review_appeal_evidence.sql` adds the baseline operator 
 - `dao.appeal_cases`
 - `projection.review_status_views`
 
+Migration `0015_operator_review_hardening.sql` adds payload hash columns for review case, operator decision, and appeal idempotency replay checks. The hashes keep mismatch detection durable while avoiding unnecessary reads of internal notes, raw-adjacent summaries, or source snapshots during replay rejection.
+
 The architectural boundary is strict: operator decisions are append-only facts and do not rewrite the original Promise, settlement, proof, or source writer truth. User-facing review status is projected from review, decision, evidence, and appeal facts using bounded status and reason codes.
 
 ISSUE-13 room progression and ISSUE-14 Promise UI are future consumers of this boundary. They are not implemented by this schema addition.

--- a/apps/backend/docs/schema_skeleton.md
+++ b/apps/backend/docs/schema_skeleton.md
@@ -125,7 +125,7 @@ Migration `0014_operator_review_appeal_evidence.sql` adds the baseline operator 
 - `dao.appeal_cases`
 - `projection.review_status_views`
 
-Migration `0015_operator_review_hardening.sql` adds payload hash columns for review case, operator decision, and appeal idempotency replay checks. The hashes keep mismatch detection durable while avoiding unnecessary reads of internal notes, raw-adjacent summaries, or source snapshots during replay rejection.
+Migration `0015_operator_review_hardening.sql` adds payload hash columns for review case, operator decision, and appeal idempotency replay checks. The hashes keep mismatch detection durable while avoiding unnecessary reads of internal notes, raw-adjacent summaries, or source snapshots during replay rejection, while legacy rows can self-heal by backfilling the missing hash on first replay.
 
 The architectural boundary is strict: operator decisions are append-only facts and do not rewrite the original Promise, settlement, proof, or source writer truth. User-facing review status is projected from review, decision, evidence, and appeal facts using bounded status and reason codes.
 

--- a/apps/backend/migrations/0015_operator_review_hardening.sql
+++ b/apps/backend/migrations/0015_operator_review_hardening.sql
@@ -14,10 +14,10 @@ ALTER TABLE dao.appeal_cases
         CHECK (appeal_payload_hash IS NULL OR char_length(appeal_payload_hash) = 64);
 
 COMMENT ON COLUMN dao.review_cases.request_payload_hash IS
-'ISSUE-12 idempotency payload hash. Replays compare this hash instead of reloading potentially sensitive source snapshots.';
+'ISSUE-12 idempotency payload hash for normal replay comparison. Legacy NULL values are backfilled from preserved review-case fields on first compatible replay.';
 
 COMMENT ON COLUMN dao.operator_decision_facts.decision_payload_hash IS
-'ISSUE-12 idempotency payload hash. Replays compare this hash instead of reloading internal operator notes or decision payload JSON.';
+'ISSUE-12 idempotency payload hash for normal replay comparison. Legacy NULL values are backfilled from preserved decision fact fields on first compatible replay.';
 
 COMMENT ON COLUMN dao.appeal_cases.appeal_payload_hash IS
-'ISSUE-12 idempotency payload hash. Replays compare this hash instead of reloading appellant statements or new evidence summaries.';
+'ISSUE-12 idempotency payload hash for normal replay comparison. Legacy NULL values are backfilled from preserved appeal fields on first compatible replay.';

--- a/apps/backend/migrations/0015_operator_review_hardening.sql
+++ b/apps/backend/migrations/0015_operator_review_hardening.sql
@@ -1,0 +1,23 @@
+-- Design source: ISSUE-12-operator-review-appeal-evidence.md
+-- GitHub issue number is intentionally not hardcoded.
+
+ALTER TABLE dao.review_cases
+    ADD COLUMN IF NOT EXISTS request_payload_hash TEXT
+        CHECK (request_payload_hash IS NULL OR char_length(request_payload_hash) = 64);
+
+ALTER TABLE dao.operator_decision_facts
+    ADD COLUMN IF NOT EXISTS decision_payload_hash TEXT
+        CHECK (decision_payload_hash IS NULL OR char_length(decision_payload_hash) = 64);
+
+ALTER TABLE dao.appeal_cases
+    ADD COLUMN IF NOT EXISTS appeal_payload_hash TEXT
+        CHECK (appeal_payload_hash IS NULL OR char_length(appeal_payload_hash) = 64);
+
+COMMENT ON COLUMN dao.review_cases.request_payload_hash IS
+'ISSUE-12 idempotency payload hash. Replays compare this hash instead of reloading potentially sensitive source snapshots.';
+
+COMMENT ON COLUMN dao.operator_decision_facts.decision_payload_hash IS
+'ISSUE-12 idempotency payload hash. Replays compare this hash instead of reloading internal operator notes or decision payload JSON.';
+
+COMMENT ON COLUMN dao.appeal_cases.appeal_payload_hash IS
+'ISSUE-12 idempotency payload hash. Replays compare this hash instead of reloading appellant statements or new evidence summaries.';

--- a/apps/backend/src/services/operator_review/repository.rs
+++ b/apps/backend/src/services/operator_review/repository.rs
@@ -1,11 +1,11 @@
 use std::{fmt::Write as _, sync::Arc};
 
 use chrono::Utc;
-use musubi_db_runtime::{DbConfig, connect_writer};
-use serde_json::{Value, json};
+use musubi_db_runtime::{connect_writer, DbConfig};
+use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use tokio::sync::Mutex;
-use tokio_postgres::{Client, GenericClient, Row, Transaction, error::SqlState};
+use tokio_postgres::{error::SqlState, Client, GenericClient, Row, Transaction};
 use uuid::Uuid;
 
 use super::types::{
@@ -217,7 +217,7 @@ impl OperatorReviewStore {
                         "review case idempotency row disappeared after conflict".to_owned(),
                     )
                 })?;
-                ensure_review_case_matches_payload_hash(&row, &request_payload_hash)?;
+                ensure_review_case_matches_payload_hash(&tx, &row, &request_payload_hash).await?;
                 row
             }
         } else {
@@ -553,7 +553,8 @@ impl OperatorReviewStore {
                         "operator decision idempotency row disappeared after conflict".to_owned(),
                     )
                 })?;
-                ensure_operator_decision_matches_payload_hash(&row, &decision_payload_hash)?;
+                ensure_operator_decision_matches_payload_hash(&tx, &row, &decision_payload_hash)
+                    .await?;
                 row
             }
         } else {
@@ -690,7 +691,7 @@ impl OperatorReviewStore {
                         "appeal idempotency row disappeared after conflict".to_owned(),
                     )
                 })?;
-                ensure_appeal_matches_payload_hash(&row, &appeal_request_payload_hash)?;
+                ensure_appeal_matches_payload_hash(&tx, &row, &appeal_request_payload_hash).await?;
                 row
             }
         } else {
@@ -1637,12 +1638,16 @@ fn write_canonical_json(value: &Value, output: &mut String) {
     }
 }
 
-fn ensure_review_case_matches_payload_hash(
+async fn ensure_review_case_matches_payload_hash<C: GenericClient + Sync>(
+    client: &C,
     row: &Row,
     request_payload_hash: &str,
 ) -> Result<(), OperatorReviewError> {
-    let existing_hash: Option<String> = row.get("request_payload_hash");
-    if existing_hash.as_deref() != Some(request_payload_hash) {
+    let existing_hash = match row.get::<_, Option<String>>("request_payload_hash") {
+        Some(hash) => hash,
+        None => backfill_review_case_payload_hash(client, row).await?,
+    };
+    if existing_hash != request_payload_hash {
         return Err(OperatorReviewError::BadRequest(
             "request_idempotency_key was already used with a different review case payload"
                 .to_owned(),
@@ -1651,12 +1656,16 @@ fn ensure_review_case_matches_payload_hash(
     Ok(())
 }
 
-fn ensure_operator_decision_matches_payload_hash(
+async fn ensure_operator_decision_matches_payload_hash<C: GenericClient + Sync>(
+    client: &C,
     row: &Row,
     decision_payload_hash: &str,
 ) -> Result<(), OperatorReviewError> {
-    let existing_hash: Option<String> = row.get("decision_payload_hash");
-    if existing_hash.as_deref() != Some(decision_payload_hash) {
+    let existing_hash = match row.get::<_, Option<String>>("decision_payload_hash") {
+        Some(hash) => hash,
+        None => backfill_operator_decision_payload_hash(client, row).await?,
+    };
+    if existing_hash != decision_payload_hash {
         return Err(OperatorReviewError::BadRequest(
             "decision_idempotency_key was already used with a different operator decision payload"
                 .to_owned(),
@@ -1665,17 +1674,180 @@ fn ensure_operator_decision_matches_payload_hash(
     Ok(())
 }
 
-fn ensure_appeal_matches_payload_hash(
+async fn ensure_appeal_matches_payload_hash<C: GenericClient + Sync>(
+    client: &C,
     row: &Row,
     appeal_payload_hash: &str,
 ) -> Result<(), OperatorReviewError> {
-    let existing_hash: Option<String> = row.get("appeal_payload_hash");
-    if existing_hash.as_deref() != Some(appeal_payload_hash) {
+    let existing_hash = match row.get::<_, Option<String>>("appeal_payload_hash") {
+        Some(hash) => hash,
+        None => backfill_appeal_payload_hash(client, row).await?,
+    };
+    if existing_hash != appeal_payload_hash {
         return Err(OperatorReviewError::BadRequest(
             "appeal_idempotency_key was already used with a different appeal payload".to_owned(),
         ));
     }
     Ok(())
+}
+
+async fn backfill_review_case_payload_hash<C: GenericClient + Sync>(
+    client: &C,
+    row: &Row,
+) -> Result<String, OperatorReviewError> {
+    let review_case_id = row.get::<_, Uuid>("review_case_id");
+    let legacy_row = client
+        .query_one(
+            "
+            SELECT
+                case_type,
+                severity,
+                subject_account_id,
+                related_promise_intent_id,
+                related_settlement_case_id,
+                related_realm_id,
+                opened_reason_code,
+                source_fact_kind,
+                source_fact_id,
+                source_snapshot_json,
+                assigned_operator_id
+            FROM dao.review_cases
+            WHERE review_case_id = $1
+            ",
+            &[&review_case_id],
+        )
+        .await
+        .map_err(db_error)?;
+    let payload_hash = review_case_payload_hash_from_row(&legacy_row);
+    client
+        .execute(
+            "
+            UPDATE dao.review_cases
+            SET request_payload_hash = $2
+            WHERE review_case_id = $1
+              AND request_payload_hash IS NULL
+            ",
+            &[&review_case_id, &payload_hash],
+        )
+        .await
+        .map_err(db_error)?;
+    Ok(payload_hash)
+}
+
+fn review_case_payload_hash_from_row(row: &Row) -> String {
+    let subject_account_id: Option<Uuid> = row.get("subject_account_id");
+    let related_promise_intent_id: Option<Uuid> = row.get("related_promise_intent_id");
+    let related_settlement_case_id: Option<Uuid> = row.get("related_settlement_case_id");
+    let assigned_operator_id: Option<Uuid> = row.get("assigned_operator_id");
+
+    hash_json_value(&json!({
+        "schema_version": 1,
+        "case_type": row.get::<_, String>("case_type"),
+        "severity": row.get::<_, String>("severity"),
+        "subject_account_id": optional_uuid_hash_value(&subject_account_id),
+        "related_promise_intent_id": optional_uuid_hash_value(&related_promise_intent_id),
+        "related_settlement_case_id": optional_uuid_hash_value(&related_settlement_case_id),
+        "related_realm_id": row.get::<_, Option<String>>("related_realm_id"),
+        "opened_reason_code": row.get::<_, String>("opened_reason_code"),
+        "source_fact_kind": row.get::<_, String>("source_fact_kind"),
+        "source_fact_id": row.get::<_, String>("source_fact_id"),
+        "source_snapshot_json": row.get::<_, Value>("source_snapshot_json"),
+        "assigned_operator_id": optional_uuid_hash_value(&assigned_operator_id),
+    }))
+}
+
+async fn backfill_operator_decision_payload_hash<C: GenericClient + Sync>(
+    client: &C,
+    row: &Row,
+) -> Result<String, OperatorReviewError> {
+    let operator_decision_fact_id = row.get::<_, Uuid>("operator_decision_fact_id");
+    let legacy_row = client
+        .query_one(
+            "
+            SELECT
+                decision_kind,
+                user_facing_reason_code,
+                operator_note_internal,
+                decision_payload_json
+            FROM dao.operator_decision_facts
+            WHERE operator_decision_fact_id = $1
+            ",
+            &[&operator_decision_fact_id],
+        )
+        .await
+        .map_err(db_error)?;
+    let payload_hash = operator_decision_payload_hash_from_row(&legacy_row);
+    client
+        .execute(
+            "
+            UPDATE dao.operator_decision_facts
+            SET decision_payload_hash = $2
+            WHERE operator_decision_fact_id = $1
+              AND decision_payload_hash IS NULL
+            ",
+            &[&operator_decision_fact_id, &payload_hash],
+        )
+        .await
+        .map_err(db_error)?;
+    Ok(payload_hash)
+}
+
+fn operator_decision_payload_hash_from_row(row: &Row) -> String {
+    hash_json_value(&json!({
+        "schema_version": 1,
+        "decision_kind": row.get::<_, String>("decision_kind"),
+        "user_facing_reason_code": row.get::<_, String>("user_facing_reason_code"),
+        "operator_note_internal": row.get::<_, Option<String>>("operator_note_internal"),
+        "decision_payload_json": row.get::<_, Value>("decision_payload_json"),
+    }))
+}
+
+async fn backfill_appeal_payload_hash<C: GenericClient + Sync>(
+    client: &C,
+    row: &Row,
+) -> Result<String, OperatorReviewError> {
+    let appeal_case_id = row.get::<_, Uuid>("appeal_case_id");
+    let legacy_row = client
+        .query_one(
+            "
+            SELECT
+                source_decision_fact_id,
+                submitted_reason_code,
+                appellant_statement,
+                new_evidence_summary_json
+            FROM dao.appeal_cases
+            WHERE appeal_case_id = $1
+            ",
+            &[&appeal_case_id],
+        )
+        .await
+        .map_err(db_error)?;
+    let payload_hash = appeal_payload_hash_from_row(&legacy_row);
+    client
+        .execute(
+            "
+            UPDATE dao.appeal_cases
+            SET appeal_payload_hash = $2
+            WHERE appeal_case_id = $1
+              AND appeal_payload_hash IS NULL
+            ",
+            &[&appeal_case_id, &payload_hash],
+        )
+        .await
+        .map_err(db_error)?;
+    Ok(payload_hash)
+}
+
+fn appeal_payload_hash_from_row(row: &Row) -> String {
+    let source_decision_fact_id: Option<Uuid> = row.get("source_decision_fact_id");
+
+    hash_json_value(&json!({
+        "schema_version": 1,
+        "source_decision_fact_id": source_decision_fact_id.map(|value| value.to_string()),
+        "submitted_reason_code": row.get::<_, String>("submitted_reason_code"),
+        "appellant_statement": row.get::<_, Option<String>>("appellant_statement"),
+        "new_evidence_summary_json": row.get::<_, Value>("new_evidence_summary_json"),
+    }))
 }
 
 fn review_case_from_row(row: &Row) -> ReviewCaseSnapshot {

--- a/apps/backend/src/services/operator_review/repository.rs
+++ b/apps/backend/src/services/operator_review/repository.rs
@@ -2,7 +2,8 @@ use std::sync::Arc;
 
 use chrono::Utc;
 use musubi_db_runtime::{DbConfig, connect_writer};
-use serde_json::Value;
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
 use tokio::sync::Mutex;
 use tokio_postgres::{Client, GenericClient, Row, Transaction, error::SqlState};
 use uuid::Uuid;
@@ -127,6 +128,13 @@ impl OperatorReviewStore {
         let assigned_operator_id =
             parse_optional_uuid(&input.assigned_operator_id, "assigned operator id")?;
         let request_idempotency_key = normalize_optional(&input.request_idempotency_key);
+        let request_payload_hash = review_case_payload_hash(
+            &input,
+            &subject_account_id,
+            &related_promise_intent_id,
+            &related_settlement_case_id,
+            &assigned_operator_id,
+        );
 
         let mut client = self.client.lock().await;
         let tx = client.transaction().await.map_err(db_error)?;
@@ -151,13 +159,28 @@ impl OperatorReviewStore {
                         source_snapshot_json,
                         assigned_operator_id,
                         opened_by_operator_id,
-                        request_idempotency_key
+                        request_idempotency_key,
+                        request_payload_hash
                     )
-                    VALUES ($1, $2, $3, 'open', $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+                    VALUES ($1, $2, $3, 'open', $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
                     ON CONFLICT (opened_by_operator_id, request_idempotency_key)
                     WHERE request_idempotency_key IS NOT NULL
                     DO NOTHING
-                    RETURNING *
+                    RETURNING
+                        review_case_id,
+                        case_type,
+                        severity,
+                        review_status,
+                        subject_account_id,
+                        related_promise_intent_id,
+                        related_settlement_case_id,
+                        related_realm_id,
+                        opened_reason_code,
+                        source_fact_kind,
+                        source_fact_id,
+                        assigned_operator_id,
+                        opened_at,
+                        updated_at
                     ",
                     &[
                         &review_case_id,
@@ -174,6 +197,7 @@ impl OperatorReviewStore {
                         &assigned_operator_id,
                         &operator_id,
                         &request_idempotency_key,
+                        &request_payload_hash,
                     ],
                 )
                 .await
@@ -193,14 +217,7 @@ impl OperatorReviewStore {
                         "review case idempotency row disappeared after conflict".to_owned(),
                     )
                 })?;
-                ensure_review_case_matches_input(
-                    &row,
-                    &input,
-                    &subject_account_id,
-                    &related_promise_intent_id,
-                    &related_settlement_case_id,
-                    &assigned_operator_id,
-                )?;
+                ensure_review_case_matches_payload_hash(&row, &request_payload_hash)?;
                 row
             }
         } else {
@@ -222,10 +239,25 @@ impl OperatorReviewStore {
                         source_snapshot_json,
                         assigned_operator_id,
                         opened_by_operator_id,
-                        request_idempotency_key
+                        request_idempotency_key,
+                        request_payload_hash
                     )
-                    VALUES ($1, $2, $3, 'open', $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
-                    RETURNING *
+                    VALUES ($1, $2, $3, 'open', $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+                    RETURNING
+                        review_case_id,
+                        case_type,
+                        severity,
+                        review_status,
+                        subject_account_id,
+                        related_promise_intent_id,
+                        related_settlement_case_id,
+                        related_realm_id,
+                        opened_reason_code,
+                        source_fact_kind,
+                        source_fact_id,
+                        assigned_operator_id,
+                        opened_at,
+                        updated_at
                     ",
                     &[
                         &review_case_id,
@@ -242,6 +274,7 @@ impl OperatorReviewStore {
                         &assigned_operator_id,
                         &operator_id,
                         &request_idempotency_key,
+                        &request_payload_hash,
                     ],
                 )
                 .await
@@ -410,7 +443,16 @@ impl OperatorReviewStore {
                     expires_at
                 )
                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-                RETURNING *
+                RETURNING
+                    access_grant_id,
+                    review_case_id,
+                    evidence_bundle_id,
+                    grantee_operator_id,
+                    access_scope,
+                    grant_reason,
+                    approved_by_operator_id,
+                    expires_at,
+                    created_at
                 ",
                 &[
                     &access_grant_id,
@@ -446,6 +488,7 @@ impl OperatorReviewStore {
             USER_FACING_REASON_CODES,
         )?;
         let decision_idempotency_key = normalize_optional(&input.decision_idempotency_key);
+        let decision_payload_hash = operator_decision_payload_hash(&input);
 
         let mut client = self.client.lock().await;
         let tx = client.transaction().await.map_err(db_error)?;
@@ -465,9 +508,10 @@ impl OperatorReviewStore {
                         operator_note_internal,
                         decision_payload_json,
                         decided_by_operator_id,
-                        decision_idempotency_key
+                        decision_idempotency_key,
+                        decision_payload_hash
                     )
-                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
                     ON CONFLICT (review_case_id, decided_by_operator_id, decision_idempotency_key)
                     WHERE decision_idempotency_key IS NOT NULL
                     DO NOTHING
@@ -489,6 +533,7 @@ impl OperatorReviewStore {
                         &input.decision_payload_json,
                         &operator_id,
                         &decision_idempotency_key,
+                        &decision_payload_hash,
                     ],
                 )
                 .await
@@ -508,7 +553,7 @@ impl OperatorReviewStore {
                         "operator decision idempotency row disappeared after conflict".to_owned(),
                     )
                 })?;
-                ensure_operator_decision_matches_input(&row, &input)?;
+                ensure_operator_decision_matches_payload_hash(&row, &decision_payload_hash)?;
                 row
             }
         } else {
@@ -522,9 +567,10 @@ impl OperatorReviewStore {
                     operator_note_internal,
                     decision_payload_json,
                     decided_by_operator_id,
-                    decision_idempotency_key
+                    decision_idempotency_key,
+                    decision_payload_hash
                 )
-                VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
                 RETURNING
                     operator_decision_fact_id,
                     review_case_id,
@@ -543,6 +589,7 @@ impl OperatorReviewStore {
                     &input.decision_payload_json,
                     &operator_id,
                     &decision_idempotency_key,
+                    &decision_payload_hash,
                 ],
             )
             .await
@@ -571,6 +618,8 @@ impl OperatorReviewStore {
             USER_FACING_REASON_CODES,
         )?;
         let appeal_idempotency_key = normalize_optional(&input.appeal_idempotency_key);
+        let appeal_request_payload_hash =
+            appeal_payload_hash(&input, source_decision_fact_id.as_ref());
 
         let mut client = self.client.lock().await;
         let tx = client.transaction().await.map_err(db_error)?;
@@ -591,9 +640,10 @@ impl OperatorReviewStore {
                         submitted_reason_code,
                         appellant_statement,
                         new_evidence_summary_json,
-                        appeal_idempotency_key
+                        appeal_idempotency_key,
+                        appeal_payload_hash
                     )
-                    VALUES ($1, $2, $3, 'submitted', $4, $5, $6, $7, $8)
+                    VALUES ($1, $2, $3, 'submitted', $4, $5, $6, $7, $8, $9)
                     ON CONFLICT (
                         source_review_case_id,
                         submitted_by_account_id,
@@ -620,6 +670,7 @@ impl OperatorReviewStore {
                         &input.appellant_statement,
                         &input.new_evidence_summary_json,
                         &appeal_idempotency_key,
+                        &appeal_request_payload_hash,
                     ],
                 )
                 .await
@@ -639,7 +690,7 @@ impl OperatorReviewStore {
                         "appeal idempotency row disappeared after conflict".to_owned(),
                     )
                 })?;
-                ensure_appeal_matches_input(&row, &input, source_decision_fact_id.as_ref())?;
+                ensure_appeal_matches_payload_hash(&row, &appeal_request_payload_hash)?;
                 row
             }
         } else {
@@ -654,9 +705,10 @@ impl OperatorReviewStore {
                     submitted_reason_code,
                     appellant_statement,
                     new_evidence_summary_json,
-                    appeal_idempotency_key
+                    appeal_idempotency_key,
+                    appeal_payload_hash
                 )
-                VALUES ($1, $2, $3, 'submitted', $4, $5, $6, $7, $8)
+                VALUES ($1, $2, $3, 'submitted', $4, $5, $6, $7, $8, $9)
                 RETURNING
                     appeal_case_id,
                     source_review_case_id,
@@ -676,6 +728,7 @@ impl OperatorReviewStore {
                     &input.appellant_statement,
                     &input.new_evidence_summary_json,
                     &appeal_idempotency_key,
+                    &appeal_request_payload_hash,
                 ],
             )
             .await
@@ -730,7 +783,21 @@ impl OperatorReviewStore {
         let row = client
             .query_opt(
                 "
-                SELECT *
+                SELECT
+                    review_case_id,
+                    subject_account_id,
+                    related_promise_intent_id,
+                    related_settlement_case_id,
+                    related_realm_id,
+                    user_facing_status,
+                    user_facing_reason_code,
+                    appeal_status,
+                    evidence_requested,
+                    appeal_available,
+                    latest_decision_fact_id,
+                    source_watermark_at,
+                    source_fact_count,
+                    last_projected_at
                 FROM projection.review_status_views
                 WHERE review_case_id = $1
                   AND subject_account_id = $2
@@ -776,7 +843,16 @@ async fn read_review_case_tx<C: GenericClient + Sync>(
     let evidence_access_grants = client
         .query(
             "
-            SELECT *
+            SELECT
+                access_grant_id,
+                review_case_id,
+                evidence_bundle_id,
+                grantee_operator_id,
+                access_scope,
+                grant_reason,
+                approved_by_operator_id,
+                expires_at,
+                created_at
             FROM dao.evidence_access_grants
             WHERE review_case_id = $1
             ORDER BY created_at ASC
@@ -854,7 +930,22 @@ async fn find_existing_review_case_by_idempotency<C: GenericClient + Sync>(
     client
         .query_opt(
             "
-            SELECT *
+            SELECT
+                review_case_id,
+                case_type,
+                severity,
+                review_status,
+                subject_account_id,
+                related_promise_intent_id,
+                related_settlement_case_id,
+                related_realm_id,
+                opened_reason_code,
+                source_fact_kind,
+                source_fact_id,
+                assigned_operator_id,
+                opened_at,
+                updated_at,
+                request_payload_hash
             FROM dao.review_cases
             WHERE opened_by_operator_id = $1
               AND request_idempotency_key = $2
@@ -877,7 +968,15 @@ async fn find_existing_decision_by_idempotency<C: GenericClient + Sync>(
     client
         .query_opt(
             "
-            SELECT *
+            SELECT
+                operator_decision_fact_id,
+                review_case_id,
+                appeal_case_id,
+                decision_kind,
+                user_facing_reason_code,
+                decided_by_operator_id,
+                recorded_at,
+                decision_payload_hash
             FROM dao.operator_decision_facts
             WHERE review_case_id = $1
               AND decided_by_operator_id = $2
@@ -901,7 +1000,16 @@ async fn find_existing_appeal_by_idempotency<C: GenericClient + Sync>(
     client
         .query_opt(
             "
-            SELECT *
+            SELECT
+                appeal_case_id,
+                source_review_case_id,
+                source_decision_fact_id,
+                appeal_status,
+                submitted_by_account_id,
+                submitted_reason_code,
+                created_at,
+                updated_at,
+                appeal_payload_hash
             FROM dao.appeal_cases
             WHERE source_review_case_id = $1
               AND submitted_by_account_id = $2
@@ -1420,30 +1528,72 @@ async fn sync_review_case_status_tx<C: GenericClient + Sync>(
     Ok(())
 }
 
-fn ensure_review_case_matches_input(
-    row: &Row,
+fn review_case_payload_hash(
     input: &CreateReviewCaseInput,
     subject_account_id: &Option<Uuid>,
     related_promise_intent_id: &Option<Uuid>,
     related_settlement_case_id: &Option<Uuid>,
     assigned_operator_id: &Option<Uuid>,
+) -> String {
+    hash_json_value(&json!({
+        "schema_version": 1,
+        "case_type": &input.case_type,
+        "severity": &input.severity,
+        "subject_account_id": optional_uuid_hash_value(subject_account_id),
+        "related_promise_intent_id": optional_uuid_hash_value(related_promise_intent_id),
+        "related_settlement_case_id": optional_uuid_hash_value(related_settlement_case_id),
+        "related_realm_id": normalize_optional(&input.related_realm_id),
+        "opened_reason_code": &input.opened_reason_code,
+        "source_fact_kind": &input.source_fact_kind,
+        "source_fact_id": &input.source_fact_id,
+        "source_snapshot_json": &input.source_snapshot_json,
+        "assigned_operator_id": optional_uuid_hash_value(assigned_operator_id),
+    }))
+}
+
+fn operator_decision_payload_hash(input: &RecordOperatorDecisionInput) -> String {
+    hash_json_value(&json!({
+        "schema_version": 1,
+        "decision_kind": &input.decision_kind,
+        "user_facing_reason_code": &input.user_facing_reason_code,
+        "operator_note_internal": &input.operator_note_internal,
+        "decision_payload_json": &input.decision_payload_json,
+    }))
+}
+
+fn appeal_payload_hash(
+    input: &CreateAppealCaseInput,
+    source_decision_fact_id: Option<&Uuid>,
+) -> String {
+    hash_json_value(&json!({
+        "schema_version": 1,
+        "source_decision_fact_id": source_decision_fact_id.map(|value| value.to_string()),
+        "submitted_reason_code": &input.submitted_reason_code,
+        "appellant_statement": &input.appellant_statement,
+        "new_evidence_summary_json": &input.new_evidence_summary_json,
+    }))
+}
+
+fn optional_uuid_hash_value(value: &Option<Uuid>) -> Option<String> {
+    value.map(|value| value.to_string())
+}
+
+fn hash_json_value(value: &Value) -> String {
+    let digest = Sha256::digest(value.to_string().as_bytes());
+    let mut encoded = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        use std::fmt::Write as _;
+        let _ = write!(&mut encoded, "{byte:02x}");
+    }
+    encoded
+}
+
+fn ensure_review_case_matches_payload_hash(
+    row: &Row,
+    request_payload_hash: &str,
 ) -> Result<(), OperatorReviewError> {
-    let existing_related_realm_id = row
-        .get::<_, Option<String>>("related_realm_id")
-        .map(|value| value.trim().to_owned())
-        .filter(|value| !value.is_empty());
-    if row.get::<_, String>("case_type") != input.case_type
-        || row.get::<_, String>("severity") != input.severity
-        || row.get::<_, Option<Uuid>>("subject_account_id") != *subject_account_id
-        || row.get::<_, Option<Uuid>>("related_promise_intent_id") != *related_promise_intent_id
-        || row.get::<_, Option<Uuid>>("related_settlement_case_id") != *related_settlement_case_id
-        || existing_related_realm_id != normalize_optional(&input.related_realm_id)
-        || row.get::<_, String>("opened_reason_code") != input.opened_reason_code
-        || row.get::<_, String>("source_fact_kind") != input.source_fact_kind
-        || row.get::<_, String>("source_fact_id") != input.source_fact_id
-        || row.get::<_, Value>("source_snapshot_json") != input.source_snapshot_json
-        || row.get::<_, Option<Uuid>>("assigned_operator_id") != *assigned_operator_id
-    {
+    let existing_hash: Option<String> = row.get("request_payload_hash");
+    if existing_hash.as_deref() != Some(request_payload_hash) {
         return Err(OperatorReviewError::BadRequest(
             "request_idempotency_key was already used with a different review case payload"
                 .to_owned(),
@@ -1452,15 +1602,12 @@ fn ensure_review_case_matches_input(
     Ok(())
 }
 
-fn ensure_operator_decision_matches_input(
+fn ensure_operator_decision_matches_payload_hash(
     row: &Row,
-    input: &RecordOperatorDecisionInput,
+    decision_payload_hash: &str,
 ) -> Result<(), OperatorReviewError> {
-    if row.get::<_, String>("decision_kind") != input.decision_kind
-        || row.get::<_, String>("user_facing_reason_code") != input.user_facing_reason_code
-        || row.get::<_, Option<String>>("operator_note_internal") != input.operator_note_internal
-        || row.get::<_, Value>("decision_payload_json") != input.decision_payload_json
-    {
+    let existing_hash: Option<String> = row.get("decision_payload_hash");
+    if existing_hash.as_deref() != Some(decision_payload_hash) {
         return Err(OperatorReviewError::BadRequest(
             "decision_idempotency_key was already used with a different operator decision payload"
                 .to_owned(),
@@ -1469,16 +1616,12 @@ fn ensure_operator_decision_matches_input(
     Ok(())
 }
 
-fn ensure_appeal_matches_input(
+fn ensure_appeal_matches_payload_hash(
     row: &Row,
-    input: &CreateAppealCaseInput,
-    source_decision_fact_id: Option<&Uuid>,
+    appeal_payload_hash: &str,
 ) -> Result<(), OperatorReviewError> {
-    if row.get::<_, Option<Uuid>>("source_decision_fact_id") != source_decision_fact_id.copied()
-        || row.get::<_, String>("submitted_reason_code") != input.submitted_reason_code
-        || row.get::<_, Option<String>>("appellant_statement") != input.appellant_statement
-        || row.get::<_, Value>("new_evidence_summary_json") != input.new_evidence_summary_json
-    {
+    let existing_hash: Option<String> = row.get("appeal_payload_hash");
+    if existing_hash.as_deref() != Some(appeal_payload_hash) {
         return Err(OperatorReviewError::BadRequest(
             "appeal_idempotency_key was already used with a different appeal payload".to_owned(),
         ));

--- a/apps/backend/src/services/operator_review/repository.rs
+++ b/apps/backend/src/services/operator_review/repository.rs
@@ -1739,6 +1739,7 @@ fn review_case_payload_hash_from_row(row: &Row) -> String {
     let related_promise_intent_id: Option<Uuid> = row.get("related_promise_intent_id");
     let related_settlement_case_id: Option<Uuid> = row.get("related_settlement_case_id");
     let assigned_operator_id: Option<Uuid> = row.get("assigned_operator_id");
+    let related_realm_id = normalize_optional(&row.get::<_, Option<String>>("related_realm_id"));
 
     hash_json_value(&json!({
         "schema_version": 1,
@@ -1747,7 +1748,7 @@ fn review_case_payload_hash_from_row(row: &Row) -> String {
         "subject_account_id": optional_uuid_hash_value(&subject_account_id),
         "related_promise_intent_id": optional_uuid_hash_value(&related_promise_intent_id),
         "related_settlement_case_id": optional_uuid_hash_value(&related_settlement_case_id),
-        "related_realm_id": row.get::<_, Option<String>>("related_realm_id"),
+        "related_realm_id": related_realm_id,
         "opened_reason_code": row.get::<_, String>("opened_reason_code"),
         "source_fact_kind": row.get::<_, String>("source_fact_kind"),
         "source_fact_id": row.get::<_, String>("source_fact_id"),

--- a/apps/backend/src/services/operator_review/repository.rs
+++ b/apps/backend/src/services/operator_review/repository.rs
@@ -1719,19 +1719,40 @@ async fn backfill_review_case_payload_hash<C: GenericClient + Sync>(
         .await
         .map_err(db_error)?;
     let payload_hash = review_case_payload_hash_from_row(&legacy_row);
-    client
-        .execute(
+    if let Some(updated_row) = client
+        .query_opt(
             "
             UPDATE dao.review_cases
             SET request_payload_hash = $2
             WHERE review_case_id = $1
               AND request_payload_hash IS NULL
+            RETURNING request_payload_hash
             ",
             &[&review_case_id, &payload_hash],
         )
         .await
+        .map_err(db_error)?
+    {
+        return Ok(updated_row.get("request_payload_hash"));
+    }
+
+    let persisted_row = client
+        .query_one(
+            "
+            SELECT request_payload_hash
+            FROM dao.review_cases
+            WHERE review_case_id = $1
+            ",
+            &[&review_case_id],
+        )
+        .await
         .map_err(db_error)?;
-    Ok(payload_hash)
+    let persisted_hash: Option<String> = persisted_row.get("request_payload_hash");
+    persisted_hash.ok_or_else(|| {
+        OperatorReviewError::Internal(
+            "review case payload hash remained null after backfill".to_owned(),
+        )
+    })
 }
 
 fn review_case_payload_hash_from_row(row: &Row) -> String {
@@ -1778,19 +1799,40 @@ async fn backfill_operator_decision_payload_hash<C: GenericClient + Sync>(
         .await
         .map_err(db_error)?;
     let payload_hash = operator_decision_payload_hash_from_row(&legacy_row);
-    client
-        .execute(
+    if let Some(updated_row) = client
+        .query_opt(
             "
             UPDATE dao.operator_decision_facts
             SET decision_payload_hash = $2
             WHERE operator_decision_fact_id = $1
               AND decision_payload_hash IS NULL
+            RETURNING decision_payload_hash
             ",
             &[&operator_decision_fact_id, &payload_hash],
         )
         .await
+        .map_err(db_error)?
+    {
+        return Ok(updated_row.get("decision_payload_hash"));
+    }
+
+    let persisted_row = client
+        .query_one(
+            "
+            SELECT decision_payload_hash
+            FROM dao.operator_decision_facts
+            WHERE operator_decision_fact_id = $1
+            ",
+            &[&operator_decision_fact_id],
+        )
+        .await
         .map_err(db_error)?;
-    Ok(payload_hash)
+    let persisted_hash: Option<String> = persisted_row.get("decision_payload_hash");
+    persisted_hash.ok_or_else(|| {
+        OperatorReviewError::Internal(
+            "operator decision payload hash remained null after backfill".to_owned(),
+        )
+    })
 }
 
 fn operator_decision_payload_hash_from_row(row: &Row) -> String {
@@ -1824,19 +1866,38 @@ async fn backfill_appeal_payload_hash<C: GenericClient + Sync>(
         .await
         .map_err(db_error)?;
     let payload_hash = appeal_payload_hash_from_row(&legacy_row);
-    client
-        .execute(
+    if let Some(updated_row) = client
+        .query_opt(
             "
             UPDATE dao.appeal_cases
             SET appeal_payload_hash = $2
             WHERE appeal_case_id = $1
               AND appeal_payload_hash IS NULL
+            RETURNING appeal_payload_hash
             ",
             &[&appeal_case_id, &payload_hash],
         )
         .await
+        .map_err(db_error)?
+    {
+        return Ok(updated_row.get("appeal_payload_hash"));
+    }
+
+    let persisted_row = client
+        .query_one(
+            "
+            SELECT appeal_payload_hash
+            FROM dao.appeal_cases
+            WHERE appeal_case_id = $1
+            ",
+            &[&appeal_case_id],
+        )
+        .await
         .map_err(db_error)?;
-    Ok(payload_hash)
+    let persisted_hash: Option<String> = persisted_row.get("appeal_payload_hash");
+    persisted_hash.ok_or_else(|| {
+        OperatorReviewError::Internal("appeal payload hash remained null after backfill".to_owned())
+    })
 }
 
 fn appeal_payload_hash_from_row(row: &Row) -> String {

--- a/apps/backend/src/services/operator_review/repository.rs
+++ b/apps/backend/src/services/operator_review/repository.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{fmt::Write as _, sync::Arc};
 
 use chrono::Utc;
 use musubi_db_runtime::{DbConfig, connect_writer};
@@ -1579,13 +1579,62 @@ fn optional_uuid_hash_value(value: &Option<Uuid>) -> Option<String> {
 }
 
 fn hash_json_value(value: &Value) -> String {
-    let digest = Sha256::digest(value.to_string().as_bytes());
+    let digest = Sha256::digest(canonical_json_text(value).as_bytes());
     let mut encoded = String::with_capacity(digest.len() * 2);
     for byte in digest {
-        use std::fmt::Write as _;
         let _ = write!(&mut encoded, "{byte:02x}");
     }
     encoded
+}
+
+fn canonical_json_text(value: &Value) -> String {
+    let mut output = String::new();
+    write_canonical_json(value, &mut output);
+    output
+}
+
+fn write_canonical_json(value: &Value, output: &mut String) {
+    match value {
+        Value::Null => output.push_str("null"),
+        Value::Bool(boolean) => output.push_str(if *boolean { "true" } else { "false" }),
+        Value::Number(number) => {
+            let _ = write!(output, "{number}");
+        }
+        Value::String(string) => {
+            output.push_str(
+                &serde_json::to_string(string).expect("serializing a JSON string should not fail"),
+            );
+        }
+        Value::Array(values) => {
+            output.push('[');
+            for (index, value) in values.iter().enumerate() {
+                if index > 0 {
+                    output.push(',');
+                }
+                write_canonical_json(value, output);
+            }
+            output.push(']');
+        }
+        Value::Object(map) => {
+            output.push('{');
+            let mut entries = map.iter().collect::<Vec<_>>();
+            entries.sort_by(|left, right| left.0.cmp(right.0));
+
+            for (index, (key, value)) in entries.into_iter().enumerate() {
+                if index > 0 {
+                    output.push(',');
+                }
+                output.push_str(
+                    &serde_json::to_string(key)
+                        .expect("serializing a JSON object key should not fail"),
+                );
+                output.push(':');
+                write_canonical_json(value, output);
+            }
+
+            output.push('}');
+        }
+    }
 }
 
 fn ensure_review_case_matches_payload_hash(

--- a/apps/backend/tests/operator_review.rs
+++ b/apps/backend/tests/operator_review.rs
@@ -496,6 +496,69 @@ async fn distinct_operator_decisions_append_new_facts_without_rewriting_source_t
 }
 
 #[tokio::test]
+async fn reused_review_case_idempotency_key_rejects_mismatched_payload() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let subject = sign_in(
+        &app,
+        "pi-user-review-case-mismatch-v2",
+        "review-case-mismatch-v2",
+    )
+    .await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let first = operator_post_json(
+        &app,
+        "/api/internal/operator/review-cases",
+        &approver_id,
+        json!({
+            "case_type": "proof_anomaly",
+            "severity": "sev1",
+            "subject_account_id": subject.account_id,
+            "related_realm_id": "realm-review-case-mismatch-v2",
+            "opened_reason_code": "proof_inconclusive",
+            "source_fact_kind": "proof_submission",
+            "source_fact_id": "proof-source-case-mismatch-v2",
+            "source_snapshot_json": {
+                "source": "proof",
+                "version": 1
+            },
+            "request_idempotency_key": "review-case-mismatch-v2"
+        }),
+    )
+    .await;
+    assert_eq!(first.status, StatusCode::OK);
+    let review_case_id = first.body["review_case_id"]
+        .as_str()
+        .expect("review_case_id must exist")
+        .to_owned();
+
+    let second = operator_post_json(
+        &app,
+        "/api/internal/operator/review-cases",
+        &approver_id,
+        json!({
+            "case_type": "proof_anomaly",
+            "severity": "sev2",
+            "subject_account_id": subject.account_id,
+            "related_realm_id": "realm-review-case-mismatch-v2",
+            "opened_reason_code": "proof_inconclusive",
+            "source_fact_kind": "proof_submission",
+            "source_fact_id": "proof-source-case-mismatch-v2",
+            "source_snapshot_json": {
+                "source": "proof",
+                "version": 2
+            },
+            "request_idempotency_key": "review-case-mismatch-v2"
+        }),
+    )
+    .await;
+    assert_eq!(second.status, StatusCode::BAD_REQUEST);
+    assert_eq!(review_case_count(&client, &review_case_id).await, 1);
+}
+
+#[tokio::test]
 async fn reused_decision_idempotency_key_rejects_mismatched_payload() {
     let test_state = new_test_state().await.expect("test database state");
     let app = build_app(test_state.state.clone());
@@ -562,6 +625,101 @@ async fn reused_decision_idempotency_key_rejects_mismatched_payload() {
     .await;
     assert_eq!(second.status, StatusCode::BAD_REQUEST);
     assert_eq!(decision_count(&client, &review_case_id).await, 1);
+}
+
+#[tokio::test]
+async fn reused_appeal_idempotency_key_rejects_mismatched_payload() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let subject = sign_in(
+        &app,
+        "pi-user-review-appeal-mismatch-v2",
+        "review-appeal-mismatch-v2",
+    )
+    .await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let create_case = operator_post_json(
+        &app,
+        "/api/internal/operator/review-cases",
+        &approver_id,
+        json!({
+            "case_type": "proof_anomaly",
+            "severity": "sev1",
+            "subject_account_id": subject.account_id,
+            "related_realm_id": "realm-review-appeal-mismatch-v2",
+            "opened_reason_code": "proof_inconclusive",
+            "source_fact_kind": "proof_submission",
+            "source_fact_id": "proof-source-appeal-mismatch-v2",
+            "source_snapshot_json": {
+                "source": "proof"
+            },
+            "request_idempotency_key": "review-case-appeal-mismatch-v2"
+        }),
+    )
+    .await;
+    assert_eq!(create_case.status, StatusCode::OK);
+    let review_case_id = create_case.body["review_case_id"]
+        .as_str()
+        .expect("review_case_id must exist")
+        .to_owned();
+
+    let decision = operator_post_json(
+        &app,
+        &format!("/api/internal/operator/review-cases/{review_case_id}/decisions"),
+        &approver_id,
+        json!({
+            "decision_kind": "restrict",
+            "user_facing_reason_code": "restricted_after_review",
+            "operator_note_internal": "private restriction detail",
+            "decision_payload_json": {
+                "resolution": "restrict"
+            },
+            "decision_idempotency_key": "decision-appeal-mismatch-v2"
+        }),
+    )
+    .await;
+    assert_eq!(decision.status, StatusCode::OK);
+    let decision_fact_id = decision.body["operator_decision_fact_id"]
+        .as_str()
+        .expect("decision fact id must exist")
+        .to_owned();
+
+    let first = post_json(
+        &app,
+        &format!("/api/review-cases/{review_case_id}/appeals"),
+        Some(subject.token.as_str()),
+        json!({
+            "source_decision_fact_id": decision_fact_id,
+            "submitted_reason_code": "appeal_received",
+            "appellant_statement": "I have new context.",
+            "new_evidence_summary_json": {
+                "safe_summary": "first appeal summary"
+            },
+            "appeal_idempotency_key": "appeal-mismatch-v2"
+        }),
+    )
+    .await;
+    assert_eq!(first.status, StatusCode::OK);
+
+    let second = post_json(
+        &app,
+        &format!("/api/review-cases/{review_case_id}/appeals"),
+        Some(subject.token.as_str()),
+        json!({
+            "source_decision_fact_id": decision_fact_id,
+            "submitted_reason_code": "appeal_received",
+            "appellant_statement": "A different appeal payload should fail.",
+            "new_evidence_summary_json": {
+                "safe_summary": "second appeal summary"
+            },
+            "appeal_idempotency_key": "appeal-mismatch-v2"
+        }),
+    )
+    .await;
+    assert_eq!(second.status, StatusCode::BAD_REQUEST);
+    assert_eq!(appeal_count(&client, &review_case_id).await, 1);
 }
 
 #[tokio::test]
@@ -920,6 +1078,36 @@ async fn decision_count(client: &tokio_postgres::Client, review_case_id: &str) -
         )
         .await
         .expect("operator decision fact count must be queryable")
+        .get("count")
+}
+
+async fn review_case_count(client: &tokio_postgres::Client, review_case_id: &str) -> i64 {
+    client
+        .query_one(
+            "
+            SELECT count(*) AS count
+            FROM dao.review_cases
+            WHERE review_case_id::text = $1
+            ",
+            &[&review_case_id],
+        )
+        .await
+        .expect("review case count must be queryable")
+        .get("count")
+}
+
+async fn appeal_count(client: &tokio_postgres::Client, review_case_id: &str) -> i64 {
+    client
+        .query_one(
+            "
+            SELECT count(*) AS count
+            FROM dao.appeal_cases
+            WHERE source_review_case_id::text = $1
+            ",
+            &[&review_case_id],
+        )
+        .await
+        .expect("appeal count must be queryable")
         .get("count")
 }
 

--- a/apps/backend/tests/operator_review.rs
+++ b/apps/backend/tests/operator_review.rs
@@ -496,6 +496,135 @@ async fn distinct_operator_decisions_append_new_facts_without_rewriting_source_t
 }
 
 #[tokio::test]
+async fn review_case_idempotency_replay_accepts_canonical_json_key_order() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let subject = sign_in(
+        &app,
+        "pi-user-review-canonical-json-v2",
+        "review-canonical-json-v2",
+    )
+    .await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let first_body = format!(
+        r#"{{
+            "case_type": "proof_anomaly",
+            "severity": "sev1",
+            "subject_account_id": "{subject_account_id}",
+            "related_realm_id": "realm-review-canonical-json-v2",
+            "opened_reason_code": "proof_inconclusive",
+            "source_fact_kind": "proof_submission",
+            "source_fact_id": "proof-source-canonical-json-v2",
+            "source_snapshot_json": {{
+                "outer": {{ "b": 2, "a": 1 }},
+                "array": [{{ "z": 3, "y": 2 }}]
+            }},
+            "request_idempotency_key": "review-case-canonical-json-v2"
+        }}"#,
+        subject_account_id = subject.account_id
+    );
+    let first = operator_post_raw_json(
+        &app,
+        "/api/internal/operator/review-cases",
+        &approver_id,
+        &first_body,
+    )
+    .await;
+    assert_eq!(first.status, StatusCode::OK);
+    let review_case_id = first.body["review_case_id"]
+        .as_str()
+        .expect("review_case_id must exist")
+        .to_owned();
+
+    let replay_body = format!(
+        r#"{{
+            "request_idempotency_key": "review-case-canonical-json-v2",
+            "source_snapshot_json": {{
+                "array": [{{ "y": 2, "z": 3 }}],
+                "outer": {{ "a": 1, "b": 2 }}
+            }},
+            "source_fact_id": "proof-source-canonical-json-v2",
+            "source_fact_kind": "proof_submission",
+            "opened_reason_code": "proof_inconclusive",
+            "related_realm_id": "realm-review-canonical-json-v2",
+            "subject_account_id": "{subject_account_id}",
+            "severity": "sev1",
+            "case_type": "proof_anomaly"
+        }}"#,
+        subject_account_id = subject.account_id
+    );
+    let replay = operator_post_raw_json(
+        &app,
+        "/api/internal/operator/review-cases",
+        &approver_id,
+        &replay_body,
+    )
+    .await;
+    assert_eq!(replay.status, StatusCode::OK);
+    assert_eq!(replay.body["review_case_id"], review_case_id);
+    assert_eq!(review_case_count(&client, &review_case_id).await, 1);
+}
+
+#[tokio::test]
+async fn review_case_idempotency_rejects_null_stored_payload_hash() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let subject = sign_in(&app, "pi-user-review-null-hash-v2", "review-null-hash-v2").await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+    let request = json!({
+        "case_type": "proof_anomaly",
+        "severity": "sev1",
+        "subject_account_id": subject.account_id,
+        "related_realm_id": "realm-review-null-hash-v2",
+        "opened_reason_code": "proof_inconclusive",
+        "source_fact_kind": "proof_submission",
+        "source_fact_id": "proof-source-null-hash-v2",
+        "source_snapshot_json": {
+            "source": "proof"
+        },
+        "request_idempotency_key": "review-case-null-hash-v2"
+    });
+
+    let first = operator_post_json(
+        &app,
+        "/api/internal/operator/review-cases",
+        &approver_id,
+        request.clone(),
+    )
+    .await;
+    assert_eq!(first.status, StatusCode::OK);
+    let review_case_id = first.body["review_case_id"]
+        .as_str()
+        .expect("review_case_id must exist")
+        .to_owned();
+
+    client
+        .execute(
+            "
+            UPDATE dao.review_cases
+            SET request_payload_hash = NULL
+            WHERE review_case_id::text = $1
+            ",
+            &[&review_case_id],
+        )
+        .await
+        .expect("review case payload hash must be nullable for legacy rows");
+
+    let replay = operator_post_json(
+        &app,
+        "/api/internal/operator/review-cases",
+        &approver_id,
+        request,
+    )
+    .await;
+    assert_eq!(replay.status, StatusCode::BAD_REQUEST);
+    assert_eq!(review_case_count(&client, &review_case_id).await, 1);
+}
+
+#[tokio::test]
 async fn reused_review_case_idempotency_key_rejects_mismatched_payload() {
     let test_state = new_test_state().await.expect("test database state");
     let app = build_app(test_state.state.clone());
@@ -1139,6 +1268,15 @@ async fn operator_post_json(
     request_json(app, "POST", path, None, Some(operator_id), Some(body)).await
 }
 
+async fn operator_post_raw_json(
+    app: &Router,
+    path: &str,
+    operator_id: &str,
+    body: &str,
+) -> JsonResponse {
+    request_raw_json(app, "POST", path, None, Some(operator_id), Some(body)).await
+}
+
 async fn operator_get_json(app: &Router, path: &str, operator_id: &str) -> JsonResponse {
     request_json(app, "GET", path, None, Some(operator_id), None).await
 }
@@ -1164,6 +1302,26 @@ async fn request_json(
     operator_id: Option<&str>,
     body: Option<Value>,
 ) -> JsonResponse {
+    let raw_body = body.map(|body| body.to_string());
+    request_raw_json(
+        app,
+        method,
+        path,
+        bearer_token,
+        operator_id,
+        raw_body.as_deref(),
+    )
+    .await
+}
+
+async fn request_raw_json(
+    app: &Router,
+    method: &str,
+    path: &str,
+    bearer_token: Option<&str>,
+    operator_id: Option<&str>,
+    body: Option<&str>,
+) -> JsonResponse {
     let mut builder = Request::builder().method(method).uri(path);
     if let Some(token) = bearer_token {
         builder = builder.header("authorization", format!("Bearer {token}"));
@@ -1175,7 +1333,7 @@ async fn request_json(
     let request = builder
         .header("content-type", "application/json")
         .body(match body {
-            Some(body) => Body::from(body.to_string()),
+            Some(body) => Body::from(body.to_owned()),
             None => Body::empty(),
         })
         .expect("request must build");

--- a/apps/backend/tests/operator_review.rs
+++ b/apps/backend/tests/operator_review.rs
@@ -597,7 +597,8 @@ async fn review_case_idempotency_replay_backfills_missing_payload_hash() {
         .execute(
             "
             UPDATE dao.review_cases
-            SET request_payload_hash = NULL
+            SET request_payload_hash = NULL,
+                related_realm_id = '  realm-review-null-hash-v2  '
             WHERE review_case_id::text = $1
             ",
             &[&review_case_id],

--- a/apps/backend/tests/operator_review.rs
+++ b/apps/backend/tests/operator_review.rs
@@ -1,11 +1,11 @@
 use axum::{
-    Router,
-    body::{Body, to_bytes},
+    body::{to_bytes, Body},
     http::{Request, StatusCode},
+    Router,
 };
 use musubi_backend::{build_app, new_state_from_config, new_test_state};
 use musubi_db_runtime::DbConfig;
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 use tower::ServiceExt;
 use uuid::Uuid;
 
@@ -105,12 +105,10 @@ async fn operator_review_flow_preserves_writer_truth_and_projects_safe_status() 
     .await;
     assert_eq!(attach_evidence.status, StatusCode::OK);
     assert!(attach_evidence.body.get("raw_locator_json").is_none());
-    assert!(
-        !attach_evidence
-            .body
-            .to_string()
-            .contains("private-raw-callback-uri")
-    );
+    assert!(!attach_evidence
+        .body
+        .to_string()
+        .contains("private-raw-callback-uri"));
     let evidence_bundle_id = attach_evidence.body["evidence_bundle_id"]
         .as_str()
         .expect("evidence_bundle_id must exist")
@@ -282,12 +280,10 @@ async fn operator_review_flow_preserves_writer_truth_and_projects_safe_status() 
         "restricted_after_review"
     );
     assert!(decided_status.body.get("operator_note_internal").is_none());
-    assert!(
-        !decided_status
-            .body
-            .to_string()
-            .contains("private operator note")
-    );
+    assert!(!decided_status
+        .body
+        .to_string()
+        .contains("private operator note"));
 
     let review_detail = operator_get_json(
         &app,
@@ -297,18 +293,14 @@ async fn operator_review_flow_preserves_writer_truth_and_projects_safe_status() 
     .await;
     assert_eq!(review_detail.status, StatusCode::OK);
     assert!(review_detail.body.get("operator_note_internal").is_none());
-    assert!(
-        !review_detail
-            .body
-            .to_string()
-            .contains("private operator note")
-    );
-    assert!(
-        !review_detail
-            .body
-            .to_string()
-            .contains("private-raw-callback-uri")
-    );
+    assert!(!review_detail
+        .body
+        .to_string()
+        .contains("private operator note"));
+    assert!(!review_detail
+        .body
+        .to_string()
+        .contains("private-raw-callback-uri"));
     assert_eq!(
         review_detail.body["operator_decision_facts"]
             .as_array()
@@ -568,7 +560,7 @@ async fn review_case_idempotency_replay_accepts_canonical_json_key_order() {
 }
 
 #[tokio::test]
-async fn review_case_idempotency_rejects_null_stored_payload_hash() {
+async fn review_case_idempotency_replay_backfills_missing_payload_hash() {
     let test_state = new_test_state().await.expect("test database state");
     let app = build_app(test_state.state.clone());
     let subject = sign_in(&app, "pi-user-review-null-hash-v2", "review-null-hash-v2").await;
@@ -620,8 +612,22 @@ async fn review_case_idempotency_rejects_null_stored_payload_hash() {
         request,
     )
     .await;
-    assert_eq!(replay.status, StatusCode::BAD_REQUEST);
+    assert_eq!(replay.status, StatusCode::OK);
+    assert_eq!(replay.body["review_case_id"], review_case_id);
     assert_eq!(review_case_count(&client, &review_case_id).await, 1);
+    let row = client
+        .query_one(
+            "
+            SELECT request_payload_hash
+            FROM dao.review_cases
+            WHERE review_case_id::text = $1
+            ",
+            &[&review_case_id],
+        )
+        .await
+        .expect("review case must exist");
+    let stored_hash: Option<String> = row.get("request_payload_hash");
+    assert!(stored_hash.is_some());
 }
 
 #[tokio::test]
@@ -757,6 +763,103 @@ async fn reused_decision_idempotency_key_rejects_mismatched_payload() {
 }
 
 #[tokio::test]
+async fn decision_idempotency_replay_backfills_missing_payload_hash() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let subject = sign_in(
+        &app,
+        "pi-user-review-decision-null-hash-v2",
+        "review-decision-null-hash-v2",
+    )
+    .await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let create_case = operator_post_json(
+        &app,
+        "/api/internal/operator/review-cases",
+        &approver_id,
+        json!({
+            "case_type": "proof_anomaly",
+            "severity": "sev1",
+            "subject_account_id": subject.account_id,
+            "related_realm_id": "realm-review-decision-null-hash-v2",
+            "opened_reason_code": "proof_inconclusive",
+            "source_fact_kind": "proof_submission",
+            "source_fact_id": "proof-source-decision-null-hash-v2",
+            "source_snapshot_json": {
+                "source": "proof"
+            },
+            "request_idempotency_key": "review-case-decision-null-hash-v2"
+        }),
+    )
+    .await;
+    assert_eq!(create_case.status, StatusCode::OK);
+    let review_case_id = create_case.body["review_case_id"]
+        .as_str()
+        .expect("review_case_id must exist")
+        .to_owned();
+
+    let request = json!({
+        "decision_kind": "restrict",
+        "user_facing_reason_code": "restricted_after_review",
+        "operator_note_internal": "legacy null hash replay",
+        "decision_payload_json": {
+            "resolution": "restrict"
+        },
+        "decision_idempotency_key": "decision-null-hash-v2"
+    });
+    let first = operator_post_json(
+        &app,
+        &format!("/api/internal/operator/review-cases/{review_case_id}/decisions"),
+        &approver_id,
+        request.clone(),
+    )
+    .await;
+    assert_eq!(first.status, StatusCode::OK);
+    let decision_fact_id = first.body["operator_decision_fact_id"]
+        .as_str()
+        .expect("decision fact id must exist")
+        .to_owned();
+
+    client
+        .execute(
+            "
+            UPDATE dao.operator_decision_facts
+            SET decision_payload_hash = NULL
+            WHERE operator_decision_fact_id::text = $1
+            ",
+            &[&decision_fact_id],
+        )
+        .await
+        .expect("decision payload hash must be nullable for legacy rows");
+
+    let replay = operator_post_json(
+        &app,
+        &format!("/api/internal/operator/review-cases/{review_case_id}/decisions"),
+        &approver_id,
+        request,
+    )
+    .await;
+    assert_eq!(replay.status, StatusCode::OK);
+    assert_eq!(replay.body["operator_decision_fact_id"], decision_fact_id);
+    assert_eq!(decision_count(&client, &review_case_id).await, 1);
+    let row = client
+        .query_one(
+            "
+            SELECT decision_payload_hash
+            FROM dao.operator_decision_facts
+            WHERE operator_decision_fact_id::text = $1
+            ",
+            &[&decision_fact_id],
+        )
+        .await
+        .expect("decision fact must exist");
+    let stored_hash: Option<String> = row.get("decision_payload_hash");
+    assert!(stored_hash.is_some());
+}
+
+#[tokio::test]
 async fn reused_appeal_idempotency_key_rejects_mismatched_payload() {
     let test_state = new_test_state().await.expect("test database state");
     let app = build_app(test_state.state.clone());
@@ -849,6 +952,124 @@ async fn reused_appeal_idempotency_key_rejects_mismatched_payload() {
     .await;
     assert_eq!(second.status, StatusCode::BAD_REQUEST);
     assert_eq!(appeal_count(&client, &review_case_id).await, 1);
+}
+
+#[tokio::test]
+async fn appeal_idempotency_replay_backfills_missing_payload_hash() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let subject = sign_in(
+        &app,
+        "pi-user-review-appeal-null-hash-v2",
+        "review-appeal-null-hash-v2",
+    )
+    .await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let create_case = operator_post_json(
+        &app,
+        "/api/internal/operator/review-cases",
+        &approver_id,
+        json!({
+            "case_type": "proof_anomaly",
+            "severity": "sev1",
+            "subject_account_id": subject.account_id,
+            "related_realm_id": "realm-review-appeal-null-hash-v2",
+            "opened_reason_code": "proof_inconclusive",
+            "source_fact_kind": "proof_submission",
+            "source_fact_id": "proof-source-appeal-null-hash-v2",
+            "source_snapshot_json": {
+                "source": "proof"
+            },
+            "request_idempotency_key": "review-case-appeal-null-hash-v2"
+        }),
+    )
+    .await;
+    assert_eq!(create_case.status, StatusCode::OK);
+    let review_case_id = create_case.body["review_case_id"]
+        .as_str()
+        .expect("review_case_id must exist")
+        .to_owned();
+
+    let decision = operator_post_json(
+        &app,
+        &format!("/api/internal/operator/review-cases/{review_case_id}/decisions"),
+        &approver_id,
+        json!({
+            "decision_kind": "restrict",
+            "user_facing_reason_code": "restricted_after_review",
+            "operator_note_internal": "appeal null hash setup",
+            "decision_payload_json": {
+                "resolution": "restrict"
+            },
+            "decision_idempotency_key": "decision-appeal-null-hash-v2"
+        }),
+    )
+    .await;
+    assert_eq!(decision.status, StatusCode::OK);
+    let decision_fact_id = decision.body["operator_decision_fact_id"]
+        .as_str()
+        .expect("decision fact id must exist")
+        .to_owned();
+
+    let request = json!({
+        "source_decision_fact_id": decision_fact_id,
+        "submitted_reason_code": "appeal_received",
+        "appellant_statement": "I have new context.",
+        "new_evidence_summary_json": {
+            "safe_summary": "legacy null hash replay"
+        },
+        "appeal_idempotency_key": "appeal-null-hash-v2"
+    });
+    let first = post_json(
+        &app,
+        &format!("/api/review-cases/{review_case_id}/appeals"),
+        Some(subject.token.as_str()),
+        request.clone(),
+    )
+    .await;
+    assert_eq!(first.status, StatusCode::OK);
+    let appeal_case_id = first.body["appeal_case_id"]
+        .as_str()
+        .expect("appeal_case_id must exist")
+        .to_owned();
+
+    client
+        .execute(
+            "
+            UPDATE dao.appeal_cases
+            SET appeal_payload_hash = NULL
+            WHERE appeal_case_id::text = $1
+            ",
+            &[&appeal_case_id],
+        )
+        .await
+        .expect("appeal payload hash must be nullable for legacy rows");
+
+    let replay = post_json(
+        &app,
+        &format!("/api/review-cases/{review_case_id}/appeals"),
+        Some(subject.token.as_str()),
+        request,
+    )
+    .await;
+    assert_eq!(replay.status, StatusCode::OK);
+    assert_eq!(replay.body["appeal_case_id"], appeal_case_id);
+    assert_eq!(appeal_count(&client, &review_case_id).await, 1);
+    let row = client
+        .query_one(
+            "
+            SELECT appeal_payload_hash
+            FROM dao.appeal_cases
+            WHERE appeal_case_id::text = $1
+            ",
+            &[&appeal_case_id],
+        )
+        .await
+        .expect("appeal case must exist");
+    let stored_hash: Option<String> = row.get("appeal_payload_hash");
+    assert!(stored_hash.is_some());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Design source

`ISSUE-12-operator-review-appeal-evidence.md`

This is design ISSUE-12, not a GitHub issue number. The GitHub issue number is intentionally not hardcoded.

## Summary

Follow-up hardening for the operator review / appeal / evidence workflow merged in PR #25.

This PR keeps the ISSUE-12 boundary intact: operator decisions remain append-only facts, Promise / settlement writer truth is not overwritten, user-facing reason codes stay bounded, raw evidence locators and internal operator notes do not leak into user-facing read models, and ISSUE-13 / ISSUE-14 remain deferred consumers.

## Current commit stack

Base hardening commit:
- `eed1bf5` `fix(ops): harden operator review idempotency`

Latest review-feedback commits:
- `c6a8fa3` `docs(ops): clarify operator review replay hash comments`
- `469e9ad` `fix(ops): compare operator review replays against persisted hashes`
- `cf7b4fc` `fix(ops): normalize legacy replay realm ids`
- `a2e54b4` `fix(ops): backfill legacy operator review replay hashes`
- `e122b36` `fix(ops): canonicalize operator review idempotency hashes`

## What changed

- Added forward-only migration `0015_operator_review_hardening.sql`
- Added payload hash columns for review case, operator decision, and appeal idempotency replay checks
- Canonicalized replay hash inputs by recursively sorting JSON object keys, preserving array order, and using stable JSON escaping for strings and object keys
- Changed normal replay mismatch checks to compare persisted hashes instead of reloading source snapshots, internal operator notes, decision payloads, appellant statements, or new evidence summaries
- Added legacy `NULL` hash handling that recomputes the hash from preserved rows once, backfills the derived hash column, and then compares against the persisted hash
- Normalized legacy `related_realm_id` hashing to match the forward request path
- Ensured concurrent backfill races compare against the value actually persisted in PostgreSQL
- Removed remaining `SELECT *` / `RETURNING *` reads from the operator review repository path
- Added edge-case tests for review case / decision / appeal idempotency drift, canonical JSON key ordering, legacy hash backfill, and concurrent replay safety
- Updated ISSUE-12 docs and migration comments to clarify the replay-hash boundary

## Legacy backfill policy

- New rows write 64-character lowercase SHA-256 replay payload hashes at creation time.
- Normal replays compare the incoming canonical payload hash against the persisted hash.
- Legacy rows with `NULL` replay hashes are not blindly accepted. The handler reconstructs the hash from the preserved writer row, backfills the derived hash with a guarded `UPDATE ... WHERE ... IS NULL RETURNING`, falls back to reading the persisted hash if another request won the race, and then performs the same hash comparison as normal replay.
- This legacy fallback is limited to the idempotency replay path and does not change authoritative writer truth.

## Core behavior preserved

- Operator decisions remain append-only facts
- Operator decisions do not mutate Promise / settlement writer truth
- User-facing reason codes remain bounded
- Raw evidence locators and internal operator notes do not leak into user-facing read models
- Evidence access remains scoped, auditable, and role-guarded
- ISSUE-13 and ISSUE-14 remain deferred consumers

## Validation

- `make ENV_FILE=.env.example db-bootstrap`
- `make ENV_FILE=.env.example db-migrate`
- `make ENV_FILE=.env.example db-status`
- `cargo check`
- `cargo test --test operator_review --no-fail-fast`
- `cargo test --no-fail-fast`
- `git diff --check`

Note: `cargo fmt --check` still reports the pre-existing formatting-only preference in `apps/backend/src/handlers/orchestration.rs`. This PR leaves that unrelated file untouched.

## Deferred

- ISSUE-13 room progression state machine
- ISSUE-14 Promise UI / proof missing fallback UI
- settlement UI
- full dispute center UI
- proof persistence
- broad operator console product work