### PR TITLE
feat(promise): implement ISSUE-14 Promise creation / completion UI baseline

### DIFF
--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -16,4 +16,9 @@ when those projections are available. The completion area is informational only:
 it does not claim completion from a local button, and it does not mutate trust,
 settlement, room progression, reward, ranking, or unlock state.
 
+The current discovery cards remain static demo fixtures. When API repositories
+are enabled, Promise creation only succeeds if the referenced counterparty
+account already exists in the backend database; otherwise the UI shows bounded
+unavailable copy instead of inventing Promise truth on the client.
+
 See `docs/promise_ui_baseline.md` for the ISSUE-14 boundary.

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -1,3 +1,19 @@
 # musubi_mobile
 
-Flutter Web client for the Pi deposit matching PoC.
+Flutter Web client for the Pi-first MUSUBI Day 1 surface.
+
+## Promise UI baseline
+
+Design source: ISSUE-14-promise-ui-baseline.md
+
+The match detail screen now creates a Promise through the backend writer-owned
+`POST /api/promise/intents` API when API repositories are enabled. The previous
+local payment/deposit success stub is no longer treated as Promise creation.
+
+After creation, the app routes to `/promises/:promiseIntentId` and displays
+participant-safe Promise / settlement / proof status from projection endpoints
+when those projections are available. The completion area is informational only:
+it does not claim completion from a local button, and it does not mutate trust,
+settlement, room progression, reward, ranking, or unlock state.
+
+See `docs/promise_ui_baseline.md` for the ISSUE-14 boundary.

--- a/apps/mobile/docs/promise_ui_baseline.md
+++ b/apps/mobile/docs/promise_ui_baseline.md
@@ -1,0 +1,54 @@
+# Promise UI Baseline
+
+Design source: ISSUE-14-promise-ui-baseline.md
+
+The GitHub issue number is intentionally not hardcoded. The design source number is a product/design reference, not a repository issue identifier.
+
+ISSUE-14 adds the first participant-facing Promise creation and status surface for the current Flutter Web app. It builds on the accepted ISSUE-12 review/evidence baseline and the accepted ISSUE-13 room progression baseline. It does not reimplement either surface.
+
+## Boundary
+
+Promise creation uses the backend writer-owned API:
+
+- `POST /api/promise/intents`
+
+The mobile app does not create local Promise truth. The match detail screen keeps a stable idempotency key for the current participant action, so retrying the same button action can replay safely without claiming a duplicate success.
+
+The Promise status screen reads participant-safe projection endpoints when available:
+
+- `GET /api/projection/promise-views/{promise_intent_id}`
+- `GET /api/projection/settlement-views/{settlement_case_id}/expanded`
+
+Projection rows are display data only. The UI must not use projection state to make writer-owned decisions.
+
+## Completion Posture
+
+The completion/proof area is intentionally informational in this baseline. It does not expose a local "complete Promise" mutation and does not update trust, settlement, room progression, reward, ranking, or unlock state.
+
+If proof status is unavailable, the UI says so directly. When a future writer-owned proof/completion endpoint exists, this screen can link to it without changing the current boundary.
+
+## Privacy
+
+Participant-facing UI models intentionally omit:
+
+- raw evidence locators
+- operator IDs
+- internal operator notes
+- review source fact IDs
+- raw source snapshots
+- decision payload internals
+- sealed fallback internals
+
+ISSUE-12 review and evidence internals remain behind the operator/review boundary. ISSUE-13 room progression remains a safe projection consumer only.
+
+## Deferred
+
+This baseline does not implement:
+
+- Promise confirm / complete / reflect writer mutations
+- proof persistence
+- room progression writer changes
+- raw evidence retrieval
+- dispute center UI
+- ranking, leaderboard, recommendation boost, swiping changes, or DM unlock behavior
+- native mobile platform work

--- a/apps/mobile/docs/promise_ui_baseline.md
+++ b/apps/mobile/docs/promise_ui_baseline.md
@@ -21,6 +21,12 @@ The Promise status screen reads participant-safe projection endpoints when avail
 
 Projection rows are display data only. The UI must not use projection state to make writer-owned decisions.
 
+The current discovery cards are still static demo fixtures, not writer-owned
+match truth. In API mode, Promise creation only succeeds when the referenced
+counterparty account already exists in the backend writer DB. If that setup is
+missing, the UI must show calm unavailable copy instead of fabricating Promise
+truth client-side.
+
 ## Completion Posture
 
 The completion/proof area is intentionally informational in this baseline. It does not expose a local "complete Promise" mutation and does not update trust, settlement, room progression, reward, ranking, or unlock state.

--- a/apps/mobile/lib/app/router.dart
+++ b/apps/mobile/lib/app/router.dart
@@ -4,6 +4,7 @@ import 'package:musubi_mobile/core/riverpod_compat.dart';
 import '../features/auth/presentation/pi_sign_in_screen.dart';
 import '../features/home/presentation/home_screen.dart';
 import '../features/home/presentation/match_detail_screen.dart';
