### PR TITLE
fix(promise): show unavailable state for stale Promise URLs

### DIFF
--- a/apps/mobile/lib/app/router.dart
+++ b/apps/mobile/lib/app/router.dart
@@ -53,10 +53,12 @@ final goRouterProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: '/promises/:promiseIntentId',
         builder: (context, state) {
+          final created = state.uri.queryParameters['created'] == 'true';
           final replayed = state.uri.queryParameters['replayed'] == 'true';
           return PromiseStatusScreen(
             promiseIntentId: state.pathParameters['promiseIntentId'] ?? '',
             settlementCaseId: state.uri.queryParameters['settlementCaseId'],
+            creationConfirmed: created,
             replayedIntent: replayed,
           );
         },

--- a/apps/mobile/lib/app/router.dart
+++ b/apps/mobile/lib/app/router.dart
@@ -53,8 +53,11 @@ final goRouterProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: '/promises/:promiseIntentId',
         builder: (context, state) {
-          final created = state.uri.queryParameters['created'] == 'true';
-          final replayed = state.uri.queryParameters['replayed'] == 'true';
+          final navigationState = state.extra;
+          final created = navigationState is Map<Object?, Object?> &&
+              navigationState['created'] == true;
+          final replayed = navigationState is Map<Object?, Object?> &&
+              navigationState['replayed'] == true;
           return PromiseStatusScreen(
             promiseIntentId: state.pathParameters['promiseIntentId'] ?? '',
             settlementCaseId: state.uri.queryParameters['settlementCaseId'],

--- a/apps/mobile/lib/features/home/presentation/match_detail_screen.dart
+++ b/apps/mobile/lib/features/home/presentation/match_detail_screen.dart
@@ -260,6 +260,7 @@ class _MatchDetailScreenState extends ConsumerState<MatchDetailScreen> {
       final uri = Uri(
         path: '/promises/${response.promiseIntentId}',
         queryParameters: {
+          'created': 'true',
           'settlementCaseId': response.settlementCaseId,
           if (response.replayedIntent) 'replayed': 'true',
         },

--- a/apps/mobile/lib/features/home/presentation/match_detail_screen.dart
+++ b/apps/mobile/lib/features/home/presentation/match_detail_screen.dart
@@ -260,12 +260,16 @@ class _MatchDetailScreenState extends ConsumerState<MatchDetailScreen> {
       final uri = Uri(
         path: '/promises/${response.promiseIntentId}',
         queryParameters: {
-          'created': 'true',
           'settlementCaseId': response.settlementCaseId,
-          if (response.replayedIntent) 'replayed': 'true',
         },
       );
-      context.push(uri.toString());
+      context.push(
+        uri.toString(),
+        extra: {
+          'created': true,
+          'replayed': response.replayedIntent,
+        },
+      );
     } catch (error) {
       if (!mounted) {
         return;

--- a/apps/mobile/lib/features/promise/models/promise_models.dart
+++ b/apps/mobile/lib/features/promise/models/promise_models.dart
@@ -202,7 +202,7 @@ String proofStatusLabel(String status) {
 
 String participantNextActionCopy(PromiseStatusBundle bundle) {
   if (!bundle.hasParticipantSafeProjection) {
-    return '作成は受け付けました。表示の準備が整うまで少し待ってください。';
+    return '表示の準備を確認しています。反映まで少し時間がかかることがあります。';
   }
   if (bundle.proofStatus == 'unavailable') {
     return '完了はまだこの画面だけでは確定しません。証明機能が使える状態になるまで、約束の状態をここで確認できます。';

--- a/apps/mobile/lib/features/promise/presentation/promise_status_screen.dart
+++ b/apps/mobile/lib/features/promise/presentation/promise_status_screen.dart
@@ -11,11 +11,13 @@ class PromiseStatusScreen extends ConsumerStatefulWidget {
     super.key,
     required this.promiseIntentId,
     this.settlementCaseId,
+    this.creationConfirmed = false,
     this.replayedIntent = false,
   });
 
   final String promiseIntentId;
   final String? settlementCaseId;
+  final bool creationConfirmed;
   final bool replayedIntent;
 
   @override
@@ -45,6 +47,16 @@ class _PromiseStatusScreenState extends ConsumerState<PromiseStatusScreen> {
     });
   }
 
+  _PromiseStatusViewState _viewStateFor(PromiseStatusBundle bundle) {
+    if (bundle.hasParticipantSafeProjection) {
+      return _PromiseStatusViewState.confirmed;
+    }
+    if (widget.creationConfirmed) {
+      return _PromiseStatusViewState.pending;
+    }
+    return _PromiseStatusViewState.unavailable;
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -69,9 +81,36 @@ class _PromiseStatusScreenState extends ConsumerState<PromiseStatusScreen> {
           }
 
           final bundle = snapshot.data!;
+          final viewState = _viewStateFor(bundle);
+          if (viewState == _PromiseStatusViewState.unavailable) {
+            return _PromiseStatusFrame(
+              title: '約束を表示できませんでした',
+              subtitle: 'URL が古いか、表示対象が見つからない可能性があります。',
+              children: [
+                const _GuidancePanel(
+                  copy: '最初の画面からもう一度開くか、正しいリンクかを確認してください。',
+                ),
+                MusubiGhostButton(label: '再読み込み', onPressed: _retry),
+              ],
+            );
+          }
+
+          final title = switch (viewState) {
+            _PromiseStatusViewState.confirmed =>
+              widget.replayedIntent ? '同じ約束を確認しました' : '約束を作成しました',
+            _PromiseStatusViewState.pending => '約束の表示を確認しています',
+            _PromiseStatusViewState.unavailable => '',
+          };
+          final subtitle = switch (viewState) {
+            _PromiseStatusViewState.confirmed =>
+              '約束の進み具合だけを、落ち着いて確認できます。',
+            _PromiseStatusViewState.pending =>
+              '作成直後は表示の反映に少し時間がかかることがあります。',
+            _PromiseStatusViewState.unavailable => '',
+          };
           return _PromiseStatusFrame(
-            title: widget.replayedIntent ? '同じ約束を確認しました' : '約束を作成しました',
-            subtitle: '約束の進み具合だけを、落ち着いて確認できます。',
+            title: title,
+            subtitle: subtitle,
             children: [
               _StatusRow(
                 label: '約束',
@@ -94,6 +133,12 @@ class _PromiseStatusScreenState extends ConsumerState<PromiseStatusScreen> {
       ),
     );
   }
+}
+
+enum _PromiseStatusViewState {
+  confirmed,
+  pending,
+  unavailable,
 }
 
 class _PromiseStatusFrame extends StatelessWidget {

--- a/apps/mobile/lib/features/promise/presentation/promise_status_screen.dart
+++ b/apps/mobile/lib/features/promise/presentation/promise_status_screen.dart
@@ -48,10 +48,10 @@ class _PromiseStatusScreenState extends ConsumerState<PromiseStatusScreen> {
   }
 
   _PromiseStatusViewState _viewStateFor(PromiseStatusBundle bundle) {
-    if (bundle.hasParticipantSafeProjection) {
+    if (bundle.promise != null) {
       return _PromiseStatusViewState.confirmed;
     }
-    if (widget.creationConfirmed) {
+    if (bundle.settlement != null || widget.creationConfirmed) {
       return _PromiseStatusViewState.pending;
     }
     return _PromiseStatusViewState.unavailable;
@@ -102,10 +102,8 @@ class _PromiseStatusScreenState extends ConsumerState<PromiseStatusScreen> {
             _PromiseStatusViewState.unavailable => '',
           };
           final subtitle = switch (viewState) {
-            _PromiseStatusViewState.confirmed =>
-              '約束の進み具合だけを、落ち着いて確認できます。',
-            _PromiseStatusViewState.pending =>
-              '作成直後は表示の反映に少し時間がかかることがあります。',
+            _PromiseStatusViewState.confirmed => '約束の進み具合だけを、落ち着いて確認できます。',
+            _PromiseStatusViewState.pending => '作成直後は表示の反映に少し時間がかかることがあります。',
             _PromiseStatusViewState.unavailable => '',
           };
           return _PromiseStatusFrame(

--- a/apps/mobile/test/features/home/match_detail_screen_test.dart
+++ b/apps/mobile/test/features/home/match_detail_screen_test.dart
@@ -25,12 +25,17 @@ void main() {
         ),
         GoRoute(
           path: '/promises/:promiseIntentId',
-          builder: (context, state) => PromiseStatusScreen(
-            promiseIntentId: state.pathParameters['promiseIntentId'] ?? '',
-            settlementCaseId: state.uri.queryParameters['settlementCaseId'],
-            creationConfirmed: state.uri.queryParameters['created'] == 'true',
-            replayedIntent: state.uri.queryParameters['replayed'] == 'true',
-          ),
+          builder: (context, state) {
+            final navigationState = state.extra;
+            return PromiseStatusScreen(
+              promiseIntentId: state.pathParameters['promiseIntentId'] ?? '',
+              settlementCaseId: state.uri.queryParameters['settlementCaseId'],
+              creationConfirmed: navigationState is Map<Object?, Object?> &&
+                  navigationState['created'] == true,
+              replayedIntent: navigationState is Map<Object?, Object?> &&
+                  navigationState['replayed'] == true,
+            );
+          },
         ),
       ],
     );
@@ -55,6 +60,45 @@ void main() {
 
     expect(find.text('約束を作成しました'), findsOneWidget);
     expect(router.canPop(), isTrue);
+  });
+
+  testWidgets('created query parameters alone do not keep stale links pending',
+      (tester) async {
+    final router = GoRouter(
+      initialLocation:
+          '/promises/promise-missing?created=true&replayed=true&settlementCaseId=settlement-1',
+      routes: [
+        GoRoute(
+          path: '/promises/:promiseIntentId',
+          builder: (context, state) {
+            final navigationState = state.extra;
+            return PromiseStatusScreen(
+              promiseIntentId: state.pathParameters['promiseIntentId'] ?? '',
+              settlementCaseId: state.uri.queryParameters['settlementCaseId'],
+              creationConfirmed: navigationState is Map<Object?, Object?> &&
+                  navigationState['created'] == true,
+              replayedIntent: navigationState is Map<Object?, Object?> &&
+                  navigationState['replayed'] == true,
+            );
+          },
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          promiseRepositoryProvider.overrideWith(
+            (ref) => const _MissingProjectionPromiseRepository(),
+          ),
+        ],
+        child: MaterialApp.router(routerConfig: router),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('約束を表示できませんでした'), findsOneWidget);
+    expect(find.text('約束の表示を確認しています'), findsNothing);
   });
 }
 
@@ -133,6 +177,30 @@ class _FakePromiseRepository implements PromiseRepository {
         proofStatus: 'unavailable',
         proofSignalCount: 0,
       ),
+    );
+  }
+}
+
+class _MissingProjectionPromiseRepository implements PromiseRepository {
+  const _MissingProjectionPromiseRepository();
+
+  @override
+  Future<CreatePromiseIntentResponse> createPromiseIntent(
+    CreatePromiseIntentRequest request,
+  ) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<PromiseStatusBundle> fetchPromiseStatus(
+    String promiseIntentId, {
+    String? settlementCaseId,
+  }) async {
+    return PromiseStatusBundle(
+      promiseIntentId: promiseIntentId,
+      initialSettlementCaseId: settlementCaseId,
+      promise: null,
+      settlement: null,
     );
   }
 }

--- a/apps/mobile/test/features/home/match_detail_screen_test.dart
+++ b/apps/mobile/test/features/home/match_detail_screen_test.dart
@@ -28,6 +28,7 @@ void main() {
           builder: (context, state) => PromiseStatusScreen(
             promiseIntentId: state.pathParameters['promiseIntentId'] ?? '',
             settlementCaseId: state.uri.queryParameters['settlementCaseId'],
+            creationConfirmed: state.uri.queryParameters['created'] == 'true',
             replayedIntent: state.uri.queryParameters['replayed'] == 'true',
           ),
         ),

--- a/apps/mobile/test/features/promise/promise_models_test.dart
+++ b/apps/mobile/test/features/promise/promise_models_test.dart
@@ -43,6 +43,19 @@ void main() {
     expect(copy, isNot(contains('ランキング')));
   });
 
+  test('missing projection copy stays neutral while the screen waits', () {
+    const bundle = PromiseStatusBundle(
+      promiseIntentId: 'promise-1',
+      initialSettlementCaseId: 'settlement-1',
+      promise: null,
+      settlement: null,
+    );
+
+    final copy = participantNextActionCopy(bundle);
+    expect(copy, '表示の準備を確認しています。反映まで少し時間がかかることがあります。');
+    expect(copy, isNot(contains('作成は受け付けました')));
+  });
+
   test('projection parsing ignores internal fields not modeled by the UI', () {
     final view = PromiseProjectionView.fromJson({
       'promise_intent_id': 'promise-1',

--- a/apps/mobile/test/features/promise/promise_status_screen_test.dart
+++ b/apps/mobile/test/features/promise/promise_status_screen_test.dart
@@ -7,7 +7,8 @@ import 'package:musubi_mobile/repositories/promise/promise_repository.dart';
 import 'package:musubi_mobile/repositories/repository_providers.dart';
 
 void main() {
-  testWidgets('missing projections without creation context show unavailable state',
+  testWidgets(
+      'missing projections without creation context show unavailable state',
       (tester) async {
     await tester.pumpWidget(
       _buildApp(
@@ -32,7 +33,8 @@ void main() {
     expect(find.text('約束を作成しました'), findsNothing);
   });
 
-  testWidgets('creation context without projections stays pending instead of success',
+  testWidgets(
+      'creation context without projections stays pending instead of success',
       (tester) async {
     await tester.pumpWidget(
       _buildApp(
@@ -54,6 +56,39 @@ void main() {
     expect(find.text('約束の表示を確認しています'), findsOneWidget);
     expect(find.text('約束を作成しました'), findsNothing);
     expect(find.text('表示準備中'), findsNWidgets(2));
+  });
+
+  testWidgets(
+      'settlement projection without promise projection stays pending instead of success',
+      (tester) async {
+    await tester.pumpWidget(
+      _buildApp(
+        repository: const _FakePromiseRepository(
+          bundle: PromiseStatusBundle(
+            promiseIntentId: 'promise-1',
+            initialSettlementCaseId: 'settlement-1',
+            promise: null,
+            settlement: ExpandedSettlementView(
+              settlementCaseId: 'settlement-1',
+              promiseIntentId: 'promise-1',
+              realmId: 'realm-tokyo-day1',
+              currentSettlementStatus: 'pending_funding',
+              totalFundedMinorUnits: 0,
+              currencyCode: 'PI',
+              proofStatus: 'unavailable',
+              proofSignalCount: 0,
+            ),
+          ),
+        ),
+        promiseIntentId: 'promise-1',
+        settlementCaseId: 'settlement-1',
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('約束の表示を確認しています'), findsOneWidget);
+    expect(find.text('約束を作成しました'), findsNothing);
+    expect(find.text('約束を表示できませんでした'), findsNothing);
   });
 }
 

--- a/apps/mobile/test/features/promise/promise_status_screen_test.dart
+++ b/apps/mobile/test/features/promise/promise_status_screen_test.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:musubi_mobile/core/riverpod_compat.dart';
+import 'package:musubi_mobile/features/promise/models/promise_models.dart';
+import 'package:musubi_mobile/features/promise/presentation/promise_status_screen.dart';
+import 'package:musubi_mobile/repositories/promise/promise_repository.dart';
+import 'package:musubi_mobile/repositories/repository_providers.dart';
+
+void main() {
+  testWidgets('missing projections without creation context show unavailable state',
+      (tester) async {
+    await tester.pumpWidget(
+      _buildApp(
+        repository: const _FakePromiseRepository(
+          bundle: PromiseStatusBundle(
+            promiseIntentId: 'promise-missing',
+            initialSettlementCaseId: null,
+            promise: null,
+            settlement: null,
+          ),
+        ),
+        promiseIntentId: 'promise-missing',
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('約束を表示できませんでした'), findsOneWidget);
+    expect(
+      find.text('URL が古いか、表示対象が見つからない可能性があります。'),
+      findsOneWidget,
+    );
+    expect(find.text('約束を作成しました'), findsNothing);
+  });
+
+  testWidgets('creation context without projections stays pending instead of success',
+      (tester) async {
+    await tester.pumpWidget(
+      _buildApp(
+        repository: const _FakePromiseRepository(
+          bundle: PromiseStatusBundle(
+            promiseIntentId: 'promise-1',
+            initialSettlementCaseId: 'settlement-1',
+            promise: null,
+            settlement: null,
+          ),
+        ),
+        promiseIntentId: 'promise-1',
+        settlementCaseId: 'settlement-1',
+        creationConfirmed: true,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('約束の表示を確認しています'), findsOneWidget);
+    expect(find.text('約束を作成しました'), findsNothing);
+    expect(find.text('表示準備中'), findsNWidgets(2));
+  });
+}
+
+Widget _buildApp({
+  required PromiseRepository repository,
+  required String promiseIntentId,
+  String? settlementCaseId,
+  bool creationConfirmed = false,
+}) {
+  return ProviderScope(
+    overrides: [
+      promiseRepositoryProvider.overrideWith((ref) => repository),
+    ],
+    child: MaterialApp(
+      home: PromiseStatusScreen(
+        promiseIntentId: promiseIntentId,
+        settlementCaseId: settlementCaseId,
+        creationConfirmed: creationConfirmed,
+      ),
+    ),
+  );
+}
+
+class _FakePromiseRepository implements PromiseRepository {
+  const _FakePromiseRepository({required this.bundle});
+
+  final PromiseStatusBundle bundle;
+
+  @override
+  Future<CreatePromiseIntentResponse> createPromiseIntent(
+    CreatePromiseIntentRequest request,
+  ) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<PromiseStatusBundle> fetchPromiseStatus(
+    String promiseIntentId, {
+    String? settlementCaseId,
+  }) async {
+    return bundle;
+  }
+}


### PR DESCRIPTION
## Summary
- gate Promise status success copy on confirmed projection data
- keep post-create routes in a neutral pending state while projections are still catching up
- add widget/model regressions for stale or mistyped Promise URLs

## Testing
- mise exec -- flutter test test/features/promise/promise_status_screen_test.dart test/features/promise/promise_models_test.dart test/features/home/match_detail_screen_test.dart test/repositories/promise/api_promise_repository_test.dart
- mise exec -- flutter analyze