### PR TITLE
feat(room): add room progression surface baseline

### DIFF
--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -19,6 +19,10 @@ Current local HTTP surface:
 - `POST /api/review-cases/{review_case_id}/appeals` for the authenticated review subject
 - `GET /api/review-cases/{review_case_id}/appeals` for the authenticated review subject
 - `GET /api/review-cases/{review_case_id}/status` for the authenticated review subject
+- `POST /api/internal/room-progressions` under the same internal/debug gate
+- `POST /api/internal/room-progressions/{room_progression_id}/facts` under the same internal/debug gate
+- `POST /api/internal/projection/room-progressions/rebuild` under the same internal/debug gate
+- `GET /api/projection/room-progression-views/{room_progression_id}` for authenticated room participants only
 - `GET /api/projection/settlement-views/{settlement_case_id}` for authenticated participants only
 - `GET /api/projection/settlement-views/{settlement_case_id}/expanded` for authenticated participants only
 - `GET /api/projection/promise-views/{promise_intent_id}` for authenticated participants only
@@ -120,6 +124,7 @@ See `docs/db_runtime.md` for the current DB bootstrap and local reset flow.
 Issue #21 wires the happy-route writer truth to PostgreSQL while preserving the existing HTTP surface and settlement-view response contract.
 Issue #22 adds derived Promise, expanded settlement, and bounded trust read models with rebuild and freshness metadata.
 Design source: ISSUE-12-operator-review-appeal-evidence.md adds the operator review / appeal / evidence workflow baseline. Operator decisions are append-only facts, original writer truth is not overwritten, concurrent idempotent replays return the preserved case or fact instead of surfacing a duplicate-write error, replay mismatches are checked with payload hashes, legacy rows backfill missing replay hashes on first retry, and user-facing review state is projected with bounded status and reason codes. See `docs/operator_review_workflow.md`.
+Design source: ISSUE-13-room-progression.md adds the room progression surface baseline. Room progression facts are append-only writer facts in `dao`, user-facing room state is rebuilt into `projection`, sealed fallback can link to ISSUE-12 review cases without duplicating review/evidence truth, and state-changing progression decisions read writer truth instead of projection rows. See `docs/room_progression_surface.md`.
 Issue #17 adds the first sandbox Pi provider adapter boundary for happy-route hold submission and callback intake.
 ISSUE-10 adds Day 1 safer venue proof primitives.
 The public HTTP surface supports the normal venue-code path only.
@@ -137,6 +142,7 @@ These proof records are input facts only; they are not settlement truth or final
 - `docs/orchestration_runtime.md`: outbox/inbox runtime rules
 - `docs/projection_read_models.md`: derived read-side contracts, rebuild path, and bounded trust boundary
 - `docs/operator_review_workflow.md`: ISSUE-12 operator review, appeal, evidence, and append-only decision boundary
+- `docs/room_progression_surface.md`: ISSUE-13 Intent / Coordination / Relationship / Sealed Room progression surface boundary
 - `docs/guardrails.md`: executable architectural guardrails
 - `docs/proof_primitives.md`: Day 1 safer venue proof input boundary
 - `docs/happy_route_walkthrough.md`: current Issue #7 end-to-end path

--- a/apps/backend/docs/room_progression_surface.md
+++ b/apps/backend/docs/room_progression_surface.md
@@ -43,6 +43,8 @@ Relationship Room -> Sealed Room
 ```
 
 Sealed fallback is a calm safety/product posture, not a punishment narrative.
+While a room remains sealed, later writer-owned facts may keep `sealed -> sealed` to record
+follow-up posture such as `sealed_under_review -> sealed_restricted` without reopening the room.
 
 ## User-Facing Projection
 

--- a/apps/backend/docs/room_progression_surface.md
+++ b/apps/backend/docs/room_progression_surface.md
@@ -60,6 +60,10 @@ participant-facing under-review posture always has writer-owned backing.
 - safe review posture fields when linked to ISSUE-12 review state
 - source watermark, source fact count, projection lag, and rebuild generation
 
+`rebuild_generation` is a monotonic `BIGINT` within this single projection surface. Unlike the
+UUID rebuild generations used by multi-projection happy-route rebuilds, it only needs to express
+local refresh ordering for room progression views.
+
 It does not expose:
 - raw evidence locators
 - internal operator notes

--- a/apps/backend/docs/room_progression_surface.md
+++ b/apps/backend/docs/room_progression_surface.md
@@ -49,6 +49,8 @@ Live-room seal transitions require a room-scoped `sealed_room_fallback` review c
 participant-facing under-review posture always has writer-owned backing.
 Restore transitions are operator-triggered only and must return the room to the live stage it
 held immediately before the current sealed fallback began.
+Reviewed restriction outcomes are also not participant-attributed: a `sealed_restricted` fact must
+be recorded as operator- or system-triggered once a writer-owned restrict decision exists.
 
 ## User-Facing Projection
 
@@ -64,7 +66,9 @@ held immediately before the current sealed fallback began.
 
 `rebuild_generation` is a monotonic `BIGINT` within this single projection surface. Unlike the
 UUID rebuild generations used by multi-projection happy-route rebuilds, it only needs to express
-local refresh ordering for room progression views.
+local refresh ordering for room progression views. Full room-progression rebuilds allocate that
+ordinal inside a single writer transaction guarded by a database advisory lock, so the local
+generation stays race-free without pretending to be shared cross-projection provenance.
 
 It does not expose:
 - raw evidence locators

--- a/apps/backend/docs/room_progression_surface.md
+++ b/apps/backend/docs/room_progression_surface.md
@@ -22,7 +22,7 @@ Room progression writer truth lives in `dao`:
 
 User-facing state lives in `projection.room_progression_views`. The projection is rebuildable and exists for display only.
 
-State-changing decisions must read writer-owned facts, not projection rows. For example, restore from a sealed room and reviewed restriction follow-up both read the latest relevant `dao.operator_decision_facts` for the linked review case. `projection.review_status_views` may shape display posture, but it is not authoritative for restore or progression decisions.
+State-changing decisions must read writer-owned facts, not projection rows. For example, sealing a live room, restore from a sealed room, and reviewed restriction follow-up all read room-scoped ISSUE-12 review truth rather than projection rows. `projection.review_status_views` may shape display posture, but it is not authoritative for restore or progression decisions.
 
 Room progression facts must not mutate Promise, settlement, proof, or operator review writer truth.
 
@@ -45,6 +45,8 @@ Relationship Room -> Sealed Room
 Sealed fallback is a calm safety/product posture, not a punishment narrative.
 While a room remains sealed, later writer-owned facts may keep `sealed -> sealed` to record
 follow-up posture such as `sealed_under_review -> sealed_restricted` without reopening the room.
+Live-room seal transitions require a room-scoped `sealed_room_fallback` review case so the
+participant-facing under-review posture always has writer-owned backing.
 
 ## User-Facing Projection
 

--- a/apps/backend/docs/room_progression_surface.md
+++ b/apps/backend/docs/room_progression_surface.md
@@ -22,7 +22,7 @@ Room progression writer truth lives in `dao`:
 
 User-facing state lives in `projection.room_progression_views`. The projection is rebuildable and exists for display only.
 
-State-changing decisions must read writer-owned facts, not projection rows. For example, restore from a sealed room reads the latest relevant `dao.operator_decision_facts` for the linked review case. `projection.review_status_views` may shape display posture, but it is not authoritative for restore or progression decisions.
+State-changing decisions must read writer-owned facts, not projection rows. For example, restore from a sealed room and reviewed restriction follow-up both read the latest relevant `dao.operator_decision_facts` for the linked review case. `projection.review_status_views` may shape display posture, but it is not authoritative for restore or progression decisions.
 
 Room progression facts must not mutate Promise, settlement, proof, or operator review writer truth.
 

--- a/apps/backend/docs/room_progression_surface.md
+++ b/apps/backend/docs/room_progression_surface.md
@@ -47,6 +47,8 @@ While a room remains sealed, later writer-owned facts may keep `sealed -> sealed
 follow-up posture such as `sealed_under_review -> sealed_restricted` without reopening the room.
 Live-room seal transitions require a room-scoped `sealed_room_fallback` review case so the
 participant-facing under-review posture always has writer-owned backing.
+Restore transitions are operator-triggered only and must return the room to the live stage it
+held immediately before the current sealed fallback began.
 
 ## User-Facing Projection
 

--- a/apps/backend/docs/room_progression_surface.md
+++ b/apps/backend/docs/room_progression_surface.md
@@ -52,6 +52,8 @@ Restore transitions are operator-triggered only and must return the room to the 
 held immediately before the current sealed fallback began.
 Reviewed restriction outcomes are also not participant-attributed: a `sealed_restricted` fact must
 be recorded as operator- or system-triggered once a writer-owned restrict decision exists.
+Once a room is `sealed_restricted`, later `seal` follow-ups cannot soften it back to
+`sealed_under_review`; that posture only clears through the reviewed restore path.
 
 ## User-Facing Projection
 
@@ -85,6 +87,8 @@ It does not expose:
 Room progression create and transition writes use durable idempotency keys and canonical payload hashes.
 Create requests reject missing `request_idempotency_key` values, and fact appends reject missing
 `fact_idempotency_key` values, so retry safety is always explicit at the writer boundary.
+When `source_snapshot_json` is omitted, the writer treats it the same as `{}` so omission and an
+explicit empty object do not drift apart under idempotent replay.
 
 Reusing the same idempotency key with the same semantic JSON payload is a replay. Object key ordering does not change the payload hash. Reusing the same key with a different semantic payload is rejected.
 

--- a/apps/backend/docs/room_progression_surface.md
+++ b/apps/backend/docs/room_progression_surface.md
@@ -45,8 +45,9 @@ Relationship Room -> Sealed Room
 Sealed fallback is a calm safety/product posture, not a punishment narrative.
 While a room remains sealed, later writer-owned facts may keep `sealed -> sealed` to record
 follow-up posture such as `sealed_under_review -> sealed_restricted` without reopening the room.
-Live-room seal transitions require a room-scoped `sealed_room_fallback` review case so the
-participant-facing under-review posture always has writer-owned backing.
+Live-room seal transitions require an active, room-scoped `sealed_room_fallback` review case so
+the participant-facing under-review posture always has writer-owned backing and does not reuse a
+stale decided review cycle.
 Restore transitions are operator-triggered only and must return the room to the live stage it
 held immediately before the current sealed fallback began.
 Reviewed restriction outcomes are also not participant-attributed: a `sealed_restricted` fact must
@@ -82,6 +83,8 @@ It does not expose:
 ## Idempotency
 
 Room progression create and transition writes use durable idempotency keys and canonical payload hashes.
+Fact appends reject missing `fact_idempotency_key` values so retry safety is always explicit at the
+writer boundary.
 
 Reusing the same idempotency key with the same semantic JSON payload is a replay. Object key ordering does not change the payload hash. Reusing the same key with a different semantic payload is rejected.
 

--- a/apps/backend/docs/room_progression_surface.md
+++ b/apps/backend/docs/room_progression_surface.md
@@ -83,8 +83,8 @@ It does not expose:
 ## Idempotency
 
 Room progression create and transition writes use durable idempotency keys and canonical payload hashes.
-Fact appends reject missing `fact_idempotency_key` values so retry safety is always explicit at the
-writer boundary.
+Create requests reject missing `request_idempotency_key` values, and fact appends reject missing
+`fact_idempotency_key` values, so retry safety is always explicit at the writer boundary.
 
 Reusing the same idempotency key with the same semantic JSON payload is a replay. Object key ordering does not change the payload hash. Reusing the same key with a different semantic payload is rejected.
 

--- a/apps/backend/docs/room_progression_surface.md
+++ b/apps/backend/docs/room_progression_surface.md
@@ -1,0 +1,85 @@
+# Room Progression Surface
+
+Design source: ISSUE-13-room-progression.md
+
+The GitHub issue number is intentionally not hardcoded. The design source number is a product/design reference, not a repository issue identifier.
+
+ISSUE-13 adds the backend baseline for calm participant-facing room progression:
+- Intent Room
+- Coordination Room
+- Relationship Room
+- Sealed Room fallback
+
+ISSUE-12 operator review / appeal / evidence is already the review foundation. Room progression consumes that boundary when sealed fallback references a review case. It does not duplicate review cases, evidence bundles, access grants, appeals, or operator decision storage.
+
+ISSUE-14 Promise UI is a future consumer of this surface. It is not implemented by this backend baseline.
+
+## Boundary
+
+Room progression writer truth lives in `dao`:
+- `dao.room_progression_tracks` stores the stable progression envelope, participants, current visible stage, and the last bounded user-facing state.
+- `dao.room_progression_facts` stores append-only progression facts. These facts are the durable transition history and may reference a writer-owned ISSUE-12 `review_case_id`.
+
+User-facing state lives in `projection.room_progression_views`. The projection is rebuildable and exists for display only.
+
+State-changing decisions must read writer-owned facts, not projection rows. For example, restore from a sealed room reads the latest relevant `dao.operator_decision_facts` for the linked review case. `projection.review_status_views` may shape display posture, but it is not authoritative for restore or progression decisions.
+
+Room progression facts must not mutate Promise, settlement, proof, or operator review writer truth.
+
+## State Shape
+
+The ordinary path is intentionally small:
+
+```text
+Intent Room -> Coordination Room -> Relationship Room
+```
+
+Skipped transitions are rejected unless a later design explicitly changes the state machine. Sealed fallback is supported from any visible stage:
+
+```text
+Intent Room       -> Sealed Room
+Coordination Room -> Sealed Room
+Relationship Room -> Sealed Room
+```
+
+Sealed fallback is a calm safety/product posture, not a punishment narrative.
+
+## User-Facing Projection
+
+`projection.room_progression_views` exposes bounded participant-facing fields:
+- room progression id
+- realm id
+- participant account ids for authorization
+- visible stage
+- status code
+- user-facing reason code
+- safe review posture fields when linked to ISSUE-12 review state
+- source watermark, source fact count, projection lag, and rebuild generation
+
+It does not expose:
+- raw evidence locators
+- internal operator notes
+- operator identities
+- raw source snapshots
+- decision payload internals
+- internal safety classifications
+- accusatory labels or private claims
+
+## Idempotency
+
+Room progression create and transition writes use durable idempotency keys and canonical payload hashes.
+
+Reusing the same idempotency key with the same semantic JSON payload is a replay. Object key ordering does not change the payload hash. Reusing the same key with a different semantic payload is rejected.
+
+## Deferred Scope
+
+This baseline intentionally does not implement:
+- ISSUE-12 review / appeal / evidence workflow again
+- ISSUE-14 Promise creation, completion, proof-missing fallback UI, or reflection UI
+- Flutter or mobile UI
+- settlement UI
+- full dispute center UI
+- proof persistence
+- raw evidence retrieval endpoints
+- broad operator console product work
+- recommendation, ranking, swiping, engagement-loop, or DM-unlock behavior

--- a/apps/backend/docs/schema_skeleton.md
+++ b/apps/backend/docs/schema_skeleton.md
@@ -144,6 +144,10 @@ Migration `0016_room_progression_surface.sql` adds the baseline room progression
 - `dao.room_progression_facts`
 - `projection.room_progression_views`
 
+Migration `0017_room_progression_actor_consistency.sql` adds the actor-consistency constraint that
+governs room progression write validity, so both migrations are part of the schema surface
+operators and developers must apply for ISSUE-13 writes.
+
 Room progression tracks preserve the stable realm-scoped participant envelope. Room progression facts are append-only writer facts for transitions between Intent Room, Coordination Room, Relationship Room, and Sealed Room fallback. These facts may reference ISSUE-12 review cases, but they do not duplicate review/evidence/appeal storage and they do not overwrite Promise or settlement writer truth.
 
 `projection.room_progression_views` is a bounded user-facing read model. It is rebuilt from writer-owned room progression facts and may include safe review posture derived from ISSUE-12 projection for display only. State-changing room progression decisions must read writer-owned `dao` facts, not projection rows.

--- a/apps/backend/docs/schema_skeleton.md
+++ b/apps/backend/docs/schema_skeleton.md
@@ -30,6 +30,7 @@ Owns:
 - settlement coordination facts
 - realm-scoped, pseudonymous references used to coordinate state progression
 - operator review cases, evidence bundles, appeal cases, and append-only operator decision facts that reference writer-owned source facts without overwriting them
+- room progression tracks and append-only room progression facts for Intent, Coordination, Relationship, and Sealed Room surface state
 
 Must not own:
 - immutable financial postings
@@ -68,6 +69,7 @@ Owns:
 - rebuildable settlement read models
 - rebuildable bounded trust read models
 - rebuildable user-facing review status models derived from operator review and appeal facts
+- rebuildable user-facing room progression models derived from room progression facts and safe ISSUE-12 review posture
 - freshness, lag, watermark, and rebuild metadata for projections
 
 Must not own:
@@ -130,3 +132,20 @@ Migration `0015_operator_review_hardening.sql` adds payload hash columns for rev
 The architectural boundary is strict: operator decisions are append-only facts and do not rewrite the original Promise, settlement, proof, or source writer truth. User-facing review status is projected from review, decision, evidence, and appeal facts using bounded status and reason codes.
 
 ISSUE-13 room progression and ISSUE-14 Promise UI are future consumers of this boundary. They are not implemented by this schema addition.
+
+## ISSUE-13 room progression additions
+
+Design source: ISSUE-13-room-progression.md
+
+The GitHub issue number is intentionally not hardcoded.
+
+Migration `0016_room_progression_surface.sql` adds the baseline room progression surface:
+- `dao.room_progression_tracks`
+- `dao.room_progression_facts`
+- `projection.room_progression_views`
+
+Room progression tracks preserve the stable realm-scoped participant envelope. Room progression facts are append-only writer facts for transitions between Intent Room, Coordination Room, Relationship Room, and Sealed Room fallback. These facts may reference ISSUE-12 review cases, but they do not duplicate review/evidence/appeal storage and they do not overwrite Promise or settlement writer truth.
+
+`projection.room_progression_views` is a bounded user-facing read model. It is rebuilt from writer-owned room progression facts and may include safe review posture derived from ISSUE-12 projection for display only. State-changing room progression decisions must read writer-owned `dao` facts, not projection rows.
+
+ISSUE-14 Promise UI is a future consumer of this room progression surface. It is not implemented by this schema addition.