+import '../features/promise/presentation/promise_status_screen.dart';
 import '../repositories/auth/auth_session_controller.dart';
 
 final goRouterProvider = Provider<GoRouter>((ref) {
@@ -15,7 +16,9 @@ final goRouterProvider = Provider<GoRouter>((ref) {
     redirect: (_, state) {
       final path = state.uri.path;
       final isSignInRoute = path == '/sign-in';
-      final isHomeFlow = path == '/home' || path.startsWith('/detail/');
+      final isHomeFlow = path == '/home' ||
+          path.startsWith('/detail/') ||
+          path.startsWith('/promises/');
 
       if (authAsync.isLoading) {
         return isSignInRoute ? null : '/sign-in';
@@ -46,6 +49,17 @@ final goRouterProvider = Provider<GoRouter>((ref) {
         builder: (context, state) => MatchDetailScreen(
           profileId: state.pathParameters['profileId'] ?? '',
         ),
+      ),
+      GoRoute(
+        path: '/promises/:promiseIntentId',
+        builder: (context, state) {
+          final replayed = state.uri.queryParameters['replayed'] == 'true';
+          return PromiseStatusScreen(
+            promiseIntentId: state.pathParameters['promiseIntentId'] ?? '',
+            settlementCaseId: state.uri.queryParameters['settlementCaseId'],
+            replayedIntent: replayed,
+          );
+        },
       ),
     ],
   );

--- a/apps/mobile/lib/features/home/models/demo_match_profile.dart
+++ b/apps/mobile/lib/features/home/models/demo_match_profile.dart
@@ -2,76 +2,106 @@ class DemoMatchProfile {
   const DemoMatchProfile({
     required this.id,
     required this.piUid,
+    required this.counterpartyAccountId,
     required this.name,
     required this.age,
     required this.city,
+    required this.realmId,
     required this.photoUrl,
     required this.headline,
     required this.bio,
     required this.hobbies,
     required this.intent,
+    required this.promisePurpose,
+    required this.promiseTimeWindow,
+    required this.promiseVenueSummary,
   });
 
   final String id;
   final String piUid;
+  final String counterpartyAccountId;
   final String name;
   final int age;
   final String city;
+  final String realmId;
   final String photoUrl;
   final String headline;
   final String bio;
   final List<String> hobbies;
   final String intent;
+  final String promisePurpose;
+  final String promiseTimeWindow;
+  final String promiseVenueSummary;
 }
 
 const demoMatchProfiles = <DemoMatchProfile>[
   DemoMatchProfile(
     id: 'mai',
     piUid: 'pi-mai-serious-01',
+    counterpartyAccountId: '10000000-0000-4000-8000-000000000001',
     name: 'Mai',
     age: 27,
     city: 'Tokyo',
+    realmId: 'realm-tokyo-day1',
     photoUrl: 'https://i.pravatar.cc/900?img=47',
     headline: '静かな夜に、ちゃんと会話できる人が好き。',
     bio: '平日はプロダクトデザイナー。休日は小さな喫茶店と、散歩の延長みたいなデートが理想です。',
     hobbies: ['Coffee', 'Gallery', 'Morning Walk'],
     intent: '2週間以内に実際に会える人だけ探しています。',
+    promisePurpose: '短いお茶の時間を、落ち着いて作る',
+    promiseTimeWindow: '今週末 夕方以降',
+    promiseVenueSummary: 'Tokyo の静かな喫茶店',
   ),
   DemoMatchProfile(
     id: 'ren',
     piUid: 'pi-ren-serious-02',
+    counterpartyAccountId: '10000000-0000-4000-8000-000000000002',
     name: 'Ren',
     age: 30,
     city: 'Yokohama',
+    realmId: 'realm-yokohama-day1',
     photoUrl: 'https://i.pravatar.cc/900?img=12',
     headline: '会う前に、礼儀とテンポが合うかを大事にしたい。',
     bio: '営業帰りに海沿いを歩くのが習慣。軽いやり取りより、短くても温度のある会話が好きです。',
     hobbies: ['Seaside', 'Wine', 'Architecture'],
     intent: 'ドタキャンなしで、丁寧に予定を決められる相手を希望。',
+    promisePurpose: '海沿いで一度会う予定を丁寧に決める',
+    promiseTimeWindow: '来週 平日夜',
+    promiseVenueSummary: 'Yokohama の駅近く',
   ),
   DemoMatchProfile(
     id: 'yui',
     piUid: 'pi-yui-serious-03',
+    counterpartyAccountId: '10000000-0000-4000-8000-000000000003',
     name: 'Yui',
     age: 25,
     city: 'Kyoto',
+    realmId: 'realm-kyoto-day1',
     photoUrl: 'https://i.pravatar.cc/900?img=32',
     headline: 'やわらかい空気感でも、約束はきちんと守りたい。',
     bio: '書店員。古い映画とレコードが好きです。派手さよりも、落ち着いて続く関係を探しています。',
     hobbies: ['Bookstore', 'Cinema', 'Records'],
     intent: '今月中に一度は会える前提でつながりたいです。',
+    promisePurpose: '本屋か映画の話から始める',
+    promiseTimeWindow: '今月中の午後',
+    promiseVenueSummary: 'Kyoto の書店近く',
   ),
   DemoMatchProfile(
     id: 'sota',
     piUid: 'pi-sota-serious-04',
+    counterpartyAccountId: '10000000-0000-4000-8000-000000000004',
     name: 'Sota',
     age: 29,
     city: 'Osaka',
+    realmId: 'realm-osaka-day1',
     photoUrl: 'https://i.pravatar.cc/900?img=15',
     headline: '仕事も恋愛も、ふわっとさせないタイプです。',
     bio: 'スタートアップで事業開発。最初の一回を気持ちよく実現するための、段取りの良さには自信があります。',
     hobbies: ['Running', 'Sushi', 'Podcasts'],
     intent: '本気の人だけ、短いメッセージから始めましょう。',
+    promisePurpose: '短い食事の約束を具体化する',
+    promiseTimeWindow: '来週末 夜',
+    promiseVenueSummary: 'Osaka の落ち着いた店',
   ),
 ];
 

--- a/apps/mobile/lib/features/home/presentation/match_detail_screen.dart
+++ b/apps/mobile/lib/features/home/presentation/match_detail_screen.dart
@@ -1,8 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:musubi_mobile/core/riverpod_compat.dart';
 
 import '../../../app/widgets/musubi_pressable.dart';
-import '../../../core/services/pi_sdk_service.dart';
+import '../../../core/errors/app_exception.dart';
+import '../../../core/utils/random_hex.dart';
+import '../../../features/promise/models/promise_models.dart';
+import '../../../repositories/auth/auth_session_controller.dart';
+import '../../../repositories/repository_providers.dart';
 import '../models/demo_match_profile.dart';
 
 class MatchDetailScreen extends ConsumerStatefulWidget {
@@ -16,7 +21,7 @@ class MatchDetailScreen extends ConsumerStatefulWidget {
 
 class _MatchDetailScreenState extends ConsumerState<MatchDetailScreen> {
   bool _isSubmitting = false;
-  PiSdkPaymentResult? _paymentResult;
+  String? _pendingIdempotencyKey;
 
   @override
   Widget build(BuildContext context) {
@@ -36,28 +41,13 @@ class _MatchDetailScreenState extends ConsumerState<MatchDetailScreen> {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            if (_paymentResult != null)
-              Container(
-                width: double.infinity,
-                margin: const EdgeInsets.only(bottom: 12),
-                padding: const EdgeInsets.all(14),
-                decoration: BoxDecoration(
-                  color: const Color(0x141CB86D),
-                  borderRadius: BorderRadius.circular(18),
-                  border: Border.all(color: const Color(0x221CB86D)),
-                ),
-                child: Text(
-                  'Stub payment accepted: ${_paymentResult!.paymentId}',
-                  style: Theme.of(context).textTheme.bodySmall,
-                ),
-              ),
             MusubiPrimaryButton(
               label: _isSubmitting
-                  ? 'Pi デポジット処理を準備中...'
-                  : 'デポジットして本気のアプローチ（10 Pi）',
-              icon: Icons.lock_open_rounded,
+                  ? 'Promise を作成しています...'
+                  : 'Promise を作成して進む（10 Pi）',
+              icon: Icons.handshake_rounded,
               isBusy: _isSubmitting,
-              onPressed: _isSubmitting ? null : () => _submitDeposit(profile),
+              onPressed: _isSubmitting ? null : () => _createPromise(profile),
             ),
           ],
         ),
@@ -118,7 +108,9 @@ class _MatchDetailScreenState extends ConsumerState<MatchDetailScreen> {
                           children: [
                             Text(
                               '${profile.name}, ${profile.age}',
-                              style: Theme.of(context).textTheme.headlineSmall
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .headlineSmall
                                   ?.copyWith(fontWeight: FontWeight.w700),
                             ),
                             const SizedBox(height: 8),
@@ -142,16 +134,44 @@ class _MatchDetailScreenState extends ConsumerState<MatchDetailScreen> {
                       _InfoBlock(title: 'Intent', body: profile.intent),
                       const SizedBox(height: 18),
                       MusubiSurfaceCard(
+                        color: const Color(0xFF111A16),
                         child: Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
                             Text(
-                              '相性の良さそうな時間',
+                              'Promise preview',
                               style: Theme.of(context).textTheme.titleMedium,
                             ),
                             const SizedBox(height: 12),
                             Text(
-                              '${profile.city} で、今週末の夕方以降に会える想定です。',
+                              profile.promisePurpose,
+                              style: Theme.of(context).textTheme.bodyLarge,
+                            ),
+                            const SizedBox(height: 12),
+                            _PromisePreviewRow(
+                              label: 'Time',
+                              value: profile.promiseTimeWindow,
+                            ),
+                            const SizedBox(height: 8),
+                            _PromisePreviewRow(
+                              label: 'Place',
+                              value: profile.promiseVenueSummary,
+                            ),
+                          ],
+                        ),
+                      ),
+                      const SizedBox(height: 18),
+                      MusubiSurfaceCard(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              '約束にする前の確認',
+                              style: Theme.of(context).textTheme.titleMedium,
+                            ),
+                            const SizedBox(height: 12),
+                            Text(
+                              '${profile.city} で会う前提を、まずは bounded な Promise として記録します。',
                               style: Theme.of(context).textTheme.bodyLarge,
                             ),
                             const SizedBox(height: 16),
@@ -191,12 +211,12 @@ class _MatchDetailScreenState extends ConsumerState<MatchDetailScreen> {
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
                             Text(
-                              'Deposit rule',
+                              'Promise rule',
                               style: Theme.of(context).textTheme.titleMedium,
                             ),
                             const SizedBox(height: 12),
                             Text(
-                              '10 Pi のデポジットは、冷やかし・Bot・ドタキャンを減らすための本気度シグナルです。',
+                              '10 Pi のデポジットは、相手へのアクセス権ではありません。約束を雑に扱わないための預かりです。',
                               style: Theme.of(context).textTheme.bodyLarge,
                             ),
                           ],
@@ -213,47 +233,55 @@ class _MatchDetailScreenState extends ConsumerState<MatchDetailScreen> {
     );
   }
 
-  Future<void> _submitDeposit(DemoMatchProfile profile) async {
+  Future<void> _createPromise(DemoMatchProfile profile) async {
+    final session = ref.read(authSessionControllerProvider).valueOrNull;
+    if (session == null) {
+      _showSnack('サインイン状態を確認できませんでした。もう一度サインインしてください。');
+      return;
+    }
+
     setState(() => _isSubmitting = true);
+    _pendingIdempotencyKey ??=
+        'promise-ui-${session.userId}-${profile.id}-${randomHex(bytes: 8)}';
     try {
-      final result = await ref
-          .read(piSdkServiceProvider)
-          .createPayment(
-            PiSdkPaymentRequest(
-              amountPi: 10,
-              memo: 'Serious approach deposit for ${profile.name}',
-              recipientPiUid: profile.piUid,
-              metadata: <String, dynamic>{
-                'target_profile_id': profile.id,
-                'target_name': profile.name,
-              },
-            ),
-          );
+      final response =
+          await ref.read(promiseRepositoryProvider).createPromiseIntent(
+                CreatePromiseIntentRequest(
+                  internalIdempotencyKey: _pendingIdempotencyKey!,
+                  realmId: profile.realmId,
+                  counterpartyAccountId: profile.counterpartyAccountId,
+                  depositAmountMinorUnits: 10000,
+                  currencyCode: 'PI',
+                ),
+              );
       if (!mounted) {
         return;
       }
-      setState(() => _paymentResult = result);
-      final messenger = ScaffoldMessenger.of(context);
-      messenger.hideCurrentSnackBar();
-      messenger.showSnackBar(
-        SnackBar(
-          content: Text('Pi デポジットのスタブを実行しました。payment_id=${result.paymentId}'),
-        ),
+      final uri = Uri(
+        path: '/promises/${response.promiseIntentId}',
+        queryParameters: {
+          'settlementCaseId': response.settlementCaseId,
+          if (response.replayedIntent) 'replayed': 'true',
+        },
       );
+      context.go(uri.toString());
     } catch (error) {
       if (!mounted) {
         return;
       }
-      final messenger = ScaffoldMessenger.of(context);
-      messenger.hideCurrentSnackBar();
-      messenger.showSnackBar(
-        SnackBar(content: Text('決済スタブの実行に失敗しました: $error')),
-      );
+      final appError = AppExceptionMapper.fromObject(error);
+      _showSnack(appError.message);
     } finally {
       if (mounted) {
         setState(() => _isSubmitting = false);
       }
     }
+  }
+
+  void _showSnack(String message) {
+    final messenger = ScaffoldMessenger.of(context);
+    messenger.hideCurrentSnackBar();
+    messenger.showSnackBar(SnackBar(content: Text(message)));
   }
 }
 
@@ -271,6 +299,29 @@ class _InfoBlock extends StatelessWidget {
         Text(title, style: Theme.of(context).textTheme.titleMedium),
         const SizedBox(height: 8),
         Text(body, style: Theme.of(context).textTheme.bodyLarge),
+      ],
+    );
+  }
+}
+
+class _PromisePreviewRow extends StatelessWidget {
+  const _PromisePreviewRow({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SizedBox(
+          width: 58,
+          child: Text(label, style: Theme.of(context).textTheme.labelMedium),
+        ),
+        Expanded(
+          child: Text(value, style: Theme.of(context).textTheme.bodyMedium),
+        ),
       ],
     );
   }

--- a/apps/mobile/lib/features/home/presentation/match_detail_screen.dart
+++ b/apps/mobile/lib/features/home/presentation/match_detail_screen.dart
@@ -264,7 +264,7 @@ class _MatchDetailScreenState extends ConsumerState<MatchDetailScreen> {
           if (response.replayedIntent) 'replayed': 'true',
         },
       );
-      context.go(uri.toString());
+      context.push(uri.toString());
     } catch (error) {
       if (!mounted) {
         return;

--- a/apps/mobile/lib/features/promise/models/promise_models.dart
+++ b/apps/mobile/lib/features/promise/models/promise_models.dart
@@ -1,0 +1,250 @@
+class CreatePromiseIntentRequest {
+  const CreatePromiseIntentRequest({
+    required this.internalIdempotencyKey,
+    required this.realmId,
+    required this.counterpartyAccountId,
+    required this.depositAmountMinorUnits,
+    required this.currencyCode,
+  });
+
+  final String internalIdempotencyKey;
+  final String realmId;
+  final String counterpartyAccountId;
+  final int depositAmountMinorUnits;
+  final String currencyCode;
+
+  Map<String, Object?> toJson() {
+    return {
+      'internal_idempotency_key': internalIdempotencyKey,
+      'realm_id': realmId,
+      'counterparty_account_id': counterpartyAccountId,
+      'deposit_amount_minor_units': depositAmountMinorUnits,
+      'currency_code': currencyCode,
+    };
+  }
+}
+
+class CreatePromiseIntentResponse {
+  const CreatePromiseIntentResponse({
+    required this.promiseIntentId,
+    required this.settlementCaseId,
+    required this.caseStatus,
+    required this.replayedIntent,
+  });
+
+  final String promiseIntentId;
+  final String settlementCaseId;
+  final String caseStatus;
+  final bool replayedIntent;
+
+  factory CreatePromiseIntentResponse.fromJson(Map<String, dynamic> json) {
+    return CreatePromiseIntentResponse(
+      promiseIntentId: _stringField(json, 'promise_intent_id'),
+      settlementCaseId: _stringField(json, 'settlement_case_id'),
+      caseStatus: _stringField(json, 'case_status'),
+      replayedIntent: json['replayed_intent'] == true,
+    );
+  }
+}
+
+class PromiseProjectionView {
+  const PromiseProjectionView({
+    required this.promiseIntentId,
+    required this.realmId,
+    required this.initiatorAccountId,
+    required this.counterpartyAccountId,
+    required this.currentIntentStatus,
+    required this.depositAmountMinorUnits,
+    required this.currencyCode,
+    required this.depositScale,
+    required this.latestSettlementCaseId,
+    required this.latestSettlementStatus,
+  });
+
+  final String promiseIntentId;
+  final String realmId;
+  final String initiatorAccountId;
+  final String counterpartyAccountId;
+  final String currentIntentStatus;
+  final int depositAmountMinorUnits;
+  final String currencyCode;
+  final int depositScale;
+  final String? latestSettlementCaseId;
+  final String? latestSettlementStatus;
+
+  factory PromiseProjectionView.fromJson(Map<String, dynamic> json) {
+    return PromiseProjectionView(
+      promiseIntentId: _stringField(json, 'promise_intent_id'),
+      realmId: _stringField(json, 'realm_id'),
+      initiatorAccountId: _stringField(json, 'initiator_account_id'),
+      counterpartyAccountId: _stringField(json, 'counterparty_account_id'),
+      currentIntentStatus: _stringField(json, 'current_intent_status'),
+      depositAmountMinorUnits: _intField(json, 'deposit_amount_minor_units'),
+      currencyCode: _stringField(json, 'currency_code'),
+      depositScale: _intField(json, 'deposit_scale'),
+      latestSettlementCaseId:
+          _nullableString(json, 'latest_settlement_case_id'),
+      latestSettlementStatus: _nullableString(json, 'latest_settlement_status'),
+    );
+  }
+}
+
+class ExpandedSettlementView {
+  const ExpandedSettlementView({
+    required this.settlementCaseId,
+    required this.promiseIntentId,
+    required this.realmId,
+    required this.currentSettlementStatus,
+    required this.totalFundedMinorUnits,
+    required this.currencyCode,
+    required this.proofStatus,
+    required this.proofSignalCount,
+  });
+
+  final String settlementCaseId;
+  final String promiseIntentId;
+  final String realmId;
+  final String currentSettlementStatus;
+  final int totalFundedMinorUnits;
+  final String currencyCode;
+  final String proofStatus;
+  final int proofSignalCount;
+
+  factory ExpandedSettlementView.fromJson(Map<String, dynamic> json) {
+    return ExpandedSettlementView(
+      settlementCaseId: _stringField(json, 'settlement_case_id'),
+      promiseIntentId: _stringField(json, 'promise_intent_id'),
+      realmId: _stringField(json, 'realm_id'),
+      currentSettlementStatus: _stringField(
+        json,
+        'current_settlement_status',
+      ),
+      totalFundedMinorUnits: _intField(json, 'total_funded_minor_units'),
+      currencyCode: _stringField(json, 'currency_code'),
+      proofStatus: _stringField(json, 'proof_status'),
+      proofSignalCount: _intField(json, 'proof_signal_count'),
+    );
+  }
+}
+
+class PromiseStatusBundle {
+  const PromiseStatusBundle({
+    required this.promiseIntentId,
+    required this.initialSettlementCaseId,
+    required this.promise,
+    required this.settlement,
+  });
+
+  final String promiseIntentId;
+  final String? initialSettlementCaseId;
+  final PromiseProjectionView? promise;
+  final ExpandedSettlementView? settlement;
+
+  String? get settlementCaseId {
+    return settlement?.settlementCaseId ??
+        promise?.latestSettlementCaseId ??
+        initialSettlementCaseId;
+  }
+
+  String get promiseStatus {
+    return promise?.currentIntentStatus ?? 'pending_projection';
+  }
+
+  String get settlementStatus {
+    return settlement?.currentSettlementStatus ??
+        promise?.latestSettlementStatus ??
+        'pending_projection';
+  }
+
+  String get proofStatus {
+    return settlement?.proofStatus ?? 'unavailable';
+  }
+
+  bool get hasParticipantSafeProjection {
+    return promise != null || settlement != null;
+  }
+}
+
+String promiseStatusLabel(String status) {
+  return switch (status) {
+    'proposed' => '提案中',
+    'confirmed' => '約束済み',
+    'fulfilled' => '完了',
+    'reflected' => 'ふりかえり済み',
+    'withdrawn' => '取り下げ',
+    'under_review' => '確認中',
+    'pending_projection' => '表示準備中',
+    _ => '確認中',
+  };
+}
+
+String settlementStatusLabel(String status) {
+  return switch (status) {
+    'pending_funding' => 'デポジット準備中',
+    'hold_opened' => 'デポジット手続き中',
+    'funded' => 'デポジット確認済み',
+    'manual_review' => '確認中',
+    'pending_projection' => '表示準備中',
+    _ => '確認中',
+  };
+}
+
+String proofStatusLabel(String status) {
+  return switch (status) {
+    'verified' => '証明確認済み',
+    'missing' => '追加確認が必要',
+    'quarantined' => '確認中',
+    'manual_review' => '確認中',
+    'unavailable' => '証明機能は準備中',
+    _ => '証明待ち',
+  };
+}
+
+String participantNextActionCopy(PromiseStatusBundle bundle) {
+  if (!bundle.hasParticipantSafeProjection) {
+    return '作成は受け付けました。表示の準備が整うまで少し待ってください。';
+  }
+  if (bundle.proofStatus == 'unavailable') {
+    return '完了はまだこの画面だけでは確定しません。証明機能が使える状態になるまで、約束の状態をここで確認できます。';
+  }
+  if (bundle.settlementStatus == 'pending_funding') {
+    return 'デポジットの確認を待っています。相手へのアクセス権ではなく、約束を丁寧に扱うための預かりです。';
+  }
+  if (bundle.proofStatus == 'missing' || bundle.proofStatus == 'quarantined') {
+    return 'すぐに相手を責めず、追加確認を待ちます。必要な場合は確認フローにつながります。';
+  }
+  return '次の案内が出るまで、この約束の状態を確認できます。';
+}
+
+String _stringField(Map<String, dynamic> json, String key) {
+  final value = json[key];
+  if (value is String && value.isNotEmpty) {
+    return value;
+  }
+  throw FormatException('Missing string field: $key');
+}
+
+String? _nullableString(Map<String, dynamic> json, String key) {
+  final value = json[key];
+  if (value == null) {
+    return null;
+  }
+  if (value is String && value.isNotEmpty) {
+    return value;
+  }
+  return null;
+}
+
+int _intField(Map<String, dynamic> json, String key) {
+  final value = json[key];
+  if (value is int) {
+    return value;
+  }
+  if (value is num) {
+    return value.toInt();
+  }
+  if (value is String) {
+    return int.parse(value);
+  }
+  throw FormatException('Missing integer field: $key');
+}

--- a/apps/mobile/lib/features/promise/presentation/promise_status_screen.dart
+++ b/apps/mobile/lib/features/promise/presentation/promise_status_screen.dart
@@ -1,0 +1,205 @@
+import 'package:flutter/material.dart';
+import 'package:musubi_mobile/core/riverpod_compat.dart';
+
+import '../../../app/widgets/musubi_pressable.dart';
+import '../../../core/errors/app_exception.dart';
+import '../../../repositories/repository_providers.dart';
+import '../models/promise_models.dart';
+
+class PromiseStatusScreen extends ConsumerStatefulWidget {
+  const PromiseStatusScreen({
+    super.key,
+    required this.promiseIntentId,
+    this.settlementCaseId,
+    this.replayedIntent = false,
+  });
+
+  final String promiseIntentId;
+  final String? settlementCaseId;
+  final bool replayedIntent;
+
+  @override
+  ConsumerState<PromiseStatusScreen> createState() =>
+      _PromiseStatusScreenState();
+}
+
+class _PromiseStatusScreenState extends ConsumerState<PromiseStatusScreen> {
+  late Future<PromiseStatusBundle> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = _load();
+  }
+
+  Future<PromiseStatusBundle> _load() {
+    return ref.read(promiseRepositoryProvider).fetchPromiseStatus(
+          widget.promiseIntentId,
+          settlementCaseId: widget.settlementCaseId,
+        );
+  }
+
+  void _retry() {
+    setState(() {
+      _future = _load();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Promise')),
+      body: FutureBuilder<PromiseStatusBundle>(
+        future: _future,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snapshot.hasError) {
+            final error = AppExceptionMapper.fromObject(
+              snapshot.error ?? const UnknownAppException(),
+            );
+            return _PromiseStatusFrame(
+              title: '約束の状態を確認できませんでした',
+              subtitle: error.message,
+              children: [
+                MusubiGhostButton(label: '再読み込み', onPressed: _retry),
+              ],
+            );
+          }
+
+          final bundle = snapshot.data!;
+          return _PromiseStatusFrame(
+            title: widget.replayedIntent ? '同じ約束を確認しました' : '約束を作成しました',
+            subtitle: '約束の進み具合だけを、落ち着いて確認できます。',
+            children: [
+              _StatusRow(
+                label: '約束',
+                value: promiseStatusLabel(bundle.promiseStatus),
+              ),
+              _StatusRow(
+                label: '預かり',
+                value: settlementStatusLabel(bundle.settlementStatus),
+              ),
+              _StatusRow(
+                label: '証明',
+                value: proofStatusLabel(bundle.proofStatus),
+              ),
+              _GuidancePanel(copy: participantNextActionCopy(bundle)),
+              _CompletionPanel(bundle: bundle),
+              MusubiGhostButton(label: '更新', onPressed: _retry),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _PromiseStatusFrame extends StatelessWidget {
+  const _PromiseStatusFrame({
+    required this.title,
+    required this.subtitle,
+    required this.children,
+  });
+
+  final String title;
+  final String subtitle;
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      padding: const EdgeInsets.fromLTRB(24, 24, 24, 40),
+      children: [
+        Text(title, style: Theme.of(context).textTheme.headlineSmall),
+        const SizedBox(height: 10),
+        Text(subtitle, style: Theme.of(context).textTheme.bodyLarge),
+        const SizedBox(height: 22),
+        for (final child in children) ...[
+          child,
+          if (child != children.last) const SizedBox(height: 14),
+        ],
+      ],
+    );
+  }
+}
+
+class _StatusRow extends StatelessWidget {
+  const _StatusRow({
+    required this.label,
+    required this.value,
+  });
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SizedBox(
+          width: 92,
+          child: Text(label, style: Theme.of(context).textTheme.labelMedium),
+        ),
+        Expanded(
+          child: Text(value, style: Theme.of(context).textTheme.titleMedium),
+        ),
+      ],
+    );
+  }
+}
+
+class _GuidancePanel extends StatelessWidget {
+  const _GuidancePanel({required this.copy});
+
+  final String copy;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: const Color(0x1474A086),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: const Color(0x2274A086)),
+      ),
+      child: Text(copy, style: Theme.of(context).textTheme.bodyMedium),
+    );
+  }
+}
+
+class _CompletionPanel extends StatelessWidget {
+  const _CompletionPanel({required this.bundle});
+
+  final PromiseStatusBundle bundle;
+
+  @override
+  Widget build(BuildContext context) {
+    final proofUnavailable = bundle.proofStatus == 'unavailable';
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: const Color(0x12FFFFFF),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: const Color(0x14FFFFFF)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('完了について', style: Theme.of(context).textTheme.titleMedium),
+          const SizedBox(height: 8),
+          Text(
+            proofUnavailable
+                ? 'この画面の操作だけで完了は確定しません。証明や確認の準備が整うまで、状態だけを確認できます。'
+                : '完了は証明や確認結果に基づいて扱われます。この画面だけで預かり金や評価は変わりません。',
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/repositories/promise/api_promise_repository.dart
+++ b/apps/mobile/lib/repositories/promise/api_promise_repository.dart
@@ -33,10 +33,26 @@ class ApiPromiseRepository implements PromiseRepository {
     String? settlementCaseId,
   }) async {
     try {
-      final promise = await _fetchPromiseProjection(promiseIntentId);
-      final caseId = promise?.latestSettlementCaseId ?? settlementCaseId;
-      final settlement =
-          caseId == null ? null : await _fetchExpandedSettlementView(caseId);
+      PromiseProjectionView? promise;
+      ExpandedSettlementView? settlement;
+      if (settlementCaseId == null) {
+        promise = await _fetchPromiseProjection(promiseIntentId);
+        final caseId = promise?.latestSettlementCaseId;
+        settlement =
+            caseId == null ? null : await _fetchExpandedSettlementView(caseId);
+      } else {
+        final results = await Future.wait<Object?>([
+          _fetchPromiseProjection(promiseIntentId),
+          _fetchExpandedSettlementView(settlementCaseId),
+        ]);
+        promise = results[0] as PromiseProjectionView?;
+        settlement = results[1] as ExpandedSettlementView?;
+
+        final latestCaseId = promise?.latestSettlementCaseId;
+        if (latestCaseId != null && latestCaseId != settlementCaseId) {
+          settlement = await _fetchExpandedSettlementView(latestCaseId);
+        }
+      }
       return PromiseStatusBundle(
         promiseIntentId: promiseIntentId,
         initialSettlementCaseId: settlementCaseId,
@@ -85,11 +101,33 @@ class ApiPromiseRepository implements PromiseRepository {
   }
 
   AppException _mapPromiseError(Object error) {
-    if (error is DioException && error.response?.statusCode == 404) {
-      return const BusinessException(
-        message: '相手または約束の準備がまだ整っていません。時間を置いてもう一度確認してください。',
-      );
+    if (error is DioException) {
+      final statusCode = error.response?.statusCode;
+      final responseMessage = _errorResponseMessage(error.response?.data);
+      if (statusCode == 404 ||
+          (statusCode == 400 &&
+              responseMessage == 'counterparty account was not found')) {
+        return const BusinessException(
+          message: '相手または約束の準備がまだ整っていません。時間を置いてもう一度確認してください。',
+        );
+      }
     }
     return AppExceptionMapper.fromObject(error);
+  }
+
+  String? _errorResponseMessage(Object? data) {
+    if (data is Map<String, dynamic>) {
+      final message = data['error'];
+      if (message is String && message.isNotEmpty) {
+        return message;
+      }
+    }
+    if (data is Map) {
+      final message = data['error'];
+      if (message is String && message.isNotEmpty) {
+        return message;
+      }
+    }
+    return null;
   }
 }

--- a/apps/mobile/lib/repositories/promise/api_promise_repository.dart
+++ b/apps/mobile/lib/repositories/promise/api_promise_repository.dart
@@ -1,0 +1,95 @@
+import 'package:dio/dio.dart';
+
+import '../../api/api_client.dart';
+import '../../core/errors/app_exception.dart';
+import '../../features/promise/models/promise_models.dart';
+import 'promise_repository.dart';
+
+class ApiPromiseRepository implements PromiseRepository {
+  ApiPromiseRepository(this._apiClient);
+
+  final ApiClient _apiClient;
+
+  @override
+  Future<CreatePromiseIntentResponse> createPromiseIntent(
+    CreatePromiseIntentRequest request,
+  ) async {
+    try {
+      final response = await _apiClient.dio.post<Map<String, dynamic>>(
+        '/api/promise/intents',
+        data: request.toJson(),
+      );
+      return CreatePromiseIntentResponse.fromJson(
+        response.data ?? const <String, dynamic>{},
+      );
+    } catch (error) {
+      throw _mapPromiseError(error);
+    }
+  }
+
+  @override
+  Future<PromiseStatusBundle> fetchPromiseStatus(
+    String promiseIntentId, {
+    String? settlementCaseId,
+  }) async {
+    try {
+      final promise = await _fetchPromiseProjection(promiseIntentId);
+      final caseId = promise?.latestSettlementCaseId ?? settlementCaseId;
+      final settlement =
+          caseId == null ? null : await _fetchExpandedSettlementView(caseId);
+      return PromiseStatusBundle(
+        promiseIntentId: promiseIntentId,
+        initialSettlementCaseId: settlementCaseId,
+        promise: promise,
+        settlement: settlement,
+      );
+    } catch (error) {
+      throw _mapPromiseError(error);
+    }
+  }
+
+  Future<PromiseProjectionView?> _fetchPromiseProjection(
+    String promiseIntentId,
+  ) async {
+    try {
+      final response = await _apiClient.dio.get<Map<String, dynamic>>(
+        '/api/projection/promise-views/$promiseIntentId',
+      );
+      return PromiseProjectionView.fromJson(
+        response.data ?? const <String, dynamic>{},
+      );
+    } on DioException catch (error) {
+      if (error.response?.statusCode == 404) {
+        return null;
+      }
+      rethrow;
+    }
+  }
+
+  Future<ExpandedSettlementView?> _fetchExpandedSettlementView(
+    String settlementCaseId,
+  ) async {
+    try {
+      final response = await _apiClient.dio.get<Map<String, dynamic>>(
+        '/api/projection/settlement-views/$settlementCaseId/expanded',
+      );
+      return ExpandedSettlementView.fromJson(
+        response.data ?? const <String, dynamic>{},
+      );
+    } on DioException catch (error) {
+      if (error.response?.statusCode == 404) {
+        return null;
+      }
+      rethrow;
+    }
+  }
+
+  AppException _mapPromiseError(Object error) {
+    if (error is DioException && error.response?.statusCode == 404) {
+      return const BusinessException(
+        message: '相手または約束の準備がまだ整っていません。時間を置いてもう一度確認してください。',
+      );
+    }
+    return AppExceptionMapper.fromObject(error);
+  }
+}

--- a/apps/mobile/lib/repositories/promise/api_promise_repository.dart
+++ b/apps/mobile/lib/repositories/promise/api_promise_repository.dart
@@ -38,19 +38,29 @@ class ApiPromiseRepository implements PromiseRepository {
       if (settlementCaseId == null) {
         promise = await _fetchPromiseProjection(promiseIntentId);
         final caseId = promise?.latestSettlementCaseId;
-        settlement =
-            caseId == null ? null : await _fetchExpandedSettlementView(caseId);
+        settlement = caseId == null
+            ? null
+            : _matchingSettlement(
+                await _fetchExpandedSettlementView(caseId),
+                promiseIntentId,
+              );
       } else {
         final results = await Future.wait<Object?>([
           _fetchPromiseProjection(promiseIntentId),
           _fetchExpandedSettlementView(settlementCaseId),
         ]);
         promise = results[0] as PromiseProjectionView?;
-        settlement = results[1] as ExpandedSettlementView?;
+        settlement = _matchingSettlement(
+          results[1] as ExpandedSettlementView?,
+          promiseIntentId,
+        );
 
         final latestCaseId = promise?.latestSettlementCaseId;
         if (latestCaseId != null && latestCaseId != settlementCaseId) {
-          settlement = await _fetchExpandedSettlementView(latestCaseId);
+          settlement = _matchingSettlement(
+            await _fetchExpandedSettlementView(latestCaseId),
+            promiseIntentId,
+          );
         }
       }
       return PromiseStatusBundle(
@@ -98,6 +108,19 @@ class ApiPromiseRepository implements PromiseRepository {
       }
       rethrow;
     }
+  }
+
+  ExpandedSettlementView? _matchingSettlement(
+    ExpandedSettlementView? settlement,
+    String promiseIntentId,
+  ) {
+    if (settlement == null) {
+      return null;
+    }
+    if (settlement.promiseIntentId != promiseIntentId) {
+      return null;
+    }
+    return settlement;
   }
 
   AppException _mapPromiseError(Object error) {

--- a/apps/mobile/lib/repositories/promise/dummy_promise_repository.dart
+++ b/apps/mobile/lib/repositories/promise/dummy_promise_repository.dart
@@ -1,0 +1,117 @@
+import '../../core/errors/app_exception.dart';
+import '../../features/promise/models/promise_models.dart';
+import 'promise_repository.dart';
+
+class DummyPromiseRepository implements PromiseRepository {
+  final Map<String, _DummyPromiseRecord> _recordsByKey = {};
+  final Map<String, _DummyPromiseRecord> _recordsByIntentId = {};
+
+  @override
+  Future<CreatePromiseIntentResponse> createPromiseIntent(
+    CreatePromiseIntentRequest request,
+  ) async {
+    await Future.delayed(const Duration(milliseconds: 450));
+    final fingerprint = _fingerprint(request);
+    final existing = _recordsByKey[request.internalIdempotencyKey];
+    if (existing != null) {
+      if (existing.fingerprint != fingerprint) {
+        throw const BusinessException(
+          message: '同じ操作キーで別の約束は作れません。もう一度画面を開き直してください。',
+        );
+      }
+      return existing.response.copyWith(replayedIntent: true);
+    }
+
+    final sequence = _recordsByKey.length + 1;
+    final response = CreatePromiseIntentResponse(
+      promiseIntentId: 'demo-promise-$sequence',
+      settlementCaseId: 'demo-settlement-$sequence',
+      caseStatus: 'pending_funding',
+      replayedIntent: false,
+    );
+    final record = _DummyPromiseRecord(
+      request: request,
+      response: response,
+      fingerprint: fingerprint,
+    );
+    _recordsByKey[request.internalIdempotencyKey] = record;
+    _recordsByIntentId[response.promiseIntentId] = record;
+    return response;
+  }
+
+  @override
+  Future<PromiseStatusBundle> fetchPromiseStatus(
+    String promiseIntentId, {
+    String? settlementCaseId,
+  }) async {
+    await Future.delayed(const Duration(milliseconds: 300));
+    final record = _recordsByIntentId[promiseIntentId];
+    if (record == null) {
+      return PromiseStatusBundle(
+        promiseIntentId: promiseIntentId,
+        initialSettlementCaseId: settlementCaseId,
+        promise: null,
+        settlement: null,
+      );
+    }
+
+    return PromiseStatusBundle(
+      promiseIntentId: promiseIntentId,
+      initialSettlementCaseId: settlementCaseId,
+      promise: PromiseProjectionView(
+        promiseIntentId: record.response.promiseIntentId,
+        realmId: record.request.realmId,
+        initiatorAccountId: 'demo-current-account',
+        counterpartyAccountId: record.request.counterpartyAccountId,
+        currentIntentStatus: 'proposed',
+        depositAmountMinorUnits: record.request.depositAmountMinorUnits,
+        currencyCode: record.request.currencyCode,
+        depositScale: 3,
+        latestSettlementCaseId: record.response.settlementCaseId,
+        latestSettlementStatus: record.response.caseStatus,
+      ),
+      settlement: ExpandedSettlementView(
+        settlementCaseId: record.response.settlementCaseId,
+        promiseIntentId: record.response.promiseIntentId,
+        realmId: record.request.realmId,
+        currentSettlementStatus: record.response.caseStatus,
+        totalFundedMinorUnits: 0,
+        currencyCode: record.request.currencyCode,
+        proofStatus: 'unavailable',
+        proofSignalCount: 0,
+      ),
+    );
+  }
+
+  String _fingerprint(CreatePromiseIntentRequest request) {
+    return [
+      request.realmId,
+      request.counterpartyAccountId,
+      request.depositAmountMinorUnits,
+      request.currencyCode,
+    ].join('|');
+  }
+}
+
+class _DummyPromiseRecord {
+  const _DummyPromiseRecord({
+    required this.request,
+    required this.response,
+    required this.fingerprint,
+  });
+
+  final CreatePromiseIntentRequest request;
+  final CreatePromiseIntentResponse response;
+  final String fingerprint;
+}
+
+extension on CreatePromiseIntentResponse {
+  CreatePromiseIntentResponse copyWith({bool? replayedIntent}) {
+    return CreatePromiseIntentResponse(
+      promiseIntentId: promiseIntentId,
+      settlementCaseId: settlementCaseId,
+      caseStatus: caseStatus,
+      replayedIntent: replayedIntent ?? this.replayedIntent,
+    );
+  }
+}

--- a/apps/mobile/lib/repositories/promise/dummy_promise_repository.dart
+++ b/apps/mobile/lib/repositories/promise/dummy_promise_repository.dart
@@ -3,14 +3,21 @@ import '../../features/promise/models/promise_models.dart';
 import 'promise_repository.dart';
 
 class DummyPromiseRepository implements PromiseRepository {
+  DummyPromiseRepository({
+    this.createDelay = const Duration(milliseconds: 450),
+    this.fetchDelay = const Duration(milliseconds: 300),
+  });
+
   final Map<String, _DummyPromiseRecord> _recordsByKey = {};
   final Map<String, _DummyPromiseRecord> _recordsByIntentId = {};
+  final Duration createDelay;
+  final Duration fetchDelay;
 
   @override
   Future<CreatePromiseIntentResponse> createPromiseIntent(
     CreatePromiseIntentRequest request,
   ) async {
-    await Future.delayed(const Duration(milliseconds: 450));
+    await Future.delayed(createDelay);
     final fingerprint = _fingerprint(request);
     final existing = _recordsByKey[request.internalIdempotencyKey];
     if (existing != null) {
@@ -44,7 +51,7 @@ class DummyPromiseRepository implements PromiseRepository {
     String promiseIntentId, {
     String? settlementCaseId,
   }) async {
-    await Future.delayed(const Duration(milliseconds: 300));
+    await Future.delayed(fetchDelay);
     final record = _recordsByIntentId[promiseIntentId];
     if (record == null) {
       return PromiseStatusBundle(

--- a/apps/mobile/lib/repositories/promise/promise_repository.dart
+++ b/apps/mobile/lib/repositories/promise/promise_repository.dart
@@ -1,0 +1,12 @@
+import '../../features/promise/models/promise_models.dart';
+
+abstract class PromiseRepository {
+  Future<CreatePromiseIntentResponse> createPromiseIntent(
+    CreatePromiseIntentRequest request,
+  );
+
+  Future<PromiseStatusBundle> fetchPromiseStatus(
+    String promiseIntentId, {
+    String? settlementCaseId,
+  });
+}

--- a/apps/mobile/lib/repositories/repository_providers.dart
+++ b/apps/mobile/lib/repositories/repository_providers.dart
@@ -7,6 +7,9 @@ import 'auth/api_auth_repository.dart';
 import 'auth/auth_repository.dart';
 import 'auth/auth_token_storage.dart';
 import 'auth/dummy_auth_repository.dart';
+import 'promise/api_promise_repository.dart';
+import 'promise/dummy_promise_repository.dart';
+import 'promise/promise_repository.dart';
 
 final authRepositoryProvider = Provider<AuthRepository>((ref) {
   if (ref.watch(useApiRepositoriesProvider)) {
@@ -17,4 +20,11 @@ final authRepositoryProvider = Provider<AuthRepository>((ref) {
     );
   }
   return DummyAuthRepository();
+});
+
+final promiseRepositoryProvider = Provider<PromiseRepository>((ref) {
+  if (ref.watch(useApiRepositoriesProvider)) {
+    return ApiPromiseRepository(ref.watch(apiClientProvider));
+  }
+  return DummyPromiseRepository();
 });

--- a/apps/mobile/pubspec.lock
+++ b/apps/mobile/pubspec.lock
@@ -164,7 +164,7 @@ packages:
     source: hosted
     version: "3.2.1"
   flutter_test:
-    dependency: transitive
+    dependency: "direct dev"
     description: flutter
     source: sdk
     version: "0.0.0"

--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -18,6 +18,8 @@ dependencies:
   web: ^1.1.1
 
 dev_dependencies:
+  flutter_test:
+    sdk: flutter
   flutter_lints: ^6.0.0
 
 flutter:

--- a/apps/mobile/test/features/home/match_detail_screen_test.dart
+++ b/apps/mobile/test/features/home/match_detail_screen_test.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:musubi_mobile/core/riverpod_compat.dart';
+import 'package:musubi_mobile/features/home/presentation/match_detail_screen.dart';
+import 'package:musubi_mobile/features/promise/models/promise_models.dart';
+import 'package:musubi_mobile/features/promise/presentation/promise_status_screen.dart';
+import 'package:musubi_mobile/repositories/auth/auth_repository.dart';
+import 'package:musubi_mobile/repositories/auth/auth_session_controller.dart';
+import 'package:musubi_mobile/repositories/auth/pi_auth_session.dart';
+import 'package:musubi_mobile/repositories/promise/promise_repository.dart';
+import 'package:musubi_mobile/repositories/repository_providers.dart';
+
+void main() {
+  testWidgets('creating a promise keeps a back path to the detail screen',
+      (tester) async {
+    final router = GoRouter(
+      initialLocation: '/detail/mai',
+      routes: [
+        GoRoute(
+          path: '/detail/:profileId',
+          builder: (context, state) => MatchDetailScreen(
+            profileId: state.pathParameters['profileId'] ?? '',
+          ),
+        ),
+        GoRoute(
+          path: '/promises/:promiseIntentId',
+          builder: (context, state) => PromiseStatusScreen(
+            promiseIntentId: state.pathParameters['promiseIntentId'] ?? '',
+            settlementCaseId: state.uri.queryParameters['settlementCaseId'],
+            replayedIntent: state.uri.queryParameters['replayed'] == 'true',
+          ),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authRepositoryProvider.overrideWith((ref) => _FakeAuthRepository()),
+          promiseRepositoryProvider.overrideWith(
+            (ref) => _FakePromiseRepository(),
+          ),
+        ],
+        child: _WarmAuthSession(
+          child: MaterialApp.router(routerConfig: router),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Promise を作成して進む（10 Pi）'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('約束を作成しました'), findsOneWidget);
+    expect(router.canPop(), isTrue);
+  });
+}
+
+class _WarmAuthSession extends ConsumerWidget {
+  const _WarmAuthSession({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.watch(authSessionControllerProvider);
+    return child;
+  }
+}
+
+class _FakeAuthRepository implements AuthRepository {
+  static const _session = PiAuthSession(
+    userId: 'test-user',
+    piUid: 'test-pi-user',
+    displayName: '@test_user',
+  );
+
+  @override
+  Future<PiAuthSession?> getCurrentSession() async => _session;
+
+  @override
+  Future<PiAuthSession> signInWithPi() async => _session;
+
+  @override
+  Future<void> signOut() async {}
+
+  @override
+  Future<PiAuthSession?> trySilentSignIn() async => _session;
+}
+
+class _FakePromiseRepository implements PromiseRepository {
+  @override
+  Future<CreatePromiseIntentResponse> createPromiseIntent(
+    CreatePromiseIntentRequest request,
+  ) async {
+    return const CreatePromiseIntentResponse(
+      promiseIntentId: 'promise-1',
+      settlementCaseId: 'settlement-1',
+      caseStatus: 'pending_funding',
+      replayedIntent: false,
+    );
+  }
+
+  @override
+  Future<PromiseStatusBundle> fetchPromiseStatus(
+    String promiseIntentId, {
+    String? settlementCaseId,
+  }) async {
+    return PromiseStatusBundle(
+      promiseIntentId: promiseIntentId,
+      initialSettlementCaseId: settlementCaseId,
+      promise: const PromiseProjectionView(
+        promiseIntentId: 'promise-1',
+        realmId: 'realm-tokyo-day1',
+        initiatorAccountId: 'account-a',
+        counterpartyAccountId: 'account-b',
+        currentIntentStatus: 'proposed',
+        depositAmountMinorUnits: 10000,
+        currencyCode: 'PI',
+        depositScale: 3,
+        latestSettlementCaseId: 'settlement-1',
+        latestSettlementStatus: 'pending_funding',
+      ),
+      settlement: const ExpandedSettlementView(
+        settlementCaseId: 'settlement-1',
+        promiseIntentId: 'promise-1',
+        realmId: 'realm-tokyo-day1',
+        currentSettlementStatus: 'pending_funding',
+        totalFundedMinorUnits: 0,
+        currencyCode: 'PI',
+        proofStatus: 'unavailable',
+        proofSignalCount: 0,
+      ),
+    );
+  }
+}

--- a/apps/mobile/test/features/promise/promise_models_test.dart
+++ b/apps/mobile/test/features/promise/promise_models_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:musubi_mobile/features/promise/models/promise_models.dart';
+
+void main() {
+  test('promise status labels stay calm and bounded', () {
+    expect(promiseStatusLabel('proposed'), '提案中');
+    expect(settlementStatusLabel('pending_funding'), 'デポジット準備中');
+    expect(proofStatusLabel('unavailable'), '証明機能は準備中');
+    expect(proofStatusLabel('quarantined'), '確認中');
+  });
+
+  test('participant next action does not claim local completion truth', () {
+    const bundle = PromiseStatusBundle(
+      promiseIntentId: 'promise-1',
+      initialSettlementCaseId: 'settlement-1',
+      promise: PromiseProjectionView(
+        promiseIntentId: 'promise-1',
+        realmId: 'realm-1',
+        initiatorAccountId: 'initiator-1',
+        counterpartyAccountId: 'counterparty-1',
+        currentIntentStatus: 'proposed',
+        depositAmountMinorUnits: 10000,
+        currencyCode: 'PI',
+        depositScale: 3,
+        latestSettlementCaseId: 'settlement-1',
+        latestSettlementStatus: 'pending_funding',
+      ),
+      settlement: ExpandedSettlementView(
+        settlementCaseId: 'settlement-1',
+        promiseIntentId: 'promise-1',
+        realmId: 'realm-1',
+        currentSettlementStatus: 'pending_funding',
+        totalFundedMinorUnits: 0,
+        currencyCode: 'PI',
+        proofStatus: 'unavailable',
+        proofSignalCount: 0,
+      ),
+    );
+
+    final copy = participantNextActionCopy(bundle);
+    expect(copy, contains('完了はまだこの画面だけでは確定しません'));
+    expect(copy, isNot(contains('DM')));
+    expect(copy, isNot(contains('ランキング')));
+  });
+
+  test('projection parsing ignores internal fields not modeled by the UI', () {
+    final view = PromiseProjectionView.fromJson({
+      'promise_intent_id': 'promise-1',
+      'realm_id': 'realm-1',
+      'initiator_account_id': 'initiator-1',
+      'counterparty_account_id': 'counterparty-1',
+      'current_intent_status': 'proposed',
+      'deposit_amount_minor_units': 10000,
+      'currency_code': 'PI',
+      'deposit_scale': 3,
+      'latest_settlement_case_id': 'settlement-1',
+      'latest_settlement_status': 'pending_funding',
+      'operator_note_internal': 'must not be rendered',
+      'raw_evidence_locator': 'private://evidence',
+      'source_fact_id': 'source-fact-1',
+    });
+
+    expect(view.promiseIntentId, 'promise-1');
+    expect(view.latestSettlementStatus, 'pending_funding');
+  });
+}

--- a/apps/mobile/test/repositories/promise/api_promise_repository_test.dart
+++ b/apps/mobile/test/repositories/promise/api_promise_repository_test.dart
@@ -1,0 +1,131 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:musubi_mobile/api/api_client.dart';
+import 'package:musubi_mobile/core/errors/app_exception.dart';
+import 'package:musubi_mobile/features/promise/models/promise_models.dart';
+import 'package:musubi_mobile/repositories/promise/api_promise_repository.dart';
+
+void main() {
+  test(
+      'api promise repository returns bounded copy when counterparty account is missing',
+      () async {
+    final dio = Dio();
+    dio.httpClientAdapter = _StubHttpClientAdapter((options) async {
+      expect(options.path, '/api/promise/intents');
+      return _jsonResponse(
+        400,
+        {'error': 'counterparty account was not found'},
+      );
+    });
+    final repository = ApiPromiseRepository(ApiClient(dio));
+
+    expect(
+      repository.createPromiseIntent(
+        const CreatePromiseIntentRequest(
+          internalIdempotencyKey: 'promise-action-1',
+          realmId: 'realm-1',
+          counterpartyAccountId: 'counterparty-1',
+          depositAmountMinorUnits: 10000,
+          currencyCode: 'PI',
+        ),
+      ),
+      throwsA(
+        isA<BusinessException>().having(
+          (error) => error.message,
+          'message',
+          '相手または約束の準備がまだ整っていません。時間を置いてもう一度確認してください。',
+        ),
+      ),
+    );
+  });
+
+  test(
+      'api promise repository starts settlement lookup before promise projection finishes',
+      () async {
+    final promiseRequested = Completer<void>();
+    final settlementRequested = Completer<void>();
+    final promiseResponse = Completer<ResponseBody>();
+    final dio = Dio();
+    dio.httpClientAdapter = _StubHttpClientAdapter((options) async {
+      switch (options.path) {
+        case '/api/projection/promise-views/promise-1':
+          promiseRequested.complete();
+          return promiseResponse.future;
+        case '/api/projection/settlement-views/settlement-1/expanded':
+          settlementRequested.complete();
+          return _jsonResponse(200, {
+            'settlement_case_id': 'settlement-1',
+            'promise_intent_id': 'promise-1',
+            'realm_id': 'realm-1',
+            'current_settlement_status': 'pending_funding',
+            'total_funded_minor_units': 0,
+            'currency_code': 'PI',
+            'proof_status': 'unavailable',
+            'proof_signal_count': 0,
+          });
+      }
+      throw StateError('unexpected path: ${options.path}');
+    });
+    final repository = ApiPromiseRepository(ApiClient(dio));
+
+    final future = repository.fetchPromiseStatus(
+      'promise-1',
+      settlementCaseId: 'settlement-1',
+    );
+
+    await promiseRequested.future;
+    await Future<void>.delayed(Duration.zero);
+    expect(settlementRequested.isCompleted, isTrue);
+
+    promiseResponse.complete(
+      _jsonResponse(200, {
+        'promise_intent_id': 'promise-1',
+        'realm_id': 'realm-1',
+        'initiator_account_id': 'account-a',
+        'counterparty_account_id': 'account-b',
+        'current_intent_status': 'proposed',
+        'deposit_amount_minor_units': 10000,
+        'currency_code': 'PI',
+        'deposit_scale': 3,
+        'latest_settlement_case_id': 'settlement-1',
+        'latest_settlement_status': 'pending_funding',
+      }),
+    );
+
+    final bundle = await future;
+    expect(bundle.promise?.promiseIntentId, 'promise-1');
+    expect(bundle.settlement?.settlementCaseId, 'settlement-1');
+  });
+}
+
+class _StubHttpClientAdapter implements HttpClientAdapter {
+  _StubHttpClientAdapter(this._handler);
+
+  final Future<ResponseBody> Function(RequestOptions options) _handler;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) {
+    return _handler(options);
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+ResponseBody _jsonResponse(int statusCode, Map<String, Object?> body) {
+  return ResponseBody.fromString(
+    jsonEncode(body),
+    statusCode,
+    headers: {
+      Headers.contentTypeHeader: [Headers.jsonContentType],
+    },
+  );
+}

--- a/apps/mobile/test/repositories/promise/api_promise_repository_test.dart
+++ b/apps/mobile/test/repositories/promise/api_promise_repository_test.dart
@@ -100,6 +100,41 @@ void main() {
     expect(bundle.promise?.promiseIntentId, 'promise-1');
     expect(bundle.settlement?.settlementCaseId, 'settlement-1');
   });
+
+  test(
+      'api promise repository ignores settlement projection for another promise',
+      () async {
+    final dio = Dio();
+    dio.httpClientAdapter = _StubHttpClientAdapter((options) async {
+      switch (options.path) {
+        case '/api/projection/promise-views/promise-a':
+          return _jsonResponse(404, {'error': 'not found'});
+        case '/api/projection/settlement-views/settlement-b/expanded':
+          return _jsonResponse(200, {
+            'settlement_case_id': 'settlement-b',
+            'promise_intent_id': 'promise-b',
+            'realm_id': 'realm-1',
+            'current_settlement_status': 'funded',
+            'total_funded_minor_units': 10000,
+            'currency_code': 'PI',
+            'proof_status': 'verified',
+            'proof_signal_count': 1,
+          });
+      }
+      throw StateError('unexpected path: ${options.path}');
+    });
+    final repository = ApiPromiseRepository(ApiClient(dio));
+
+    final bundle = await repository.fetchPromiseStatus(
+      'promise-a',
+      settlementCaseId: 'settlement-b',
+    );
+
+    expect(bundle.promise, isNull);
+    expect(bundle.settlement, isNull);
+    expect(bundle.settlementStatus, 'pending_projection');
+    expect(bundle.proofStatus, 'unavailable');
+  });
 }
 
 class _StubHttpClientAdapter implements HttpClientAdapter {

--- a/apps/mobile/test/repositories/promise/dummy_promise_repository_test.dart
+++ b/apps/mobile/test/repositories/promise/dummy_promise_repository_test.dart
@@ -6,7 +6,10 @@ import 'package:musubi_mobile/repositories/promise/dummy_promise_repository.dart
 void main() {
   test('dummy promise repository replays same idempotency key and payload',
       () async {
-    final repository = DummyPromiseRepository();
+    final repository = DummyPromiseRepository(
+      createDelay: Duration.zero,
+      fetchDelay: Duration.zero,
+    );
     const request = CreatePromiseIntentRequest(
       internalIdempotencyKey: 'promise-action-1',
       realmId: 'realm-1',
@@ -24,7 +27,10 @@ void main() {
   });
 
   test('dummy promise repository rejects idempotency payload drift', () async {
-    final repository = DummyPromiseRepository();
+    final repository = DummyPromiseRepository(
+      createDelay: Duration.zero,
+      fetchDelay: Duration.zero,
+    );
     const request = CreatePromiseIntentRequest(
       internalIdempotencyKey: 'promise-action-1',
       realmId: 'realm-1',

--- a/apps/mobile/test/repositories/promise/dummy_promise_repository_test.dart
+++ b/apps/mobile/test/repositories/promise/dummy_promise_repository_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:musubi_mobile/core/errors/app_exception.dart';
+import 'package:musubi_mobile/features/promise/models/promise_models.dart';
+import 'package:musubi_mobile/repositories/promise/dummy_promise_repository.dart';
+
+void main() {
+  test('dummy promise repository replays same idempotency key and payload',
+      () async {
+    final repository = DummyPromiseRepository();
+    const request = CreatePromiseIntentRequest(
+      internalIdempotencyKey: 'promise-action-1',
+      realmId: 'realm-1',
+      counterpartyAccountId: 'counterparty-1',
+      depositAmountMinorUnits: 10000,
+      currencyCode: 'PI',
+    );
+
+    final created = await repository.createPromiseIntent(request);
+    final replayed = await repository.createPromiseIntent(request);
+
+    expect(created.promiseIntentId, replayed.promiseIntentId);
+    expect(created.replayedIntent, isFalse);
+    expect(replayed.replayedIntent, isTrue);
+  });
+
+  test('dummy promise repository rejects idempotency payload drift', () async {
+    final repository = DummyPromiseRepository();
+    const request = CreatePromiseIntentRequest(
+      internalIdempotencyKey: 'promise-action-1',
+      realmId: 'realm-1',
+      counterpartyAccountId: 'counterparty-1',
+      depositAmountMinorUnits: 10000,
+      currencyCode: 'PI',
+    );
+    const drift = CreatePromiseIntentRequest(
+      internalIdempotencyKey: 'promise-action-1',
+      realmId: 'realm-1',
+      counterpartyAccountId: 'counterparty-2',
+      depositAmountMinorUnits: 10000,
+      currencyCode: 'PI',
+    );
+
+    await repository.createPromiseIntent(request);
+
+    expect(
+      repository.createPromiseIntent(drift),
+      throwsA(isA<BusinessException>()),
+    );
+  });
+}


### PR DESCRIPTION
## Design source

`ISSUE-14-promise-ui-baseline.md`

This is design ISSUE-14, not GitHub issue #14. The GitHub issue number is intentionally not hardcoded.

## Summary

Implements the first participant-facing Promise creation / completion UI baseline for the Flutter Web app.

This builds on the accepted ISSUE-12 operator review baseline and ISSUE-13 room progression baseline. It does not reimplement either surface, and it does not add ranking, DM unlock, paid romantic advantage, broad product UI, or local-only completion truth.

## What changed

- Replaced the match detail Promise/deposit success stub with backend-backed Promise intent creation.
- Added typed mobile Promise request/response and participant-safe status models.
- Added Promise repository adapters:
  - API adapter using `POST /api/promise/intents`
  - dummy adapter with idempotent replay behavior for local fixture mode
- Added `/promises/:promiseIntentId` participant-facing status route.
- Added Promise status screen showing safe Promise / settlement / proof state from existing projection endpoints when available.
- Added informational completion/proof posture without any local completion mutation.
- Added ISSUE-14 mobile docs and README notes.
- Added mobile tests for bounded status copy, safe projection parsing, and idempotent dummy replay/drift rejection.

## Backend surface

No backend endpoint or migration was added.

The UI reuses existing participant-safe/backend-owned surfaces:

- `POST /api/promise/intents`
- `GET /api/projection/promise-views/{promise_intent_id}`
- `GET /api/projection/settlement-views/{settlement_case_id}/expanded`

## Safety boundary

The participant-facing UI does not expose:

- raw evidence locators
- operator IDs
- internal operator notes
- review source fact IDs
- raw source snapshots
- decision payload internals
- sealed fallback internals

Completion remains non-authoritative unless a future writer-owned proof/completion API supports it.

## Validation

Passed:

- `make pub-get` from `apps/mobile`
- `make analyze` from `apps/mobile`
- `mise exec -- dart format --set-exit-if-changed ...` on touched mobile Dart files
- `mise exec -- flutter test` from `apps/mobile`
- `cargo check` from `apps/backend`
- `cargo test --no-fail-fast` from `apps/backend`
- `make ENV_FILE=.env.example db-status` from `apps/backend`
- `git diff --check`

DB status reported:

- applied migrations: 17
- pending migrations: 0
- failed migrations: 0
- checksum drift: 0

## Deferred

- Promise confirm / complete / reflect writer mutations
- proof persistence
- room progression writer changes
- raw evidence retrieval
- dispute center UI
- ranking, leaderboard, recommendation boost, swiping changes, or DM unlock behavior
- native mobile platform work

## Notes

The demo match profiles now carry stable counterparty account IDs so the UI can call the real writer-owned Promise intent API. In API mode, those counterparties must exist in the backend database; if not, the UI shows safe unavailable copy rather than fabricating Promise truth client-side.