--- a/apps/backend/migrations/0016_room_progression_surface.sql
+++ b/apps/backend/migrations/0016_room_progression_surface.sql
@@ -1,0 +1,218 @@
+-- Design source: ISSUE-13-room-progression.md
+-- GitHub issue number is intentionally not hardcoded.
+
+CREATE TABLE IF NOT EXISTS dao.room_progression_tracks (
+    room_progression_id UUID PRIMARY KEY,
+    realm_id TEXT NOT NULL CHECK (char_length(trim(realm_id)) > 0),
+    participant_a_account_id UUID NOT NULL REFERENCES core.accounts(account_id),
+    participant_b_account_id UUID NOT NULL REFERENCES core.accounts(account_id),
+    related_promise_intent_id UUID REFERENCES dao.promise_intents(promise_intent_id),
+    related_settlement_case_id UUID REFERENCES dao.settlement_cases(settlement_case_id),
+    current_stage TEXT NOT NULL CHECK (
+        current_stage IN ('intent', 'coordination', 'relationship', 'sealed')
+    ),
+    current_status_code TEXT NOT NULL CHECK (
+        current_status_code IN (
+            'intent_open',
+            'coordination_open',
+            'relationship_open',
+            'sealed_under_review',
+            'sealed_restricted',
+            'withdrawn',
+            'blocked',
+            'muted'
+        )
+    ),
+    current_user_facing_reason_code TEXT NOT NULL CHECK (
+        current_user_facing_reason_code IN (
+            'room_created',
+            'mutual_intent_acknowledged',
+            'promise_draft_created',
+            'bounded_coordination_accepted',
+            'coordination_completed',
+            'qualifying_promise_completed',
+            'safety_review',
+            'policy_review',
+            'manual_hold_safety_review',
+            'appeal_received',
+            'proof_missing',
+            'proof_inconclusive',
+            'duplicate_or_invalid',
+            'resolved_no_action',
+            'restricted_after_review',
+            'restored_after_review',
+            'user_withdrew',
+            'user_blocked',
+            'user_muted'
+        )
+    ),
+    current_review_case_id UUID REFERENCES dao.review_cases(review_case_id),
+    source_fact_kind TEXT NOT NULL CHECK (char_length(trim(source_fact_kind)) > 0),
+    source_fact_id TEXT NOT NULL CHECK (char_length(trim(source_fact_id)) > 0),
+    source_snapshot_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+    request_idempotency_key TEXT,
+    request_payload_hash TEXT NOT NULL CHECK (request_payload_hash ~ '^[0-9a-f]{64}$'),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CHECK (participant_a_account_id <> participant_b_account_id)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS room_progression_tracks_idempotency_unique
+    ON dao.room_progression_tracks (request_idempotency_key)
+    WHERE request_idempotency_key IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS room_progression_tracks_participant_a_idx
+    ON dao.room_progression_tracks (participant_a_account_id, updated_at);
+
+CREATE INDEX IF NOT EXISTS room_progression_tracks_participant_b_idx
+    ON dao.room_progression_tracks (participant_b_account_id, updated_at);
+
+COMMENT ON TABLE dao.room_progression_tracks IS
+'ISSUE-13 room progression writer envelope. It tracks current room posture from append-only progression facts without mutating Promise, settlement, or review truth.';
+
+CREATE TABLE IF NOT EXISTS dao.room_progression_facts (
+    room_progression_fact_id UUID PRIMARY KEY,
+    room_progression_id UUID NOT NULL REFERENCES dao.room_progression_tracks(room_progression_id),
+    from_stage TEXT NOT NULL CHECK (
+        from_stage IN ('intent', 'coordination', 'relationship', 'sealed')
+    ),
+    to_stage TEXT NOT NULL CHECK (
+        to_stage IN ('intent', 'coordination', 'relationship', 'sealed')
+    ),
+    transition_kind TEXT NOT NULL CHECK (
+        transition_kind IN (
+            'create',
+            'advance_to_coordination',
+            'advance_to_relationship',
+            'seal',
+            'restore',
+            'mute',
+            'block',
+            'withdraw'
+        )
+    ),
+    status_code TEXT NOT NULL CHECK (
+        status_code IN (
+            'intent_open',
+            'coordination_open',
+            'relationship_open',
+            'sealed_under_review',
+            'sealed_restricted',
+            'withdrawn',
+            'blocked',
+            'muted'
+        )
+    ),
+    user_facing_reason_code TEXT NOT NULL CHECK (
+        user_facing_reason_code IN (
+            'room_created',
+            'mutual_intent_acknowledged',
+            'promise_draft_created',
+            'bounded_coordination_accepted',
+            'coordination_completed',
+            'qualifying_promise_completed',
+            'safety_review',
+            'policy_review',
+            'manual_hold_safety_review',
+            'appeal_received',
+            'proof_missing',
+            'proof_inconclusive',
+            'duplicate_or_invalid',
+            'resolved_no_action',
+            'restricted_after_review',
+            'restored_after_review',
+            'user_withdrew',
+            'user_blocked',
+            'user_muted'
+        )
+    ),
+    triggered_by_kind TEXT NOT NULL CHECK (
+        triggered_by_kind IN ('system', 'participant', 'operator')
+    ),
+    triggered_by_account_id UUID REFERENCES core.accounts(account_id),
+    source_fact_kind TEXT NOT NULL CHECK (char_length(trim(source_fact_kind)) > 0),
+    source_fact_id TEXT NOT NULL CHECK (char_length(trim(source_fact_id)) > 0),
+    source_snapshot_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+    review_case_id UUID REFERENCES dao.review_cases(review_case_id),
+    fact_idempotency_key TEXT,
+    fact_payload_hash TEXT NOT NULL CHECK (fact_payload_hash ~ '^[0-9a-f]{64}$'),
+    recorded_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS room_progression_facts_idempotency_unique
+    ON dao.room_progression_facts (room_progression_id, fact_idempotency_key)
+    WHERE fact_idempotency_key IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS room_progression_facts_track_idx
+    ON dao.room_progression_facts (room_progression_id, recorded_at);
+
+CREATE INDEX IF NOT EXISTS room_progression_facts_review_case_idx
+    ON dao.room_progression_facts (review_case_id, recorded_at)
+    WHERE review_case_id IS NOT NULL;
+
+COMMENT ON TABLE dao.room_progression_facts IS
+'Append-only ISSUE-13 room progression facts. Safety, block, mute, withdraw, seal, and restore actions add facts rather than rewriting Promise, settlement, or review truth.';
+
+CREATE TABLE IF NOT EXISTS projection.room_progression_views (
+    room_progression_id UUID PRIMARY KEY,
+    realm_id TEXT NOT NULL,
+    participant_a_account_id UUID NOT NULL,
+    participant_b_account_id UUID NOT NULL,
+    visible_stage TEXT NOT NULL CHECK (
+        visible_stage IN ('intent', 'coordination', 'relationship', 'sealed')
+    ),
+    status_code TEXT NOT NULL CHECK (
+        status_code IN (
+            'intent_open',
+            'coordination_open',
+            'relationship_open',
+            'sealed_under_review',
+            'sealed_restricted',
+            'withdrawn',
+            'blocked',
+            'muted'
+        )
+    ),
+    user_facing_reason_code TEXT NOT NULL CHECK (
+        user_facing_reason_code IN (
+            'room_created',
+            'mutual_intent_acknowledged',
+            'promise_draft_created',
+            'bounded_coordination_accepted',
+            'coordination_completed',
+            'qualifying_promise_completed',
+            'safety_review',
+            'policy_review',
+            'manual_hold_safety_review',
+            'appeal_received',
+            'proof_missing',
+            'proof_inconclusive',
+            'duplicate_or_invalid',
+            'resolved_no_action',
+            'restricted_after_review',
+            'restored_after_review',
+            'user_withdrew',
+            'user_blocked',
+            'user_muted'
+        )
+    ),
+    review_case_id UUID,
+    review_pending BOOLEAN NOT NULL DEFAULT false,
+    review_status TEXT,
+    appeal_available BOOLEAN NOT NULL DEFAULT false,
+    evidence_requested BOOLEAN NOT NULL DEFAULT false,
+    source_watermark_at TIMESTAMPTZ NOT NULL,
+    source_fact_count BIGINT NOT NULL CHECK (source_fact_count >= 0),
+    projection_lag_ms BIGINT NOT NULL CHECK (projection_lag_ms >= 0),
+    rebuild_generation BIGINT NOT NULL DEFAULT 1 CHECK (rebuild_generation > 0),
+    last_projected_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS room_progression_views_participant_a_idx
+    ON projection.room_progression_views (participant_a_account_id, last_projected_at);
+
+CREATE INDEX IF NOT EXISTS room_progression_views_participant_b_idx
+    ON projection.room_progression_views (participant_b_account_id, last_projected_at);
+
+COMMENT ON TABLE projection.room_progression_views IS
+'Rebuildable ISSUE-13 participant-facing room progression read model. It exposes calm bounded status and reason codes, not raw evidence, internal notes, or operator identities.';

--- a/apps/backend/migrations/0017_room_progression_actor_consistency.sql
+++ b/apps/backend/migrations/0017_room_progression_actor_consistency.sql
@@ -1,0 +1,9 @@
+ALTER TABLE dao.room_progression_facts
+    ADD CONSTRAINT room_progression_facts_triggered_by_actor_consistency_chk
+    CHECK (
+        (triggered_by_kind = 'system' AND triggered_by_account_id IS NULL)
+        OR (
+            triggered_by_kind IN ('participant', 'operator')
+            AND triggered_by_account_id IS NOT NULL
+        )
+    );

--- a/apps/backend/src/handlers/mod.rs
+++ b/apps/backend/src/handlers/mod.rs
@@ -13,6 +13,7 @@ pub mod payments;
 pub mod projection;
 pub mod promise_intents;
 pub mod proof;
+pub mod room_progression;
 
 #[derive(Debug, Serialize)]
 pub struct ErrorResponse {

--- a/apps/backend/src/handlers/room_progression.rs
+++ b/apps/backend/src/handlers/room_progression.rs
@@ -1,0 +1,304 @@
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::HeaderMap,
+};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{
+    SharedState,
+    handlers::{
+        ApiError, ApiResult, bad_request, internal_server_error, map_happy_route_error, not_found,
+        require_bearer_token, require_internal_bearer_token, service_unavailable, unauthorized,
+    },
+    services::{
+        happy_route::authorize_account,
+        room_progression::{
+            AppendRoomProgressionFactInput, CreateRoomProgressionInput, RoomProgressionError,
+            RoomProgressionFactSnapshot, RoomProgressionRebuildSnapshot,
+            RoomProgressionTrackSnapshot, RoomProgressionViewSnapshot,
+        },
+    },
+};
+
+#[derive(Debug, Deserialize)]
+pub struct CreateRoomProgressionRequest {
+    pub realm_id: String,
+    pub participant_account_ids: Vec<String>,
+    pub related_promise_intent_id: Option<String>,
+    pub related_settlement_case_id: Option<String>,
+    pub user_facing_reason_code: String,
+    pub source_fact_kind: String,
+    pub source_fact_id: String,
+    pub source_snapshot_json: Option<Value>,
+    pub request_idempotency_key: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AppendRoomProgressionFactRequest {
+    pub transition_kind: String,
+    pub to_stage: String,
+    pub user_facing_reason_code: String,
+    pub triggered_by_kind: String,
+    pub triggered_by_account_id: Option<String>,
+    pub source_fact_kind: String,
+    pub source_fact_id: String,
+    pub source_snapshot_json: Option<Value>,
+    pub review_case_id: Option<String>,
+    pub fact_idempotency_key: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RoomProgressionTrackResponse {
+    pub room_progression_id: String,
+    pub realm_id: String,
+    pub participant_a_account_id: String,
+    pub participant_b_account_id: String,
+    pub related_promise_intent_id: Option<String>,
+    pub related_settlement_case_id: Option<String>,
+    pub current_stage: String,
+    pub current_status_code: String,
+    pub current_user_facing_reason_code: String,
+    pub current_review_case_id: Option<String>,
+    pub source_fact_kind: String,
+    pub source_fact_id: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RoomProgressionFactResponse {
+    pub room_progression_fact_id: String,
+    pub room_progression_id: String,
+    pub from_stage: String,
+    pub to_stage: String,
+    pub transition_kind: String,
+    pub status_code: String,
+    pub user_facing_reason_code: String,
+    pub triggered_by_kind: String,
+    pub triggered_by_account_id: Option<String>,
+    pub source_fact_kind: String,
+    pub source_fact_id: String,
+    pub review_case_id: Option<String>,
+    pub recorded_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RoomProgressionViewResponse {
+    pub room_progression_id: String,
+    pub realm_id: String,
+    pub participant_a_account_id: String,
+    pub participant_b_account_id: String,
+    pub visible_stage: String,
+    pub status_code: String,
+    pub user_facing_reason_code: String,
+    pub review_case_id: Option<String>,
+    pub review_pending: bool,
+    pub review_status: Option<String>,
+    pub appeal_available: bool,
+    pub evidence_requested: bool,
+    pub source_watermark_at: DateTime<Utc>,
+    pub source_fact_count: i64,
+    pub projection_lag_ms: i64,
+    pub rebuild_generation: i64,
+    pub last_projected_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RoomProgressionRebuildResponse {
+    pub rebuilt_count: i64,
+}
+
+pub async fn create_room_progression(
+    State(state): State<SharedState>,
+    headers: HeaderMap,
+    Json(payload): Json<CreateRoomProgressionRequest>,
+) -> ApiResult<RoomProgressionTrackResponse> {
+    require_internal_bearer_token(&headers)?;
+    let snapshot = state
+        .room_progression
+        .create_room_progression(CreateRoomProgressionInput {
+            realm_id: payload.realm_id,
+            participant_account_ids: payload.participant_account_ids,
+            related_promise_intent_id: payload.related_promise_intent_id,
+            related_settlement_case_id: payload.related_settlement_case_id,
+            user_facing_reason_code: payload.user_facing_reason_code,
+            source_fact_kind: payload.source_fact_kind,
+            source_fact_id: payload.source_fact_id,
+            source_snapshot_json: payload.source_snapshot_json.unwrap_or_else(|| {
+                serde_json::json!({
+                    "source": "room_progression",
+                    "note": "no source snapshot supplied"
+                })
+            }),
+            request_idempotency_key: payload.request_idempotency_key,
+        })
+        .await
+        .map_err(map_room_progression_error)?;
+
+    Ok(Json(room_progression_track_response(snapshot)))
+}
+
+pub async fn append_room_progression_fact(
+    State(state): State<SharedState>,
+    headers: HeaderMap,
+    Path(room_progression_id): Path<String>,
+    Json(payload): Json<AppendRoomProgressionFactRequest>,
+) -> ApiResult<RoomProgressionFactResponse> {
+    require_internal_bearer_token(&headers)?;
+    let snapshot = state
+        .room_progression
+        .append_room_progression_fact(
+            room_progression_id.trim(),
+            AppendRoomProgressionFactInput {
+                transition_kind: payload.transition_kind,
+                to_stage: payload.to_stage,
+                user_facing_reason_code: payload.user_facing_reason_code,
+                triggered_by_kind: payload.triggered_by_kind,
+                triggered_by_account_id: payload.triggered_by_account_id,
+                source_fact_kind: payload.source_fact_kind,
+                source_fact_id: payload.source_fact_id,
+                source_snapshot_json: payload.source_snapshot_json.unwrap_or_else(|| {
+                    serde_json::json!({
+                        "source": "room_progression",
+                        "note": "no source snapshot supplied"
+                    })
+                }),
+                review_case_id: payload.review_case_id,
+                fact_idempotency_key: payload.fact_idempotency_key,
+            },
+        )
+        .await
+        .map_err(map_room_progression_error)?;
+
+    Ok(Json(room_progression_fact_response(snapshot)))
+}
+
+pub async fn get_room_progression_view(
+    State(state): State<SharedState>,
+    headers: HeaderMap,
+    Path(room_progression_id): Path<String>,
+) -> ApiResult<RoomProgressionViewResponse> {
+    let token = require_bearer_token(&headers)?;
+    let account = authorize_account(&state, &token)
+        .await
+        .map_err(map_happy_route_error)?;
+    let snapshot = state
+        .room_progression
+        .get_room_progression_view_for_participant(&account.account_id, room_progression_id.trim())
+        .await
+        .map_err(map_room_progression_error)?;
+
+    Ok(Json(room_progression_view_response(snapshot)))
+}
+
+pub async fn rebuild_room_progression_views(
+    State(state): State<SharedState>,
+    headers: HeaderMap,
+) -> ApiResult<RoomProgressionRebuildResponse> {
+    require_internal_bearer_token(&headers)?;
+    let snapshot = state
+        .room_progression
+        .rebuild_room_progression_views()
+        .await
+        .map_err(map_room_progression_error)?;
+
+    Ok(Json(room_progression_rebuild_response(snapshot)))
+}
+
+fn room_progression_track_response(
+    snapshot: RoomProgressionTrackSnapshot,
+) -> RoomProgressionTrackResponse {
+    RoomProgressionTrackResponse {
+        room_progression_id: snapshot.room_progression_id,
+        realm_id: snapshot.realm_id,
+        participant_a_account_id: snapshot.participant_a_account_id,
+        participant_b_account_id: snapshot.participant_b_account_id,
+        related_promise_intent_id: snapshot.related_promise_intent_id,
+        related_settlement_case_id: snapshot.related_settlement_case_id,
+        current_stage: snapshot.current_stage,
+        current_status_code: snapshot.current_status_code,
+        current_user_facing_reason_code: snapshot.current_user_facing_reason_code,
+        current_review_case_id: snapshot.current_review_case_id,
+        source_fact_kind: snapshot.source_fact_kind,
+        source_fact_id: snapshot.source_fact_id,
+        created_at: snapshot.created_at,
+        updated_at: snapshot.updated_at,
+    }
+}
+
+fn room_progression_fact_response(
+    snapshot: RoomProgressionFactSnapshot,
+) -> RoomProgressionFactResponse {
+    RoomProgressionFactResponse {
+        room_progression_fact_id: snapshot.room_progression_fact_id,
+        room_progression_id: snapshot.room_progression_id,
+        from_stage: snapshot.from_stage,
+        to_stage: snapshot.to_stage,
+        transition_kind: snapshot.transition_kind,
+        status_code: snapshot.status_code,
+        user_facing_reason_code: snapshot.user_facing_reason_code,
+        triggered_by_kind: snapshot.triggered_by_kind,
+        triggered_by_account_id: snapshot.triggered_by_account_id,
+        source_fact_kind: snapshot.source_fact_kind,
+        source_fact_id: snapshot.source_fact_id,
+        review_case_id: snapshot.review_case_id,
+        recorded_at: snapshot.recorded_at,
+    }
+}
+
+fn room_progression_view_response(
+    snapshot: RoomProgressionViewSnapshot,
+) -> RoomProgressionViewResponse {
+    RoomProgressionViewResponse {
+        room_progression_id: snapshot.room_progression_id,
+        realm_id: snapshot.realm_id,
+        participant_a_account_id: snapshot.participant_a_account_id,
+        participant_b_account_id: snapshot.participant_b_account_id,
+        visible_stage: snapshot.visible_stage,
+        status_code: snapshot.status_code,
+        user_facing_reason_code: snapshot.user_facing_reason_code,
+        review_case_id: snapshot.review_case_id,
+        review_pending: snapshot.review_pending,
+        review_status: snapshot.review_status,
+        appeal_available: snapshot.appeal_available,
+        evidence_requested: snapshot.evidence_requested,
+        source_watermark_at: snapshot.source_watermark_at,
+        source_fact_count: snapshot.source_fact_count,
+        projection_lag_ms: snapshot.projection_lag_ms,
+        rebuild_generation: snapshot.rebuild_generation,
+        last_projected_at: snapshot.last_projected_at,
+    }
+}
+
+fn room_progression_rebuild_response(
+    snapshot: RoomProgressionRebuildSnapshot,
+) -> RoomProgressionRebuildResponse {
+    RoomProgressionRebuildResponse {
+        rebuilt_count: snapshot.rebuilt_count,
+    }
+}
+
+fn map_room_progression_error(error: RoomProgressionError) -> ApiError {
+    match error {
+        RoomProgressionError::BadRequest(message) => bad_request(message),
+        RoomProgressionError::Unauthorized(message) => unauthorized(message),
+        RoomProgressionError::NotFound(message) => not_found(message),
+        RoomProgressionError::Database {
+            message, retryable, ..
+        } => {
+            eprintln!("database room progression error: {message}");
+            if retryable {
+                service_unavailable("temporarily unavailable")
+            } else {
+                internal_server_error("internal server error")
+            }
+        }
+        RoomProgressionError::Internal(message) => {
+            eprintln!("internal room progression error: {message}");
+            internal_server_error("internal server error")
+        }
+    }
+}

--- a/apps/backend/src/handlers/room_progression.rs
+++ b/apps/backend/src/handlers/room_progression.rs
@@ -127,12 +127,9 @@ pub async fn create_room_progression(
             user_facing_reason_code: payload.user_facing_reason_code,
             source_fact_kind: payload.source_fact_kind,
             source_fact_id: payload.source_fact_id,
-            source_snapshot_json: payload.source_snapshot_json.unwrap_or_else(|| {
-                serde_json::json!({
-                    "source": "room_progression",
-                    "note": "no source snapshot supplied"
-                })
-            }),
+            source_snapshot_json: payload
+                .source_snapshot_json
+                .unwrap_or_else(|| serde_json::json!({})),
             request_idempotency_key: payload.request_idempotency_key,
         })
         .await
@@ -160,12 +157,9 @@ pub async fn append_room_progression_fact(
                 triggered_by_account_id: payload.triggered_by_account_id,
                 source_fact_kind: payload.source_fact_kind,
                 source_fact_id: payload.source_fact_id,
-                source_snapshot_json: payload.source_snapshot_json.unwrap_or_else(|| {
-                    serde_json::json!({
-                        "source": "room_progression",
-                        "note": "no source snapshot supplied"
-                    })
-                }),
+                source_snapshot_json: payload
+                    .source_snapshot_json
+                    .unwrap_or_else(|| serde_json::json!({})),
                 review_case_id: payload.review_case_id,
                 fact_idempotency_key: payload.fact_idempotency_key,
             },

--- a/apps/backend/src/lib.rs
+++ b/apps/backend/src/lib.rs
@@ -24,6 +24,7 @@ pub type SharedState = Arc<AppState>;
 pub struct AppState {
     pub happy_route: services::happy_route::HappyRouteStore,
     pub operator_review: services::operator_review::OperatorReviewStore,
+    pub room_progression: services::room_progression::RoomProgressionStore,
     pub proof: RwLock<services::proof::ProofState>,
 }
 
@@ -43,6 +44,7 @@ pub async fn new_state_from_config(config: &DbConfig) -> musubi_db_runtime::Resu
     Ok(Arc::new(AppState {
         happy_route: services::happy_route::HappyRouteStore::connect(config).await?,
         operator_review: services::operator_review::OperatorReviewStore::connect(config).await?,
+        room_progression: services::room_progression::RoomProgressionStore::connect(config).await?,
         proof: RwLock::new(services::proof::ProofState::default()),
     }))
 }
@@ -91,6 +93,11 @@ pub async fn new_test_state() -> Result<TestState, String> {
         .map_err(|error| error.message().to_owned())?;
     state
         .operator_review
+        .reset_for_test()
+        .await
+        .map_err(|error| error.message().to_owned())?;
+    state
+        .room_progression
         .reset_for_test()
         .await
         .map_err(|error| error.message().to_owned())?;
@@ -149,6 +156,10 @@ pub fn build_app(state: SharedState) -> Router {
         .route(
             "/api/review-cases/{review_case_id}/status",
             get(handlers::operator_review::get_review_status),
+        )
+        .route(
+            "/api/projection/room-progression-views/{room_progression_id}",
+            get(handlers::room_progression::get_room_progression_view),
         );
     let app = if unauthenticated_pi_callback_enabled() {
         app.route(
@@ -187,6 +198,18 @@ pub fn build_app(state: SharedState) -> Router {
         .route(
             "/api/internal/operator/review-cases/{review_case_id}/decisions",
             post(handlers::operator_review::record_operator_decision),
+        )
+        .route(
+            "/api/internal/room-progressions",
+            post(handlers::room_progression::create_room_progression),
+        )
+        .route(
+            "/api/internal/room-progressions/{room_progression_id}/facts",
+            post(handlers::room_progression::append_room_progression_fact),
+        )
+        .route(
+            "/api/internal/projection/room-progressions/rebuild",
+            post(handlers::room_progression::rebuild_room_progression_views),
         )
     } else {
         app

--- a/apps/backend/src/services/mod.rs
+++ b/apps/backend/src/services/mod.rs
@@ -2,3 +2,4 @@
 pub mod happy_route;
 pub mod operator_review;
 pub mod proof;
+pub mod room_progression;

--- a/apps/backend/src/services/room_progression/mod.rs
+++ b/apps/backend/src/services/room_progression/mod.rs
@@ -1,0 +1,9 @@
+mod repository;
+mod types;
+
+pub use repository::RoomProgressionStore;
+pub use types::{
+    AppendRoomProgressionFactInput, CreateRoomProgressionInput, RoomProgressionError,
+    RoomProgressionFactSnapshot, RoomProgressionRebuildSnapshot, RoomProgressionTrackSnapshot,
+    RoomProgressionViewSnapshot,
+};

--- a/apps/backend/src/services/room_progression/repository.rs
+++ b/apps/backend/src/services/room_progression/repository.rs
@@ -52,14 +52,14 @@ pub struct RoomProgressionStore {
 }
 
 impl RoomProgressionStore {
-    pub async fn connect(config: &DbConfig) -> musubi_db_runtime::Result<Self> {
+    pub(crate) async fn connect(config: &DbConfig) -> musubi_db_runtime::Result<Self> {
         let client = connect_writer(config, "musubi-backend room-progression").await?;
         Ok(Self {
             client: Arc::new(Mutex::new(client)),
         })
     }
 
-    pub async fn reset_for_test(&self) -> Result<(), RoomProgressionError> {
+    pub(crate) async fn reset_for_test(&self) -> Result<(), RoomProgressionError> {
         let client = self.client.lock().await;
         client
             .batch_execute(
@@ -106,8 +106,6 @@ impl RoomProgressionStore {
 
         let mut client = self.client.lock().await;
         let tx = client.transaction().await.map_err(db_error)?;
-        ensure_account_exists_tx(&tx, &participants.0).await?;
-        ensure_account_exists_tx(&tx, &participants.1).await?;
 
         let row = if let Some(existing) =
             find_existing_track_by_idempotency(&tx, &request_idempotency_key).await?
@@ -117,6 +115,8 @@ impl RoomProgressionStore {
                 .await?;
             existing
         } else {
+            ensure_account_exists_tx(&tx, &participants.0).await?;
+            ensure_account_exists_tx(&tx, &participants.1).await?;
             let room_progression_id = Uuid::new_v4();
             let maybe_row = tx
                 .query_opt(
@@ -334,6 +334,12 @@ impl RoomProgressionStore {
             &fact_payload_hash,
         )
         .await?;
+        let current_review_case_id: Option<Uuid> = track.get("current_review_case_id");
+        let next_review_case_id = if input.to_stage == "sealed" {
+            review_case_id.or(current_review_case_id)
+        } else {
+            None
+        };
 
         tx.execute(
             "
@@ -341,7 +347,7 @@ impl RoomProgressionStore {
             SET current_stage = $2,
                 current_status_code = $3,
                 current_user_facing_reason_code = $4,
-                current_review_case_id = COALESCE($5, current_review_case_id),
+                current_review_case_id = $5,
                 updated_at = CURRENT_TIMESTAMP
             WHERE room_progression_id = $1
             ",
@@ -350,7 +356,7 @@ impl RoomProgressionStore {
                 &input.to_stage,
                 &status_code,
                 &input.user_facing_reason_code,
-                &review_case_id,
+                &next_review_case_id,
             ],
         )
         .await

--- a/apps/backend/src/services/room_progression/repository.rs
+++ b/apps/backend/src/services/room_progression/repository.rs
@@ -886,6 +886,11 @@ async fn validate_transition_tx<C: GenericClient + Sync>(
                 };
                 ensure_review_case_is_active_for_live_seal_tx(client, review_case_id).await?;
             }
+            if current_status_code == "sealed_restricted" && status_code != "sealed_restricted" {
+                return Err(RoomProgressionError::BadRequest(
+                    "restricted sealed rooms cannot downgrade via seal follow-up".to_owned(),
+                ));
+            }
             if status_code == "sealed_restricted" {
                 let Some(review_case_id) = review_case_id else {
                     return Err(RoomProgressionError::BadRequest(

--- a/apps/backend/src/services/room_progression/repository.rs
+++ b/apps/backend/src/services/room_progression/repository.rs
@@ -258,7 +258,13 @@ impl RoomProgressionStore {
         let triggered_by_account_id =
             parse_optional_uuid(&input.triggered_by_account_id, "triggered by account id")?;
         let review_case_id = parse_optional_uuid(&input.review_case_id, "review case id")?;
-        let fact_idempotency_key = normalize_optional(&input.fact_idempotency_key);
+        let fact_idempotency_key =
+            normalize_optional(&input.fact_idempotency_key).ok_or_else(|| {
+                RoomProgressionError::BadRequest(
+                    "room progression fact appends require fact_idempotency_key".to_owned(),
+                )
+            })?;
+        let fact_idempotency_key_param = Some(fact_idempotency_key.clone());
 
         let mut client = self.client.lock().await;
         let tx = client.transaction().await.map_err(db_error)?;
@@ -336,7 +342,7 @@ impl RoomProgressionStore {
             &input.source_fact_id,
             &input.source_snapshot_json,
             &review_case_id,
-            &fact_idempotency_key,
+            &fact_idempotency_key_param,
             &fact_payload_hash,
         )
         .await?;
@@ -710,11 +716,8 @@ async fn find_existing_track_by_idempotency<C: GenericClient + Sync>(
 async fn find_existing_fact_by_idempotency<C: GenericClient + Sync>(
     client: &C,
     room_progression_id: &Uuid,
-    fact_idempotency_key: &Option<String>,
+    fact_idempotency_key: &str,
 ) -> Result<Option<Row>, RoomProgressionError> {
-    let Some(fact_idempotency_key) = fact_idempotency_key else {
-        return Ok(None);
-    };
     client
         .query_opt(
             "
@@ -737,7 +740,7 @@ async fn find_existing_fact_by_idempotency<C: GenericClient + Sync>(
             WHERE room_progression_id = $1
               AND fact_idempotency_key = $2
             ",
-            &[room_progression_id, fact_idempotency_key],
+            &[room_progression_id, &fact_idempotency_key],
         )
         .await
         .map_err(db_error)
@@ -871,6 +874,14 @@ async fn validate_transition_tx<C: GenericClient + Sync>(
                 return Err(RoomProgressionError::BadRequest(
                     "seal transitions from live rooms require review_case_id".to_owned(),
                 ));
+            }
+            if from_stage != "sealed" {
+                let Some(review_case_id) = review_case_id else {
+                    return Err(RoomProgressionError::BadRequest(
+                        "seal transitions from live rooms require review_case_id".to_owned(),
+                    ));
+                };
+                ensure_review_case_is_active_for_live_seal_tx(client, review_case_id).await?;
             }
             if status_code == "sealed_restricted" {
                 let Some(review_case_id) = review_case_id else {
@@ -1030,6 +1041,32 @@ async fn ensure_review_case_matches_room_scope_tx<C: GenericClient + Sync>(
     } else {
         Err(RoomProgressionError::BadRequest(
             "review_case_id must reference the room's sealed fallback review case".to_owned(),
+        ))
+    }
+}
+
+async fn ensure_review_case_is_active_for_live_seal_tx<C: GenericClient + Sync>(
+    client: &C,
+    review_case_id: &Uuid,
+) -> Result<(), RoomProgressionError> {
+    let is_active = client
+        .query_opt(
+            "
+            SELECT 1
+            FROM dao.review_cases
+            WHERE review_case_id = $1
+              AND review_status IN ('open', 'triaged', 'under_review', 'awaiting_evidence')
+            ",
+            &[review_case_id],
+        )
+        .await
+        .map_err(db_error)?
+        .is_some();
+    if is_active {
+        Ok(())
+    } else {
+        Err(RoomProgressionError::BadRequest(
+            "live-room seal transitions require an active room-scoped review case".to_owned(),
         ))
     }
 }

--- a/apps/backend/src/services/room_progression/repository.rs
+++ b/apps/backend/src/services/room_progression/repository.rs
@@ -124,8 +124,8 @@ impl RoomProgressionStore {
             ensure_account_exists_tx(&tx, &participants.0).await?;
             ensure_account_exists_tx(&tx, &participants.1).await?;
             let room_progression_id = Uuid::new_v4();
-            let maybe_row = tx
-                .query_opt(
+            let row = tx
+                .query_one(
                     "
                     INSERT INTO dao.room_progression_tracks (
                         room_progression_id,
@@ -152,7 +152,8 @@ impl RoomProgressionStore {
                     )
                     ON CONFLICT (request_idempotency_key)
                         WHERE request_idempotency_key IS NOT NULL
-                    DO NOTHING
+                    DO UPDATE SET
+                        request_payload_hash = dao.room_progression_tracks.request_payload_hash
                     RETURNING
                         room_progression_id,
                         realm_id,
@@ -167,7 +168,8 @@ impl RoomProgressionStore {
                         source_fact_kind,
                         source_fact_id,
                         created_at,
-                        updated_at
+                        updated_at,
+                        request_payload_hash
                     ",
                     &[
                         &room_progression_id,
@@ -186,8 +188,10 @@ impl RoomProgressionStore {
                 )
                 .await
                 .map_err(db_error)?;
+            ensure_track_matches_payload_hash(&row, &request_payload_hash)?;
+            let persisted_room_progression_id: Uuid = row.get("room_progression_id");
 
-            if let Some(row) = maybe_row {
+            if persisted_room_progression_id == room_progression_id {
                 let fact_payload_hash = create_room_progression_fact_payload_hash(
                     "create",
                     "intent",
@@ -203,7 +207,7 @@ impl RoomProgressionStore {
                 );
                 insert_room_progression_fact_tx(
                     &tx,
-                    &room_progression_id,
+                    &persisted_room_progression_id,
                     "intent",
                     "intent",
                     "create",
@@ -219,21 +223,9 @@ impl RoomProgressionStore {
                     &fact_payload_hash,
                 )
                 .await?;
-                refresh_room_progression_view_tx(&tx, &room_progression_id, None).await?;
-                row
-            } else {
-                let existing =
-                    find_existing_track_by_idempotency(&tx, &request_idempotency_key).await?;
-                let existing = existing.ok_or_else(|| {
-                    RoomProgressionError::Internal(
-                        "room progression idempotency conflict could not be reloaded".to_owned(),
-                    )
-                })?;
-                ensure_track_matches_payload_hash(&existing, &request_payload_hash)?;
-                let room_progression_id: Uuid = existing.get("room_progression_id");
-                refresh_room_progression_view_tx(&tx, &room_progression_id, None).await?;
-                existing
             }
+            refresh_room_progression_view_tx(&tx, &persisted_room_progression_id, None).await?;
+            row
         };
 
         tx.commit().await.map_err(db_error)?;

--- a/apps/backend/src/services/room_progression/repository.rs
+++ b/apps/backend/src/services/room_progression/repository.rs
@@ -1,10 +1,10 @@
 use std::{fmt::Write as _, sync::Arc};
 
-use musubi_db_runtime::{connect_writer, DbConfig};
-use serde_json::{json, Value};
+use musubi_db_runtime::{DbConfig, connect_writer};
+use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 use tokio::sync::Mutex;
-use tokio_postgres::{error::SqlState, Client, GenericClient, Row, Transaction};
+use tokio_postgres::{Client, GenericClient, Row, Transaction, error::SqlState};
 use uuid::Uuid;
 
 use super::types::{
@@ -281,6 +281,7 @@ impl RoomProgressionStore {
         validate_triggered_by_tx(
             &tx,
             &track,
+            &input.transition_kind,
             &input.triggered_by_kind,
             &triggered_by_account_id,
         )
@@ -768,9 +769,15 @@ async fn select_track_for_update_tx(
 async fn validate_triggered_by_tx<C: GenericClient + Sync>(
     client: &C,
     track: &Row,
+    transition_kind: &str,
     triggered_by_kind: &str,
     triggered_by_account_id: &Option<Uuid>,
 ) -> Result<(), RoomProgressionError> {
+    if transition_kind == "restore" && triggered_by_kind != "operator" {
+        return Err(RoomProgressionError::BadRequest(
+            "restore transitions must be operator-triggered".to_owned(),
+        ));
+    }
     match triggered_by_kind {
         "participant" => {
             let Some(account_id) = triggered_by_account_id else {
@@ -874,9 +881,9 @@ async fn validate_transition_tx<C: GenericClient + Sync>(
             Ok(())
         }
         "restore" => {
-            if from_stage != "sealed" || !matches!(to_stage, "coordination" | "relationship") {
+            if from_stage != "sealed" {
                 return Err(RoomProgressionError::BadRequest(
-                    "restore transitions must move sealed rooms to coordination or relationship"
+                    "restore transitions must move sealed rooms back to their prior live stage"
                         .to_owned(),
                 ));
             }
@@ -890,6 +897,13 @@ async fn validate_transition_tx<C: GenericClient + Sync>(
                 return Err(RoomProgressionError::BadRequest(
                     "restore review_case_id must match the room's current review case".to_owned(),
                 ));
+            }
+            let restore_target_stage =
+                current_restore_target_stage_tx(client, track, review_case_id).await?;
+            if to_stage != restore_target_stage {
+                return Err(RoomProgressionError::BadRequest(format!(
+                    "restore transitions must return this sealed room to {restore_target_stage}"
+                )));
             }
             ensure_review_supports_restore_tx(client, review_case_id).await
         }
@@ -1001,6 +1015,37 @@ async fn ensure_review_case_matches_room_scope_tx<C: GenericClient + Sync>(
             "review_case_id must reference the room's sealed fallback review case".to_owned(),
         ))
     }
+}
+
+async fn current_restore_target_stage_tx<C: GenericClient + Sync>(
+    client: &C,
+    track: &Row,
+    review_case_id: &Uuid,
+) -> Result<String, RoomProgressionError> {
+    let room_progression_id = track.get::<_, Uuid>("room_progression_id");
+    let row = client
+        .query_opt(
+            "
+            SELECT from_stage
+            FROM dao.room_progression_facts
+            WHERE room_progression_id = $1
+              AND transition_kind = 'seal'
+              AND to_stage = 'sealed'
+              AND from_stage <> 'sealed'
+              AND review_case_id = $2
+            ORDER BY recorded_at DESC, room_progression_fact_id DESC
+            LIMIT 1
+            ",
+            &[&room_progression_id, review_case_id],
+        )
+        .await
+        .map_err(db_error)?
+        .ok_or_else(|| {
+            RoomProgressionError::BadRequest(
+                "restore review_case_id must reference the room's active live-room seal".to_owned(),
+            )
+        })?;
+    Ok(row.get("from_stage"))
 }
 
 async fn ensure_review_supports_restore_tx<C: GenericClient + Sync>(

--- a/apps/backend/src/services/room_progression/repository.rs
+++ b/apps/backend/src/services/room_progression/repository.rs
@@ -112,8 +112,8 @@ impl RoomProgressionStore {
             find_existing_track_by_idempotency(&tx, &request_idempotency_key).await?
         {
             ensure_track_matches_payload_hash(&existing, &request_payload_hash)?;
-            refresh_room_progression_view_tx(&tx, &existing.get("room_progression_id"), None)
-                .await?;
+            let room_progression_id: Uuid = existing.get("room_progression_id");
+            refresh_room_progression_view_tx(&tx, &room_progression_id, None).await?;
             existing
         } else {
             ensure_account_exists_tx(&tx, &participants.0).await?;
@@ -225,8 +225,8 @@ impl RoomProgressionStore {
                     )
                 })?;
                 ensure_track_matches_payload_hash(&existing, &request_payload_hash)?;
-                refresh_room_progression_view_tx(&tx, &existing.get("room_progression_id"), None)
-                    .await?;
+                let room_progression_id: Uuid = existing.get("room_progression_id");
+                refresh_room_progression_view_tx(&tx, &room_progression_id, None).await?;
                 existing
             }
         };
@@ -442,9 +442,10 @@ impl RoomProgressionStore {
             .map_err(db_error)?;
         let rebuild_generation: i64 = generation_row.get("rebuild_generation");
         for row in &rows {
+            let room_progression_id: Uuid = row.get("room_progression_id");
             refresh_room_progression_view_tx(
                 &*client,
-                &row.get("room_progression_id"),
+                &room_progression_id,
                 Some(rebuild_generation),
             )
             .await?;

--- a/apps/backend/src/services/room_progression/repository.rs
+++ b/apps/backend/src/services/room_progression/repository.rs
@@ -96,7 +96,12 @@ impl RoomProgressionStore {
             &input.related_settlement_case_id,
             "related settlement case id",
         )?;
-        let request_idempotency_key = normalize_optional(&input.request_idempotency_key);
+        let request_idempotency_key = normalize_optional(&input.request_idempotency_key)
+            .ok_or_else(|| {
+                RoomProgressionError::BadRequest(
+                    "room progression creation requires request_idempotency_key".to_owned(),
+                )
+            })?;
         let request_payload_hash = create_room_progression_payload_hash(
             &input,
             &realm_id,
@@ -175,7 +180,7 @@ impl RoomProgressionStore {
                         &input.source_fact_kind,
                         &input.source_fact_id,
                         &input.source_snapshot_json,
-                        &request_idempotency_key,
+                        &Some(request_idempotency_key.clone()),
                         &request_payload_hash,
                     ],
                 )
@@ -680,11 +685,8 @@ async fn refresh_room_progression_view_tx<C: GenericClient + Sync>(
 
 async fn find_existing_track_by_idempotency<C: GenericClient + Sync>(
     client: &C,
-    request_idempotency_key: &Option<String>,
+    request_idempotency_key: &str,
 ) -> Result<Option<Row>, RoomProgressionError> {
-    let Some(request_idempotency_key) = request_idempotency_key else {
-        return Ok(None);
-    };
     client
         .query_opt(
             "
@@ -707,7 +709,7 @@ async fn find_existing_track_by_idempotency<C: GenericClient + Sync>(
             FROM dao.room_progression_tracks
             WHERE request_idempotency_key = $1
             ",
-            &[request_idempotency_key],
+            &[&request_idempotency_key],
         )
         .await
         .map_err(db_error)
@@ -804,6 +806,7 @@ async fn validate_triggered_by_tx<C: GenericClient + Sync>(
                     "participant is not a room member".to_owned(),
                 ));
             }
+            ensure_account_exists_tx(client, account_id).await?;
             Ok(())
         }
         "operator" => {

--- a/apps/backend/src/services/room_progression/repository.rs
+++ b/apps/backend/src/services/room_progression/repository.rs
@@ -1,10 +1,10 @@
 use std::{fmt::Write as _, sync::Arc};
 
-use musubi_db_runtime::{DbConfig, connect_writer};
-use serde_json::{Value, json};
+use musubi_db_runtime::{connect_writer, DbConfig};
+use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use tokio::sync::Mutex;
-use tokio_postgres::{Client, GenericClient, Row, Transaction, error::SqlState};
+use tokio_postgres::{error::SqlState, Client, GenericClient, Row, Transaction};
 use uuid::Uuid;
 
 use super::types::{
@@ -390,7 +390,10 @@ impl RoomProgressionStore {
         room_progression_id: &str,
     ) -> Result<RoomProgressionViewSnapshot, RoomProgressionError> {
         let account_id = parse_uuid(account_id, "account id")?;
-        let room_progression_id = parse_uuid(room_progression_id, "room progression id")?;
+        let room_progression_id =
+            parse_uuid(room_progression_id, "room progression id").map_err(|_| {
+                RoomProgressionError::NotFound("room progression view was not found".to_owned())
+            })?;
         let client = self.client.lock().await;
         let row = client
             .query_opt(

--- a/apps/backend/src/services/room_progression/repository.rs
+++ b/apps/backend/src/services/room_progression/repository.rs
@@ -302,6 +302,7 @@ impl RoomProgressionStore {
             &from_stage,
             &current_status_code,
             &input.transition_kind,
+            &input.triggered_by_kind,
             &input.to_stage,
             &status_code,
             review_case_id.as_ref(),
@@ -419,8 +420,19 @@ impl RoomProgressionStore {
     pub async fn rebuild_room_progression_views(
         &self,
     ) -> Result<RoomProgressionRebuildSnapshot, RoomProgressionError> {
-        let client = self.client.lock().await;
-        let rows = client
+        let mut client = self.client.lock().await;
+        let tx = client.transaction().await.map_err(db_error)?;
+        tx.query_one(
+            "
+            SELECT pg_advisory_xact_lock(
+                hashtext('projection.room_progression_views.rebuild')::bigint
+            )
+            ",
+            &[],
+        )
+        .await
+        .map_err(db_error)?;
+        let rows = tx
             .query(
                 "
                 SELECT room_progression_id
@@ -431,7 +443,7 @@ impl RoomProgressionStore {
             )
             .await
             .map_err(db_error)?;
-        let generation_row = client
+        let generation_row = tx
             .query_one(
                 "
                 SELECT COALESCE(MAX(rebuild_generation), 0)::bigint + 1 AS rebuild_generation
@@ -444,13 +456,10 @@ impl RoomProgressionStore {
         let rebuild_generation: i64 = generation_row.get("rebuild_generation");
         for row in &rows {
             let room_progression_id: Uuid = row.get("room_progression_id");
-            refresh_room_progression_view_tx(
-                &*client,
-                &room_progression_id,
-                Some(rebuild_generation),
-            )
-            .await?;
+            refresh_room_progression_view_tx(&tx, &room_progression_id, Some(rebuild_generation))
+                .await?;
         }
+        tx.commit().await.map_err(db_error)?;
 
         Ok(RoomProgressionRebuildSnapshot {
             rebuilt_count: rows.len() as i64,
@@ -823,6 +832,7 @@ async fn validate_transition_tx<C: GenericClient + Sync>(
     from_stage: &str,
     current_status_code: &str,
     transition_kind: &str,
+    triggered_by_kind: &str,
     to_stage: &str,
     status_code: &str,
     review_case_id: Option<&Uuid>,
@@ -868,6 +878,12 @@ async fn validate_transition_tx<C: GenericClient + Sync>(
                         "restricted seal transitions require review_case_id".to_owned(),
                     ));
                 };
+                if !matches!(triggered_by_kind, "operator" | "system") {
+                    return Err(RoomProgressionError::BadRequest(
+                        "restricted seal transitions must be operator- or system-triggered"
+                            .to_owned(),
+                    ));
+                }
                 if let Some(current_review_case_id) = current_review_case_id.as_ref() {
                     if current_review_case_id != review_case_id {
                         return Err(RoomProgressionError::BadRequest(
@@ -960,6 +976,7 @@ fn next_status_code(
             }
         }
         "restore" => match to_stage {
+            "intent" => "intent_open",
             "coordination" => "coordination_open",
             "relationship" => "relationship_open",
             _ => {

--- a/apps/backend/src/services/room_progression/repository.rs
+++ b/apps/backend/src/services/room_progression/repository.rs
@@ -1,0 +1,1335 @@
+use std::{fmt::Write as _, sync::Arc};
+
+use musubi_db_runtime::{DbConfig, connect_writer};
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+use tokio::sync::Mutex;
+use tokio_postgres::{Client, GenericClient, Row, Transaction, error::SqlState};
+use uuid::Uuid;
+
+use super::types::{
+    AppendRoomProgressionFactInput, CreateRoomProgressionInput, RoomProgressionError,
+    RoomProgressionFactSnapshot, RoomProgressionRebuildSnapshot, RoomProgressionTrackSnapshot,
+    RoomProgressionViewSnapshot,
+};
+
+const ROOM_STAGES: &[&str] = &["intent", "coordination", "relationship", "sealed"];
+const TRANSITION_KINDS: &[&str] = &[
+    "advance_to_coordination",
+    "advance_to_relationship",
+    "seal",
+    "restore",
+    "mute",
+    "block",
+    "withdraw",
+];
+const TRIGGERED_BY_KINDS: &[&str] = &["system", "participant", "operator"];
+const USER_FACING_REASON_CODES: &[&str] = &[
+    "room_created",
+    "mutual_intent_acknowledged",
+    "promise_draft_created",
+    "bounded_coordination_accepted",
+    "coordination_completed",
+    "qualifying_promise_completed",
+    "safety_review",
+    "policy_review",
+    "manual_hold_safety_review",
+    "appeal_received",
+    "proof_missing",
+    "proof_inconclusive",
+    "duplicate_or_invalid",
+    "resolved_no_action",
+    "restricted_after_review",
+    "restored_after_review",
+    "user_withdrew",
+    "user_blocked",
+    "user_muted",
+];
+
+#[derive(Clone)]
+pub struct RoomProgressionStore {
+    client: Arc<Mutex<Client>>,
+}
+
+impl RoomProgressionStore {
+    pub async fn connect(config: &DbConfig) -> musubi_db_runtime::Result<Self> {
+        let client = connect_writer(config, "musubi-backend room-progression").await?;
+        Ok(Self {
+            client: Arc::new(Mutex::new(client)),
+        })
+    }
+
+    pub async fn reset_for_test(&self) -> Result<(), RoomProgressionError> {
+        let client = self.client.lock().await;
+        client
+            .batch_execute(
+                "
+                DELETE FROM projection.room_progression_views;
+                DELETE FROM dao.room_progression_facts;
+                DELETE FROM dao.room_progression_tracks;
+                ",
+            )
+            .await
+            .map_err(db_error)?;
+        Ok(())
+    }
+
+    pub async fn create_room_progression(
+        &self,
+        input: CreateRoomProgressionInput,
+    ) -> Result<RoomProgressionTrackSnapshot, RoomProgressionError> {
+        let realm_id = normalize_required(&input.realm_id, "realm_id")?;
+        validate_allowed(
+            "user_facing_reason_code",
+            &input.user_facing_reason_code,
+            USER_FACING_REASON_CODES,
+        )?;
+        require_non_empty("source_fact_kind", &input.source_fact_kind)?;
+        require_non_empty("source_fact_id", &input.source_fact_id)?;
+        let participants = parse_participant_pair(&input.participant_account_ids)?;
+        let related_promise_intent_id = parse_optional_uuid(
+            &input.related_promise_intent_id,
+            "related promise intent id",
+        )?;
+        let related_settlement_case_id = parse_optional_uuid(
+            &input.related_settlement_case_id,
+            "related settlement case id",
+        )?;
+        let request_idempotency_key = normalize_optional(&input.request_idempotency_key);
+        let request_payload_hash = create_room_progression_payload_hash(
+            &input,
+            &realm_id,
+            &participants,
+            &related_promise_intent_id,
+            &related_settlement_case_id,
+        );
+
+        let mut client = self.client.lock().await;
+        let tx = client.transaction().await.map_err(db_error)?;
+        ensure_account_exists_tx(&tx, &participants.0).await?;
+        ensure_account_exists_tx(&tx, &participants.1).await?;
+
+        let row = if let Some(existing) =
+            find_existing_track_by_idempotency(&tx, &request_idempotency_key).await?
+        {
+            ensure_track_matches_payload_hash(&existing, &request_payload_hash)?;
+            refresh_room_progression_view_tx(&tx, &existing.get("room_progression_id"), None)
+                .await?;
+            existing
+        } else {
+            let room_progression_id = Uuid::new_v4();
+            let maybe_row = tx
+                .query_opt(
+                    "
+                    INSERT INTO dao.room_progression_tracks (
+                        room_progression_id,
+                        realm_id,
+                        participant_a_account_id,
+                        participant_b_account_id,
+                        related_promise_intent_id,
+                        related_settlement_case_id,
+                        current_stage,
+                        current_status_code,
+                        current_user_facing_reason_code,
+                        source_fact_kind,
+                        source_fact_id,
+                        source_snapshot_json,
+                        request_idempotency_key,
+                        request_payload_hash
+                    )
+                    VALUES (
+                        $1, $2, $3, $4, $5, $6,
+                        'intent',
+                        'intent_open',
+                        $7,
+                        $8, $9, $10, $11, $12
+                    )
+                    ON CONFLICT (request_idempotency_key)
+                        WHERE request_idempotency_key IS NOT NULL
+                    DO NOTHING
+                    RETURNING
+                        room_progression_id,
+                        realm_id,
+                        participant_a_account_id,
+                        participant_b_account_id,
+                        related_promise_intent_id,
+                        related_settlement_case_id,
+                        current_stage,
+                        current_status_code,
+                        current_user_facing_reason_code,
+                        current_review_case_id,
+                        source_fact_kind,
+                        source_fact_id,
+                        created_at,
+                        updated_at
+                    ",
+                    &[
+                        &room_progression_id,
+                        &realm_id,
+                        &participants.0,
+                        &participants.1,
+                        &related_promise_intent_id,
+                        &related_settlement_case_id,
+                        &input.user_facing_reason_code,
+                        &input.source_fact_kind,
+                        &input.source_fact_id,
+                        &input.source_snapshot_json,
+                        &request_idempotency_key,
+                        &request_payload_hash,
+                    ],
+                )
+                .await
+                .map_err(db_error)?;
+
+            if let Some(row) = maybe_row {
+                let fact_payload_hash = create_room_progression_fact_payload_hash(
+                    "create",
+                    "intent",
+                    "intent",
+                    "intent_open",
+                    &input.user_facing_reason_code,
+                    "system",
+                    &None,
+                    &input.source_fact_kind,
+                    &input.source_fact_id,
+                    &input.source_snapshot_json,
+                    &None,
+                );
+                insert_room_progression_fact_tx(
+                    &tx,
+                    &room_progression_id,
+                    "intent",
+                    "intent",
+                    "create",
+                    "intent_open",
+                    &input.user_facing_reason_code,
+                    "system",
+                    &None,
+                    &input.source_fact_kind,
+                    &input.source_fact_id,
+                    &input.source_snapshot_json,
+                    &None,
+                    &None,
+                    &fact_payload_hash,
+                )
+                .await?;
+                refresh_room_progression_view_tx(&tx, &room_progression_id, None).await?;
+                row
+            } else {
+                let existing =
+                    find_existing_track_by_idempotency(&tx, &request_idempotency_key).await?;
+                let existing = existing.ok_or_else(|| {
+                    RoomProgressionError::Internal(
+                        "room progression idempotency conflict could not be reloaded".to_owned(),
+                    )
+                })?;
+                ensure_track_matches_payload_hash(&existing, &request_payload_hash)?;
+                refresh_room_progression_view_tx(&tx, &existing.get("room_progression_id"), None)
+                    .await?;
+                existing
+            }
+        };
+
+        tx.commit().await.map_err(db_error)?;
+        Ok(room_progression_track_from_row(&row))
+    }
+
+    pub async fn append_room_progression_fact(
+        &self,
+        room_progression_id: &str,
+        input: AppendRoomProgressionFactInput,
+    ) -> Result<RoomProgressionFactSnapshot, RoomProgressionError> {
+        let room_progression_id = parse_uuid(room_progression_id, "room progression id")?;
+        validate_allowed("transition_kind", &input.transition_kind, TRANSITION_KINDS)?;
+        validate_allowed("to_stage", &input.to_stage, ROOM_STAGES)?;
+        validate_allowed(
+            "user_facing_reason_code",
+            &input.user_facing_reason_code,
+            USER_FACING_REASON_CODES,
+        )?;
+        validate_allowed(
+            "triggered_by_kind",
+            &input.triggered_by_kind,
+            TRIGGERED_BY_KINDS,
+        )?;
+        require_non_empty("source_fact_kind", &input.source_fact_kind)?;
+        require_non_empty("source_fact_id", &input.source_fact_id)?;
+        let triggered_by_account_id =
+            parse_optional_uuid(&input.triggered_by_account_id, "triggered by account id")?;
+        let review_case_id = parse_optional_uuid(&input.review_case_id, "review case id")?;
+        let fact_idempotency_key = normalize_optional(&input.fact_idempotency_key);
+
+        let mut client = self.client.lock().await;
+        let tx = client.transaction().await.map_err(db_error)?;
+        let track = select_track_for_update_tx(&tx, &room_progression_id).await?;
+        if let Some(existing) =
+            find_existing_fact_by_idempotency(&tx, &room_progression_id, &fact_idempotency_key)
+                .await?
+        {
+            let expected_hash = room_progression_fact_payload_hash_from_input(&existing, &input)?;
+            ensure_fact_matches_payload_hash(&existing, &expected_hash)?;
+            refresh_room_progression_view_tx(&tx, &room_progression_id, None).await?;
+            tx.commit().await.map_err(db_error)?;
+            return Ok(room_progression_fact_from_row(&existing));
+        }
+
+        let from_stage: String = track.get("current_stage");
+        let current_status_code: String = track.get("current_status_code");
+        validate_triggered_by_tx(
+            &tx,
+            &track,
+            &input.triggered_by_kind,
+            &triggered_by_account_id,
+        )
+        .await?;
+        if let Some(review_case_id) = review_case_id.as_ref() {
+            ensure_review_case_exists_tx(&tx, review_case_id).await?;
+        }
+
+        let status_code = next_status_code(
+            &input.transition_kind,
+            &from_stage,
+            &input.to_stage,
+            &input.user_facing_reason_code,
+        )?;
+        validate_transition_tx(
+            &tx,
+            &track,
+            &from_stage,
+            &current_status_code,
+            &input.transition_kind,
+            &input.to_stage,
+            review_case_id.as_ref(),
+        )
+        .await?;
+
+        let fact_payload_hash = create_room_progression_fact_payload_hash(
+            &input.transition_kind,
+            &from_stage,
+            &input.to_stage,
+            &status_code,
+            &input.user_facing_reason_code,
+            &input.triggered_by_kind,
+            &triggered_by_account_id,
+            &input.source_fact_kind,
+            &input.source_fact_id,
+            &input.source_snapshot_json,
+            &review_case_id,
+        );
+        let row = insert_room_progression_fact_tx(
+            &tx,
+            &room_progression_id,
+            &from_stage,
+            &input.to_stage,
+            &input.transition_kind,
+            &status_code,
+            &input.user_facing_reason_code,
+            &input.triggered_by_kind,
+            &triggered_by_account_id,
+            &input.source_fact_kind,
+            &input.source_fact_id,
+            &input.source_snapshot_json,
+            &review_case_id,
+            &fact_idempotency_key,
+            &fact_payload_hash,
+        )
+        .await?;
+
+        tx.execute(
+            "
+            UPDATE dao.room_progression_tracks
+            SET current_stage = $2,
+                current_status_code = $3,
+                current_user_facing_reason_code = $4,
+                current_review_case_id = COALESCE($5, current_review_case_id),
+                updated_at = CURRENT_TIMESTAMP
+            WHERE room_progression_id = $1
+            ",
+            &[
+                &room_progression_id,
+                &input.to_stage,
+                &status_code,
+                &input.user_facing_reason_code,
+                &review_case_id,
+            ],
+        )
+        .await
+        .map_err(db_error)?;
+        refresh_room_progression_view_tx(&tx, &room_progression_id, None).await?;
+        tx.commit().await.map_err(db_error)?;
+
+        Ok(room_progression_fact_from_row(&row))
+    }
+
+    pub async fn get_room_progression_view_for_participant(
+        &self,
+        account_id: &str,
+        room_progression_id: &str,
+    ) -> Result<RoomProgressionViewSnapshot, RoomProgressionError> {
+        let account_id = parse_uuid(account_id, "account id")?;
+        let room_progression_id = parse_uuid(room_progression_id, "room progression id")?;
+        let client = self.client.lock().await;
+        let row = client
+            .query_opt(
+                "
+                SELECT
+                    room_progression_id,
+                    realm_id,
+                    participant_a_account_id,
+                    participant_b_account_id,
+                    visible_stage,
+                    status_code,
+                    user_facing_reason_code,
+                    review_case_id,
+                    review_pending,
+                    review_status,
+                    appeal_available,
+                    evidence_requested,
+                    source_watermark_at,
+                    source_fact_count,
+                    projection_lag_ms,
+                    rebuild_generation,
+                    last_projected_at
+                FROM projection.room_progression_views
+                WHERE room_progression_id = $1
+                  AND $2 IN (participant_a_account_id, participant_b_account_id)
+                ",
+                &[&room_progression_id, &account_id],
+            )
+            .await
+            .map_err(db_error)?
+            .ok_or_else(|| {
+                RoomProgressionError::NotFound("room progression view was not found".to_owned())
+            })?;
+
+        Ok(room_progression_view_from_row(&row))
+    }
+
+    pub async fn rebuild_room_progression_views(
+        &self,
+    ) -> Result<RoomProgressionRebuildSnapshot, RoomProgressionError> {
+        let client = self.client.lock().await;
+        let rows = client
+            .query(
+                "
+                SELECT room_progression_id
+                FROM dao.room_progression_tracks
+                ORDER BY created_at ASC
+                ",
+                &[],
+            )
+            .await
+            .map_err(db_error)?;
+        let generation_row = client
+            .query_one(
+                "
+                SELECT COALESCE(MAX(rebuild_generation), 0)::bigint + 1 AS rebuild_generation
+                FROM projection.room_progression_views
+                ",
+                &[],
+            )
+            .await
+            .map_err(db_error)?;
+        let rebuild_generation: i64 = generation_row.get("rebuild_generation");
+        for row in &rows {
+            refresh_room_progression_view_tx(
+                &*client,
+                &row.get("room_progression_id"),
+                Some(rebuild_generation),
+            )
+            .await?;
+        }
+
+        Ok(RoomProgressionRebuildSnapshot {
+            rebuilt_count: rows.len() as i64,
+        })
+    }
+}
+
+async fn insert_room_progression_fact_tx<C: GenericClient + Sync>(
+    client: &C,
+    room_progression_id: &Uuid,
+    from_stage: &str,
+    to_stage: &str,
+    transition_kind: &str,
+    status_code: &str,
+    user_facing_reason_code: &str,
+    triggered_by_kind: &str,
+    triggered_by_account_id: &Option<Uuid>,
+    source_fact_kind: &str,
+    source_fact_id: &str,
+    source_snapshot_json: &Value,
+    review_case_id: &Option<Uuid>,
+    fact_idempotency_key: &Option<String>,
+    fact_payload_hash: &str,
+) -> Result<Row, RoomProgressionError> {
+    client
+        .query_one(
+            "
+            INSERT INTO dao.room_progression_facts (
+                room_progression_fact_id,
+                room_progression_id,
+                from_stage,
+                to_stage,
+                transition_kind,
+                status_code,
+                user_facing_reason_code,
+                triggered_by_kind,
+                triggered_by_account_id,
+                source_fact_kind,
+                source_fact_id,
+                source_snapshot_json,
+                review_case_id,
+                fact_idempotency_key,
+                fact_payload_hash
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+            RETURNING
+                room_progression_fact_id,
+                room_progression_id,
+                from_stage,
+                to_stage,
+                transition_kind,
+                status_code,
+                user_facing_reason_code,
+                triggered_by_kind,
+                triggered_by_account_id,
+                source_fact_kind,
+                source_fact_id,
+                review_case_id,
+                recorded_at,
+                fact_payload_hash
+            ",
+            &[
+                &Uuid::new_v4(),
+                room_progression_id,
+                &from_stage,
+                &to_stage,
+                &transition_kind,
+                &status_code,
+                &user_facing_reason_code,
+                &triggered_by_kind,
+                triggered_by_account_id,
+                &source_fact_kind,
+                &source_fact_id,
+                source_snapshot_json,
+                review_case_id,
+                fact_idempotency_key,
+                &fact_payload_hash,
+            ],
+        )
+        .await
+        .map_err(db_error)
+}
+
+async fn refresh_room_progression_view_tx<C: GenericClient + Sync>(
+    client: &C,
+    room_progression_id: &Uuid,
+    rebuild_generation: Option<i64>,
+) -> Result<(), RoomProgressionError> {
+    client
+        .execute(
+            "
+            WITH fact_stats AS (
+                SELECT
+                    room_progression_id,
+                    count(*)::bigint AS source_fact_count,
+                    max(recorded_at) AS latest_fact_at
+                FROM dao.room_progression_facts
+                WHERE room_progression_id = $1
+                GROUP BY room_progression_id
+            ),
+            shaped AS (
+                SELECT
+                    track.room_progression_id,
+                    track.realm_id,
+                    track.participant_a_account_id,
+                    track.participant_b_account_id,
+                    track.current_stage AS visible_stage,
+                    track.current_status_code AS status_code,
+                    track.current_user_facing_reason_code AS user_facing_reason_code,
+                    track.current_review_case_id AS review_case_id,
+                    (
+                        track.current_review_case_id IS NOT NULL
+                        AND COALESCE(
+                            review_view.user_facing_status IN (
+                                'pending_review',
+                                'under_review',
+                                'evidence_requested',
+                                'appeal_submitted'
+                            ),
+                            true
+                        )
+                    ) AS review_pending,
+                    CASE
+                        WHEN track.current_review_case_id IS NULL THEN NULL
+                        ELSE COALESCE(review_view.user_facing_status, 'pending_review')
+                    END AS review_status,
+                    COALESCE(review_view.appeal_available, false) AS appeal_available,
+                    COALESCE(review_view.evidence_requested, false) AS evidence_requested,
+                    GREATEST(
+                        track.updated_at,
+                        COALESCE(fact_stats.latest_fact_at, track.updated_at),
+                        COALESCE(review_view.source_watermark_at, track.updated_at)
+                    ) AS source_watermark_at,
+                    COALESCE(fact_stats.source_fact_count, 0)::bigint
+                        + CASE WHEN track.current_review_case_id IS NULL THEN 0 ELSE 1 END
+                        AS source_fact_count
+                FROM dao.room_progression_tracks track
+                LEFT JOIN fact_stats
+                    ON fact_stats.room_progression_id = track.room_progression_id
+                LEFT JOIN projection.review_status_views review_view
+                    ON review_view.review_case_id = track.current_review_case_id
+                WHERE track.room_progression_id = $1
+            )
+            INSERT INTO projection.room_progression_views (
+                room_progression_id,
+                realm_id,
+                participant_a_account_id,
+                participant_b_account_id,
+                visible_stage,
+                status_code,
+                user_facing_reason_code,
+                review_case_id,
+                review_pending,
+                review_status,
+                appeal_available,
+                evidence_requested,
+                source_watermark_at,
+                source_fact_count,
+                projection_lag_ms,
+                rebuild_generation,
+                last_projected_at
+            )
+            SELECT
+                shaped.room_progression_id,
+                shaped.realm_id,
+                shaped.participant_a_account_id,
+                shaped.participant_b_account_id,
+                shaped.visible_stage,
+                shaped.status_code,
+                shaped.user_facing_reason_code,
+                shaped.review_case_id,
+                shaped.review_pending,
+                shaped.review_status,
+                shaped.appeal_available,
+                shaped.evidence_requested,
+                shaped.source_watermark_at,
+                shaped.source_fact_count,
+                GREATEST(
+                    0,
+                    (EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - shaped.source_watermark_at)) * 1000)::bigint
+                ),
+                COALESCE($2::bigint, existing.rebuild_generation, 1),
+                CURRENT_TIMESTAMP
+            FROM shaped
+            LEFT JOIN projection.room_progression_views existing
+                ON existing.room_progression_id = shaped.room_progression_id
+            ON CONFLICT (room_progression_id)
+            DO UPDATE SET
+                realm_id = EXCLUDED.realm_id,
+                participant_a_account_id = EXCLUDED.participant_a_account_id,
+                participant_b_account_id = EXCLUDED.participant_b_account_id,
+                visible_stage = EXCLUDED.visible_stage,
+                status_code = EXCLUDED.status_code,
+                user_facing_reason_code = EXCLUDED.user_facing_reason_code,
+                review_case_id = EXCLUDED.review_case_id,
+                review_pending = EXCLUDED.review_pending,
+                review_status = EXCLUDED.review_status,
+                appeal_available = EXCLUDED.appeal_available,
+                evidence_requested = EXCLUDED.evidence_requested,
+                source_watermark_at = EXCLUDED.source_watermark_at,
+                source_fact_count = EXCLUDED.source_fact_count,
+                projection_lag_ms = EXCLUDED.projection_lag_ms,
+                rebuild_generation = EXCLUDED.rebuild_generation,
+                last_projected_at = EXCLUDED.last_projected_at
+            ",
+            &[room_progression_id, &rebuild_generation],
+        )
+        .await
+        .map_err(db_error)?;
+    Ok(())
+}
+
+async fn find_existing_track_by_idempotency<C: GenericClient + Sync>(
+    client: &C,
+    request_idempotency_key: &Option<String>,
+) -> Result<Option<Row>, RoomProgressionError> {
+    let Some(request_idempotency_key) = request_idempotency_key else {
+        return Ok(None);
+    };
+    client
+        .query_opt(
+            "
+            SELECT
+                room_progression_id,
+                realm_id,
+                participant_a_account_id,
+                participant_b_account_id,
+                related_promise_intent_id,
+                related_settlement_case_id,
+                current_stage,
+                current_status_code,
+                current_user_facing_reason_code,
+                current_review_case_id,
+                source_fact_kind,
+                source_fact_id,
+                created_at,
+                updated_at,
+                request_payload_hash
+            FROM dao.room_progression_tracks
+            WHERE request_idempotency_key = $1
+            ",
+            &[request_idempotency_key],
+        )
+        .await
+        .map_err(db_error)
+}
+
+async fn find_existing_fact_by_idempotency<C: GenericClient + Sync>(
+    client: &C,
+    room_progression_id: &Uuid,
+    fact_idempotency_key: &Option<String>,
+) -> Result<Option<Row>, RoomProgressionError> {
+    let Some(fact_idempotency_key) = fact_idempotency_key else {
+        return Ok(None);
+    };
+    client
+        .query_opt(
+            "
+            SELECT
+                room_progression_fact_id,
+                room_progression_id,
+                from_stage,
+                to_stage,
+                transition_kind,
+                status_code,
+                user_facing_reason_code,
+                triggered_by_kind,
+                triggered_by_account_id,
+                source_fact_kind,
+                source_fact_id,
+                review_case_id,
+                recorded_at,
+                fact_payload_hash
+            FROM dao.room_progression_facts
+            WHERE room_progression_id = $1
+              AND fact_idempotency_key = $2
+            ",
+            &[room_progression_id, fact_idempotency_key],
+        )
+        .await
+        .map_err(db_error)
+}
+
+async fn select_track_for_update_tx(
+    tx: &Transaction<'_>,
+    room_progression_id: &Uuid,
+) -> Result<Row, RoomProgressionError> {
+    tx.query_opt(
+        "
+        SELECT
+            room_progression_id,
+            realm_id,
+            participant_a_account_id,
+            participant_b_account_id,
+            related_promise_intent_id,
+            related_settlement_case_id,
+            current_stage,
+            current_status_code,
+            current_user_facing_reason_code,
+            current_review_case_id,
+            source_fact_kind,
+            source_fact_id,
+            created_at,
+            updated_at
+        FROM dao.room_progression_tracks
+        WHERE room_progression_id = $1
+        FOR UPDATE
+        ",
+        &[room_progression_id],
+    )
+    .await
+    .map_err(db_error)?
+    .ok_or_else(|| RoomProgressionError::NotFound("room progression was not found".to_owned()))
+}
+
+async fn validate_triggered_by_tx<C: GenericClient + Sync>(
+    client: &C,
+    track: &Row,
+    triggered_by_kind: &str,
+    triggered_by_account_id: &Option<Uuid>,
+) -> Result<(), RoomProgressionError> {
+    match triggered_by_kind {
+        "participant" => {
+            let Some(account_id) = triggered_by_account_id else {
+                return Err(RoomProgressionError::BadRequest(
+                    "participant-triggered transitions require triggered_by_account_id".to_owned(),
+                ));
+            };
+            let participant_a: Uuid = track.get("participant_a_account_id");
+            let participant_b: Uuid = track.get("participant_b_account_id");
+            if *account_id != participant_a && *account_id != participant_b {
+                return Err(RoomProgressionError::Unauthorized(
+                    "participant is not a room member".to_owned(),
+                ));
+            }
+            Ok(())
+        }
+        "operator" => {
+            let Some(account_id) = triggered_by_account_id else {
+                return Err(RoomProgressionError::BadRequest(
+                    "operator-triggered transitions require triggered_by_account_id".to_owned(),
+                ));
+            };
+            ensure_account_exists_tx(client, account_id).await
+        }
+        "system" => Ok(()),
+        _ => Err(RoomProgressionError::BadRequest(
+            "triggered_by_kind is not supported".to_owned(),
+        )),
+    }
+}
+
+async fn validate_transition_tx<C: GenericClient + Sync>(
+    client: &C,
+    track: &Row,
+    from_stage: &str,
+    current_status_code: &str,
+    transition_kind: &str,
+    to_stage: &str,
+    review_case_id: Option<&Uuid>,
+) -> Result<(), RoomProgressionError> {
+    if matches!(current_status_code, "blocked" | "withdrawn") {
+        return Err(RoomProgressionError::BadRequest(
+            "blocked or withdrawn rooms cannot progress".to_owned(),
+        ));
+    }
+
+    match transition_kind {
+        "advance_to_coordination" => {
+            require_transition(from_stage, to_stage, "intent", "coordination")
+        }
+        "advance_to_relationship" => {
+            require_transition(from_stage, to_stage, "coordination", "relationship")
+        }
+        "seal" => {
+            if to_stage != "sealed" {
+                return Err(RoomProgressionError::BadRequest(
+                    "seal transitions must target sealed".to_owned(),
+                ));
+            }
+            Ok(())
+        }
+        "restore" => {
+            if from_stage != "sealed" || !matches!(to_stage, "coordination" | "relationship") {
+                return Err(RoomProgressionError::BadRequest(
+                    "restore transitions must move sealed rooms to coordination or relationship"
+                        .to_owned(),
+                ));
+            }
+            let Some(review_case_id) = review_case_id else {
+                return Err(RoomProgressionError::BadRequest(
+                    "restore transitions require review_case_id".to_owned(),
+                ));
+            };
+            let current_review_case_id: Option<Uuid> = track.get("current_review_case_id");
+            if current_review_case_id.as_ref() != Some(review_case_id) {
+                return Err(RoomProgressionError::BadRequest(
+                    "restore review_case_id must match the room's current review case".to_owned(),
+                ));
+            }
+            ensure_review_supports_restore_tx(client, review_case_id).await
+        }
+        "mute" | "block" | "withdraw" => {
+            if to_stage != from_stage {
+                return Err(RoomProgressionError::BadRequest(
+                    "mute, block, and withdraw keep the visible room stage unchanged".to_owned(),
+                ));
+            }
+            let participant_a: Uuid = track.get("participant_a_account_id");
+            let participant_b: Uuid = track.get("participant_b_account_id");
+            if participant_a == participant_b {
+                return Err(RoomProgressionError::Internal(
+                    "room participant invariant was violated".to_owned(),
+                ));
+            }
+            Ok(())
+        }
+        _ => Err(RoomProgressionError::BadRequest(
+            "transition_kind is not supported".to_owned(),
+        )),
+    }
+}
+
+fn require_transition(
+    from_stage: &str,
+    to_stage: &str,
+    expected_from: &str,
+    expected_to: &str,
+) -> Result<(), RoomProgressionError> {
+    if from_stage == expected_from && to_stage == expected_to {
+        Ok(())
+    } else {
+        Err(RoomProgressionError::BadRequest(format!(
+            "invalid room transition: expected {expected_from} -> {expected_to}"
+        )))
+    }
+}
+
+fn next_status_code(
+    transition_kind: &str,
+    from_stage: &str,
+    to_stage: &str,
+    user_facing_reason_code: &str,
+) -> Result<String, RoomProgressionError> {
+    let status = match transition_kind {
+        "advance_to_coordination" => "coordination_open",
+        "advance_to_relationship" => "relationship_open",
+        "seal" => {
+            if user_facing_reason_code == "restricted_after_review" {
+                "sealed_restricted"
+            } else {
+                "sealed_under_review"
+            }
+        }
+        "restore" => match to_stage {
+            "coordination" => "coordination_open",
+            "relationship" => "relationship_open",
+            _ => {
+                return Err(RoomProgressionError::BadRequest(
+                    "restore target is not supported".to_owned(),
+                ));
+            }
+        },
+        "mute" => "muted",
+        "block" => "blocked",
+        "withdraw" => "withdrawn",
+        _ => {
+            return Err(RoomProgressionError::BadRequest(
+                "transition_kind is not supported".to_owned(),
+            ));
+        }
+    };
+    if matches!(transition_kind, "mute" | "block" | "withdraw") && from_stage != to_stage {
+        return Err(RoomProgressionError::BadRequest(
+            "local safety controls must preserve visible_stage".to_owned(),
+        ));
+    }
+    Ok(status.to_owned())
+}
+
+async fn ensure_review_case_exists_tx<C: GenericClient + Sync>(
+    client: &C,
+    review_case_id: &Uuid,
+) -> Result<(), RoomProgressionError> {
+    let exists = client
+        .query_opt(
+            "
+            SELECT 1
+            FROM dao.review_cases
+            WHERE review_case_id = $1
+            ",
+            &[review_case_id],
+        )
+        .await
+        .map_err(db_error)?
+        .is_some();
+    if exists {
+        Ok(())
+    } else {
+        Err(RoomProgressionError::BadRequest(
+            "review_case_id must reference an existing review case".to_owned(),
+        ))
+    }
+}
+
+async fn ensure_review_supports_restore_tx<C: GenericClient + Sync>(
+    client: &C,
+    review_case_id: &Uuid,
+) -> Result<(), RoomProgressionError> {
+    let row = client
+        .query_opt(
+            "
+            SELECT decision_kind
+            FROM dao.operator_decision_facts
+            WHERE review_case_id = $1
+            ORDER BY recorded_at DESC, operator_decision_fact_id DESC
+            LIMIT 1
+            ",
+            &[review_case_id],
+        )
+        .await
+        .map_err(db_error)?
+        .ok_or_else(|| {
+            RoomProgressionError::BadRequest(
+                "restore requires a writer-owned operator decision fact".to_owned(),
+            )
+        })?;
+    let decision_kind: String = row.get("decision_kind");
+    if matches!(decision_kind.as_str(), "restore" | "no_action") {
+        Ok(())
+    } else {
+        Err(RoomProgressionError::BadRequest(
+            "latest operator decision fact does not allow room restore".to_owned(),
+        ))
+    }
+}
+
+async fn ensure_account_exists_tx<C: GenericClient + Sync>(
+    client: &C,
+    account_id: &Uuid,
+) -> Result<(), RoomProgressionError> {
+    let exists = client
+        .query_opt(
+            "
+            SELECT 1
+            FROM core.accounts
+            WHERE account_id = $1
+              AND account_state = 'active'
+            ",
+            &[account_id],
+        )
+        .await
+        .map_err(db_error)?
+        .is_some();
+    if exists {
+        Ok(())
+    } else {
+        Err(RoomProgressionError::BadRequest(
+            "account id must reference an active account".to_owned(),
+        ))
+    }
+}
+
+fn create_room_progression_payload_hash(
+    input: &CreateRoomProgressionInput,
+    realm_id: &str,
+    participants: &(Uuid, Uuid),
+    related_promise_intent_id: &Option<Uuid>,
+    related_settlement_case_id: &Option<Uuid>,
+) -> String {
+    hash_json_value(&json!({
+        "schema_version": 1,
+        "realm_id": realm_id,
+        "participant_account_ids": [
+            participants.0.to_string(),
+            participants.1.to_string()
+        ],
+        "related_promise_intent_id": optional_uuid_hash_value(related_promise_intent_id),
+        "related_settlement_case_id": optional_uuid_hash_value(related_settlement_case_id),
+        "user_facing_reason_code": &input.user_facing_reason_code,
+        "source_fact_kind": &input.source_fact_kind,
+        "source_fact_id": &input.source_fact_id,
+        "source_snapshot_json": &input.source_snapshot_json,
+    }))
+}
+
+fn room_progression_fact_payload_hash_from_input(
+    existing: &Row,
+    input: &AppendRoomProgressionFactInput,
+) -> Result<String, RoomProgressionError> {
+    let triggered_by_account_id =
+        parse_optional_uuid(&input.triggered_by_account_id, "triggered by account id")?;
+    let review_case_id = parse_optional_uuid(&input.review_case_id, "review case id")?;
+    Ok(create_room_progression_fact_payload_hash(
+        &input.transition_kind,
+        &existing.get::<_, String>("from_stage"),
+        &input.to_stage,
+        &existing.get::<_, String>("status_code"),
+        &input.user_facing_reason_code,
+        &input.triggered_by_kind,
+        &triggered_by_account_id,
+        &input.source_fact_kind,
+        &input.source_fact_id,
+        &input.source_snapshot_json,
+        &review_case_id,
+    ))
+}
+
+fn create_room_progression_fact_payload_hash(
+    transition_kind: &str,
+    from_stage: &str,
+    to_stage: &str,
+    status_code: &str,
+    user_facing_reason_code: &str,
+    triggered_by_kind: &str,
+    triggered_by_account_id: &Option<Uuid>,
+    source_fact_kind: &str,
+    source_fact_id: &str,
+    source_snapshot_json: &Value,
+    review_case_id: &Option<Uuid>,
+) -> String {
+    hash_json_value(&json!({
+        "schema_version": 1,
+        "transition_kind": transition_kind,
+        "from_stage": from_stage,
+        "to_stage": to_stage,
+        "status_code": status_code,
+        "user_facing_reason_code": user_facing_reason_code,
+        "triggered_by_kind": triggered_by_kind,
+        "triggered_by_account_id": optional_uuid_hash_value(triggered_by_account_id),
+        "source_fact_kind": source_fact_kind,
+        "source_fact_id": source_fact_id,
+        "source_snapshot_json": source_snapshot_json,
+        "review_case_id": optional_uuid_hash_value(review_case_id),
+    }))
+}
+
+fn ensure_track_matches_payload_hash(
+    row: &Row,
+    request_payload_hash: &str,
+) -> Result<(), RoomProgressionError> {
+    let existing_hash: String = row.get("request_payload_hash");
+    if existing_hash == request_payload_hash {
+        Ok(())
+    } else {
+        Err(RoomProgressionError::BadRequest(
+            "request_idempotency_key was already used with a different room progression payload"
+                .to_owned(),
+        ))
+    }
+}
+
+fn ensure_fact_matches_payload_hash(
+    row: &Row,
+    fact_payload_hash: &str,
+) -> Result<(), RoomProgressionError> {
+    let existing_hash: String = row.get("fact_payload_hash");
+    if existing_hash == fact_payload_hash {
+        Ok(())
+    } else {
+        Err(RoomProgressionError::BadRequest(
+            "fact_idempotency_key was already used with a different room progression fact payload"
+                .to_owned(),
+        ))
+    }
+}
+
+fn hash_json_value(value: &Value) -> String {
+    let digest = Sha256::digest(canonical_json_text(value).as_bytes());
+    let mut encoded = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        let _ = write!(&mut encoded, "{byte:02x}");
+    }
+    encoded
+}
+
+fn canonical_json_text(value: &Value) -> String {
+    let mut output = String::new();
+    write_canonical_json(value, &mut output);
+    output
+}
+
+fn write_canonical_json(value: &Value, output: &mut String) {
+    match value {
+        Value::Null => output.push_str("null"),
+        Value::Bool(boolean) => output.push_str(if *boolean { "true" } else { "false" }),
+        Value::Number(number) => {
+            let _ = write!(output, "{number}");
+        }
+        Value::String(string) => {
+            output.push_str(
+                &serde_json::to_string(string).expect("serializing a JSON string should not fail"),
+            );
+        }
+        Value::Array(values) => {
+            output.push('[');
+            for (index, value) in values.iter().enumerate() {
+                if index > 0 {
+                    output.push(',');
+                }
+                write_canonical_json(value, output);
+            }
+            output.push(']');
+        }
+        Value::Object(map) => {
+            output.push('{');
+            let mut entries = map.iter().collect::<Vec<_>>();
+            entries.sort_by(|left, right| left.0.cmp(right.0));
+
+            for (index, (key, value)) in entries.into_iter().enumerate() {
+                if index > 0 {
+                    output.push(',');
+                }
+                output.push_str(
+                    &serde_json::to_string(key)
+                        .expect("serializing a JSON object key should not fail"),
+                );
+                output.push(':');
+                write_canonical_json(value, output);
+            }
+
+            output.push('}');
+        }
+    }
+}
+
+fn parse_participant_pair(values: &[String]) -> Result<(Uuid, Uuid), RoomProgressionError> {
+    if values.len() != 2 {
+        return Err(RoomProgressionError::BadRequest(
+            "participant_account_ids must contain exactly two account ids".to_owned(),
+        ));
+    }
+    let mut parsed = vec![
+        parse_uuid(&values[0], "participant account id")?,
+        parse_uuid(&values[1], "participant account id")?,
+    ];
+    parsed.sort();
+    parsed.dedup();
+    if parsed.len() != 2 {
+        return Err(RoomProgressionError::BadRequest(
+            "room participants must be distinct".to_owned(),
+        ));
+    }
+    Ok((parsed[0], parsed[1]))
+}
+
+fn parse_uuid(value: &str, label: &str) -> Result<Uuid, RoomProgressionError> {
+    Uuid::parse_str(value.trim())
+        .map_err(|_| RoomProgressionError::BadRequest(format!("{label} must be a valid UUID")))
+}
+
+fn parse_optional_uuid(
+    value: &Option<String>,
+    label: &str,
+) -> Result<Option<Uuid>, RoomProgressionError> {
+    value
+        .as_ref()
+        .map(|value| parse_uuid(value, label))
+        .transpose()
+}
+
+fn optional_uuid_hash_value(value: &Option<Uuid>) -> Option<String> {
+    value.map(|value| value.to_string())
+}
+
+fn optional_uuid_to_string(value: Option<Uuid>) -> Option<String> {
+    value.map(|value| value.to_string())
+}
+
+fn normalize_required(value: &str, label: &str) -> Result<String, RoomProgressionError> {
+    let normalized = value.trim();
+    if normalized.is_empty() {
+        Err(RoomProgressionError::BadRequest(format!(
+            "{label} must not be empty"
+        )))
+    } else {
+        Ok(normalized.to_owned())
+    }
+}
+
+fn normalize_optional(value: &Option<String>) -> Option<String> {
+    value
+        .as_ref()
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
+}
+
+fn require_non_empty(label: &str, value: &str) -> Result<(), RoomProgressionError> {
+    if value.trim().is_empty() {
+        Err(RoomProgressionError::BadRequest(format!(
+            "{label} must not be empty"
+        )))
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_allowed(
+    label: &str,
+    value: &str,
+    allowed: &[&str],
+) -> Result<(), RoomProgressionError> {
+    if allowed.contains(&value) {
+        Ok(())
+    } else {
+        Err(RoomProgressionError::BadRequest(format!(
+            "{label} is not supported"
+        )))
+    }
+}
+
+fn room_progression_track_from_row(row: &Row) -> RoomProgressionTrackSnapshot {
+    RoomProgressionTrackSnapshot {
+        room_progression_id: row.get::<_, Uuid>("room_progression_id").to_string(),
+        realm_id: row.get("realm_id"),
+        participant_a_account_id: row.get::<_, Uuid>("participant_a_account_id").to_string(),
+        participant_b_account_id: row.get::<_, Uuid>("participant_b_account_id").to_string(),
+        related_promise_intent_id: optional_uuid_to_string(row.get("related_promise_intent_id")),
+        related_settlement_case_id: optional_uuid_to_string(row.get("related_settlement_case_id")),
+        current_stage: row.get("current_stage"),
+        current_status_code: row.get("current_status_code"),
+        current_user_facing_reason_code: row.get("current_user_facing_reason_code"),
+        current_review_case_id: optional_uuid_to_string(row.get("current_review_case_id")),
+        source_fact_kind: row.get("source_fact_kind"),
+        source_fact_id: row.get("source_fact_id"),
+        created_at: row.get("created_at"),
+        updated_at: row.get("updated_at"),
+    }
+}
+
+fn room_progression_fact_from_row(row: &Row) -> RoomProgressionFactSnapshot {
+    RoomProgressionFactSnapshot {
+        room_progression_fact_id: row.get::<_, Uuid>("room_progression_fact_id").to_string(),
+        room_progression_id: row.get::<_, Uuid>("room_progression_id").to_string(),
+        from_stage: row.get("from_stage"),
+        to_stage: row.get("to_stage"),
+        transition_kind: row.get("transition_kind"),
+        status_code: row.get("status_code"),
+        user_facing_reason_code: row.get("user_facing_reason_code"),
+        triggered_by_kind: row.get("triggered_by_kind"),
+        triggered_by_account_id: optional_uuid_to_string(row.get("triggered_by_account_id")),
+        source_fact_kind: row.get("source_fact_kind"),
+        source_fact_id: row.get("source_fact_id"),
+        review_case_id: optional_uuid_to_string(row.get("review_case_id")),
+        recorded_at: row.get("recorded_at"),
+    }
+}
+
+fn room_progression_view_from_row(row: &Row) -> RoomProgressionViewSnapshot {
+    RoomProgressionViewSnapshot {
+        room_progression_id: row.get::<_, Uuid>("room_progression_id").to_string(),
+        realm_id: row.get("realm_id"),
+        participant_a_account_id: row.get::<_, Uuid>("participant_a_account_id").to_string(),
+        participant_b_account_id: row.get::<_, Uuid>("participant_b_account_id").to_string(),
+        visible_stage: row.get("visible_stage"),
+        status_code: row.get("status_code"),
+        user_facing_reason_code: row.get("user_facing_reason_code"),
+        review_case_id: optional_uuid_to_string(row.get("review_case_id")),
+        review_pending: row.get("review_pending"),
+        review_status: row.get("review_status"),
+        appeal_available: row.get("appeal_available"),
+        evidence_requested: row.get("evidence_requested"),
+        source_watermark_at: row.get("source_watermark_at"),
+        source_fact_count: row.get("source_fact_count"),
+        projection_lag_ms: row.get("projection_lag_ms"),
+        rebuild_generation: row.get("rebuild_generation"),
+        last_projected_at: row.get("last_projected_at"),
+    }
+}
+
+fn db_error(error: tokio_postgres::Error) -> RoomProgressionError {
+    let code = error.code().map(|code| code.code().to_owned());
+    let constraint = error
+        .as_db_error()
+        .and_then(|db_error| db_error.constraint().map(str::to_owned));
+    let retryable = matches!(
+        error.code(),
+        Some(&SqlState::T_R_SERIALIZATION_FAILURE)
+            | Some(&SqlState::T_R_DEADLOCK_DETECTED)
+            | Some(&SqlState::CONNECTION_EXCEPTION)
+            | Some(&SqlState::CONNECTION_DOES_NOT_EXIST)
+            | Some(&SqlState::CONNECTION_FAILURE)
+            | Some(&SqlState::SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION)
+            | Some(&SqlState::SQLSERVER_REJECTED_ESTABLISHMENT_OF_SQLCONNECTION)
+            | Some(&SqlState::TRANSACTION_RESOLUTION_UNKNOWN)
+            | Some(&SqlState::PROTOCOL_VIOLATION)
+    );
+    RoomProgressionError::Database {
+        message: error.to_string(),
+        code,
+        constraint,
+        retryable,
+    }
+}

--- a/apps/backend/src/services/room_progression/repository.rs
+++ b/apps/backend/src/services/room_progression/repository.rs
@@ -600,6 +600,7 @@ async fn refresh_room_progression_view_tx<C: GenericClient + Sync>(
                         COALESCE(review_view.source_watermark_at, track.updated_at)
                     ) AS source_watermark_at,
                     COALESCE(fact_stats.source_fact_count, 0)::bigint
+                        + COALESCE(review_view.source_fact_count, 0)::bigint
                         + CASE WHEN track.current_review_case_id IS NULL THEN 0 ELSE 1 END
                         AS source_fact_count
                 FROM dao.room_progression_tracks track

--- a/apps/backend/src/services/room_progression/repository.rs
+++ b/apps/backend/src/services/room_progression/repository.rs
@@ -284,7 +284,7 @@ impl RoomProgressionStore {
         )
         .await?;
         if let Some(review_case_id) = review_case_id.as_ref() {
-            ensure_review_case_exists_tx(&tx, review_case_id).await?;
+            ensure_review_case_matches_room_scope_tx(&tx, &track, review_case_id).await?;
         }
 
         let status_code = next_status_code(
@@ -338,7 +338,7 @@ impl RoomProgressionStore {
         .await?;
         let current_review_case_id: Option<Uuid> = track.get("current_review_case_id");
         let next_review_case_id = if input.to_stage == "sealed" {
-            review_case_id.or(current_review_case_id)
+            current_review_case_id.or(review_case_id)
         } else {
             None
         };
@@ -792,7 +792,15 @@ async fn validate_triggered_by_tx<C: GenericClient + Sync>(
             };
             ensure_operator_transition_role_tx(client, account_id).await
         }
-        "system" => Ok(()),
+        "system" => {
+            if triggered_by_account_id.is_some() {
+                return Err(RoomProgressionError::BadRequest(
+                    "system-triggered transitions must not include triggered_by_account_id"
+                        .to_owned(),
+                ));
+            }
+            Ok(())
+        }
         _ => Err(RoomProgressionError::BadRequest(
             "triggered_by_kind is not supported".to_owned(),
         )),
@@ -828,13 +836,28 @@ async fn validate_transition_tx<C: GenericClient + Sync>(
                     "seal transitions must target sealed".to_owned(),
                 ));
             }
+            let current_review_case_id: Option<Uuid> = track.get("current_review_case_id");
+            if let Some(review_case_id) = review_case_id {
+                if let Some(current_review_case_id) = current_review_case_id.as_ref() {
+                    if current_review_case_id != review_case_id {
+                        return Err(RoomProgressionError::BadRequest(
+                            "seal review_case_id must match the room's current review case"
+                                .to_owned(),
+                        ));
+                    }
+                }
+            }
+            if from_stage != "sealed" && review_case_id.is_none() {
+                return Err(RoomProgressionError::BadRequest(
+                    "seal transitions from live rooms require review_case_id".to_owned(),
+                ));
+            }
             if status_code == "sealed_restricted" {
                 let Some(review_case_id) = review_case_id else {
                     return Err(RoomProgressionError::BadRequest(
                         "restricted seal transitions require review_case_id".to_owned(),
                     ));
                 };
-                let current_review_case_id: Option<Uuid> = track.get("current_review_case_id");
                 if let Some(current_review_case_id) = current_review_case_id.as_ref() {
                     if current_review_case_id != review_case_id {
                         return Err(RoomProgressionError::BadRequest(
@@ -945,27 +968,34 @@ fn next_status_code(
     Ok(status.to_owned())
 }
 
-async fn ensure_review_case_exists_tx<C: GenericClient + Sync>(
+async fn ensure_review_case_matches_room_scope_tx<C: GenericClient + Sync>(
     client: &C,
+    track: &Row,
     review_case_id: &Uuid,
 ) -> Result<(), RoomProgressionError> {
-    let exists = client
+    let room_progression_id = track.get::<_, Uuid>("room_progression_id").to_string();
+    let realm_id = track.get::<_, String>("realm_id");
+    let matches_scope = client
         .query_opt(
             "
             SELECT 1
             FROM dao.review_cases
             WHERE review_case_id = $1
+              AND case_type = 'sealed_room_fallback'
+              AND source_fact_kind = 'room_progression'
+              AND source_fact_id = $2
+              AND (related_realm_id IS NULL OR related_realm_id = $3)
             ",
-            &[review_case_id],
+            &[review_case_id, &room_progression_id, &realm_id],
         )
         .await
         .map_err(db_error)?
         .is_some();
-    if exists {
+    if matches_scope {
         Ok(())
     } else {
         Err(RoomProgressionError::BadRequest(
-            "review_case_id must reference an existing review case".to_owned(),
+            "review_case_id must reference the room's sealed fallback review case".to_owned(),
         ))
     }
 }

--- a/apps/backend/src/services/room_progression/repository.rs
+++ b/apps/backend/src/services/room_progression/repository.rs
@@ -1,10 +1,10 @@
 use std::{fmt::Write as _, sync::Arc};
 
-use musubi_db_runtime::{DbConfig, connect_writer};
-use serde_json::{Value, json};
+use musubi_db_runtime::{connect_writer, DbConfig};
+use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use tokio::sync::Mutex;
-use tokio_postgres::{Client, GenericClient, Row, Transaction, error::SqlState};
+use tokio_postgres::{error::SqlState, Client, GenericClient, Row, Transaction};
 use uuid::Uuid;
 
 use super::types::{
@@ -24,6 +24,7 @@ const TRANSITION_KINDS: &[&str] = &[
     "withdraw",
 ];
 const TRIGGERED_BY_KINDS: &[&str] = &["system", "participant", "operator"];
+const OPERATOR_TRANSITION_ROLES: &[&str] = &["reviewer", "approver", "steward"];
 const USER_FACING_REASON_CODES: &[&str] = &[
     "room_created",
     "mutual_intent_acknowledged",
@@ -299,6 +300,7 @@ impl RoomProgressionStore {
             &current_status_code,
             &input.transition_kind,
             &input.to_stage,
+            &status_code,
             review_case_id.as_ref(),
         )
         .await?;
@@ -788,7 +790,7 @@ async fn validate_triggered_by_tx<C: GenericClient + Sync>(
                     "operator-triggered transitions require triggered_by_account_id".to_owned(),
                 ));
             };
-            ensure_account_exists_tx(client, account_id).await
+            ensure_operator_transition_role_tx(client, account_id).await
         }
         "system" => Ok(()),
         _ => Err(RoomProgressionError::BadRequest(
@@ -804,6 +806,7 @@ async fn validate_transition_tx<C: GenericClient + Sync>(
     current_status_code: &str,
     transition_kind: &str,
     to_stage: &str,
+    status_code: &str,
     review_case_id: Option<&Uuid>,
 ) -> Result<(), RoomProgressionError> {
     if matches!(current_status_code, "blocked" | "withdrawn") {
@@ -824,6 +827,23 @@ async fn validate_transition_tx<C: GenericClient + Sync>(
                 return Err(RoomProgressionError::BadRequest(
                     "seal transitions must target sealed".to_owned(),
                 ));
+            }
+            if status_code == "sealed_restricted" {
+                let Some(review_case_id) = review_case_id else {
+                    return Err(RoomProgressionError::BadRequest(
+                        "restricted seal transitions require review_case_id".to_owned(),
+                    ));
+                };
+                let current_review_case_id: Option<Uuid> = track.get("current_review_case_id");
+                if let Some(current_review_case_id) = current_review_case_id.as_ref() {
+                    if current_review_case_id != review_case_id {
+                        return Err(RoomProgressionError::BadRequest(
+                            "restricted seal review_case_id must match the room's current review case"
+                                .to_owned(),
+                        ));
+                    }
+                }
+                ensure_review_supports_restriction_tx(client, review_case_id).await?;
             }
             Ok(())
         }
@@ -982,6 +1002,38 @@ async fn ensure_review_supports_restore_tx<C: GenericClient + Sync>(
     }
 }
 
+async fn ensure_review_supports_restriction_tx<C: GenericClient + Sync>(
+    client: &C,
+    review_case_id: &Uuid,
+) -> Result<(), RoomProgressionError> {
+    let row = client
+        .query_opt(
+            "
+            SELECT decision_kind
+            FROM dao.operator_decision_facts
+            WHERE review_case_id = $1
+            ORDER BY recorded_at DESC, operator_decision_fact_id DESC
+            LIMIT 1
+            ",
+            &[review_case_id],
+        )
+        .await
+        .map_err(db_error)?
+        .ok_or_else(|| {
+            RoomProgressionError::BadRequest(
+                "restricted seal requires a writer-owned operator decision fact".to_owned(),
+            )
+        })?;
+    let decision_kind: String = row.get("decision_kind");
+    if decision_kind == "restrict" {
+        Ok(())
+    } else {
+        Err(RoomProgressionError::BadRequest(
+            "latest operator decision fact does not allow restricted seal".to_owned(),
+        ))
+    }
+}
+
 async fn ensure_account_exists_tx<C: GenericClient + Sync>(
     client: &C,
     account_id: &Uuid,
@@ -1004,6 +1056,38 @@ async fn ensure_account_exists_tx<C: GenericClient + Sync>(
     } else {
         Err(RoomProgressionError::BadRequest(
             "account id must reference an active account".to_owned(),
+        ))
+    }
+}
+
+async fn ensure_operator_transition_role_tx<C: GenericClient + Sync>(
+    client: &C,
+    operator_id: &Uuid,
+) -> Result<(), RoomProgressionError> {
+    let row = client
+        .query_one(
+            "
+            SELECT EXISTS (
+                SELECT 1
+                FROM core.operator_role_assignments
+                JOIN core.accounts
+                  ON core.accounts.account_id = core.operator_role_assignments.operator_account_id
+                WHERE operator_account_id = $1
+                  AND operator_role = ANY($2::text[])
+                  AND revoked_at IS NULL
+                  AND core.accounts.account_class = 'Controlled Exceptional Account'
+                  AND core.accounts.account_state = 'active'
+            ) AS has_role
+            ",
+            &[operator_id, &OPERATOR_TRANSITION_ROLES],
+        )
+        .await
+        .map_err(db_error)?;
+    if row.get("has_role") {
+        Ok(())
+    } else {
+        Err(RoomProgressionError::Unauthorized(
+            "operator role is not allowed for room progression transitions".to_owned(),
         ))
     }
 }

--- a/apps/backend/src/services/room_progression/repository.rs
+++ b/apps/backend/src/services/room_progression/repository.rs
@@ -262,6 +262,8 @@ impl RoomProgressionStore {
 
         let mut client = self.client.lock().await;
         let tx = client.transaction().await.map_err(db_error)?;
+        // Serialize fact appends per room so same-room idempotent retries cannot race past the
+        // existing-fact lookup and collide at the INSERT boundary.
         let track = select_track_for_update_tx(&tx, &room_progression_id).await?;
         if let Some(existing) =
             find_existing_fact_by_idempotency(&tx, &room_progression_id, &fact_idempotency_key)

--- a/apps/backend/src/services/room_progression/types.rs
+++ b/apps/backend/src/services/room_progression/types.rs
@@ -1,0 +1,116 @@
+use chrono::{DateTime, Utc};
+use serde_json::Value;
+
+#[derive(Debug)]
+pub enum RoomProgressionError {
+    BadRequest(String),
+    Unauthorized(String),
+    NotFound(String),
+    Database {
+        message: String,
+        code: Option<String>,
+        constraint: Option<String>,
+        retryable: bool,
+    },
+    Internal(String),
+}
+
+impl RoomProgressionError {
+    pub fn message(&self) -> &str {
+        match self {
+            Self::BadRequest(message)
+            | Self::Unauthorized(message)
+            | Self::NotFound(message)
+            | Self::Database { message, .. }
+            | Self::Internal(message) => message,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct CreateRoomProgressionInput {
+    pub realm_id: String,
+    pub participant_account_ids: Vec<String>,
+    pub related_promise_intent_id: Option<String>,
+    pub related_settlement_case_id: Option<String>,
+    pub user_facing_reason_code: String,
+    pub source_fact_kind: String,
+    pub source_fact_id: String,
+    pub source_snapshot_json: Value,
+    pub request_idempotency_key: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct AppendRoomProgressionFactInput {
+    pub transition_kind: String,
+    pub to_stage: String,
+    pub user_facing_reason_code: String,
+    pub triggered_by_kind: String,
+    pub triggered_by_account_id: Option<String>,
+    pub source_fact_kind: String,
+    pub source_fact_id: String,
+    pub source_snapshot_json: Value,
+    pub review_case_id: Option<String>,
+    pub fact_idempotency_key: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct RoomProgressionTrackSnapshot {
+    pub room_progression_id: String,
+    pub realm_id: String,
+    pub participant_a_account_id: String,
+    pub participant_b_account_id: String,
+    pub related_promise_intent_id: Option<String>,
+    pub related_settlement_case_id: Option<String>,
+    pub current_stage: String,
+    pub current_status_code: String,
+    pub current_user_facing_reason_code: String,
+    pub current_review_case_id: Option<String>,
+    pub source_fact_kind: String,
+    pub source_fact_id: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Clone, Debug)]
+pub struct RoomProgressionFactSnapshot {
+    pub room_progression_fact_id: String,
+    pub room_progression_id: String,
+    pub from_stage: String,
+    pub to_stage: String,
+    pub transition_kind: String,
+    pub status_code: String,
+    pub user_facing_reason_code: String,
+    pub triggered_by_kind: String,
+    pub triggered_by_account_id: Option<String>,
+    pub source_fact_kind: String,
+    pub source_fact_id: String,
+    pub review_case_id: Option<String>,
+    pub recorded_at: DateTime<Utc>,
+}
+
+#[derive(Clone, Debug)]
+pub struct RoomProgressionViewSnapshot {
+    pub room_progression_id: String,
+    pub realm_id: String,
+    pub participant_a_account_id: String,
+    pub participant_b_account_id: String,
+    pub visible_stage: String,
+    pub status_code: String,
+    pub user_facing_reason_code: String,
+    pub review_case_id: Option<String>,
+    pub review_pending: bool,
+    pub review_status: Option<String>,
+    pub appeal_available: bool,
+    pub evidence_requested: bool,
+    pub source_watermark_at: DateTime<Utc>,
+    pub source_fact_count: i64,
+    pub projection_lag_ms: i64,
+    pub rebuild_generation: i64,
+    pub last_projected_at: DateTime<Utc>,
+}
+
+#[derive(Clone, Debug)]
+pub struct RoomProgressionRebuildSnapshot {
+    pub rebuilt_count: i64,
+}

--- a/apps/backend/tests/room_progression.rs
+++ b/apps/backend/tests/room_progression.rs
@@ -111,6 +111,32 @@ async fn room_progression_follows_normal_path_and_keeps_view_private() {
 }
 
 #[tokio::test]
+async fn room_progression_create_requires_idempotency_key() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let subject = sign_in(&app, "pi-user-room-create-key-a", "room-create-key-a").await;
+    let counterparty = sign_in(&app, "pi-user-room-create-key-b", "room-create-key-b").await;
+
+    let response = internal_post_json(
+        &app,
+        "/api/internal/room-progressions",
+        json!({
+            "realm_id": "realm-room-create-key",
+            "participant_account_ids": [
+                subject.account_id,
+                counterparty.account_id
+            ],
+            "user_facing_reason_code": "room_created",
+            "source_fact_kind": "intent_room_request",
+            "source_fact_id": "room-create-key-source",
+            "source_snapshot_json": {}
+        }),
+    )
+    .await;
+    assert_eq!(response.status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
 async fn room_progression_rejects_skipped_transition() {
     let test_state = new_test_state().await.expect("test database state");
     let app = build_app(test_state.state.clone());
@@ -1357,6 +1383,48 @@ async fn room_progression_create_replay_survives_participant_deactivation() {
     .await;
     assert_eq!(replayed.status, StatusCode::OK);
     assert_eq!(replayed.body["room_progression_id"], room_progression_id);
+}
+
+#[tokio::test]
+async fn participant_triggered_transitions_require_active_account() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let subject = sign_in(&app, "pi-user-room-actor-active-a", "room-actor-active-a").await;
+    let counterparty = sign_in(&app, "pi-user-room-actor-active-b", "room-actor-active-b").await;
+    let client = test_db_client().await;
+    let room_progression_id =
+        create_room(&app, &subject.account_id, &counterparty.account_id).await;
+
+    client
+        .execute(
+            "
+            UPDATE core.accounts
+            SET account_state = 'suspended',
+                updated_at = CURRENT_TIMESTAMP
+            WHERE account_id::text = $1
+            ",
+            &[&subject.account_id],
+        )
+        .await
+        .expect("account state must update");
+
+    let response = internal_post_json(
+        &app,
+        &format!("/api/internal/room-progressions/{room_progression_id}/facts"),
+        json!({
+            "transition_kind": "advance_to_coordination",
+            "to_stage": "coordination",
+            "user_facing_reason_code": "mutual_intent_acknowledged",
+            "triggered_by_kind": "participant",
+            "triggered_by_account_id": subject.account_id,
+            "source_fact_kind": "mutual_intent_acknowledgment",
+            "source_fact_id": "room-actor-active-coordinate",
+            "source_snapshot_json": {},
+            "fact_idempotency_key": "room-actor-active-coordinate"
+        }),
+    )
+    .await;
+    assert_eq!(response.status, StatusCode::BAD_REQUEST);
 }
 
 #[tokio::test]

--- a/apps/backend/tests/room_progression.rs
+++ b/apps/backend/tests/room_progression.rs
@@ -152,6 +152,200 @@ async fn room_progression_create_requires_idempotency_key() {
 }
 
 #[tokio::test]
+async fn mute_transition_preserves_visible_stage() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let subject = sign_in(&app, "pi-user-room-mute-a", "room-mute-a").await;
+    let counterparty = sign_in(&app, "pi-user-room-mute-b", "room-mute-b").await;
+    let room_progression_id =
+        create_room(&app, &subject.account_id, &counterparty.account_id).await;
+
+    let coordination = internal_post_json(
+        &app,
+        &format!("/api/internal/room-progressions/{room_progression_id}/facts"),
+        json!({
+            "transition_kind": "advance_to_coordination",
+            "to_stage": "coordination",
+            "user_facing_reason_code": "mutual_intent_acknowledged",
+            "triggered_by_kind": "participant",
+            "triggered_by_account_id": subject.account_id,
+            "source_fact_kind": "mutual_intent_acknowledgment",
+            "source_fact_id": "room-mute-coordinate",
+            "source_snapshot_json": {},
+            "fact_idempotency_key": "room-mute-coordinate"
+        }),
+    )
+    .await;
+    assert_eq!(coordination.status, StatusCode::OK);
+
+    let muted = internal_post_json(
+        &app,
+        &format!("/api/internal/room-progressions/{room_progression_id}/facts"),
+        json!({
+            "transition_kind": "mute",
+            "to_stage": "coordination",
+            "user_facing_reason_code": "user_muted",
+            "triggered_by_kind": "participant",
+            "triggered_by_account_id": subject.account_id,
+            "source_fact_kind": "participant_safety_control",
+            "source_fact_id": "room-mute-toggle",
+            "source_snapshot_json": {},
+            "fact_idempotency_key": "room-mute-toggle"
+        }),
+    )
+    .await;
+    assert_eq!(muted.status, StatusCode::OK);
+    assert_eq!(muted.body["from_stage"], "coordination");
+    assert_eq!(muted.body["to_stage"], "coordination");
+    assert_eq!(muted.body["status_code"], "muted");
+
+    let view = get_json(
+        &app,
+        &format!("/api/projection/room-progression-views/{room_progression_id}"),
+        Some(subject.token.as_str()),
+    )
+    .await;
+    assert_eq!(view.status, StatusCode::OK);
+    assert_eq!(view.body["visible_stage"], "coordination");
+    assert_eq!(view.body["status_code"], "muted");
+}
+
+#[tokio::test]
+async fn blocked_room_becomes_terminal_without_changing_stage() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let subject = sign_in(&app, "pi-user-room-block-a", "room-block-a").await;
+    let counterparty = sign_in(&app, "pi-user-room-block-b", "room-block-b").await;
+    let room_progression_id =
+        create_room(&app, &subject.account_id, &counterparty.account_id).await;
+
+    let blocked = internal_post_json(
+        &app,
+        &format!("/api/internal/room-progressions/{room_progression_id}/facts"),
+        json!({
+            "transition_kind": "block",
+            "to_stage": "intent",
+            "user_facing_reason_code": "user_blocked",
+            "triggered_by_kind": "participant",
+            "triggered_by_account_id": subject.account_id,
+            "source_fact_kind": "participant_safety_control",
+            "source_fact_id": "room-block-toggle",
+            "source_snapshot_json": {},
+            "fact_idempotency_key": "room-block-toggle"
+        }),
+    )
+    .await;
+    assert_eq!(blocked.status, StatusCode::OK);
+    assert_eq!(blocked.body["from_stage"], "intent");
+    assert_eq!(blocked.body["to_stage"], "intent");
+    assert_eq!(blocked.body["status_code"], "blocked");
+
+    let view = get_json(
+        &app,
+        &format!("/api/projection/room-progression-views/{room_progression_id}"),
+        Some(subject.token.as_str()),
+    )
+    .await;
+    assert_eq!(view.status, StatusCode::OK);
+    assert_eq!(view.body["visible_stage"], "intent");
+    assert_eq!(view.body["status_code"], "blocked");
+
+    let progression_after_block = internal_post_json(
+        &app,
+        &format!("/api/internal/room-progressions/{room_progression_id}/facts"),
+        json!({
+            "transition_kind": "advance_to_coordination",
+            "to_stage": "coordination",
+            "user_facing_reason_code": "mutual_intent_acknowledged",
+            "triggered_by_kind": "participant",
+            "triggered_by_account_id": subject.account_id,
+            "source_fact_kind": "mutual_intent_acknowledgment",
+            "source_fact_id": "room-block-after",
+            "source_snapshot_json": {},
+            "fact_idempotency_key": "room-block-after"
+        }),
+    )
+    .await;
+    assert_eq!(progression_after_block.status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn withdrawn_room_becomes_terminal_without_changing_stage() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let subject = sign_in(&app, "pi-user-room-withdraw-a", "room-withdraw-a").await;
+    let counterparty = sign_in(&app, "pi-user-room-withdraw-b", "room-withdraw-b").await;
+    let room_progression_id =
+        create_room(&app, &subject.account_id, &counterparty.account_id).await;
+
+    let coordination = internal_post_json(
+        &app,
+        &format!("/api/internal/room-progressions/{room_progression_id}/facts"),
+        json!({
+            "transition_kind": "advance_to_coordination",
+            "to_stage": "coordination",
+            "user_facing_reason_code": "mutual_intent_acknowledged",
+            "triggered_by_kind": "participant",
+            "triggered_by_account_id": subject.account_id,
+            "source_fact_kind": "mutual_intent_acknowledgment",
+            "source_fact_id": "room-withdraw-coordinate",
+            "source_snapshot_json": {},
+            "fact_idempotency_key": "room-withdraw-coordinate"
+        }),
+    )
+    .await;
+    assert_eq!(coordination.status, StatusCode::OK);
+
+    let withdrawn = internal_post_json(
+        &app,
+        &format!("/api/internal/room-progressions/{room_progression_id}/facts"),
+        json!({
+            "transition_kind": "withdraw",
+            "to_stage": "coordination",
+            "user_facing_reason_code": "user_withdrew",
+            "triggered_by_kind": "participant",
+            "triggered_by_account_id": subject.account_id,
+            "source_fact_kind": "participant_safety_control",
+            "source_fact_id": "room-withdraw-toggle",
+            "source_snapshot_json": {},
+            "fact_idempotency_key": "room-withdraw-toggle"
+        }),
+    )
+    .await;
+    assert_eq!(withdrawn.status, StatusCode::OK);
+    assert_eq!(withdrawn.body["from_stage"], "coordination");
+    assert_eq!(withdrawn.body["to_stage"], "coordination");
+    assert_eq!(withdrawn.body["status_code"], "withdrawn");
+
+    let view = get_json(
+        &app,
+        &format!("/api/projection/room-progression-views/{room_progression_id}"),
+        Some(subject.token.as_str()),
+    )
+    .await;
+    assert_eq!(view.status, StatusCode::OK);
+    assert_eq!(view.body["visible_stage"], "coordination");
+    assert_eq!(view.body["status_code"], "withdrawn");
+
+    let progression_after_withdraw = internal_post_json(
+        &app,
+        &format!("/api/internal/room-progressions/{room_progression_id}/facts"),
+        json!({
+            "transition_kind": "advance_to_relationship",
+            "to_stage": "relationship",
+            "user_facing_reason_code": "qualifying_promise_completed",
+            "triggered_by_kind": "system",
+            "source_fact_kind": "qualifying_promise_completion",
+            "source_fact_id": "room-withdraw-after",
+            "source_snapshot_json": {},
+            "fact_idempotency_key": "room-withdraw-after"
+        }),
+    )
+    .await;
+    assert_eq!(progression_after_withdraw.status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
 async fn room_progression_rejects_skipped_transition() {
     let test_state = new_test_state().await.expect("test database state");
     let app = build_app(test_state.state.clone());

--- a/apps/backend/tests/room_progression.rs
+++ b/apps/backend/tests/room_progression.rs
@@ -395,6 +395,76 @@ async fn restricted_seal_requires_writer_owned_restrict_decision() {
 }
 
 #[tokio::test]
+async fn live_room_seal_rejects_decided_review_case() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let subject = sign_in(&app, "pi-user-room-stale-review-a", "room-stale-review-a").await;
+    let counterparty = sign_in(&app, "pi-user-room-stale-review-b", "room-stale-review-b").await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+    let room_progression_id =
+        create_room(&app, &subject.account_id, &counterparty.account_id).await;
+
+    let review_case = operator_post_json(
+        &app,
+        "/api/internal/operator/review-cases",
+        &approver_id,
+        json!({
+            "case_type": "sealed_room_fallback",
+            "severity": "sev1",
+            "subject_account_id": subject.account_id,
+            "related_realm_id": "realm-room-default",
+            "opened_reason_code": "manual_hold_safety_review",
+            "source_fact_kind": "room_progression",
+            "source_fact_id": room_progression_id,
+            "source_snapshot_json": {},
+            "request_idempotency_key": "room-stale-review-create"
+        }),
+    )
+    .await;
+    assert_eq!(review_case.status, StatusCode::OK);
+    let review_case_id = review_case.body["review_case_id"]
+        .as_str()
+        .expect("review case id must exist")
+        .to_owned();
+
+    let decision = operator_post_json(
+        &app,
+        &format!("/api/internal/operator/review-cases/{review_case_id}/decisions"),
+        &approver_id,
+        json!({
+            "decision_kind": "restrict",
+            "user_facing_reason_code": "restricted_after_review",
+            "operator_note_internal": "restriction rationale is internal",
+            "decision_payload_json": {
+                "resolution": "restrict"
+            },
+            "decision_idempotency_key": "room-stale-review-decision"
+        }),
+    )
+    .await;
+    assert_eq!(decision.status, StatusCode::OK);
+
+    let sealed = internal_post_json(
+        &app,
+        &format!("/api/internal/room-progressions/{room_progression_id}/facts"),
+        json!({
+            "transition_kind": "seal",
+            "to_stage": "sealed",
+            "user_facing_reason_code": "manual_hold_safety_review",
+            "triggered_by_kind": "system",
+            "source_fact_kind": "review_case",
+            "source_fact_id": review_case_id,
+            "source_snapshot_json": {},
+            "review_case_id": review_case_id,
+            "fact_idempotency_key": "room-stale-review-seal"
+        }),
+    )
+    .await;
+    assert_eq!(sealed.status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
 async fn restricted_seal_rejects_participant_actor() {
     let test_state = new_test_state().await.expect("test database state");
     let app = build_app(test_state.state.clone());
@@ -497,6 +567,33 @@ async fn restricted_seal_rejects_participant_actor() {
     )
     .await;
     assert_eq!(restricted.status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn fact_append_requires_idempotency_key() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let subject = sign_in(&app, "pi-user-room-no-key-a", "room-no-key-a").await;
+    let counterparty = sign_in(&app, "pi-user-room-no-key-b", "room-no-key-b").await;
+    let room_progression_id =
+        create_room(&app, &subject.account_id, &counterparty.account_id).await;
+
+    let response = internal_post_json(
+        &app,
+        &format!("/api/internal/room-progressions/{room_progression_id}/facts"),
+        json!({
+            "transition_kind": "advance_to_coordination",
+            "to_stage": "coordination",
+            "user_facing_reason_code": "mutual_intent_acknowledged",
+            "triggered_by_kind": "participant",
+            "triggered_by_account_id": subject.account_id,
+            "source_fact_kind": "mutual_intent_acknowledgment",
+            "source_fact_id": "room-no-key-coordinate",
+            "source_snapshot_json": {}
+        }),
+    )
+    .await;
+    assert_eq!(response.status, StatusCode::BAD_REQUEST);
 }
 
 #[tokio::test]

--- a/apps/backend/tests/room_progression.rs
+++ b/apps/backend/tests/room_progression.rs
@@ -1,10 +1,10 @@
 use axum::{
-    Router,
-    body::{Body, to_bytes},
+    body::{to_bytes, Body},
     http::{Request, StatusCode},
+    Router,
 };
 use musubi_backend::{build_app, new_test_state};
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 use tower::ServiceExt;
 use uuid::Uuid;
 
@@ -320,6 +320,106 @@ async fn sealed_room_can_record_restriction_follow_up_without_reopening() {
     assert_eq!(view.body["visible_stage"], "sealed");
     assert_eq!(view.body["status_code"], "sealed_restricted");
     assert_eq!(view.body["review_case_id"], review_case_id);
+}
+
+#[tokio::test]
+async fn restricted_seal_requires_writer_owned_restrict_decision() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let subject = sign_in(&app, "pi-user-room-restrict-gate-a", "room-restrict-gate-a").await;
+    let counterparty = sign_in(&app, "pi-user-room-restrict-gate-b", "room-restrict-gate-b").await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+    let room_progression_id =
+        create_room(&app, &subject.account_id, &counterparty.account_id).await;
+
+    let missing_review = internal_post_json(
+        &app,
+        &format!("/api/internal/room-progressions/{room_progression_id}/facts"),
+        json!({
+            "transition_kind": "seal",
+            "to_stage": "sealed",
+            "user_facing_reason_code": "restricted_after_review",
+            "triggered_by_kind": "operator",
+            "triggered_by_account_id": approver_id,
+            "source_fact_kind": "operator_decision",
+            "source_fact_id": "room-restrict-missing-review",
+            "source_snapshot_json": {},
+            "fact_idempotency_key": "room-restrict-missing-review"
+        }),
+    )
+    .await;
+    assert_eq!(missing_review.status, StatusCode::BAD_REQUEST);
+
+    let review_case = operator_post_json(
+        &app,
+        "/api/internal/operator/review-cases",
+        &approver_id,
+        json!({
+            "case_type": "sealed_room_fallback",
+            "severity": "sev1",
+            "subject_account_id": subject.account_id,
+            "related_realm_id": "realm-room-default",
+            "opened_reason_code": "manual_hold_safety_review",
+            "source_fact_kind": "room_progression",
+            "source_fact_id": room_progression_id,
+            "source_snapshot_json": {},
+            "request_idempotency_key": "room-restrict-gate-review"
+        }),
+    )
+    .await;
+    assert_eq!(review_case.status, StatusCode::OK);
+    let review_case_id = review_case.body["review_case_id"]
+        .as_str()
+        .expect("review case id must exist")
+        .to_owned();
+
+    let without_decision = internal_post_json(
+        &app,
+        &format!("/api/internal/room-progressions/{room_progression_id}/facts"),
+        json!({
+            "transition_kind": "seal",
+            "to_stage": "sealed",
+            "user_facing_reason_code": "restricted_after_review",
+            "triggered_by_kind": "operator",
+            "triggered_by_account_id": approver_id,
+            "source_fact_kind": "operator_decision",
+            "source_fact_id": "room-restrict-without-decision",
+            "source_snapshot_json": {},
+            "review_case_id": review_case_id,
+            "fact_idempotency_key": "room-restrict-without-decision"
+        }),
+    )
+    .await;
+    assert_eq!(without_decision.status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn operator_triggered_facts_require_operator_role_assignment() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let subject = sign_in(&app, "pi-user-room-operator-role-a", "room-operator-role-a").await;
+    let counterparty = sign_in(&app, "pi-user-room-operator-role-b", "room-operator-role-b").await;
+    let room_progression_id =
+        create_room(&app, &subject.account_id, &counterparty.account_id).await;
+
+    let unauthorized = internal_post_json(
+        &app,
+        &format!("/api/internal/room-progressions/{room_progression_id}/facts"),
+        json!({
+            "transition_kind": "seal",
+            "to_stage": "sealed",
+            "user_facing_reason_code": "manual_hold_safety_review",
+            "triggered_by_kind": "operator",
+            "triggered_by_account_id": subject.account_id,
+            "source_fact_kind": "operator_hold",
+            "source_fact_id": "room-operator-role-missing",
+            "source_snapshot_json": {},
+            "fact_idempotency_key": "room-operator-role-missing"
+        }),
+    )
+    .await;
+    assert_eq!(unauthorized.status, StatusCode::UNAUTHORIZED);
 }
 
 #[tokio::test]

--- a/apps/backend/tests/room_progression.rs
+++ b/apps/backend/tests/room_progression.rs
@@ -395,6 +395,111 @@ async fn restricted_seal_requires_writer_owned_restrict_decision() {
 }
 
 #[tokio::test]
+async fn restricted_seal_rejects_participant_actor() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let subject = sign_in(
+        &app,
+        "pi-user-room-restrict-actor-a",
+        "room-restrict-actor-a",
+    )
+    .await;
+    let counterparty = sign_in(
+        &app,
+        "pi-user-room-restrict-actor-b",
+        "room-restrict-actor-b",
+    )
+    .await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+    let room_progression_id =
+        create_room(&app, &subject.account_id, &counterparty.account_id).await;
+
+    let review_case = operator_post_json(
+        &app,
+        "/api/internal/operator/review-cases",
+        &approver_id,
+        json!({
+            "case_type": "sealed_room_fallback",
+            "severity": "sev1",
+            "subject_account_id": subject.account_id,
+            "related_realm_id": "realm-room-default",
+            "opened_reason_code": "manual_hold_safety_review",
+            "source_fact_kind": "room_progression",
+            "source_fact_id": room_progression_id,
+            "source_snapshot_json": {},
+            "request_idempotency_key": "room-restrict-actor-review"
+        }),
+    )
+    .await;
+    assert_eq!(review_case.status, StatusCode::OK);
+    let review_case_id = review_case.body["review_case_id"]
+        .as_str()
+        .expect("review case id must exist")
+        .to_owned();
+
+    let sealed = internal_post_json(
+        &app,
+        &format!("/api/internal/room-progressions/{room_progression_id}/facts"),
+        json!({
+            "transition_kind": "seal",
+            "to_stage": "sealed",
+            "user_facing_reason_code": "manual_hold_safety_review",
+            "triggered_by_kind": "system",
+            "source_fact_kind": "review_case",
+            "source_fact_id": review_case_id,
+            "source_snapshot_json": {},
+            "review_case_id": review_case_id,
+            "fact_idempotency_key": "room-restrict-actor-sealed"
+        }),
+    )
+    .await;
+    assert_eq!(sealed.status, StatusCode::OK);
+
+    let decision = operator_post_json(
+        &app,
+        &format!("/api/internal/operator/review-cases/{review_case_id}/decisions"),
+        &approver_id,
+        json!({
+            "decision_kind": "restrict",
+            "user_facing_reason_code": "restricted_after_review",
+            "operator_note_internal": "restriction rationale is internal",
+            "decision_payload_json": {
+                "resolution": "restrict"
+            },
+            "decision_idempotency_key": "room-restrict-actor-decision"
+        }),
+    )
+    .await;
+    assert_eq!(decision.status, StatusCode::OK);
+    let decision_fact_id = decision.body["operator_decision_fact_id"]
+        .as_str()
+        .expect("operator decision fact id must exist")
+        .to_owned();
+
+    let restricted = internal_post_json(
+        &app,
+        &format!("/api/internal/room-progressions/{room_progression_id}/facts"),
+        json!({
+            "transition_kind": "seal",
+            "to_stage": "sealed",
+            "user_facing_reason_code": "restricted_after_review",
+            "triggered_by_kind": "participant",
+            "triggered_by_account_id": subject.account_id,
+            "source_fact_kind": "operator_decision",
+            "source_fact_id": decision_fact_id,
+            "source_snapshot_json": {
+                "resolution": "restrict"
+            },
+            "review_case_id": review_case_id,
+            "fact_idempotency_key": "room-restrict-actor-follow-up"
+        }),
+    )
+    .await;
+    assert_eq!(restricted.status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
 async fn live_room_seal_requires_room_scoped_review_case() {
     let test_state = new_test_state().await.expect("test database state");
     let app = build_app(test_state.state.clone());
@@ -782,6 +887,124 @@ async fn restore_clears_review_link_from_live_room_projection() {
     assert_eq!(relationship_view.body["status_code"], "relationship_open");
     assert!(relationship_view.body["review_case_id"].is_null());
     assert!(relationship_view.body["review_status"].is_null());
+}
+
+#[tokio::test]
+async fn intent_room_restore_returns_to_intent_open() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let subject = sign_in(
+        &app,
+        "pi-user-room-restore-intent-a",
+        "room-restore-intent-a",
+    )
+    .await;
+    let counterparty = sign_in(
+        &app,
+        "pi-user-room-restore-intent-b",
+        "room-restore-intent-b",
+    )
+    .await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+    let room_progression_id =
+        create_room(&app, &subject.account_id, &counterparty.account_id).await;
+
+    let review_case = operator_post_json(
+        &app,
+        "/api/internal/operator/review-cases",
+        &approver_id,
+        json!({
+            "case_type": "sealed_room_fallback",
+            "severity": "sev1",
+            "subject_account_id": subject.account_id,
+            "related_realm_id": "realm-room-default",
+            "opened_reason_code": "manual_hold_safety_review",
+            "source_fact_kind": "room_progression",
+            "source_fact_id": room_progression_id,
+            "source_snapshot_json": {},
+            "request_idempotency_key": "room-restore-intent-review"
+        }),
+    )
+    .await;
+    assert_eq!(review_case.status, StatusCode::OK);
+    let review_case_id = review_case.body["review_case_id"]
+        .as_str()
+        .expect("review case id must exist")
+        .to_owned();
+
+    let sealed = internal_post_json(
+        &app,
+        &format!("/api/internal/room-progressions/{room_progression_id}/facts"),
+        json!({
+            "transition_kind": "seal",
+            "to_stage": "sealed",
+            "user_facing_reason_code": "manual_hold_safety_review",
+            "triggered_by_kind": "system",
+            "source_fact_kind": "review_case",
+            "source_fact_id": review_case_id,
+            "source_snapshot_json": {},
+            "review_case_id": review_case_id,
+            "fact_idempotency_key": "room-restore-intent-sealed"
+        }),
+    )
+    .await;
+    assert_eq!(sealed.status, StatusCode::OK);
+
+    let decision = operator_post_json(
+        &app,
+        &format!("/api/internal/operator/review-cases/{review_case_id}/decisions"),
+        &approver_id,
+        json!({
+            "decision_kind": "restore",
+            "user_facing_reason_code": "restored_after_review",
+            "operator_note_internal": "restore rationale is internal",
+            "decision_payload_json": {
+                "resolution": "restore"
+            },
+            "decision_idempotency_key": "room-restore-intent-decision"
+        }),
+    )
+    .await;
+    assert_eq!(decision.status, StatusCode::OK);
+    let decision_fact_id = decision.body["operator_decision_fact_id"]
+        .as_str()
+        .expect("operator decision fact id must exist")
+        .to_owned();
+
+    let restored = internal_post_json(
+        &app,
+        &format!("/api/internal/room-progressions/{room_progression_id}/facts"),
+        json!({
+            "transition_kind": "restore",
+            "to_stage": "intent",
+            "user_facing_reason_code": "restored_after_review",
+            "triggered_by_kind": "operator",
+            "triggered_by_account_id": approver_id,
+            "source_fact_kind": "operator_decision",
+            "source_fact_id": decision_fact_id,
+            "source_snapshot_json": {
+                "resolution": "restore"
+            },
+            "review_case_id": review_case_id,
+            "fact_idempotency_key": "room-restore-intent-transition"
+        }),
+    )
+    .await;
+    assert_eq!(restored.status, StatusCode::OK);
+    assert_eq!(restored.body["to_stage"], "intent");
+    assert_eq!(restored.body["status_code"], "intent_open");
+
+    let restored_view = get_json(
+        &app,
+        &format!("/api/projection/room-progression-views/{room_progression_id}"),
+        Some(subject.token.as_str()),
+    )
+    .await;
+    assert_eq!(restored_view.status, StatusCode::OK);
+    assert_eq!(restored_view.body["visible_stage"], "intent");
+    assert_eq!(restored_view.body["status_code"], "intent_open");
+    assert!(restored_view.body["review_case_id"].is_null());
 }
 
 #[tokio::test]

--- a/apps/backend/tests/room_progression.rs
+++ b/apps/backend/tests/room_progression.rs
@@ -3,7 +3,8 @@ use axum::{
     http::{Request, StatusCode},
     Router,
 };
-use musubi_backend::{build_app, new_test_state};
+use musubi_backend::{build_app, new_state_from_config, new_test_state};
+use musubi_db_runtime::DbConfig;
 use serde_json::{json, Value};
 use tower::ServiceExt;
 use uuid::Uuid;
@@ -1715,6 +1716,85 @@ async fn room_progression_create_replay_survives_participant_deactivation() {
     .await;
     assert_eq!(replayed.status, StatusCode::OK);
     assert_eq!(replayed.body["room_progression_id"], room_progression_id);
+}
+
+#[tokio::test]
+async fn concurrent_room_progression_create_replay_returns_existing_track_across_two_app_states() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let database_url = std::env::var("MUSUBI_TEST_DATABASE_URL")
+        .or_else(|_| std::env::var("DATABASE_URL"))
+        .expect("test database url must be present");
+    let config = DbConfig::from_lookup(|name| match name {
+        "APP_ENV" => Some("local".to_owned()),
+        "DATABASE_URL" => Some(database_url.clone()),
+        _ => std::env::var(name).ok(),
+    })
+    .expect("db config");
+    let second_state = new_state_from_config(&config).await.expect("second state");
+    let second_app = build_app(second_state.clone());
+    let subject = sign_in(
+        &app,
+        "pi-user-room-create-concurrent-a",
+        "room-create-concurrent-a",
+    )
+    .await;
+    let counterparty = sign_in(
+        &app,
+        "pi-user-room-create-concurrent-b",
+        "room-create-concurrent-b",
+    )
+    .await;
+    let client = test_db_client().await;
+
+    let body = json!({
+        "realm_id": "realm-room-create-concurrent",
+        "participant_account_ids": [
+            subject.account_id,
+            counterparty.account_id
+        ],
+        "user_facing_reason_code": "room_created",
+        "source_fact_kind": "intent_room_request",
+        "source_fact_id": "room-create-concurrent-source",
+        "source_snapshot_json": {
+            "source": "intent"
+        },
+        "request_idempotency_key": "room-create-concurrent"
+    });
+
+    let (first, second) = tokio::join!(
+        internal_post_json(&app, "/api/internal/room-progressions", body.clone()),
+        internal_post_json(&second_app, "/api/internal/room-progressions", body)
+    );
+    assert_eq!(first.status, StatusCode::OK);
+    assert_eq!(second.status, StatusCode::OK);
+    assert_eq!(
+        first.body["room_progression_id"],
+        second.body["room_progression_id"]
+    );
+
+    let row = client
+        .query_one(
+            "
+            SELECT
+                COUNT(*)::bigint AS track_count,
+                (
+                    SELECT COUNT(*)::bigint
+                    FROM dao.room_progression_facts
+                    WHERE room_progression_id = track.room_progression_id
+                ) AS fact_count
+            FROM dao.room_progression_tracks track
+            WHERE request_idempotency_key = $1
+            GROUP BY track.room_progression_id
+            ",
+            &[&"room-create-concurrent"],
+        )
+        .await
+        .expect("concurrent create track must exist");
+    let track_count: i64 = row.get("track_count");
+    let fact_count: i64 = row.get("fact_count");
+    assert_eq!(track_count, 1);
+    assert_eq!(fact_count, 1);
 }
 
 #[tokio::test]

--- a/apps/backend/tests/room_progression.rs
+++ b/apps/backend/tests/room_progression.rs
@@ -1,0 +1,602 @@
+use axum::{
+    Router,
+    body::{Body, to_bytes},
+    http::{Request, StatusCode},
+};
+use musubi_backend::{build_app, new_test_state};
+use serde_json::{Value, json};
+use tower::ServiceExt;
+use uuid::Uuid;
+
+#[tokio::test]
+async fn room_progression_follows_normal_path_and_keeps_view_private() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let subject = sign_in(&app, "pi-user-room-normal-a", "room-normal-a").await;
+    let counterparty = sign_in(&app, "pi-user-room-normal-b", "room-normal-b").await;
+    let outsider = sign_in(&app, "pi-user-room-normal-c", "room-normal-c").await;
+
+    let room = internal_post_json(
+        &app,
+        "/api/internal/room-progressions",
+        json!({
+            "realm_id": "realm-room-normal",
+            "participant_account_ids": [
+                subject.account_id,
+                counterparty.account_id
+            ],
+            "user_facing_reason_code": "room_created",
+            "source_fact_kind": "intent_room_request",
+            "source_fact_id": "room-normal-source",
+            "source_snapshot_json": {
+                "private_internal_note": "must not leak"
+            },
+            "request_idempotency_key": "room-normal-create"
+        }),
+    )
+    .await;
+    assert_eq!(room.status, StatusCode::OK);
+    assert_eq!(room.body["current_stage"], "intent");
+    let room_progression_id = room.body["room_progression_id"]
+        .as_str()
+        .expect("room progression id must exist")
+        .to_owned();
+
+    let outsider_view = get_json(
+        &app,
+        &format!("/api/projection/room-progression-views/{room_progression_id}"),
+        Some(outsider.token.as_str()),
+    )
+    .await;
+    assert_eq!(outsider_view.status, StatusCode::NOT_FOUND);
+
+    let coordination = internal_post_json(
+        &app,
+        &format!("/api/internal/room-progressions/{room_progression_id}/facts"),
+        json!({
+            "transition_kind": "advance_to_coordination",
+            "to_stage": "coordination",
+            "user_facing_reason_code": "mutual_intent_acknowledged",
+            "triggered_by_kind": "participant",
+            "triggered_by_account_id": subject.account_id,
+            "source_fact_kind": "mutual_intent_acknowledgment",
+            "source_fact_id": "room-normal-coordinate",
+            "source_snapshot_json": {
+                "operator_internal_note": "must not leak"
+            },
+            "fact_idempotency_key": "room-normal-coordinate"
+        }),
+    )
+    .await;
+    assert_eq!(coordination.status, StatusCode::OK);
+    assert_eq!(coordination.body["from_stage"], "intent");
+    assert_eq!(coordination.body["to_stage"], "coordination");
+
+    let relationship = internal_post_json(
+        &app,
+        &format!("/api/internal/room-progressions/{room_progression_id}/facts"),
+        json!({
+            "transition_kind": "advance_to_relationship",
+            "to_stage": "relationship",
+            "user_facing_reason_code": "qualifying_promise_completed",
+            "triggered_by_kind": "system",
+            "source_fact_kind": "qualifying_promise_completion",
+            "source_fact_id": "room-normal-relationship",
+            "source_snapshot_json": {
+                "raw_source_snapshot": "must not leak"
+            },
+            "fact_idempotency_key": "room-normal-relationship"
+        }),
+    )
+    .await;
+    assert_eq!(relationship.status, StatusCode::OK);
+
+    let view = get_json(
+        &app,
+        &format!("/api/projection/room-progression-views/{room_progression_id}"),
+        Some(subject.token.as_str()),
+    )
+    .await;
+    assert_eq!(view.status, StatusCode::OK);
+    assert_eq!(view.body["visible_stage"], "relationship");
+    assert_eq!(view.body["status_code"], "relationship_open");
+    assert_eq!(
+        view.body["user_facing_reason_code"],
+        "qualifying_promise_completed"
+    );
+    assert_eq!(view.body["source_fact_count"], 3);
+    assert!(!view.body.to_string().contains("must not leak"));
+    assert!(view.body.get("source_snapshot_json").is_none());
+    assert!(view.body.get("triggered_by_account_id").is_none());
+}
+
+#[tokio::test]
+async fn room_progression_rejects_skipped_transition() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let subject = sign_in(&app, "pi-user-room-skip-a", "room-skip-a").await;
+    let counterparty = sign_in(&app, "pi-user-room-skip-b", "room-skip-b").await;
+    let room_progression_id =
+        create_room(&app, &subject.account_id, &counterparty.account_id).await;
+
+    let skipped = internal_post_json(
+        &app,
+        &format!("/api/internal/room-progressions/{room_progression_id}/facts"),
+        json!({
+            "transition_kind": "advance_to_relationship",
+            "to_stage": "relationship",
+            "user_facing_reason_code": "qualifying_promise_completed",
+            "triggered_by_kind": "system",
+            "source_fact_kind": "invalid_skip",
+            "source_fact_id": "room-skip-invalid",
+            "source_snapshot_json": {},
+            "fact_idempotency_key": "room-skip-invalid"
+        }),
+    )
+    .await;
+    assert_eq!(skipped.status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn sealed_fallback_links_review_without_leaking_evidence_or_notes() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let subject = sign_in(&app, "pi-user-room-sealed-a", "room-sealed-a").await;
+    let counterparty = sign_in(&app, "pi-user-room-sealed-b", "room-sealed-b").await;
+    let client = test_db_client().await;
+    let reviewer_id = insert_operator_account(&client, "reviewer").await;
+    let room_progression_id =
+        create_room(&app, &subject.account_id, &counterparty.account_id).await;
+
+    let review_case = operator_post_json(
+        &app,
+        "/api/internal/operator/review-cases",
+        &reviewer_id,
+        json!({
+            "case_type": "sealed_room_fallback",
+            "severity": "sev1",
+            "subject_account_id": subject.account_id,
+            "related_realm_id": "realm-room-default",
+            "opened_reason_code": "manual_hold_safety_review",
+            "source_fact_kind": "room_progression",
+            "source_fact_id": room_progression_id,
+            "source_snapshot_json": {
+                "raw_evidence_locator": "private-room-evidence-uri",
+                "internal_safety_classification": "do-not-display"
+            },
+            "request_idempotency_key": "room-sealed-review"
+        }),
+    )
+    .await;
+    assert_eq!(review_case.status, StatusCode::OK);
+    let review_case_id = review_case.body["review_case_id"]
+        .as_str()
+        .expect("review case id must exist")
+        .to_owned();
+
+    let sealed = internal_post_json(
+        &app,
+        &format!("/api/internal/room-progressions/{room_progression_id}/facts"),
+        json!({
+            "transition_kind": "seal",
+            "to_stage": "sealed",
+            "user_facing_reason_code": "manual_hold_safety_review",
+            "triggered_by_kind": "system",
+            "source_fact_kind": "review_case",
+            "source_fact_id": review_case_id,
+            "source_snapshot_json": {
+                "operator_note_internal": "must not leak",
+                "raw_evidence_locator": "private-room-evidence-uri"
+            },
+            "review_case_id": review_case_id,
+            "fact_idempotency_key": "room-sealed"
+        }),
+    )
+    .await;
+    assert_eq!(sealed.status, StatusCode::OK);
+
+    let view = get_json(
+        &app,
+        &format!("/api/projection/room-progression-views/{room_progression_id}"),
+        Some(subject.token.as_str()),
+    )
+    .await;
+    assert_eq!(view.status, StatusCode::OK);
+    assert_eq!(view.body["visible_stage"], "sealed");
+    assert_eq!(view.body["status_code"], "sealed_under_review");
+    assert_eq!(view.body["review_case_id"], review_case_id);
+    assert_eq!(view.body["review_pending"], true);
+    assert_eq!(view.body["review_status"], "pending_review");
+    assert!(!view.body.to_string().contains("private-room-evidence-uri"));
+    assert!(!view.body.to_string().contains("operator_note_internal"));
+    assert!(!view.body.to_string().contains("do-not-display"));
+    assert!(!view.body.to_string().contains(&reviewer_id));
+}
+
+#[tokio::test]
+async fn room_projection_rebuild_is_idempotent() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let subject = sign_in(&app, "pi-user-room-rebuild-a", "room-rebuild-a").await;
+    let counterparty = sign_in(&app, "pi-user-room-rebuild-b", "room-rebuild-b").await;
+    let room_progression_id =
+        create_room(&app, &subject.account_id, &counterparty.account_id).await;
+
+    let first = internal_post_json(
+        &app,
+        "/api/internal/projection/room-progressions/rebuild",
+        json!({}),
+    )
+    .await;
+    assert_eq!(first.status, StatusCode::OK);
+    assert_eq!(first.body["rebuilt_count"], 1);
+
+    let first_view = get_json(
+        &app,
+        &format!("/api/projection/room-progression-views/{room_progression_id}"),
+        Some(subject.token.as_str()),
+    )
+    .await;
+    assert_eq!(first_view.status, StatusCode::OK);
+    assert!(first_view.body["source_watermark_at"].as_str().is_some());
+    assert!(first_view.body["last_projected_at"].as_str().is_some());
+    assert!(first_view.body["projection_lag_ms"].as_i64().unwrap_or(-1) >= 0);
+    let first_generation = first_view.body["rebuild_generation"]
+        .as_i64()
+        .expect("rebuild_generation must be numeric");
+
+    let second = internal_post_json(
+        &app,
+        "/api/internal/projection/room-progressions/rebuild",
+        json!({}),
+    )
+    .await;
+    assert_eq!(second.status, StatusCode::OK);
+    assert_eq!(second.body["rebuilt_count"], 1);
+
+    let view = get_json(
+        &app,
+        &format!("/api/projection/room-progression-views/{room_progression_id}"),
+        Some(subject.token.as_str()),
+    )
+    .await;
+    assert_eq!(view.status, StatusCode::OK);
+    assert_eq!(view.body["source_fact_count"], 1);
+    let second_generation = view.body["rebuild_generation"]
+        .as_i64()
+        .expect("rebuild_generation must be numeric");
+    assert!(second_generation > first_generation);
+}
+
+#[tokio::test]
+async fn room_progression_idempotency_uses_canonical_payload_hashes() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let subject = sign_in(&app, "pi-user-room-replay-a", "room-replay-a").await;
+    let counterparty = sign_in(&app, "pi-user-room-replay-b", "room-replay-b").await;
+
+    let create_body = format!(
+        r#"{{
+            "realm_id": "realm-room-replay",
+            "participant_account_ids": ["{subject_id}", "{counterparty_id}"],
+            "user_facing_reason_code": "room_created",
+            "source_fact_kind": "intent_room_request",
+            "source_fact_id": "room-replay-source",
+            "source_snapshot_json": {{
+                "outer": {{ "b": 2, "a": 1 }},
+                "array": [{{ "z": 3, "y": 2 }}]
+            }},
+            "request_idempotency_key": "room-replay-create"
+        }}"#,
+        subject_id = subject.account_id,
+        counterparty_id = counterparty.account_id
+    );
+    let created =
+        internal_post_raw_json(&app, "/api/internal/room-progressions", &create_body).await;
+    assert_eq!(created.status, StatusCode::OK);
+    let room_progression_id = created.body["room_progression_id"]
+        .as_str()
+        .expect("room progression id must exist")
+        .to_owned();
+
+    let replay_body = format!(
+        r#"{{
+            "request_idempotency_key": "room-replay-create",
+            "source_snapshot_json": {{
+                "array": [{{ "y": 2, "z": 3 }}],
+                "outer": {{ "a": 1, "b": 2 }}
+            }},
+            "source_fact_id": "room-replay-source",
+            "source_fact_kind": "intent_room_request",
+            "user_facing_reason_code": "room_created",
+            "participant_account_ids": ["{counterparty_id}", "{subject_id}"],
+            "realm_id": "realm-room-replay"
+        }}"#,
+        subject_id = subject.account_id,
+        counterparty_id = counterparty.account_id
+    );
+    let replayed =
+        internal_post_raw_json(&app, "/api/internal/room-progressions", &replay_body).await;
+    assert_eq!(replayed.status, StatusCode::OK);
+    assert_eq!(replayed.body["room_progression_id"], room_progression_id);
+
+    let mismatched = internal_post_json(
+        &app,
+        "/api/internal/room-progressions",
+        json!({
+            "realm_id": "realm-room-replay",
+            "participant_account_ids": [
+                subject.account_id,
+                counterparty.account_id
+            ],
+            "user_facing_reason_code": "policy_review",
+            "source_fact_kind": "intent_room_request",
+            "source_fact_id": "room-replay-source",
+            "source_snapshot_json": {},
+            "request_idempotency_key": "room-replay-create"
+        }),
+    )
+    .await;
+    assert_eq!(mismatched.status, StatusCode::BAD_REQUEST);
+
+    let fact = internal_post_json(
+        &app,
+        &format!("/api/internal/room-progressions/{room_progression_id}/facts"),
+        json!({
+            "transition_kind": "advance_to_coordination",
+            "to_stage": "coordination",
+            "user_facing_reason_code": "mutual_intent_acknowledged",
+            "triggered_by_kind": "participant",
+            "triggered_by_account_id": subject.account_id,
+            "source_fact_kind": "mutual_intent_acknowledgment",
+            "source_fact_id": "room-replay-coordinate",
+            "source_snapshot_json": {
+                "outer": { "b": 2, "a": 1 }
+            },
+            "fact_idempotency_key": "room-replay-coordinate"
+        }),
+    )
+    .await;
+    assert_eq!(fact.status, StatusCode::OK);
+    let fact_id = fact.body["room_progression_fact_id"]
+        .as_str()
+        .expect("fact id must exist")
+        .to_owned();
+
+    let replay_fact = internal_post_json(
+        &app,
+        &format!("/api/internal/room-progressions/{room_progression_id}/facts"),
+        json!({
+            "transition_kind": "advance_to_coordination",
+            "to_stage": "coordination",
+            "user_facing_reason_code": "mutual_intent_acknowledged",
+            "triggered_by_kind": "participant",
+            "triggered_by_account_id": subject.account_id,
+            "source_fact_kind": "mutual_intent_acknowledgment",
+            "source_fact_id": "room-replay-coordinate",
+            "source_snapshot_json": {
+                "outer": { "a": 1, "b": 2 }
+            },
+            "fact_idempotency_key": "room-replay-coordinate"
+        }),
+    )
+    .await;
+    assert_eq!(replay_fact.status, StatusCode::OK);
+    assert_eq!(replay_fact.body["room_progression_fact_id"], fact_id);
+
+    let mismatched_fact = internal_post_json(
+        &app,
+        &format!("/api/internal/room-progressions/{room_progression_id}/facts"),
+        json!({
+            "transition_kind": "advance_to_coordination",
+            "to_stage": "coordination",
+            "user_facing_reason_code": "policy_review",
+            "triggered_by_kind": "participant",
+            "triggered_by_account_id": subject.account_id,
+            "source_fact_kind": "mutual_intent_acknowledgment",
+            "source_fact_id": "room-replay-coordinate",
+            "source_snapshot_json": {
+                "outer": { "a": 1, "b": 999 }
+            },
+            "fact_idempotency_key": "room-replay-coordinate"
+        }),
+    )
+    .await;
+    assert_eq!(mismatched_fact.status, StatusCode::BAD_REQUEST);
+}
+
+struct SignedInUser {
+    token: String,
+    account_id: String,
+}
+
+struct JsonResponse {
+    status: StatusCode,
+    body: Value,
+}
+
+async fn create_room(app: &Router, participant_a: &str, participant_b: &str) -> String {
+    let response = internal_post_json(
+        app,
+        "/api/internal/room-progressions",
+        json!({
+            "realm_id": "realm-room-default",
+            "participant_account_ids": [participant_a, participant_b],
+            "user_facing_reason_code": "room_created",
+            "source_fact_kind": "intent_room_request",
+            "source_fact_id": format!("room-source-{}", Uuid::new_v4()),
+            "source_snapshot_json": {},
+            "request_idempotency_key": format!("room-create-{}", Uuid::new_v4())
+        }),
+    )
+    .await;
+    assert_eq!(response.status, StatusCode::OK);
+    response.body["room_progression_id"]
+        .as_str()
+        .expect("room progression id must exist")
+        .to_owned()
+}
+
+async fn sign_in(app: &Router, pi_uid: &str, username: &str) -> SignedInUser {
+    let response = post_json(
+        app,
+        "/api/auth/pi",
+        None,
+        json!({
+            "pi_uid": pi_uid,
+            "username": username,
+            "wallet_address": format!("wallet-{pi_uid}"),
+            "access_token": format!("access-token-{pi_uid}")
+        }),
+    )
+    .await;
+    assert_eq!(response.status, StatusCode::OK);
+
+    SignedInUser {
+        token: response.body["token"]
+            .as_str()
+            .expect("token must exist")
+            .to_owned(),
+        account_id: response.body["user"]["id"]
+            .as_str()
+            .expect("user id must exist")
+            .to_owned(),
+    }
+}
+
+async fn insert_operator_account(client: &tokio_postgres::Client, role: &str) -> String {
+    let account_id = Uuid::new_v4();
+    client
+        .execute(
+            "
+            INSERT INTO core.accounts (account_id, account_class, account_state)
+            VALUES ($1, 'Controlled Exceptional Account', 'active')
+            ",
+            &[&account_id],
+        )
+        .await
+        .expect("operator account must insert");
+    client
+        .execute(
+            "
+            INSERT INTO core.operator_role_assignments (
+                operator_role_assignment_id,
+                operator_account_id,
+                operator_role,
+                grant_reason
+            )
+            VALUES ($1, $2, $3, 'room progression test role')
+            ",
+            &[&Uuid::new_v4(), &account_id, &role],
+        )
+        .await
+        .expect("operator role assignment must insert");
+    account_id.to_string()
+}
+
+async fn test_db_client() -> tokio_postgres::Client {
+    let database_url = std::env::var("MUSUBI_TEST_DATABASE_URL")
+        .or_else(|_| std::env::var("DATABASE_URL"))
+        .expect("test database url must be present");
+    let (client, connection) = tokio_postgres::connect(&database_url, tokio_postgres::NoTls)
+        .await
+        .expect("test database must be reachable");
+    tokio::spawn(async move {
+        if let Err(error) = connection.await {
+            eprintln!("test database connection error: {error}");
+        }
+    });
+    client
+}
+
+async fn operator_post_json(
+    app: &Router,
+    path: &str,
+    operator_id: &str,
+    body: Value,
+) -> JsonResponse {
+    request_json(app, "POST", path, None, Some(operator_id), Some(body)).await
+}
+
+async fn internal_post_json(app: &Router, path: &str, body: Value) -> JsonResponse {
+    request_json(app, "POST", path, None, None, Some(body)).await
+}
+
+async fn internal_post_raw_json(app: &Router, path: &str, body: &str) -> JsonResponse {
+    request_raw_json(app, "POST", path, None, None, Some(body)).await
+}
+
+async fn post_json(
+    app: &Router,
+    path: &str,
+    bearer_token: Option<&str>,
+    body: Value,
+) -> JsonResponse {
+    request_json(app, "POST", path, bearer_token, None, Some(body)).await
+}
+
+async fn get_json(app: &Router, path: &str, bearer_token: Option<&str>) -> JsonResponse {
+    request_json(app, "GET", path, bearer_token, None, None).await
+}
+
+async fn request_json(
+    app: &Router,
+    method: &str,
+    path: &str,
+    bearer_token: Option<&str>,
+    operator_id: Option<&str>,
+    body: Option<Value>,
+) -> JsonResponse {
+    let raw_body = body.map(|body| body.to_string());
+    request_raw_json(
+        app,
+        method,
+        path,
+        bearer_token,
+        operator_id,
+        raw_body.as_deref(),
+    )
+    .await
+}
+
+async fn request_raw_json(
+    app: &Router,
+    method: &str,
+    path: &str,
+    bearer_token: Option<&str>,
+    operator_id: Option<&str>,
+    body: Option<&str>,
+) -> JsonResponse {
+    let mut builder = Request::builder().method(method).uri(path);
+    if let Some(token) = bearer_token {
+        builder = builder.header("authorization", format!("Bearer {token}"));
+    }
+    if let Some(operator_id) = operator_id {
+        builder = builder.header("x-musubi-operator-id", operator_id);
+    }
+
+    let request = builder
+        .header("content-type", "application/json")
+        .body(match body {
+            Some(body) => Body::from(body.to_owned()),
+            None => Body::empty(),
+        })
+        .expect("request must build");
+
+    let response = app
+        .clone()
+        .oneshot(request)
+        .await
+        .expect("app should respond");
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body must be readable");
+    let body = if bytes.is_empty() {
+        json!({})
+    } else {
+        serde_json::from_slice(&bytes).expect("response body must be valid json")
+    };
+
+    JsonResponse { status, body }
+}

--- a/apps/backend/tests/room_progression.rs
+++ b/apps/backend/tests/room_progression.rs
@@ -214,6 +214,318 @@ async fn sealed_fallback_links_review_without_leaking_evidence_or_notes() {
 }
 
 #[tokio::test]
+async fn sealed_room_can_record_restriction_follow_up_without_reopening() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let subject = sign_in(&app, "pi-user-room-restrict-a", "room-restrict-a").await;
+    let counterparty = sign_in(&app, "pi-user-room-restrict-b", "room-restrict-b").await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+    let room_progression_id =
+        create_room(&app, &subject.account_id, &counterparty.account_id).await;
+
+    let review_case = operator_post_json(
+        &app,
+        "/api/internal/operator/review-cases",
+        &approver_id,
+        json!({
+            "case_type": "sealed_room_fallback",
+            "severity": "sev1",
+            "subject_account_id": subject.account_id,
+            "related_realm_id": "realm-room-default",
+            "opened_reason_code": "manual_hold_safety_review",
+            "source_fact_kind": "room_progression",
+            "source_fact_id": room_progression_id,
+            "source_snapshot_json": {},
+            "request_idempotency_key": "room-restrict-review"
+        }),
+    )
+    .await;
+    assert_eq!(review_case.status, StatusCode::OK);
+    let review_case_id = review_case.body["review_case_id"]
+        .as_str()
+        .expect("review case id must exist")
+        .to_owned();
+
+    let sealed = internal_post_json(
+        &app,
+        &format!("/api/internal/room-progressions/{room_progression_id}/facts"),
+        json!({
+            "transition_kind": "seal",
+            "to_stage": "sealed",
+            "user_facing_reason_code": "manual_hold_safety_review",
+            "triggered_by_kind": "system",
+            "source_fact_kind": "review_case",
+            "source_fact_id": review_case_id,
+            "source_snapshot_json": {},
+            "review_case_id": review_case_id,
+            "fact_idempotency_key": "room-restrict-sealed"
+        }),
+    )
+    .await;
+    assert_eq!(sealed.status, StatusCode::OK);
+
+    let decision = operator_post_json(
+        &app,
+        &format!("/api/internal/operator/review-cases/{review_case_id}/decisions"),
+        &approver_id,
+        json!({
+            "decision_kind": "restrict",
+            "user_facing_reason_code": "restricted_after_review",
+            "operator_note_internal": "restriction rationale is internal",
+            "decision_payload_json": {
+                "resolution": "restrict"
+            },
+            "decision_idempotency_key": "room-restrict-decision"
+        }),
+    )
+    .await;
+    assert_eq!(decision.status, StatusCode::OK);
+    let decision_fact_id = decision.body["operator_decision_fact_id"]
+        .as_str()
+        .expect("operator decision fact id must exist")
+        .to_owned();
+
+    let restricted = internal_post_json(
+        &app,
+        &format!("/api/internal/room-progressions/{room_progression_id}/facts"),
+        json!({
+            "transition_kind": "seal",
+            "to_stage": "sealed",
+            "user_facing_reason_code": "restricted_after_review",
+            "triggered_by_kind": "operator",
+            "triggered_by_account_id": approver_id,
+            "source_fact_kind": "operator_decision",
+            "source_fact_id": decision_fact_id,
+            "source_snapshot_json": {
+                "resolution": "restrict"
+            },
+            "review_case_id": review_case_id,
+            "fact_idempotency_key": "room-restrict-follow-up"
+        }),
+    )
+    .await;
+    assert_eq!(restricted.status, StatusCode::OK);
+    assert_eq!(restricted.body["from_stage"], "sealed");
+    assert_eq!(restricted.body["to_stage"], "sealed");
+    assert_eq!(restricted.body["status_code"], "sealed_restricted");
+
+    let view = get_json(
+        &app,
+        &format!("/api/projection/room-progression-views/{room_progression_id}"),
+        Some(subject.token.as_str()),
+    )
+    .await;
+    assert_eq!(view.status, StatusCode::OK);
+    assert_eq!(view.body["visible_stage"], "sealed");
+    assert_eq!(view.body["status_code"], "sealed_restricted");
+    assert_eq!(view.body["review_case_id"], review_case_id);
+}
+
+#[tokio::test]
+async fn restore_clears_review_link_from_live_room_projection() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let subject = sign_in(&app, "pi-user-room-restore-a", "room-restore-a").await;
+    let counterparty = sign_in(&app, "pi-user-room-restore-b", "room-restore-b").await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+    let room_progression_id =
+        create_room(&app, &subject.account_id, &counterparty.account_id).await;
+
+    let review_case = operator_post_json(
+        &app,
+        "/api/internal/operator/review-cases",
+        &approver_id,
+        json!({
+            "case_type": "sealed_room_fallback",
+            "severity": "sev1",
+            "subject_account_id": subject.account_id,
+            "related_realm_id": "realm-room-default",
+            "opened_reason_code": "manual_hold_safety_review",
+            "source_fact_kind": "room_progression",
+            "source_fact_id": room_progression_id,
+            "source_snapshot_json": {},
+            "request_idempotency_key": "room-restore-review"
+        }),
+    )
+    .await;
+    assert_eq!(review_case.status, StatusCode::OK);
+    let review_case_id = review_case.body["review_case_id"]
+        .as_str()
+        .expect("review case id must exist")
+        .to_owned();
+
+    let sealed = internal_post_json(
+        &app,
+        &format!("/api/internal/room-progressions/{room_progression_id}/facts"),
+        json!({
+            "transition_kind": "seal",
+            "to_stage": "sealed",
+            "user_facing_reason_code": "manual_hold_safety_review",
+            "triggered_by_kind": "system",
+            "source_fact_kind": "review_case",
+            "source_fact_id": review_case_id,
+            "source_snapshot_json": {},
+            "review_case_id": review_case_id,
+            "fact_idempotency_key": "room-restore-sealed"
+        }),
+    )
+    .await;
+    assert_eq!(sealed.status, StatusCode::OK);
+
+    let decision = operator_post_json(
+        &app,
+        &format!("/api/internal/operator/review-cases/{review_case_id}/decisions"),
+        &approver_id,
+        json!({
+            "decision_kind": "restore",
+            "user_facing_reason_code": "restored_after_review",
+            "operator_note_internal": "restore rationale is internal",
+            "decision_payload_json": {
+                "resolution": "restore"
+            },
+            "decision_idempotency_key": "room-restore-decision"
+        }),
+    )
+    .await;
+    assert_eq!(decision.status, StatusCode::OK);
+    let decision_fact_id = decision.body["operator_decision_fact_id"]
+        .as_str()
+        .expect("operator decision fact id must exist")
+        .to_owned();
+
+    let restored = internal_post_json(
+        &app,
+        &format!("/api/internal/room-progressions/{room_progression_id}/facts"),
+        json!({
+            "transition_kind": "restore",
+            "to_stage": "coordination",
+            "user_facing_reason_code": "restored_after_review",
+            "triggered_by_kind": "operator",
+            "triggered_by_account_id": approver_id,
+            "source_fact_kind": "operator_decision",
+            "source_fact_id": decision_fact_id,
+            "source_snapshot_json": {
+                "resolution": "restore"
+            },
+            "review_case_id": review_case_id,
+            "fact_idempotency_key": "room-restore-transition"
+        }),
+    )
+    .await;
+    assert_eq!(restored.status, StatusCode::OK);
+    assert_eq!(restored.body["to_stage"], "coordination");
+
+    let restored_view = get_json(
+        &app,
+        &format!("/api/projection/room-progression-views/{room_progression_id}"),
+        Some(subject.token.as_str()),
+    )
+    .await;
+    assert_eq!(restored_view.status, StatusCode::OK);
+    assert_eq!(restored_view.body["visible_stage"], "coordination");
+    assert_eq!(restored_view.body["status_code"], "coordination_open");
+    assert!(restored_view.body["review_case_id"].is_null());
+    assert_eq!(restored_view.body["review_pending"], false);
+    assert!(restored_view.body["review_status"].is_null());
+
+    let relationship = internal_post_json(
+        &app,
+        &format!("/api/internal/room-progressions/{room_progression_id}/facts"),
+        json!({
+            "transition_kind": "advance_to_relationship",
+            "to_stage": "relationship",
+            "user_facing_reason_code": "qualifying_promise_completed",
+            "triggered_by_kind": "system",
+            "source_fact_kind": "qualifying_promise_completion",
+            "source_fact_id": "room-restore-relationship",
+            "source_snapshot_json": {},
+            "fact_idempotency_key": "room-restore-relationship"
+        }),
+    )
+    .await;
+    assert_eq!(relationship.status, StatusCode::OK);
+
+    let relationship_view = get_json(
+        &app,
+        &format!("/api/projection/room-progression-views/{room_progression_id}"),
+        Some(subject.token.as_str()),
+    )
+    .await;
+    assert_eq!(relationship_view.status, StatusCode::OK);
+    assert_eq!(relationship_view.body["visible_stage"], "relationship");
+    assert_eq!(relationship_view.body["status_code"], "relationship_open");
+    assert!(relationship_view.body["review_case_id"].is_null());
+    assert!(relationship_view.body["review_status"].is_null());
+}
+
+#[tokio::test]
+async fn room_progression_create_replay_survives_participant_deactivation() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let subject = sign_in(&app, "pi-user-room-replay-active-a", "room-replay-active-a").await;
+    let counterparty = sign_in(&app, "pi-user-room-replay-active-b", "room-replay-active-b").await;
+    let client = test_db_client().await;
+
+    let created = internal_post_json(
+        &app,
+        "/api/internal/room-progressions",
+        json!({
+            "realm_id": "realm-room-replay-active",
+            "participant_account_ids": [
+                subject.account_id,
+                counterparty.account_id
+            ],
+            "user_facing_reason_code": "room_created",
+            "source_fact_kind": "intent_room_request",
+            "source_fact_id": "room-replay-active-source",
+            "source_snapshot_json": {},
+            "request_idempotency_key": "room-replay-active-create"
+        }),
+    )
+    .await;
+    assert_eq!(created.status, StatusCode::OK);
+    let room_progression_id = created.body["room_progression_id"]
+        .as_str()
+        .expect("room progression id must exist")
+        .to_owned();
+
+    client
+        .execute(
+            "
+            UPDATE core.accounts
+            SET account_state = 'suspended',
+                updated_at = CURRENT_TIMESTAMP
+            WHERE account_id::text = $1
+            ",
+            &[&counterparty.account_id],
+        )
+        .await
+        .expect("account state must update");
+
+    let replayed = internal_post_json(
+        &app,
+        "/api/internal/room-progressions",
+        json!({
+            "realm_id": "realm-room-replay-active",
+            "participant_account_ids": [
+                subject.account_id,
+                counterparty.account_id
+            ],
+            "user_facing_reason_code": "room_created",
+            "source_fact_kind": "intent_room_request",
+            "source_fact_id": "room-replay-active-source",
+            "source_snapshot_json": {},
+            "request_idempotency_key": "room-replay-active-create"
+        }),
+    )
+    .await;
+    assert_eq!(replayed.status, StatusCode::OK);
+    assert_eq!(replayed.body["room_progression_id"], room_progression_id);
+}
+
+#[tokio::test]
 async fn room_projection_rebuild_is_idempotent() {
     let test_state = new_test_state().await.expect("test database state");
     let app = build_app(test_state.state.clone());

--- a/apps/backend/tests/room_progression.rs
+++ b/apps/backend/tests/room_progression.rs
@@ -395,6 +395,212 @@ async fn restricted_seal_requires_writer_owned_restrict_decision() {
 }
 
 #[tokio::test]
+async fn live_room_seal_requires_room_scoped_review_case() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let subject = sign_in(&app, "pi-user-room-seal-scope-a", "room-seal-scope-a").await;
+    let counterparty = sign_in(&app, "pi-user-room-seal-scope-b", "room-seal-scope-b").await;
+    let outsider_subject = sign_in(&app, "pi-user-room-seal-scope-c", "room-seal-scope-c").await;
+    let client = test_db_client().await;
+    let reviewer_id = insert_operator_account(&client, "reviewer").await;
+    let room_progression_id =
+        create_room(&app, &subject.account_id, &counterparty.account_id).await;
+    let other_room_progression_id =
+        create_room(&app, &subject.account_id, &outsider_subject.account_id).await;
+
+    let missing_review_case = internal_post_json(
+        &app,
+        &format!("/api/internal/room-progressions/{room_progression_id}/facts"),
+        json!({
+            "transition_kind": "seal",
+            "to_stage": "sealed",
+            "user_facing_reason_code": "manual_hold_safety_review",
+            "triggered_by_kind": "system",
+            "source_fact_kind": "review_case",
+            "source_fact_id": "room-seal-scope-missing",
+            "source_snapshot_json": {},
+            "fact_idempotency_key": "room-seal-scope-missing"
+        }),
+    )
+    .await;
+    assert_eq!(missing_review_case.status, StatusCode::BAD_REQUEST);
+
+    let unrelated_review_case = operator_post_json(
+        &app,
+        "/api/internal/operator/review-cases",
+        &reviewer_id,
+        json!({
+            "case_type": "sealed_room_fallback",
+            "severity": "sev1",
+            "subject_account_id": subject.account_id,
+            "related_realm_id": "realm-room-default",
+            "opened_reason_code": "manual_hold_safety_review",
+            "source_fact_kind": "room_progression",
+            "source_fact_id": other_room_progression_id,
+            "source_snapshot_json": {},
+            "request_idempotency_key": "room-seal-scope-unrelated"
+        }),
+    )
+    .await;
+    assert_eq!(unrelated_review_case.status, StatusCode::OK);
+    let unrelated_review_case_id = unrelated_review_case.body["review_case_id"]
+        .as_str()
+        .expect("review case id must exist")
+        .to_owned();
+
+    let wrong_scope = internal_post_json(
+        &app,
+        &format!("/api/internal/room-progressions/{room_progression_id}/facts"),
+        json!({
+            "transition_kind": "seal",
+            "to_stage": "sealed",
+            "user_facing_reason_code": "manual_hold_safety_review",
+            "triggered_by_kind": "system",
+            "source_fact_kind": "review_case",
+            "source_fact_id": unrelated_review_case_id,
+            "source_snapshot_json": {},
+            "review_case_id": unrelated_review_case_id,
+            "fact_idempotency_key": "room-seal-scope-wrong"
+        }),
+    )
+    .await;
+    assert_eq!(wrong_scope.status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn system_triggered_facts_reject_triggered_by_account_id() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let subject = sign_in(&app, "pi-user-room-system-actor-a", "room-system-actor-a").await;
+    let counterparty = sign_in(&app, "pi-user-room-system-actor-b", "room-system-actor-b").await;
+    let room_progression_id =
+        create_room(&app, &subject.account_id, &counterparty.account_id).await;
+
+    let invalid = internal_post_json(
+        &app,
+        &format!("/api/internal/room-progressions/{room_progression_id}/facts"),
+        json!({
+            "transition_kind": "advance_to_coordination",
+            "to_stage": "coordination",
+            "user_facing_reason_code": "mutual_intent_acknowledged",
+            "triggered_by_kind": "system",
+            "triggered_by_account_id": subject.account_id,
+            "source_fact_kind": "mutual_intent_acknowledgment",
+            "source_fact_id": "room-system-actor-invalid",
+            "source_snapshot_json": {},
+            "fact_idempotency_key": "room-system-actor-invalid"
+        }),
+    )
+    .await;
+    assert_eq!(invalid.status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn sealed_room_cannot_rebind_review_case_on_follow_up_fact() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let subject = sign_in(&app, "pi-user-room-rebind-a", "room-rebind-a").await;
+    let counterparty = sign_in(&app, "pi-user-room-rebind-b", "room-rebind-b").await;
+    let client = test_db_client().await;
+    let reviewer_id = insert_operator_account(&client, "reviewer").await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+    let room_progression_id =
+        create_room(&app, &subject.account_id, &counterparty.account_id).await;
+
+    let review_case_a = operator_post_json(
+        &app,
+        "/api/internal/operator/review-cases",
+        &reviewer_id,
+        json!({
+            "case_type": "sealed_room_fallback",
+            "severity": "sev1",
+            "subject_account_id": subject.account_id,
+            "related_realm_id": "realm-room-default",
+            "opened_reason_code": "manual_hold_safety_review",
+            "source_fact_kind": "room_progression",
+            "source_fact_id": room_progression_id,
+            "source_snapshot_json": {},
+            "request_idempotency_key": "room-rebind-review-a"
+        }),
+    )
+    .await;
+    assert_eq!(review_case_a.status, StatusCode::OK);
+    let review_case_a_id = review_case_a.body["review_case_id"]
+        .as_str()
+        .expect("review case id must exist")
+        .to_owned();
+
+    let sealed = internal_post_json(
+        &app,
+        &format!("/api/internal/room-progressions/{room_progression_id}/facts"),
+        json!({
+            "transition_kind": "seal",
+            "to_stage": "sealed",
+            "user_facing_reason_code": "manual_hold_safety_review",
+            "triggered_by_kind": "system",
+            "source_fact_kind": "review_case",
+            "source_fact_id": review_case_a_id,
+            "source_snapshot_json": {},
+            "review_case_id": review_case_a_id,
+            "fact_idempotency_key": "room-rebind-sealed"
+        }),
+    )
+    .await;
+    assert_eq!(sealed.status, StatusCode::OK);
+
+    let review_case_b = operator_post_json(
+        &app,
+        "/api/internal/operator/review-cases",
+        &reviewer_id,
+        json!({
+            "case_type": "sealed_room_fallback",
+            "severity": "sev1",
+            "subject_account_id": subject.account_id,
+            "related_realm_id": "realm-room-default",
+            "opened_reason_code": "manual_hold_safety_review",
+            "source_fact_kind": "room_progression",
+            "source_fact_id": room_progression_id,
+            "source_snapshot_json": {},
+            "request_idempotency_key": "room-rebind-review-b"
+        }),
+    )
+    .await;
+    assert_eq!(review_case_b.status, StatusCode::OK);
+    let review_case_b_id = review_case_b.body["review_case_id"]
+        .as_str()
+        .expect("review case id must exist")
+        .to_owned();
+
+    let rebind_attempt = internal_post_json(
+        &app,
+        &format!("/api/internal/room-progressions/{room_progression_id}/facts"),
+        json!({
+            "transition_kind": "seal",
+            "to_stage": "sealed",
+            "user_facing_reason_code": "manual_hold_safety_review",
+            "triggered_by_kind": "operator",
+            "triggered_by_account_id": approver_id,
+            "source_fact_kind": "review_case",
+            "source_fact_id": review_case_b_id,
+            "source_snapshot_json": {},
+            "review_case_id": review_case_b_id,
+            "fact_idempotency_key": "room-rebind-attempt"
+        }),
+    )
+    .await;
+    assert_eq!(rebind_attempt.status, StatusCode::BAD_REQUEST);
+
+    let view = get_json(
+        &app,
+        &format!("/api/projection/room-progression-views/{room_progression_id}"),
+        Some(subject.token.as_str()),
+    )
+    .await;
+    assert_eq!(view.status, StatusCode::OK);
+    assert_eq!(view.body["review_case_id"], review_case_a_id);
+}
+
+#[tokio::test]
 async fn operator_triggered_facts_require_operator_role_assignment() {
     let test_state = new_test_state().await.expect("test database state");
     let app = build_app(test_state.state.clone());

--- a/apps/backend/tests/room_progression.rs
+++ b/apps/backend/tests/room_progression.rs
@@ -596,6 +596,129 @@ async fn restricted_seal_rejects_participant_actor() {
 }
 
 #[tokio::test]
+async fn restricted_seal_cannot_downgrade_via_seal_follow_up() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let subject = sign_in(
+        &app,
+        "pi-user-room-restrict-downgrade-a",
+        "room-restrict-downgrade-a",
+    )
+    .await;
+    let counterparty = sign_in(
+        &app,
+        "pi-user-room-restrict-downgrade-b",
+        "room-restrict-downgrade-b",
+    )
+    .await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+    let room_progression_id =
+        create_room(&app, &subject.account_id, &counterparty.account_id).await;
+
+    let review_case = operator_post_json(
+        &app,
+        "/api/internal/operator/review-cases",
+        &approver_id,
+        json!({
+            "case_type": "sealed_room_fallback",
+            "severity": "sev1",
+            "subject_account_id": subject.account_id,
+            "related_realm_id": "realm-room-default",
+            "opened_reason_code": "manual_hold_safety_review",
+            "source_fact_kind": "room_progression",
+            "source_fact_id": room_progression_id,
+            "source_snapshot_json": {},
+            "request_idempotency_key": "room-restrict-downgrade-review"
+        }),
+    )
+    .await;
+    assert_eq!(review_case.status, StatusCode::OK);
+    let review_case_id = review_case.body["review_case_id"]
+        .as_str()
+        .expect("review case id must exist")
+        .to_owned();
+
+    let sealed = internal_post_json(
+        &app,
+        &format!("/api/internal/room-progressions/{room_progression_id}/facts"),
+        json!({
+            "transition_kind": "seal",
+            "to_stage": "sealed",
+            "user_facing_reason_code": "manual_hold_safety_review",
+            "triggered_by_kind": "system",
+            "source_fact_kind": "review_case",
+            "source_fact_id": review_case_id,
+            "source_snapshot_json": {},
+            "review_case_id": review_case_id,
+            "fact_idempotency_key": "room-restrict-downgrade-sealed"
+        }),
+    )
+    .await;
+    assert_eq!(sealed.status, StatusCode::OK);
+
+    let decision = operator_post_json(
+        &app,
+        &format!("/api/internal/operator/review-cases/{review_case_id}/decisions"),
+        &approver_id,
+        json!({
+            "decision_kind": "restrict",
+            "user_facing_reason_code": "restricted_after_review",
+            "operator_note_internal": "restriction rationale is internal",
+            "decision_payload_json": {
+                "resolution": "restrict"
+            },
+            "decision_idempotency_key": "room-restrict-downgrade-decision"
+        }),
+    )
+    .await;
+    assert_eq!(decision.status, StatusCode::OK);
+    let decision_fact_id = decision.body["operator_decision_fact_id"]
+        .as_str()
+        .expect("operator decision fact id must exist")
+        .to_owned();
+
+    let restricted = internal_post_json(
+        &app,
+        &format!("/api/internal/room-progressions/{room_progression_id}/facts"),
+        json!({
+            "transition_kind": "seal",
+            "to_stage": "sealed",
+            "user_facing_reason_code": "restricted_after_review",
+            "triggered_by_kind": "operator",
+            "triggered_by_account_id": approver_id,
+            "source_fact_kind": "operator_decision",
+            "source_fact_id": decision_fact_id,
+            "source_snapshot_json": {
+                "resolution": "restrict"
+            },
+            "review_case_id": review_case_id,
+            "fact_idempotency_key": "room-restrict-downgrade-follow-up"
+        }),
+    )
+    .await;
+    assert_eq!(restricted.status, StatusCode::OK);
+
+    let downgrade_attempt = internal_post_json(
+        &app,
+        &format!("/api/internal/room-progressions/{room_progression_id}/facts"),
+        json!({
+            "transition_kind": "seal",
+            "to_stage": "sealed",
+            "user_facing_reason_code": "manual_hold_safety_review",
+            "triggered_by_kind": "participant",
+            "triggered_by_account_id": subject.account_id,
+            "source_fact_kind": "participant_retry",
+            "source_fact_id": "room-restrict-downgrade-attempt",
+            "source_snapshot_json": {},
+            "fact_idempotency_key": "room-restrict-downgrade-attempt"
+        }),
+    )
+    .await;
+    assert_eq!(downgrade_attempt.status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
 async fn fact_append_requires_idempotency_key() {
     let test_state = new_test_state().await.expect("test database state");
     let app = build_app(test_state.state.clone());
@@ -1534,6 +1657,53 @@ async fn room_progression_idempotency_uses_canonical_payload_hashes() {
     assert_eq!(replayed.status, StatusCode::OK);
     assert_eq!(replayed.body["room_progression_id"], room_progression_id);
 
+    let omitted_snapshot_create_body = format!(
+        r#"{{
+            "realm_id": "realm-room-replay-missing",
+            "participant_account_ids": ["{subject_id}", "{counterparty_id}"],
+            "user_facing_reason_code": "room_created",
+            "source_fact_kind": "intent_room_request",
+            "source_fact_id": "room-replay-missing-source",
+            "request_idempotency_key": "room-replay-missing-create"
+        }}"#,
+        subject_id = subject.account_id,
+        counterparty_id = counterparty.account_id
+    );
+    let omitted_created = internal_post_raw_json(
+        &app,
+        "/api/internal/room-progressions",
+        &omitted_snapshot_create_body,
+    )
+    .await;
+    assert_eq!(omitted_created.status, StatusCode::OK);
+    let omitted_room_progression_id = omitted_created.body["room_progression_id"]
+        .as_str()
+        .expect("room progression id must exist")
+        .to_owned();
+
+    let explicit_empty_create = internal_post_json(
+        &app,
+        "/api/internal/room-progressions",
+        json!({
+            "realm_id": "realm-room-replay-missing",
+            "participant_account_ids": [
+                subject.account_id,
+                counterparty.account_id
+            ],
+            "user_facing_reason_code": "room_created",
+            "source_fact_kind": "intent_room_request",
+            "source_fact_id": "room-replay-missing-source",
+            "source_snapshot_json": {},
+            "request_idempotency_key": "room-replay-missing-create"
+        }),
+    )
+    .await;
+    assert_eq!(explicit_empty_create.status, StatusCode::OK);
+    assert_eq!(
+        explicit_empty_create.body["room_progression_id"],
+        omitted_room_progression_id
+    );
+
     let mismatched = internal_post_json(
         &app,
         "/api/internal/room-progressions",
@@ -1597,6 +1767,53 @@ async fn room_progression_idempotency_uses_canonical_payload_hashes() {
     .await;
     assert_eq!(replay_fact.status, StatusCode::OK);
     assert_eq!(replay_fact.body["room_progression_fact_id"], fact_id);
+
+    let omitted_snapshot_fact_body = format!(
+        r#"{{
+            "transition_kind": "advance_to_coordination",
+            "to_stage": "coordination",
+            "user_facing_reason_code": "mutual_intent_acknowledged",
+            "triggered_by_kind": "participant",
+            "triggered_by_account_id": "{subject_id}",
+            "source_fact_kind": "mutual_intent_acknowledgment",
+            "source_fact_id": "room-replay-coordinate-missing",
+            "fact_idempotency_key": "room-replay-coordinate-missing"
+        }}"#,
+        subject_id = subject.account_id
+    );
+    let omitted_fact = internal_post_raw_json(
+        &app,
+        &format!("/api/internal/room-progressions/{omitted_room_progression_id}/facts"),
+        &omitted_snapshot_fact_body,
+    )
+    .await;
+    assert_eq!(omitted_fact.status, StatusCode::OK);
+    let omitted_fact_id = omitted_fact.body["room_progression_fact_id"]
+        .as_str()
+        .expect("fact id must exist")
+        .to_owned();
+
+    let explicit_empty_fact = internal_post_json(
+        &app,
+        &format!("/api/internal/room-progressions/{omitted_room_progression_id}/facts"),
+        json!({
+            "transition_kind": "advance_to_coordination",
+            "to_stage": "coordination",
+            "user_facing_reason_code": "mutual_intent_acknowledged",
+            "triggered_by_kind": "participant",
+            "triggered_by_account_id": subject.account_id,
+            "source_fact_kind": "mutual_intent_acknowledgment",
+            "source_fact_id": "room-replay-coordinate-missing",
+            "source_snapshot_json": {},
+            "fact_idempotency_key": "room-replay-coordinate-missing"
+        }),
+    )
+    .await;
+    assert_eq!(explicit_empty_fact.status, StatusCode::OK);
+    assert_eq!(
+        explicit_empty_fact.body["room_progression_fact_id"],
+        omitted_fact_id
+    );
 
     let mismatched_fact = internal_post_json(
         &app,

--- a/apps/backend/tests/room_progression.rs
+++ b/apps/backend/tests/room_progression.rs
@@ -1,10 +1,10 @@
 use axum::{
-    body::{to_bytes, Body},
-    http::{Request, StatusCode},
     Router,
+    body::{Body, to_bytes},
+    http::{Request, StatusCode},
 };
 use musubi_backend::{build_app, new_test_state};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use tower::ServiceExt;
 use uuid::Uuid;
 
@@ -639,6 +639,24 @@ async fn restore_clears_review_link_from_live_room_projection() {
     let room_progression_id =
         create_room(&app, &subject.account_id, &counterparty.account_id).await;
 
+    let coordination = internal_post_json(
+        &app,
+        &format!("/api/internal/room-progressions/{room_progression_id}/facts"),
+        json!({
+            "transition_kind": "advance_to_coordination",
+            "to_stage": "coordination",
+            "user_facing_reason_code": "mutual_intent_acknowledged",
+            "triggered_by_kind": "participant",
+            "triggered_by_account_id": subject.account_id,
+            "source_fact_kind": "mutual_intent_acknowledgment",
+            "source_fact_id": "room-restore-coordinate",
+            "source_snapshot_json": {},
+            "fact_idempotency_key": "room-restore-coordinate"
+        }),
+    )
+    .await;
+    assert_eq!(coordination.status, StatusCode::OK);
+
     let review_case = operator_post_json(
         &app,
         "/api/internal/operator/review-cases",
@@ -764,6 +782,196 @@ async fn restore_clears_review_link_from_live_room_projection() {
     assert_eq!(relationship_view.body["status_code"], "relationship_open");
     assert!(relationship_view.body["review_case_id"].is_null());
     assert!(relationship_view.body["review_status"].is_null());
+}
+
+#[tokio::test]
+async fn restore_rejects_non_operator_actor() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let subject = sign_in(&app, "pi-user-room-restore-actor-a", "room-restore-actor-a").await;
+    let counterparty = sign_in(&app, "pi-user-room-restore-actor-b", "room-restore-actor-b").await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+    let room_progression_id =
+        create_room(&app, &subject.account_id, &counterparty.account_id).await;
+
+    let review_case = operator_post_json(
+        &app,
+        "/api/internal/operator/review-cases",
+        &approver_id,
+        json!({
+            "case_type": "sealed_room_fallback",
+            "severity": "sev1",
+            "subject_account_id": subject.account_id,
+            "related_realm_id": "realm-room-default",
+            "opened_reason_code": "manual_hold_safety_review",
+            "source_fact_kind": "room_progression",
+            "source_fact_id": room_progression_id,
+            "source_snapshot_json": {},
+            "request_idempotency_key": "room-restore-actor-review"
+        }),
+    )
+    .await;
+    assert_eq!(review_case.status, StatusCode::OK);
+    let review_case_id = review_case.body["review_case_id"]
+        .as_str()
+        .expect("review case id must exist")
+        .to_owned();
+
+    let sealed = internal_post_json(
+        &app,
+        &format!("/api/internal/room-progressions/{room_progression_id}/facts"),
+        json!({
+            "transition_kind": "seal",
+            "to_stage": "sealed",
+            "user_facing_reason_code": "manual_hold_safety_review",
+            "triggered_by_kind": "system",
+            "source_fact_kind": "review_case",
+            "source_fact_id": review_case_id,
+            "source_snapshot_json": {},
+            "review_case_id": review_case_id,
+            "fact_idempotency_key": "room-restore-actor-sealed"
+        }),
+    )
+    .await;
+    assert_eq!(sealed.status, StatusCode::OK);
+
+    let decision = operator_post_json(
+        &app,
+        &format!("/api/internal/operator/review-cases/{review_case_id}/decisions"),
+        &approver_id,
+        json!({
+            "decision_kind": "restore",
+            "user_facing_reason_code": "restored_after_review",
+            "operator_note_internal": "restore rationale is internal",
+            "decision_payload_json": {
+                "resolution": "restore"
+            },
+            "decision_idempotency_key": "room-restore-actor-decision"
+        }),
+    )
+    .await;
+    assert_eq!(decision.status, StatusCode::OK);
+    let decision_fact_id = decision.body["operator_decision_fact_id"]
+        .as_str()
+        .expect("operator decision fact id must exist")
+        .to_owned();
+
+    let restored = internal_post_json(
+        &app,
+        &format!("/api/internal/room-progressions/{room_progression_id}/facts"),
+        json!({
+            "transition_kind": "restore",
+            "to_stage": "intent",
+            "user_facing_reason_code": "restored_after_review",
+            "triggered_by_kind": "participant",
+            "triggered_by_account_id": subject.account_id,
+            "source_fact_kind": "operator_decision",
+            "source_fact_id": decision_fact_id,
+            "source_snapshot_json": {
+                "resolution": "restore"
+            },
+            "review_case_id": review_case_id,
+            "fact_idempotency_key": "room-restore-actor-transition"
+        }),
+    )
+    .await;
+    assert_eq!(restored.status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn restore_must_return_to_stage_before_current_seal() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let subject = sign_in(&app, "pi-user-room-restore-stage-a", "room-restore-stage-a").await;
+    let counterparty = sign_in(&app, "pi-user-room-restore-stage-b", "room-restore-stage-b").await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+    let room_progression_id =
+        create_room(&app, &subject.account_id, &counterparty.account_id).await;
+
+    let review_case = operator_post_json(
+        &app,
+        "/api/internal/operator/review-cases",
+        &approver_id,
+        json!({
+            "case_type": "sealed_room_fallback",
+            "severity": "sev1",
+            "subject_account_id": subject.account_id,
+            "related_realm_id": "realm-room-default",
+            "opened_reason_code": "manual_hold_safety_review",
+            "source_fact_kind": "room_progression",
+            "source_fact_id": room_progression_id,
+            "source_snapshot_json": {},
+            "request_idempotency_key": "room-restore-stage-review"
+        }),
+    )
+    .await;
+    assert_eq!(review_case.status, StatusCode::OK);
+    let review_case_id = review_case.body["review_case_id"]
+        .as_str()
+        .expect("review case id must exist")
+        .to_owned();
+
+    let sealed = internal_post_json(
+        &app,
+        &format!("/api/internal/room-progressions/{room_progression_id}/facts"),
+        json!({
+            "transition_kind": "seal",
+            "to_stage": "sealed",
+            "user_facing_reason_code": "manual_hold_safety_review",
+            "triggered_by_kind": "system",
+            "source_fact_kind": "review_case",
+            "source_fact_id": review_case_id,
+            "source_snapshot_json": {},
+            "review_case_id": review_case_id,
+            "fact_idempotency_key": "room-restore-stage-sealed"
+        }),
+    )
+    .await;
+    assert_eq!(sealed.status, StatusCode::OK);
+
+    let decision = operator_post_json(
+        &app,
+        &format!("/api/internal/operator/review-cases/{review_case_id}/decisions"),
+        &approver_id,
+        json!({
+            "decision_kind": "restore",
+            "user_facing_reason_code": "restored_after_review",
+            "operator_note_internal": "restore rationale is internal",
+            "decision_payload_json": {
+                "resolution": "restore"
+            },
+            "decision_idempotency_key": "room-restore-stage-decision"
+        }),
+    )
+    .await;
+    assert_eq!(decision.status, StatusCode::OK);
+    let decision_fact_id = decision.body["operator_decision_fact_id"]
+        .as_str()
+        .expect("operator decision fact id must exist")
+        .to_owned();
+
+    let restored = internal_post_json(
+        &app,
+        &format!("/api/internal/room-progressions/{room_progression_id}/facts"),
+        json!({
+            "transition_kind": "restore",
+            "to_stage": "relationship",
+            "user_facing_reason_code": "restored_after_review",
+            "triggered_by_kind": "operator",
+            "triggered_by_account_id": approver_id,
+            "source_fact_kind": "operator_decision",
+            "source_fact_id": decision_fact_id,
+            "source_snapshot_json": {
+                "resolution": "restore"
+            },
+            "review_case_id": review_case_id,
+            "fact_idempotency_key": "room-restore-stage-transition"
+        }),
+    )
+    .await;
+    assert_eq!(restored.status, StatusCode::BAD_REQUEST);
 }
 
 #[tokio::test]

--- a/apps/backend/tests/room_progression.rs
+++ b/apps/backend/tests/room_progression.rs
@@ -1,10 +1,10 @@
 use axum::{
-    Router,
-    body::{Body, to_bytes},
+    body::{to_bytes, Body},
     http::{Request, StatusCode},
+    Router,
 };
 use musubi_backend::{build_app, new_test_state};
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 use tower::ServiceExt;
 use uuid::Uuid;
 
@@ -108,6 +108,21 @@ async fn room_progression_follows_normal_path_and_keeps_view_private() {
     assert!(!view.body.to_string().contains("must not leak"));
     assert!(view.body.get("source_snapshot_json").is_none());
     assert!(view.body.get("triggered_by_account_id").is_none());
+}
+
+#[tokio::test]
+async fn room_progression_view_treats_invalid_id_as_not_found() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let subject = sign_in(&app, "pi-user-room-invalid-view-a", "room-invalid-view-a").await;
+
+    let response = get_json(
+        &app,
+        "/api/projection/room-progression-views/not-a-uuid",
+        Some(subject.token.as_str()),
+    )
+    .await;
+    assert_eq!(response.status, StatusCode::NOT_FOUND);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Implements the backend baseline for design ISSUE-13: room progression surface.

Design source: `ISSUE-13-room-progression.md`

Note: this is design ISSUE-13, not GitHub issue #13. The GitHub issue number is intentionally not hardcoded.

This adds a bounded room progression state surface for:

- Intent Room
- Coordination Room
- Relationship Room
- Sealed Room fallback

The implementation builds on the completed ISSUE-12 operator review / appeal / evidence workflow. It does not reimplement ISSUE-12 and does not implement ISSUE-14 Promise UI.

## What changed

- Added forward-only migrations:
  - `apps/backend/migrations/0016_room_progression_surface.sql`
  - `apps/backend/migrations/0017_room_progression_actor_consistency.sql`
- Added writer-owned room progression tables:
  - `dao.room_progression_tracks`
  - `dao.room_progression_facts`
- Added participant-facing projection:
  - `projection.room_progression_views`
- Added room progression service/domain layer:
  - `apps/backend/src/services/room_progression/mod.rs`
  - `apps/backend/src/services/room_progression/repository.rs`
  - `apps/backend/src/services/room_progression/types.rs`
- Added handlers/routes:
  - `POST /api/internal/room-progressions`
  - `POST /api/internal/room-progressions/{room_progression_id}/facts`
  - `POST /api/internal/projection/room-progressions/rebuild`
  - `GET /api/projection/room-progression-views/{room_progression_id}`
- Added integration tests:
  - `apps/backend/tests/room_progression.rs`
- Added/updated docs:
  - `apps/backend/docs/room_progression_surface.md`
  - `apps/backend/docs/schema_skeleton.md`
  - `apps/backend/README.md`

## Behavior

- Supports normal room progression:

```text
intent -> coordination -> relationship
```

- Rejects invalid/skipped transitions.
- Supports sealed fallback from visible room stages.
- Allows sealed fallback to link to ISSUE-12 review cases.
- Keeps review/evidence/appeal storage in ISSUE-12 tables.
- Keeps room progression facts append-only.
- Keeps user-facing room progression state in a derived projection.
- Keeps state-changing restore/progression decisions on writer-owned facts, not projection truth.
- Requires restore `review_case_id` to match the room's current linked review case.
- Uses durable idempotency keys and canonical JSON payload hashes.
- Replays the same semantic payload for the same idempotency key.
- Rejects payload drift for reused idempotency keys, including room progression facts.

## Privacy / safety boundary

The participant-facing projection exposes only bounded, calm fields such as:

- room progression id
- realm id
- visible stage
- status code
- user-facing reason code
- safe review posture
- projection freshness metadata

It does not expose:

- raw evidence locators
- internal operator notes
- operator identities
- raw source snapshots
- decision payload internals
- internal safety classifications

## ISSUE-12 integration

ISSUE-12 remains the source of truth for:

- review cases
- appeal cases
- evidence bundles
- evidence access grants
- operator role grants
- append-only operator decision facts
- user-facing review status projection

ISSUE-13 consumes that foundation for room progression and sealed fallback. It does not duplicate the ISSUE-12 review/evidence workflow.

## Out of scope

This PR does not implement:

- ISSUE-14 Promise creation / completion UI
- Flutter/mobile UI
- settlement UI
- proof persistence
- raw evidence retrieval endpoints
- full dispute center UI
- broad operator console product work
- recommendation/ranking/swiping/engagement-loop behavior
- DM unlock behavior

## Validation

Passed:

- `make ENV_FILE=.env.example db-bootstrap`
- `make ENV_FILE=.env.example db-migrate`
- `make ENV_FILE=.env.example db-status`
- `cargo check`
- `cargo test --test room_progression --no-fail-fast`
- `cargo test --no-fail-fast`
- `git diff --check`
- `git diff --cached --check`

`db-status` reported:

- applied 17
- pending 0
- checksum drift 0

Known unrelated formatting note:

`cargo fmt --check` still fails only on pre-existing unrelated formatting differences in:

- `apps/backend/src/handlers/orchestration.rs`
- `apps/backend/src/services/operator_review/repository.rs`
- `apps/backend/tests/operator_review.rs`

Those files are not part of this PR's intended scope.

