### PR TITLE
feat(realm): add ISSUE-15 bootstrap admission baseline

### DIFF
--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -19,9 +19,20 @@ Current local HTTP surface:
 - `POST /api/review-cases/{review_case_id}/appeals` for the authenticated review subject
 - `GET /api/review-cases/{review_case_id}/appeals` for the authenticated review subject
 - `GET /api/review-cases/{review_case_id}/status` for the authenticated review subject
+- `POST /api/realms/requests` for authenticated realm request creation
+- `GET /api/realms/requests/{realm_request_id}` for the authenticated requester
+- `GET /api/projection/realms/{realm_id}/bootstrap-summary` for the authenticated requester or admitted participant; returns bounded realm/admission state without operator IDs or internal review details
 - `POST /api/internal/room-progressions` under the same internal/debug gate
 - `POST /api/internal/room-progressions/{room_progression_id}/facts` under the same internal/debug gate
 - `POST /api/internal/projection/room-progressions/rebuild` under the same internal/debug gate
+- `GET /api/internal/operator/realms/requests` under the same internal/debug gate; requires `x-musubi-operator-id` with a durable operator role grant
+- `GET /api/internal/operator/realms/requests/{realm_request_id}` under the same internal/debug gate; returns operator review detail for the request
+- `POST /api/internal/operator/realms/requests/{realm_request_id}/approve` under the same internal/debug gate; approves a bounded bootstrap or active realm from a request
+- `POST /api/internal/operator/realms/requests/{realm_request_id}/reject` under the same internal/debug gate
+- `POST /api/internal/realms/{realm_id}/sponsor-records` under the same internal/debug gate; writes explicit sponsor authority with quota
+- `POST /api/internal/realms/{realm_id}/admissions` under the same internal/debug gate; derives admission kind from writer truth, sponsor status, and corridor state
+- `GET /api/internal/operator/realms/{realm_id}/review-summary` under the same internal/debug gate; returns redacted bootstrap health state
+- `POST /api/internal/projection/realms/rebuild` under the same internal/debug gate
 - `GET /api/projection/room-progression-views/{room_progression_id}` for authenticated room participants only
 - `GET /api/projection/settlement-views/{settlement_case_id}` for authenticated participants only
 - `GET /api/projection/settlement-views/{settlement_case_id}/expanded` for authenticated participants only
@@ -125,6 +136,7 @@ Issue #21 wires the happy-route writer truth to PostgreSQL while preserving the 
 Issue #22 adds derived Promise, expanded settlement, and bounded trust read models with rebuild and freshness metadata.
 Design source: ISSUE-12-operator-review-appeal-evidence.md adds the operator review / appeal / evidence workflow baseline. Operator decisions are append-only facts, original writer truth is not overwritten, concurrent idempotent replays return the preserved case or fact instead of surfacing a duplicate-write error, replay mismatches are checked with payload hashes, legacy rows backfill missing replay hashes on first retry, and user-facing review state is projected with bounded status and reason codes. See `docs/operator_review_workflow.md`.
 Design source: ISSUE-13-room-progression.md adds the room progression surface baseline. Room progression facts are append-only writer facts in `dao`, user-facing room state is rebuilt into `projection`, sealed fallback can link to ISSUE-12 review cases without duplicating review/evidence truth, and state-changing progression decisions read writer truth instead of projection rows. See `docs/room_progression_surface.md`.
+Design source: ISSUE-15-realm-bootstrap-and-admission.md adds the first bounded realm bootstrap and admission baseline. Realm creation requests, sponsor records, bootstrap corridors, admissions, and review triggers live in writer-owned `dao` tables, while participant-safe and operator-safe realm summaries stay rebuildable in `projection`. Sponsor quota, revoked/rate-limited sponsor state, corridor expiry/caps, and restricted/suspended realm blocking are enforced on the writer path, not by client/UI state or projection rows. See `docs/realm_bootstrap_surface.md`.
 Issue #17 adds the first sandbox Pi provider adapter boundary for happy-route hold submission and callback intake.
 ISSUE-10 adds Day 1 safer venue proof primitives.
 The public HTTP surface supports the normal venue-code path only.
@@ -143,6 +155,7 @@ These proof records are input facts only; they are not settlement truth or final
 - `docs/projection_read_models.md`: derived read-side contracts, rebuild path, and bounded trust boundary
 - `docs/operator_review_workflow.md`: ISSUE-12 operator review, appeal, evidence, and append-only decision boundary
 - `docs/room_progression_surface.md`: ISSUE-13 Intent / Coordination / Relationship / Sealed Room progression surface boundary
+- `docs/realm_bootstrap_surface.md`: ISSUE-15 bounded realm bootstrap, admission, sponsor, and corridor boundary
 - `docs/guardrails.md`: executable architectural guardrails
 - `docs/proof_primitives.md`: Day 1 safer venue proof input boundary
 - `docs/happy_route_walkthrough.md`: current Issue #7 end-to-end path

--- a/apps/backend/docs/realm_bootstrap_surface.md
+++ b/apps/backend/docs/realm_bootstrap_surface.md
@@ -1,0 +1,125 @@
+# Realm Bootstrap Surface
+
+Design source: ISSUE-15-realm-bootstrap-and-admission.md
+
+The GitHub issue number is intentionally not hardcoded.
+
+## Purpose
+
+ISSUE-15 adds the first bounded Realm bootstrap and admission baseline.
+
+It exists to solve a narrow launch problem:
+- fully manual Realm creation does not scale
+- fully public self-serve Realm creation would become cheap Sybil issuance
+
+The implemented shape is explicit and boring:
+- authenticated Realm creation requests
+- operator-reviewed Realm approval or rejection
+- explicit sponsor records with bounded quota
+- temporary bootstrap corridors with server-enforced caps and expiry
+- server-derived admissions
+- rebuildable participant-safe and operator-safe projections
+
+This is not public realm issuance, not a referral loop, and not a growth hack.
+
+## Writer-owned truth
+
+Writer truth lives in `dao`:
+- `dao.realm_requests`
+- `dao.realms`
+- `dao.realm_sponsor_records`
+- `dao.bootstrap_corridors`
+- `dao.realm_admissions`
+- `dao.realm_review_triggers`
+
+Important boundaries:
+- requests are reviewable facts, not self-serve realm activation
+- sponsor quota is enforced from writer-owned admission rows
+- corridor expiry and corridor caps are enforced on the writer path
+- restricted or suspended realms block new admissions on the writer path
+- idempotency is durable for retryable request, approval, sponsor-record, and admission writes
+
+Projection rows are never used to decide whether a Realm can admit someone.
+
+## Projection surface
+
+Derived read models live in `projection`:
+- `projection.realm_bootstrap_views`
+- `projection.realm_admission_views`
+- `projection.realm_review_summaries`
+
+Participant-safe summary:
+- realm display identity
+- safe realm status
+- admission posture such as `open`, `limited`, or `review_required`
+- current viewer admission status when present
+- safe sponsor/steward display state when intentionally public
+
+Participant-safe summary does not expose:
+- operator IDs
+- raw review trigger context
+- source fact IDs
+- source fact counts
+- moderation internals
+- raw evidence
+- operator notes
+
+Operator/steward summary may expose:
+- current realm status
+- corridor status and remaining time
+- sponsor-backed usage counts
+- open review trigger counts
+- open review case counts
+- redacted reason codes
+- freshness metadata
+
+Operator/steward summary still does not become writer authority.
+
+## HTTP surface
+
+Participant-facing:
+- `POST /api/realms/requests`
+- `GET /api/realms/requests/{realm_request_id}`
+- `GET /api/projection/realms/{realm_id}/bootstrap-summary`
+
+Internal/debug-gated:
+- `GET /api/internal/operator/realms/requests`
+- `GET /api/internal/operator/realms/requests/{realm_request_id}`
+- `POST /api/internal/operator/realms/requests/{realm_request_id}/approve`
+- `POST /api/internal/operator/realms/requests/{realm_request_id}/reject`
+- `POST /api/internal/realms/{realm_id}/sponsor-records`
+- `POST /api/internal/realms/{realm_id}/admissions`
+- `GET /api/internal/operator/realms/{realm_id}/review-summary`
+- `POST /api/internal/projection/realms/rebuild`
+
+The internal operator routes reuse the existing internal/debug gate and `x-musubi-operator-id` role checks. ISSUE-15 does not add a separate launch framework.
+
+## Policy posture
+
+The bootstrap corridor is intentionally bounded:
+- sponsor-backed admissions are quota-bounded
+- rate-limited or revoked sponsors do not auto-admit new members
+- corridor benefits stop when the corridor expires or is disabled
+- quota/cap pressure opens internal review triggers instead of silently admitting
+
+The participant-facing copy must stay calm:
+- no guaranteed admission language
+- no urgency loop
+- no ranking or boost framing
+- no DM unlock or paid romantic advantage framing
+
+## Integration boundaries
+
+ISSUE-15 reuses existing work and does not replace it:
+- ISSUE-12 operator review remains the review/evidence workflow
+- ISSUE-13 room progression remains the room progression writer/projection baseline
+- ISSUE-14 Promise UI remains out of scope here
+
+This implementation also does not add:
+- Promise proof persistence
+- Promise completion writer truth
+- public realm discovery
+- federation
+- governance
+- referral growth loops
+- ranking or recommendation boosts

--- a/apps/backend/docs/realm_bootstrap_surface.md
+++ b/apps/backend/docs/realm_bootstrap_surface.md
@@ -84,6 +84,8 @@ Participant-facing:
 
 Internal/debug-gated:
 - `GET /api/internal/operator/realms/requests`
+  - accepts `limit`, `before_created_at`, and `before_realm_request_id`
+  - the store enforces a bounded page size; callers page with the last row's `created_at` and `realm_request_id`
 - `GET /api/internal/operator/realms/requests/{realm_request_id}`
 - `POST /api/internal/operator/realms/requests/{realm_request_id}/approve`
 - `POST /api/internal/operator/realms/requests/{realm_request_id}/reject`
@@ -93,6 +95,8 @@ Internal/debug-gated:
 - `POST /api/internal/projection/realms/rebuild`
 
 The internal operator routes reuse the existing internal/debug gate and `x-musubi-operator-id` role checks. ISSUE-15 does not add a separate launch framework.
+
+Projection rebuilds use set-based `INSERT ... SELECT` refreshes for bootstrap views, admission views, and review summaries. Rebuild output stays derived display state and must not be used for writer-owned admission decisions.
 
 ## Policy posture
 

--- a/apps/backend/docs/realm_bootstrap_surface.md
+++ b/apps/backend/docs/realm_bootstrap_surface.md
@@ -87,6 +87,7 @@ Internal/debug-gated:
   - accepts `limit`, `before_created_at`, and `before_realm_request_id`
   - the store enforces a bounded page size; callers page with the last row's `created_at` and `realm_request_id`
 - `GET /api/internal/operator/realms/requests/{realm_request_id}`
+  - includes request-scoped open review triggers with redacted reason codes only; raw trigger context stays writer-owned
 - `POST /api/internal/operator/realms/requests/{realm_request_id}/approve`
 - `POST /api/internal/operator/realms/requests/{realm_request_id}/reject`
 - `POST /api/internal/realms/{realm_id}/sponsor-records`

--- a/apps/backend/docs/schema_skeleton.md
+++ b/apps/backend/docs/schema_skeleton.md
@@ -31,6 +31,7 @@ Owns:
 - realm-scoped, pseudonymous references used to coordinate state progression
 - operator review cases, evidence bundles, appeal cases, and append-only operator decision facts that reference writer-owned source facts without overwriting them
 - room progression tracks and append-only room progression facts for Intent, Coordination, Relationship, and Sealed Room surface state
+- realm creation requests, sponsor-backed bootstrap records, bootstrap corridors, realm admissions, and internal review triggers for bounded Day 1 realm growth
 
 Must not own:
 - immutable financial postings
@@ -70,6 +71,8 @@ Owns:
 - rebuildable bounded trust read models
 - rebuildable user-facing review status models derived from operator review and appeal facts
 - rebuildable user-facing room progression models derived from room progression facts and safe ISSUE-12 review posture
+- rebuildable participant-safe realm bootstrap and admission views
+- rebuildable operator-safe realm bootstrap health summaries
 - freshness, lag, watermark, and rebuild metadata for projections
 
 Must not own:
@@ -153,3 +156,29 @@ Room progression tracks preserve the stable realm-scoped participant envelope. R
 `projection.room_progression_views` is a bounded user-facing read model. It is rebuilt from writer-owned room progression facts and may include safe review posture derived from ISSUE-12 projection for display only. State-changing room progression decisions must read writer-owned `dao` facts, not projection rows.
 
 ISSUE-14 Promise UI is a future consumer of this room progression surface. It is not implemented by this schema addition.
+
+## ISSUE-15 realm bootstrap and admission additions
+
+Design source: ISSUE-15-realm-bootstrap-and-admission.md
+
+The GitHub issue number is intentionally not hardcoded.
+
+Migration `0018_realm_bootstrap_admission.sql` adds the bounded realm bootstrap baseline:
+- `dao.realm_requests`
+- `dao.realms`
+- `dao.realm_sponsor_records`
+- `dao.bootstrap_corridors`
+- `dao.realm_admissions`
+- `dao.realm_review_triggers`
+- `projection.realm_bootstrap_views`
+- `projection.realm_admission_views`
+- `projection.realm_review_summaries`
+
+The architectural boundary is strict:
+- realm creation requests do not become public self-serve realm issuance
+- sponsor authority is explicit, quota-bounded, auditable, and revocable
+- corridor expiry, corridor caps, sponsor quota, and restricted/suspended realm blocking are enforced server-side on writer truth
+- participant-safe projections are rebuildable convenience views and do not expose operator IDs, raw review triggers, source fact IDs/counts, or moderation internals
+- operator/steward summaries are redacted, rebuildable, and still non-authoritative
+
+ISSUE-12 operator review remains the review/evidence system of record, ISSUE-13 room progression remains the room surface baseline, and ISSUE-14 Promise UI remains out of scope for this schema addition.

--- a/apps/backend/migrations/0018_realm_bootstrap_admission.sql
+++ b/apps/backend/migrations/0018_realm_bootstrap_admission.sql
@@ -38,10 +38,15 @@ CREATE TABLE IF NOT EXISTS dao.realm_requests (
             'operator_restriction'
         )
     ),
-    request_idempotency_key TEXT,
+    request_idempotency_key TEXT CHECK (
+        request_idempotency_key IS NULL OR char_length(trim(request_idempotency_key)) > 0
+    ),
     request_payload_hash TEXT NOT NULL CHECK (request_payload_hash ~ '^[0-9a-f]{64}$'),
     reviewed_by_operator_id UUID REFERENCES core.accounts(account_id),
-    review_decision_idempotency_key TEXT,
+    review_decision_idempotency_key TEXT CHECK (
+        review_decision_idempotency_key IS NULL
+        OR char_length(trim(review_decision_idempotency_key)) > 0
+    ),
     review_decision_payload_hash TEXT CHECK (
         review_decision_payload_hash IS NULL OR review_decision_payload_hash ~ '^[0-9a-f]{64}$'
     ),
@@ -157,7 +162,9 @@ CREATE TABLE IF NOT EXISTS dao.realm_sponsor_records (
         )
     ),
     approved_by_operator_id UUID NOT NULL REFERENCES core.accounts(account_id),
-    request_idempotency_key TEXT,
+    request_idempotency_key TEXT CHECK (
+        request_idempotency_key IS NULL OR char_length(trim(request_idempotency_key)) > 0
+    ),
     request_payload_hash TEXT NOT NULL CHECK (request_payload_hash ~ '^[0-9a-f]{64}$'),
     created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
@@ -261,7 +268,9 @@ CREATE TABLE IF NOT EXISTS dao.realm_admissions (
     source_fact_kind TEXT NOT NULL CHECK (char_length(trim(source_fact_kind)) > 0),
     source_fact_id TEXT NOT NULL CHECK (char_length(trim(source_fact_id)) > 0),
     source_snapshot_json JSONB NOT NULL DEFAULT '{}'::jsonb,
-    request_idempotency_key TEXT,
+    request_idempotency_key TEXT CHECK (
+        request_idempotency_key IS NULL OR char_length(trim(request_idempotency_key)) > 0
+    ),
     request_payload_hash TEXT NOT NULL CHECK (request_payload_hash ~ '^[0-9a-f]{64}$'),
     created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/apps/backend/migrations/0018_realm_bootstrap_admission.sql
+++ b/apps/backend/migrations/0018_realm_bootstrap_admission.sql
@@ -291,7 +291,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS realm_admissions_idempotency_unique
 
 CREATE UNIQUE INDEX IF NOT EXISTS realm_admissions_active_unique
     ON dao.realm_admissions (realm_id, account_id)
-    WHERE admission_status IN ('pending', 'admitted');
+    WHERE admission_status = 'admitted';
 
 CREATE INDEX IF NOT EXISTS realm_admissions_realm_status_idx
     ON dao.realm_admissions (realm_id, admission_status, created_at);

--- a/apps/backend/migrations/0018_realm_bootstrap_admission.sql
+++ b/apps/backend/migrations/0018_realm_bootstrap_admission.sql
@@ -244,6 +244,11 @@ CREATE TABLE IF NOT EXISTS dao.realm_admissions (
     admission_kind TEXT NOT NULL CHECK (
         admission_kind IN ('normal', 'sponsor_backed', 'corridor', 'review_required')
     ),
+    admission_status TEXT NOT NULL CHECK (
+        admission_status IN ('pending', 'admitted', 'rejected', 'revoked')
+    ),
+    sponsor_record_id UUID,
+    bootstrap_corridor_id UUID,
     CONSTRAINT realm_admissions_kind_lineage_check CHECK (
         (
             admission_kind = 'sponsor_backed'
@@ -261,11 +266,6 @@ CREATE TABLE IF NOT EXISTS dao.realm_admissions (
         )
         OR admission_kind = 'review_required'
     ),
-    admission_status TEXT NOT NULL CHECK (
-        admission_status IN ('pending', 'admitted', 'rejected', 'revoked')
-    ),
-    sponsor_record_id UUID,
-    bootstrap_corridor_id UUID,
     granted_by_actor_kind TEXT NOT NULL CHECK (
         granted_by_actor_kind IN ('system', 'steward', 'operator')
     ),

--- a/apps/backend/migrations/0018_realm_bootstrap_admission.sql
+++ b/apps/backend/migrations/0018_realm_bootstrap_admission.sql
@@ -244,6 +244,23 @@ CREATE TABLE IF NOT EXISTS dao.realm_admissions (
     admission_kind TEXT NOT NULL CHECK (
         admission_kind IN ('normal', 'sponsor_backed', 'corridor', 'review_required')
     ),
+    CONSTRAINT realm_admissions_kind_lineage_check CHECK (
+        (
+            admission_kind = 'sponsor_backed'
+            AND sponsor_record_id IS NOT NULL
+        )
+        OR (
+            admission_kind = 'corridor'
+            AND sponsor_record_id IS NULL
+            AND bootstrap_corridor_id IS NOT NULL
+        )
+        OR (
+            admission_kind = 'normal'
+            AND sponsor_record_id IS NULL
+            AND bootstrap_corridor_id IS NULL
+        )
+        OR admission_kind = 'review_required'
+    ),
     admission_status TEXT NOT NULL CHECK (
         admission_status IN ('pending', 'admitted', 'rejected', 'revoked')
     ),

--- a/apps/backend/migrations/0018_realm_bootstrap_admission.sql
+++ b/apps/backend/migrations/0018_realm_bootstrap_admission.sql
@@ -155,10 +155,6 @@ CREATE UNIQUE INDEX IF NOT EXISTS realm_sponsor_records_idempotency_unique
     ON dao.realm_sponsor_records (realm_id, approved_by_operator_id, request_idempotency_key)
     WHERE request_idempotency_key IS NOT NULL;
 
-CREATE UNIQUE INDEX IF NOT EXISTS realm_sponsor_records_active_unique
-    ON dao.realm_sponsor_records (realm_id, sponsor_account_id)
-    WHERE sponsor_status IN ('proposed', 'approved', 'active');
-
 CREATE UNIQUE INDEX IF NOT EXISTS realm_sponsor_records_id_realm_unique
     ON dao.realm_sponsor_records (realm_sponsor_record_id, realm_id);
 

--- a/apps/backend/migrations/0018_realm_bootstrap_admission.sql
+++ b/apps/backend/migrations/0018_realm_bootstrap_admission.sql
@@ -51,6 +51,18 @@ CREATE TABLE IF NOT EXISTS dao.realm_requests (
     CHECK (
         (reviewed_at IS NULL AND reviewed_by_operator_id IS NULL)
         OR (reviewed_at IS NOT NULL AND reviewed_by_operator_id IS NOT NULL)
+    ),
+    CHECK (
+        (
+            request_state IN ('approved', 'rejected')
+            AND review_decision_idempotency_key IS NOT NULL
+            AND review_decision_payload_hash IS NOT NULL
+        )
+        OR (
+            request_state IN ('requested', 'pending_review')
+            AND review_decision_idempotency_key IS NULL
+            AND review_decision_payload_hash IS NULL
+        )
     )
 );
 

--- a/apps/backend/migrations/0018_realm_bootstrap_admission.sql
+++ b/apps/backend/migrations/0018_realm_bootstrap_admission.sql
@@ -157,7 +157,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS realm_sponsor_records_idempotency_unique
 
 CREATE UNIQUE INDEX IF NOT EXISTS realm_sponsor_records_active_unique
     ON dao.realm_sponsor_records (realm_id, sponsor_account_id)
-    WHERE sponsor_status IN ('proposed', 'approved', 'active', 'rate_limited');
+    WHERE sponsor_status IN ('proposed', 'approved', 'active');
 
 CREATE UNIQUE INDEX IF NOT EXISTS realm_sponsor_records_id_realm_unique
     ON dao.realm_sponsor_records (realm_sponsor_record_id, realm_id);

--- a/apps/backend/migrations/0018_realm_bootstrap_admission.sql
+++ b/apps/backend/migrations/0018_realm_bootstrap_admission.sql
@@ -54,8 +54,16 @@ CREATE TABLE IF NOT EXISTS dao.realm_requests (
     created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
     CHECK (
-        (reviewed_at IS NULL AND reviewed_by_operator_id IS NULL)
-        OR (reviewed_at IS NOT NULL AND reviewed_by_operator_id IS NOT NULL)
+        (
+            request_state IN ('approved', 'rejected')
+            AND reviewed_at IS NOT NULL
+            AND reviewed_by_operator_id IS NOT NULL
+        )
+        OR (
+            request_state IN ('requested', 'pending_review')
+            AND reviewed_at IS NULL
+            AND reviewed_by_operator_id IS NULL
+        )
     ),
     CHECK (
         (

--- a/apps/backend/migrations/0018_realm_bootstrap_admission.sql
+++ b/apps/backend/migrations/0018_realm_bootstrap_admission.sql
@@ -270,6 +270,9 @@ CREATE UNIQUE INDEX IF NOT EXISTS realm_admissions_active_unique
 CREATE INDEX IF NOT EXISTS realm_admissions_realm_status_idx
     ON dao.realm_admissions (realm_id, admission_status, created_at);
 
+CREATE INDEX IF NOT EXISTS realm_admissions_account_latest_idx
+    ON dao.realm_admissions (realm_id, account_id, updated_at DESC, created_at DESC, realm_admission_id DESC);
+
 CREATE INDEX IF NOT EXISTS realm_admissions_sponsor_idx
     ON dao.realm_admissions (sponsor_record_id, admission_status)
     WHERE sponsor_record_id IS NOT NULL;

--- a/apps/backend/migrations/0018_realm_bootstrap_admission.sql
+++ b/apps/backend/migrations/0018_realm_bootstrap_admission.sql
@@ -38,8 +38,8 @@ CREATE TABLE IF NOT EXISTS dao.realm_requests (
             'operator_restriction'
         )
     ),
-    request_idempotency_key TEXT CHECK (
-        request_idempotency_key IS NULL OR char_length(trim(request_idempotency_key)) > 0
+    request_idempotency_key TEXT NOT NULL CHECK (
+        char_length(trim(request_idempotency_key)) > 0
     ),
     request_payload_hash TEXT NOT NULL CHECK (request_payload_hash ~ '^[0-9a-f]{64}$'),
     reviewed_by_operator_id UUID REFERENCES core.accounts(account_id),
@@ -72,8 +72,7 @@ CREATE TABLE IF NOT EXISTS dao.realm_requests (
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS realm_requests_request_idempotency_unique
-    ON dao.realm_requests (requested_by_account_id, request_idempotency_key)
-    WHERE request_idempotency_key IS NOT NULL;
+    ON dao.realm_requests (requested_by_account_id, request_idempotency_key);
 
 CREATE UNIQUE INDEX IF NOT EXISTS realm_requests_open_slug_candidate_unique
     ON dao.realm_requests (slug_candidate)
@@ -162,8 +161,8 @@ CREATE TABLE IF NOT EXISTS dao.realm_sponsor_records (
         )
     ),
     approved_by_operator_id UUID NOT NULL REFERENCES core.accounts(account_id),
-    request_idempotency_key TEXT CHECK (
-        request_idempotency_key IS NULL OR char_length(trim(request_idempotency_key)) > 0
+    request_idempotency_key TEXT NOT NULL CHECK (
+        char_length(trim(request_idempotency_key)) > 0
     ),
     request_payload_hash TEXT NOT NULL CHECK (request_payload_hash ~ '^[0-9a-f]{64}$'),
     created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -171,8 +170,7 @@ CREATE TABLE IF NOT EXISTS dao.realm_sponsor_records (
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS realm_sponsor_records_idempotency_unique
-    ON dao.realm_sponsor_records (realm_id, approved_by_operator_id, request_idempotency_key)
-    WHERE request_idempotency_key IS NOT NULL;
+    ON dao.realm_sponsor_records (realm_id, approved_by_operator_id, request_idempotency_key);
 
 CREATE UNIQUE INDEX IF NOT EXISTS realm_sponsor_records_id_realm_unique
     ON dao.realm_sponsor_records (realm_sponsor_record_id, realm_id);
@@ -268,8 +266,8 @@ CREATE TABLE IF NOT EXISTS dao.realm_admissions (
     source_fact_kind TEXT NOT NULL CHECK (char_length(trim(source_fact_kind)) > 0),
     source_fact_id TEXT NOT NULL CHECK (char_length(trim(source_fact_id)) > 0),
     source_snapshot_json JSONB NOT NULL DEFAULT '{}'::jsonb,
-    request_idempotency_key TEXT CHECK (
-        request_idempotency_key IS NULL OR char_length(trim(request_idempotency_key)) > 0
+    request_idempotency_key TEXT NOT NULL CHECK (
+        char_length(trim(request_idempotency_key)) > 0
     ),
     request_payload_hash TEXT NOT NULL CHECK (request_payload_hash ~ '^[0-9a-f]{64}$'),
     created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -281,8 +279,7 @@ CREATE TABLE IF NOT EXISTS dao.realm_admissions (
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS realm_admissions_idempotency_unique
-    ON dao.realm_admissions (realm_id, granted_by_actor_id, request_idempotency_key)
-    WHERE request_idempotency_key IS NOT NULL;
+    ON dao.realm_admissions (realm_id, granted_by_actor_id, request_idempotency_key);
 
 CREATE UNIQUE INDEX IF NOT EXISTS realm_admissions_active_unique
     ON dao.realm_admissions (realm_id, account_id)

--- a/apps/backend/migrations/0018_realm_bootstrap_admission.sql
+++ b/apps/backend/migrations/0018_realm_bootstrap_admission.sql
@@ -1,0 +1,488 @@
+-- Design source: ISSUE-15-realm-bootstrap-and-admission.md
+-- GitHub issue number is intentionally not hardcoded.
+
+CREATE TABLE IF NOT EXISTS dao.realm_requests (
+    realm_request_id UUID PRIMARY KEY,
+    requested_by_account_id UUID NOT NULL REFERENCES core.accounts(account_id),
+    display_name TEXT NOT NULL CHECK (char_length(trim(display_name)) > 0),
+    slug_candidate TEXT NOT NULL CHECK (char_length(trim(slug_candidate)) > 0),
+    purpose_text TEXT NOT NULL CHECK (char_length(trim(purpose_text)) > 0),
+    venue_context_json JSONB NOT NULL CHECK (
+        jsonb_typeof(venue_context_json) = 'object' AND venue_context_json <> '{}'::jsonb
+    ),
+    expected_member_shape_json JSONB NOT NULL CHECK (
+        jsonb_typeof(expected_member_shape_json) = 'object'
+        AND expected_member_shape_json <> '{}'::jsonb
+    ),
+    bootstrap_rationale_text TEXT NOT NULL CHECK (char_length(trim(bootstrap_rationale_text)) > 0),
+    proposed_sponsor_account_id UUID REFERENCES core.accounts(account_id),
+    proposed_steward_account_id UUID REFERENCES core.accounts(account_id),
+    request_state TEXT NOT NULL CHECK (
+        request_state IN ('requested', 'pending_review', 'approved', 'rejected')
+    ),
+    review_reason_code TEXT NOT NULL CHECK (
+        review_reason_code IN (
+            'request_received',
+            'review_required',
+            'limited_bootstrap_active',
+            'active_after_review',
+            'request_rejected',
+            'duplicate_or_invalid',
+            'sponsor_required',
+            'bootstrap_capacity_reached',
+            'bootstrap_expired',
+            'sponsor_rate_limited',
+            'sponsor_revoked',
+            'restricted_after_review',
+            'suspended_after_review',
+            'operator_restriction'
+        )
+    ),
+    request_idempotency_key TEXT,
+    request_payload_hash TEXT NOT NULL CHECK (request_payload_hash ~ '^[0-9a-f]{64}$'),
+    reviewed_by_operator_id UUID REFERENCES core.accounts(account_id),
+    review_decision_idempotency_key TEXT,
+    review_decision_payload_hash TEXT CHECK (
+        review_decision_payload_hash IS NULL OR review_decision_payload_hash ~ '^[0-9a-f]{64}$'
+    ),
+    reviewed_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CHECK (
+        (reviewed_at IS NULL AND reviewed_by_operator_id IS NULL)
+        OR (reviewed_at IS NOT NULL AND reviewed_by_operator_id IS NOT NULL)
+    )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS realm_requests_request_idempotency_unique
+    ON dao.realm_requests (requested_by_account_id, request_idempotency_key)
+    WHERE request_idempotency_key IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS realm_requests_open_slug_candidate_unique
+    ON dao.realm_requests (slug_candidate)
+    WHERE request_state IN ('requested', 'pending_review', 'approved');
+
+CREATE INDEX IF NOT EXISTS realm_requests_state_created_idx
+    ON dao.realm_requests (request_state, created_at);
+
+COMMENT ON TABLE dao.realm_requests IS
+'ISSUE-15 realm creation requests. Requests are reviewable writer truth and do not create public self-serve realm issuance by themselves.';
+
+CREATE TABLE IF NOT EXISTS dao.realms (
+    realm_id TEXT PRIMARY KEY CHECK (char_length(trim(realm_id)) > 0),
+    slug TEXT NOT NULL UNIQUE CHECK (char_length(trim(slug)) > 0),
+    display_name TEXT NOT NULL CHECK (char_length(trim(display_name)) > 0),
+    realm_status TEXT NOT NULL CHECK (
+        realm_status IN (
+            'requested',
+            'pending_review',
+            'limited_bootstrap',
+            'active',
+            'restricted',
+            'suspended'
+        )
+    ),
+    public_reason_code TEXT NOT NULL CHECK (
+        public_reason_code IN (
+            'request_received',
+            'review_required',
+            'limited_bootstrap_active',
+            'active_after_review',
+            'request_rejected',
+            'duplicate_or_invalid',
+            'sponsor_required',
+            'bootstrap_capacity_reached',
+            'bootstrap_expired',
+            'sponsor_rate_limited',
+            'sponsor_revoked',
+            'restricted_after_review',
+            'suspended_after_review',
+            'operator_restriction'
+        )
+    ),
+    created_from_realm_request_id UUID NOT NULL REFERENCES dao.realm_requests(realm_request_id),
+    steward_account_id UUID REFERENCES core.accounts(account_id),
+    created_by_operator_id UUID NOT NULL REFERENCES core.accounts(account_id),
+    restricted_at TIMESTAMPTZ,
+    suspended_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS realms_status_updated_idx
+    ON dao.realms (realm_status, updated_at);
+
+CREATE UNIQUE INDEX IF NOT EXISTS realms_created_from_request_unique
+    ON dao.realms (created_from_realm_request_id);
+
+COMMENT ON TABLE dao.realms IS
+'ISSUE-15 realm writer truth. Realms move through bounded bootstrap and restriction states; projection rows must not replace this truth.';
+
+CREATE TABLE IF NOT EXISTS dao.realm_sponsor_records (
+    realm_sponsor_record_id UUID PRIMARY KEY,
+    realm_id TEXT NOT NULL REFERENCES dao.realms(realm_id),
+    sponsor_account_id UUID NOT NULL REFERENCES core.accounts(account_id),
+    sponsor_status TEXT NOT NULL CHECK (
+        sponsor_status IN ('proposed', 'approved', 'active', 'rate_limited', 'revoked')
+    ),
+    quota_total BIGINT NOT NULL CHECK (quota_total > 0),
+    status_reason_code TEXT NOT NULL CHECK (
+        status_reason_code IN (
+            'request_received',
+            'review_required',
+            'limited_bootstrap_active',
+            'active_after_review',
+            'request_rejected',
+            'duplicate_or_invalid',
+            'sponsor_required',
+            'bootstrap_capacity_reached',
+            'bootstrap_expired',
+            'sponsor_rate_limited',
+            'sponsor_revoked',
+            'restricted_after_review',
+            'suspended_after_review',
+            'operator_restriction'
+        )
+    ),
+    approved_by_operator_id UUID NOT NULL REFERENCES core.accounts(account_id),
+    request_idempotency_key TEXT,
+    request_payload_hash TEXT NOT NULL CHECK (request_payload_hash ~ '^[0-9a-f]{64}$'),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS realm_sponsor_records_idempotency_unique
+    ON dao.realm_sponsor_records (realm_id, approved_by_operator_id, request_idempotency_key)
+    WHERE request_idempotency_key IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS realm_sponsor_records_active_unique
+    ON dao.realm_sponsor_records (realm_id, sponsor_account_id)
+    WHERE sponsor_status IN ('proposed', 'approved', 'active', 'rate_limited');
+
+CREATE UNIQUE INDEX IF NOT EXISTS realm_sponsor_records_id_realm_unique
+    ON dao.realm_sponsor_records (realm_sponsor_record_id, realm_id);
+
+CREATE INDEX IF NOT EXISTS realm_sponsor_records_lookup_idx
+    ON dao.realm_sponsor_records (sponsor_account_id, sponsor_status, realm_id);
+
+COMMENT ON TABLE dao.realm_sponsor_records IS
+'ISSUE-15 sponsor-backed bootstrap records. Sponsor authority is explicit, quota-bounded, reviewable, and revocable.';
+
+CREATE TABLE IF NOT EXISTS dao.bootstrap_corridors (
+    bootstrap_corridor_id UUID PRIMARY KEY,
+    realm_id TEXT NOT NULL REFERENCES dao.realms(realm_id),
+    corridor_status TEXT NOT NULL CHECK (
+        corridor_status IN ('active', 'cooling_down', 'expired', 'disabled_by_operator')
+    ),
+    starts_at TIMESTAMPTZ NOT NULL,
+    ends_at TIMESTAMPTZ NOT NULL,
+    member_cap BIGINT NOT NULL CHECK (member_cap > 0),
+    sponsor_cap BIGINT NOT NULL CHECK (sponsor_cap > 0),
+    review_threshold_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+    disabled_reason_code TEXT CHECK (
+        disabled_reason_code IS NULL OR disabled_reason_code IN (
+            'request_received',
+            'review_required',
+            'limited_bootstrap_active',
+            'active_after_review',
+            'request_rejected',
+            'duplicate_or_invalid',
+            'sponsor_required',
+            'bootstrap_capacity_reached',
+            'bootstrap_expired',
+            'sponsor_rate_limited',
+            'sponsor_revoked',
+            'restricted_after_review',
+            'suspended_after_review',
+            'operator_restriction'
+        )
+    ),
+    created_by_operator_id UUID NOT NULL REFERENCES core.accounts(account_id),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CHECK (ends_at > starts_at)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS bootstrap_corridors_active_unique
+    ON dao.bootstrap_corridors (realm_id)
+    WHERE corridor_status IN ('active', 'cooling_down');
+
+CREATE UNIQUE INDEX IF NOT EXISTS bootstrap_corridors_id_realm_unique
+    ON dao.bootstrap_corridors (bootstrap_corridor_id, realm_id);
+
+CREATE INDEX IF NOT EXISTS bootstrap_corridors_expiry_idx
+    ON dao.bootstrap_corridors (corridor_status, ends_at, realm_id);
+
+COMMENT ON TABLE dao.bootstrap_corridors IS
+'ISSUE-15 bootstrap corridor flags. Corridors are temporary, bounded, observable, and enforced server-side.';
+
+CREATE TABLE IF NOT EXISTS dao.realm_admissions (
+    realm_admission_id UUID PRIMARY KEY,
+    realm_id TEXT NOT NULL REFERENCES dao.realms(realm_id),
+    account_id UUID NOT NULL REFERENCES core.accounts(account_id),
+    admission_kind TEXT NOT NULL CHECK (
+        admission_kind IN ('normal', 'sponsor_backed', 'corridor', 'review_required')
+    ),
+    admission_status TEXT NOT NULL CHECK (
+        admission_status IN ('pending', 'admitted', 'rejected', 'revoked')
+    ),
+    sponsor_record_id UUID,
+    bootstrap_corridor_id UUID,
+    granted_by_actor_kind TEXT NOT NULL CHECK (
+        granted_by_actor_kind IN ('system', 'steward', 'operator')
+    ),
+    granted_by_actor_id UUID NOT NULL REFERENCES core.accounts(account_id),
+    review_reason_code TEXT NOT NULL CHECK (
+        review_reason_code IN (
+            'request_received',
+            'review_required',
+            'limited_bootstrap_active',
+            'active_after_review',
+            'request_rejected',
+            'duplicate_or_invalid',
+            'sponsor_required',
+            'bootstrap_capacity_reached',
+            'bootstrap_expired',
+            'sponsor_rate_limited',
+            'sponsor_revoked',
+            'restricted_after_review',
+            'suspended_after_review',
+            'operator_restriction'
+        )
+    ),
+    source_fact_kind TEXT NOT NULL CHECK (char_length(trim(source_fact_kind)) > 0),
+    source_fact_id TEXT NOT NULL CHECK (char_length(trim(source_fact_id)) > 0),
+    source_snapshot_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+    request_idempotency_key TEXT,
+    request_payload_hash TEXT NOT NULL CHECK (request_payload_hash ~ '^[0-9a-f]{64}$'),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (sponsor_record_id, realm_id)
+        REFERENCES dao.realm_sponsor_records(realm_sponsor_record_id, realm_id),
+    FOREIGN KEY (bootstrap_corridor_id, realm_id)
+        REFERENCES dao.bootstrap_corridors(bootstrap_corridor_id, realm_id)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS realm_admissions_idempotency_unique
+    ON dao.realm_admissions (realm_id, granted_by_actor_id, request_idempotency_key)
+    WHERE request_idempotency_key IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS realm_admissions_active_unique
+    ON dao.realm_admissions (realm_id, account_id)
+    WHERE admission_status IN ('pending', 'admitted');
+
+CREATE INDEX IF NOT EXISTS realm_admissions_realm_status_idx
+    ON dao.realm_admissions (realm_id, admission_status, created_at);
+
+CREATE INDEX IF NOT EXISTS realm_admissions_sponsor_idx
+    ON dao.realm_admissions (sponsor_record_id, admission_status)
+    WHERE sponsor_record_id IS NOT NULL;
+
+COMMENT ON TABLE dao.realm_admissions IS
+'ISSUE-15 realm admissions. Admission kind is explicit and server-derived; UI state and projections must not create admission truth.';
+
+CREATE TABLE IF NOT EXISTS dao.realm_review_triggers (
+    realm_review_trigger_id UUID PRIMARY KEY,
+    realm_id TEXT REFERENCES dao.realms(realm_id),
+    trigger_kind TEXT NOT NULL CHECK (
+        trigger_kind IN (
+            'sponsor_concentration',
+            'duplicate_venue_context',
+            'suspicious_member_overlap',
+            'proof_failure_rate',
+            'safety_case_concentration',
+            'operator_restriction',
+            'quota_exceeded',
+            'quota_abuse',
+            'corridor_cap_pressure',
+            'revoked_sponsor_lineage',
+            'repeated_rejected_requests'
+        )
+    ),
+    trigger_state TEXT NOT NULL CHECK (
+        trigger_state IN ('open', 'acknowledged', 'resolved', 'suppressed')
+    ),
+    redacted_reason_code TEXT NOT NULL CHECK (
+        redacted_reason_code IN (
+            'request_received',
+            'review_required',
+            'limited_bootstrap_active',
+            'active_after_review',
+            'request_rejected',
+            'duplicate_or_invalid',
+            'sponsor_required',
+            'bootstrap_capacity_reached',
+            'bootstrap_expired',
+            'sponsor_rate_limited',
+            'sponsor_revoked',
+            'restricted_after_review',
+            'suspended_after_review',
+            'operator_restriction'
+        )
+    ),
+    related_account_id UUID REFERENCES core.accounts(account_id),
+    related_realm_request_id UUID REFERENCES dao.realm_requests(realm_request_id),
+    related_sponsor_record_id UUID REFERENCES dao.realm_sponsor_records(realm_sponsor_record_id),
+    context_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+    trigger_fingerprint TEXT NOT NULL CHECK (char_length(trim(trigger_fingerprint)) > 0),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    resolved_at TIMESTAMPTZ
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS realm_review_triggers_open_unique
+    ON dao.realm_review_triggers (trigger_fingerprint)
+    WHERE trigger_state = 'open';
+
+CREATE INDEX IF NOT EXISTS realm_review_triggers_queue_idx
+    ON dao.realm_review_triggers (trigger_state, created_at, realm_id);
+
+COMMENT ON TABLE dao.realm_review_triggers IS
+'ISSUE-15 internal review signals for bootstrap/admission anomalies. These are operator-facing only and must not leak to participants.';
+
+CREATE TABLE IF NOT EXISTS projection.realm_bootstrap_views (
+    realm_id TEXT PRIMARY KEY REFERENCES dao.realms(realm_id),
+    slug TEXT NOT NULL,
+    display_name TEXT NOT NULL,
+    realm_status TEXT NOT NULL CHECK (
+        realm_status IN (
+            'requested',
+            'pending_review',
+            'limited_bootstrap',
+            'active',
+            'restricted',
+            'suspended'
+        )
+    ),
+    admission_posture TEXT NOT NULL CHECK (
+        admission_posture IN ('open', 'limited', 'review_required', 'closed')
+    ),
+    corridor_status TEXT NOT NULL CHECK (
+        corridor_status IN ('none', 'active', 'cooling_down', 'expired', 'disabled_by_operator')
+    ),
+    public_reason_code TEXT NOT NULL CHECK (
+        public_reason_code IN (
+            'request_received',
+            'review_required',
+            'limited_bootstrap_active',
+            'active_after_review',
+            'request_rejected',
+            'duplicate_or_invalid',
+            'sponsor_required',
+            'bootstrap_capacity_reached',
+            'bootstrap_expired',
+            'sponsor_rate_limited',
+            'sponsor_revoked',
+            'restricted_after_review',
+            'suspended_after_review',
+            'operator_restriction'
+        )
+    ),
+    sponsor_display_state TEXT NOT NULL CHECK (
+        sponsor_display_state IN ('none', 'sponsor_backed', 'steward_present', 'sponsor_and_steward')
+    ),
+    source_watermark_at TIMESTAMPTZ NOT NULL,
+    source_fact_count BIGINT NOT NULL CHECK (source_fact_count >= 0),
+    projection_lag_ms BIGINT NOT NULL CHECK (projection_lag_ms >= 0),
+    rebuild_generation BIGINT NOT NULL DEFAULT 1 CHECK (rebuild_generation > 0),
+    last_projected_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS realm_bootstrap_views_status_idx
+    ON projection.realm_bootstrap_views (realm_status, last_projected_at);
+
+COMMENT ON TABLE projection.realm_bootstrap_views IS
+'ISSUE-15 participant-safe realm bootstrap summary. It exposes calm bounded status without quota internals, raw notes, or review trigger detail.';
+
+CREATE TABLE IF NOT EXISTS projection.realm_admission_views (
+    realm_id TEXT NOT NULL REFERENCES dao.realms(realm_id),
+    account_id UUID NOT NULL REFERENCES core.accounts(account_id),
+    admission_status TEXT NOT NULL CHECK (
+        admission_status IN ('pending', 'admitted', 'rejected', 'revoked')
+    ),
+    admission_kind TEXT NOT NULL CHECK (
+        admission_kind IN ('normal', 'sponsor_backed', 'corridor', 'review_required')
+    ),
+    public_reason_code TEXT NOT NULL CHECK (
+        public_reason_code IN (
+            'request_received',
+            'review_required',
+            'limited_bootstrap_active',
+            'active_after_review',
+            'request_rejected',
+            'duplicate_or_invalid',
+            'sponsor_required',
+            'bootstrap_capacity_reached',
+            'bootstrap_expired',
+            'sponsor_rate_limited',
+            'sponsor_revoked',
+            'restricted_after_review',
+            'suspended_after_review',
+            'operator_restriction'
+        )
+    ),
+    source_watermark_at TIMESTAMPTZ NOT NULL,
+    source_fact_count BIGINT NOT NULL CHECK (source_fact_count >= 0),
+    projection_lag_ms BIGINT NOT NULL CHECK (projection_lag_ms >= 0),
+    rebuild_generation BIGINT NOT NULL DEFAULT 1 CHECK (rebuild_generation > 0),
+    last_projected_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (realm_id, account_id)
+);
+
+CREATE INDEX IF NOT EXISTS realm_admission_views_account_idx
+    ON projection.realm_admission_views (account_id, last_projected_at);
+
+COMMENT ON TABLE projection.realm_admission_views IS
+'ISSUE-15 participant-safe admission summary per realm/account. It must not expose sponsor quota internals, operator identities, or review trigger detail.';
+
+CREATE TABLE IF NOT EXISTS projection.realm_review_summaries (
+    realm_id TEXT PRIMARY KEY REFERENCES dao.realms(realm_id),
+    realm_status TEXT NOT NULL CHECK (
+        realm_status IN (
+            'requested',
+            'pending_review',
+            'limited_bootstrap',
+            'active',
+            'restricted',
+            'suspended'
+        )
+    ),
+    corridor_status TEXT NOT NULL CHECK (
+        corridor_status IN ('none', 'active', 'cooling_down', 'expired', 'disabled_by_operator')
+    ),
+    corridor_remaining_seconds BIGINT NOT NULL CHECK (corridor_remaining_seconds >= 0),
+    active_sponsor_count BIGINT NOT NULL CHECK (active_sponsor_count >= 0),
+    sponsor_backed_admission_count BIGINT NOT NULL CHECK (sponsor_backed_admission_count >= 0),
+    recent_admission_count_7d BIGINT NOT NULL CHECK (recent_admission_count_7d >= 0),
+    open_review_trigger_count BIGINT NOT NULL CHECK (open_review_trigger_count >= 0),
+    open_review_case_count BIGINT NOT NULL CHECK (open_review_case_count >= 0),
+    latest_redacted_reason_code TEXT NOT NULL CHECK (
+        latest_redacted_reason_code IN (
+            'request_received',
+            'review_required',
+            'limited_bootstrap_active',
+            'active_after_review',
+            'request_rejected',
+            'duplicate_or_invalid',
+            'sponsor_required',
+            'bootstrap_capacity_reached',
+            'bootstrap_expired',
+            'sponsor_rate_limited',
+            'sponsor_revoked',
+            'restricted_after_review',
+            'suspended_after_review',
+            'operator_restriction'
+        )
+    ),
+    source_watermark_at TIMESTAMPTZ NOT NULL,
+    source_fact_count BIGINT NOT NULL CHECK (source_fact_count >= 0),
+    projection_lag_ms BIGINT NOT NULL CHECK (projection_lag_ms >= 0),
+    rebuild_generation BIGINT NOT NULL DEFAULT 1 CHECK (rebuild_generation > 0),
+    last_projected_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS realm_review_summaries_status_idx
+    ON projection.realm_review_summaries (realm_status, last_projected_at);
+
+COMMENT ON TABLE projection.realm_review_summaries IS
+'ISSUE-15 operator/steward bootstrap health summary. It is rebuildable and redacted, and must not become writer authority.';

--- a/apps/backend/migrations/0018_realm_bootstrap_admission.sql
+++ b/apps/backend/migrations/0018_realm_bootstrap_admission.sql
@@ -306,6 +306,21 @@ CREATE TABLE IF NOT EXISTS dao.realm_admissions (
 CREATE UNIQUE INDEX IF NOT EXISTS realm_admissions_idempotency_unique
     ON dao.realm_admissions (realm_id, granted_by_actor_id, request_idempotency_key);
 
+CREATE TABLE IF NOT EXISTS dao.realm_admission_idempotency_keys (
+    realm_id TEXT NOT NULL REFERENCES dao.realms(realm_id),
+    granted_by_actor_id UUID NOT NULL REFERENCES core.accounts(account_id),
+    request_idempotency_key TEXT NOT NULL CHECK (
+        char_length(trim(request_idempotency_key)) > 0
+    ),
+    realm_admission_id UUID NOT NULL REFERENCES dao.realm_admissions(realm_admission_id),
+    request_payload_hash TEXT NOT NULL CHECK (request_payload_hash ~ '^[0-9a-f]{64}$'),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (realm_id, granted_by_actor_id, request_idempotency_key)
+);
+
+CREATE INDEX IF NOT EXISTS realm_admission_idempotency_keys_admission_idx
+    ON dao.realm_admission_idempotency_keys (realm_admission_id);
+
 CREATE UNIQUE INDEX IF NOT EXISTS realm_admissions_active_unique
     ON dao.realm_admissions (realm_id, account_id)
     WHERE admission_status = 'admitted';

--- a/apps/backend/src/handlers/mod.rs
+++ b/apps/backend/src/handlers/mod.rs
@@ -13,6 +13,7 @@ pub mod payments;
 pub mod projection;
 pub mod promise_intents;
 pub mod proof;
+pub mod realm_bootstrap;
 pub mod room_progression;
 
 #[derive(Debug, Serialize)]

--- a/apps/backend/src/handlers/realm_bootstrap.rs
+++ b/apps/backend/src/handlers/realm_bootstrap.rs
@@ -1,0 +1,703 @@
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::HeaderMap,
+};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{
+    SharedState,
+    handlers::{
+        ApiError, ApiResult, bad_request, internal_server_error, not_found, require_bearer_token,
+        require_internal_bearer_token, require_operator_id, service_unavailable, unauthorized,
+    },
+    services::{
+        happy_route::authorize_account,
+        realm_bootstrap::{
+            CreateRealmAdmissionInput, CreateRealmRequestInput, CreateRealmSponsorRecordInput,
+            RealmAdmissionSnapshot, RealmAdmissionViewSnapshot, RealmBootstrapError,
+            RealmBootstrapRebuildSnapshot, RealmBootstrapSummarySnapshot,
+            RealmBootstrapViewSnapshot, RealmRequestSnapshot, RealmReviewSummarySnapshot,
+            RealmReviewTriggerSnapshot, RealmSnapshot, RealmSponsorRecordSnapshot,
+            RejectRealmRequestInput, ReviewRealmRequestInput,
+        },
+    },
+};
+
+#[derive(Debug, Deserialize)]
+pub struct CreateRealmRequestRequest {
+    pub display_name: String,
+    pub slug_candidate: String,
+    pub purpose_text: String,
+    pub venue_context_json: Value,
+    pub expected_member_shape_json: Value,
+    pub bootstrap_rationale_text: String,
+    pub proposed_sponsor_account_id: Option<String>,
+    pub proposed_steward_account_id: Option<String>,
+    pub request_idempotency_key: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ReviewRealmRequestRequest {
+    pub target_realm_status: String,
+    pub approved_slug: Option<String>,
+    pub approved_display_name: Option<String>,
+    pub review_reason_code: String,
+    pub steward_account_id: Option<String>,
+    pub sponsor_quota_total: Option<i64>,
+    pub corridor_starts_at: Option<DateTime<Utc>>,
+    pub corridor_ends_at: Option<DateTime<Utc>>,
+    pub corridor_member_cap: Option<i64>,
+    pub corridor_sponsor_cap: Option<i64>,
+    pub review_threshold_json: Option<Value>,
+    pub review_decision_idempotency_key: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RejectRealmRequestRequest {
+    pub review_reason_code: String,
+    pub review_decision_idempotency_key: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateRealmSponsorRecordRequest {
+    pub sponsor_account_id: String,
+    pub sponsor_status: String,
+    pub quota_total: i64,
+    pub status_reason_code: String,
+    pub request_idempotency_key: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateRealmAdmissionRequest {
+    pub account_id: String,
+    pub sponsor_record_id: Option<String>,
+    pub source_fact_kind: String,
+    pub source_fact_id: String,
+    pub source_snapshot_json: Option<Value>,
+    pub request_idempotency_key: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RealmRequestResponse {
+    pub realm_request_id: String,
+    pub requested_by_account_id: String,
+    pub display_name: String,
+    pub slug_candidate: String,
+    pub purpose_text: String,
+    pub venue_context_json: Value,
+    pub expected_member_shape_json: Value,
+    pub bootstrap_rationale_text: String,
+    pub proposed_sponsor_account_id: Option<String>,
+    pub proposed_steward_account_id: Option<String>,
+    pub request_state: String,
+    pub review_reason_code: String,
+    pub reviewed_at: Option<DateTime<Utc>>,
+    pub created_realm_id: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RealmRequestOperatorResponse {
+    pub realm_request_id: String,
+    pub requested_by_account_id: String,
+    pub display_name: String,
+    pub slug_candidate: String,
+    pub purpose_text: String,
+    pub venue_context_json: Value,
+    pub expected_member_shape_json: Value,
+    pub bootstrap_rationale_text: String,
+    pub proposed_sponsor_account_id: Option<String>,
+    pub proposed_steward_account_id: Option<String>,
+    pub request_state: String,
+    pub review_reason_code: String,
+    pub reviewed_by_operator_id: Option<String>,
+    pub reviewed_at: Option<DateTime<Utc>>,
+    pub created_realm_id: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RealmResponse {
+    pub realm_id: String,
+    pub slug: String,
+    pub display_name: String,
+    pub realm_status: String,
+    pub public_reason_code: String,
+    pub created_from_realm_request_id: String,
+    pub steward_account_id: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RealmSponsorRecordResponse {
+    pub realm_sponsor_record_id: String,
+    pub realm_id: String,
+    pub sponsor_account_id: String,
+    pub sponsor_status: String,
+    pub quota_total: i64,
+    pub status_reason_code: String,
+    pub approved_by_operator_id: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RealmAdmissionResponse {
+    pub realm_admission_id: String,
+    pub realm_id: String,
+    pub account_id: String,
+    pub admission_kind: String,
+    pub admission_status: String,
+    pub sponsor_record_id: Option<String>,
+    pub bootstrap_corridor_id: Option<String>,
+    pub granted_by_actor_kind: String,
+    pub granted_by_actor_id: String,
+    pub review_reason_code: String,
+    pub source_fact_kind: String,
+    pub source_fact_id: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RealmBootstrapViewResponse {
+    pub realm_id: String,
+    pub slug: String,
+    pub display_name: String,
+    pub realm_status: String,
+    pub admission_posture: String,
+    pub corridor_status: String,
+    pub public_reason_code: String,
+    pub sponsor_display_state: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RealmAdmissionViewResponse {
+    pub realm_id: String,
+    pub account_id: String,
+    pub admission_status: String,
+    pub admission_kind: String,
+    pub public_reason_code: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RealmBootstrapSummaryResponse {
+    pub realm_request: Option<RealmRequestResponse>,
+    pub bootstrap_view: RealmBootstrapViewResponse,
+    pub admission_view: Option<RealmAdmissionViewResponse>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RealmReviewTriggerResponse {
+    pub realm_review_trigger_id: String,
+    pub realm_id: Option<String>,
+    pub trigger_kind: String,
+    pub trigger_state: String,
+    pub redacted_reason_code: String,
+    pub related_account_id: Option<String>,
+    pub related_realm_request_id: Option<String>,
+    pub related_sponsor_record_id: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub resolved_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RealmReviewSummaryResponse {
+    pub realm_id: String,
+    pub realm_status: String,
+    pub corridor_status: String,
+    pub corridor_remaining_seconds: i64,
+    pub active_sponsor_count: i64,
+    pub sponsor_backed_admission_count: i64,
+    pub recent_admission_count_7d: i64,
+    pub open_review_trigger_count: i64,
+    pub open_review_case_count: i64,
+    pub latest_redacted_reason_code: String,
+    pub source_watermark_at: DateTime<Utc>,
+    pub source_fact_count: i64,
+    pub projection_lag_ms: i64,
+    pub rebuild_generation: i64,
+    pub last_projected_at: DateTime<Utc>,
+    pub open_review_triggers: Vec<RealmReviewTriggerResponse>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RealmBootstrapRebuildResponse {
+    pub bootstrap_view_count: i64,
+    pub admission_view_count: i64,
+    pub review_summary_count: i64,
+}
+
+pub async fn create_realm_request(
+    State(state): State<SharedState>,
+    headers: HeaderMap,
+    Json(payload): Json<CreateRealmRequestRequest>,
+) -> ApiResult<RealmRequestResponse> {
+    let token = require_bearer_token(&headers)?;
+    let account = authorize_account(&state, &token)
+        .await
+        .map_err(map_realm_bootstrap_happy_route_error)?;
+    let snapshot = state
+        .realm_bootstrap
+        .create_realm_request(
+            &account.account_id,
+            CreateRealmRequestInput {
+                display_name: payload.display_name,
+                slug_candidate: payload.slug_candidate,
+                purpose_text: payload.purpose_text,
+                venue_context_json: payload.venue_context_json,
+                expected_member_shape_json: payload.expected_member_shape_json,
+                bootstrap_rationale_text: payload.bootstrap_rationale_text,
+                proposed_sponsor_account_id: payload.proposed_sponsor_account_id,
+                proposed_steward_account_id: payload.proposed_steward_account_id,
+                request_idempotency_key: payload.request_idempotency_key,
+            },
+        )
+        .await
+        .map_err(map_realm_bootstrap_error)?;
+    Ok(Json(realm_request_response(snapshot)))
+}
+
+pub async fn get_realm_request(
+    State(state): State<SharedState>,
+    headers: HeaderMap,
+    Path(realm_request_id): Path<String>,
+) -> ApiResult<RealmRequestResponse> {
+    let token = require_bearer_token(&headers)?;
+    let account = authorize_account(&state, &token)
+        .await
+        .map_err(map_realm_bootstrap_happy_route_error)?;
+    let snapshot = state
+        .realm_bootstrap
+        .get_realm_request_for_requester(&account.account_id, realm_request_id.trim())
+        .await
+        .map_err(map_realm_bootstrap_error)?;
+    Ok(Json(realm_request_response(snapshot)))
+}
+
+pub async fn list_realm_requests(
+    State(state): State<SharedState>,
+    headers: HeaderMap,
+) -> ApiResult<Vec<RealmRequestOperatorResponse>> {
+    require_internal_bearer_token(&headers)?;
+    let operator_id = require_operator_id(&headers)?;
+    let snapshots = state
+        .realm_bootstrap
+        .list_realm_requests_for_operator(&operator_id)
+        .await
+        .map_err(map_realm_bootstrap_error)?;
+    Ok(Json(
+        snapshots
+            .into_iter()
+            .map(realm_request_operator_response)
+            .collect(),
+    ))
+}
+
+pub async fn read_realm_request(
+    State(state): State<SharedState>,
+    headers: HeaderMap,
+    Path(realm_request_id): Path<String>,
+) -> ApiResult<RealmRequestOperatorResponse> {
+    require_internal_bearer_token(&headers)?;
+    let operator_id = require_operator_id(&headers)?;
+    let snapshot = state
+        .realm_bootstrap
+        .read_realm_request_for_operator(&operator_id, realm_request_id.trim())
+        .await
+        .map_err(map_realm_bootstrap_error)?;
+    Ok(Json(realm_request_operator_response(snapshot)))
+}
+
+pub async fn approve_realm_request(
+    State(state): State<SharedState>,
+    headers: HeaderMap,
+    Path(realm_request_id): Path<String>,
+    Json(payload): Json<ReviewRealmRequestRequest>,
+) -> ApiResult<RealmResponse> {
+    require_internal_bearer_token(&headers)?;
+    let operator_id = require_operator_id(&headers)?;
+    let snapshot = state
+        .realm_bootstrap
+        .approve_realm_request(
+            &operator_id,
+            realm_request_id.trim(),
+            ReviewRealmRequestInput {
+                target_realm_status: payload.target_realm_status,
+                approved_slug: payload.approved_slug,
+                approved_display_name: payload.approved_display_name,
+                review_reason_code: payload.review_reason_code,
+                steward_account_id: payload.steward_account_id,
+                sponsor_quota_total: payload.sponsor_quota_total,
+                corridor_starts_at: payload.corridor_starts_at,
+                corridor_ends_at: payload.corridor_ends_at,
+                corridor_member_cap: payload.corridor_member_cap,
+                corridor_sponsor_cap: payload.corridor_sponsor_cap,
+                review_threshold_json: payload
+                    .review_threshold_json
+                    .unwrap_or_else(|| Value::Object(Default::default())),
+                review_decision_idempotency_key: payload.review_decision_idempotency_key,
+            },
+        )
+        .await
+        .map_err(map_realm_bootstrap_error)?;
+    Ok(Json(realm_response(snapshot)))
+}
+
+pub async fn reject_realm_request(
+    State(state): State<SharedState>,
+    headers: HeaderMap,
+    Path(realm_request_id): Path<String>,
+    Json(payload): Json<RejectRealmRequestRequest>,
+) -> ApiResult<RealmRequestOperatorResponse> {
+    require_internal_bearer_token(&headers)?;
+    let operator_id = require_operator_id(&headers)?;
+    let snapshot = state
+        .realm_bootstrap
+        .reject_realm_request(
+            &operator_id,
+            realm_request_id.trim(),
+            RejectRealmRequestInput {
+                review_reason_code: payload.review_reason_code,
+                review_decision_idempotency_key: payload.review_decision_idempotency_key,
+            },
+        )
+        .await
+        .map_err(map_realm_bootstrap_error)?;
+    Ok(Json(realm_request_operator_response(snapshot)))
+}
+
+pub async fn create_realm_sponsor_record(
+    State(state): State<SharedState>,
+    headers: HeaderMap,
+    Path(realm_id): Path<String>,
+    Json(payload): Json<CreateRealmSponsorRecordRequest>,
+) -> ApiResult<RealmSponsorRecordResponse> {
+    require_internal_bearer_token(&headers)?;
+    let operator_id = require_operator_id(&headers)?;
+    let snapshot = state
+        .realm_bootstrap
+        .create_realm_sponsor_record(
+            &operator_id,
+            realm_id.trim(),
+            CreateRealmSponsorRecordInput {
+                sponsor_account_id: payload.sponsor_account_id,
+                sponsor_status: payload.sponsor_status,
+                quota_total: payload.quota_total,
+                status_reason_code: payload.status_reason_code,
+                request_idempotency_key: payload.request_idempotency_key,
+            },
+        )
+        .await
+        .map_err(map_realm_bootstrap_error)?;
+    Ok(Json(realm_sponsor_record_response(snapshot)))
+}
+
+pub async fn create_realm_admission(
+    State(state): State<SharedState>,
+    headers: HeaderMap,
+    Path(realm_id): Path<String>,
+    Json(payload): Json<CreateRealmAdmissionRequest>,
+) -> ApiResult<RealmAdmissionResponse> {
+    require_internal_bearer_token(&headers)?;
+    let operator_id = require_operator_id(&headers)?;
+    let snapshot = state
+        .realm_bootstrap
+        .create_realm_admission(
+            &operator_id,
+            realm_id.trim(),
+            CreateRealmAdmissionInput {
+                account_id: payload.account_id,
+                sponsor_record_id: payload.sponsor_record_id,
+                source_fact_kind: payload.source_fact_kind,
+                source_fact_id: payload.source_fact_id,
+                source_snapshot_json: payload
+                    .source_snapshot_json
+                    .unwrap_or_else(|| Value::Object(Default::default())),
+                request_idempotency_key: payload.request_idempotency_key,
+            },
+        )
+        .await
+        .map_err(map_realm_bootstrap_error)?;
+    Ok(Json(realm_admission_response(snapshot)))
+}
+
+pub async fn get_bootstrap_summary(
+    State(state): State<SharedState>,
+    headers: HeaderMap,
+    Path(realm_id): Path<String>,
+) -> ApiResult<RealmBootstrapSummaryResponse> {
+    let token = require_bearer_token(&headers)?;
+    let account = authorize_account(&state, &token)
+        .await
+        .map_err(map_realm_bootstrap_happy_route_error)?;
+    let snapshot = state
+        .realm_bootstrap
+        .get_bootstrap_summary_for_viewer(&account.account_id, realm_id.trim())
+        .await
+        .map_err(map_realm_bootstrap_error)?;
+    Ok(Json(realm_bootstrap_summary_response(snapshot)))
+}
+
+pub async fn get_review_summary(
+    State(state): State<SharedState>,
+    headers: HeaderMap,
+    Path(realm_id): Path<String>,
+) -> ApiResult<RealmReviewSummaryResponse> {
+    require_internal_bearer_token(&headers)?;
+    let operator_id = require_operator_id(&headers)?;
+    let snapshot = state
+        .realm_bootstrap
+        .get_review_summary_for_operator(&operator_id, realm_id.trim())
+        .await
+        .map_err(map_realm_bootstrap_error)?;
+    Ok(Json(realm_review_summary_response(snapshot)))
+}
+
+pub async fn rebuild_realm_bootstrap_views(
+    State(state): State<SharedState>,
+    headers: HeaderMap,
+) -> ApiResult<RealmBootstrapRebuildResponse> {
+    require_internal_bearer_token(&headers)?;
+    let snapshot = state
+        .realm_bootstrap
+        .rebuild_realm_bootstrap_views()
+        .await
+        .map_err(map_realm_bootstrap_error)?;
+    Ok(Json(realm_bootstrap_rebuild_response(snapshot)))
+}
+
+fn realm_request_response(snapshot: RealmRequestSnapshot) -> RealmRequestResponse {
+    RealmRequestResponse {
+        realm_request_id: snapshot.realm_request_id,
+        requested_by_account_id: snapshot.requested_by_account_id,
+        display_name: snapshot.display_name,
+        slug_candidate: snapshot.slug_candidate,
+        purpose_text: snapshot.purpose_text,
+        venue_context_json: snapshot.venue_context_json,
+        expected_member_shape_json: snapshot.expected_member_shape_json,
+        bootstrap_rationale_text: snapshot.bootstrap_rationale_text,
+        proposed_sponsor_account_id: snapshot.proposed_sponsor_account_id,
+        proposed_steward_account_id: snapshot.proposed_steward_account_id,
+        request_state: snapshot.request_state,
+        review_reason_code: snapshot.review_reason_code,
+        reviewed_at: snapshot.reviewed_at,
+        created_realm_id: snapshot.created_realm_id,
+        created_at: snapshot.created_at,
+        updated_at: snapshot.updated_at,
+    }
+}
+
+fn realm_request_operator_response(snapshot: RealmRequestSnapshot) -> RealmRequestOperatorResponse {
+    RealmRequestOperatorResponse {
+        realm_request_id: snapshot.realm_request_id,
+        requested_by_account_id: snapshot.requested_by_account_id,
+        display_name: snapshot.display_name,
+        slug_candidate: snapshot.slug_candidate,
+        purpose_text: snapshot.purpose_text,
+        venue_context_json: snapshot.venue_context_json,
+        expected_member_shape_json: snapshot.expected_member_shape_json,
+        bootstrap_rationale_text: snapshot.bootstrap_rationale_text,
+        proposed_sponsor_account_id: snapshot.proposed_sponsor_account_id,
+        proposed_steward_account_id: snapshot.proposed_steward_account_id,
+        request_state: snapshot.request_state,
+        review_reason_code: snapshot.review_reason_code,
+        reviewed_by_operator_id: snapshot.reviewed_by_operator_id,
+        reviewed_at: snapshot.reviewed_at,
+        created_realm_id: snapshot.created_realm_id,
+        created_at: snapshot.created_at,
+        updated_at: snapshot.updated_at,
+    }
+}
+
+fn realm_response(snapshot: RealmSnapshot) -> RealmResponse {
+    RealmResponse {
+        realm_id: snapshot.realm_id,
+        slug: snapshot.slug,
+        display_name: snapshot.display_name,
+        realm_status: snapshot.realm_status,
+        public_reason_code: snapshot.public_reason_code,
+        created_from_realm_request_id: snapshot.created_from_realm_request_id,
+        steward_account_id: snapshot.steward_account_id,
+        created_at: snapshot.created_at,
+        updated_at: snapshot.updated_at,
+    }
+}
+
+fn realm_sponsor_record_response(
+    snapshot: RealmSponsorRecordSnapshot,
+) -> RealmSponsorRecordResponse {
+    RealmSponsorRecordResponse {
+        realm_sponsor_record_id: snapshot.realm_sponsor_record_id,
+        realm_id: snapshot.realm_id,
+        sponsor_account_id: snapshot.sponsor_account_id,
+        sponsor_status: snapshot.sponsor_status,
+        quota_total: snapshot.quota_total,
+        status_reason_code: snapshot.status_reason_code,
+        approved_by_operator_id: snapshot.approved_by_operator_id,
+        created_at: snapshot.created_at,
+        updated_at: snapshot.updated_at,
+    }
+}
+
+fn realm_admission_response(snapshot: RealmAdmissionSnapshot) -> RealmAdmissionResponse {
+    RealmAdmissionResponse {
+        realm_admission_id: snapshot.realm_admission_id,
+        realm_id: snapshot.realm_id,
+        account_id: snapshot.account_id,
+        admission_kind: snapshot.admission_kind,
+        admission_status: snapshot.admission_status,
+        sponsor_record_id: snapshot.sponsor_record_id,
+        bootstrap_corridor_id: snapshot.bootstrap_corridor_id,
+        granted_by_actor_kind: snapshot.granted_by_actor_kind,
+        granted_by_actor_id: snapshot.granted_by_actor_id,
+        review_reason_code: snapshot.review_reason_code,
+        source_fact_kind: snapshot.source_fact_kind,
+        source_fact_id: snapshot.source_fact_id,
+        created_at: snapshot.created_at,
+        updated_at: snapshot.updated_at,
+    }
+}
+
+fn realm_bootstrap_view_response(
+    snapshot: RealmBootstrapViewSnapshot,
+) -> RealmBootstrapViewResponse {
+    RealmBootstrapViewResponse {
+        realm_id: snapshot.realm_id,
+        slug: snapshot.slug,
+        display_name: snapshot.display_name,
+        realm_status: snapshot.realm_status,
+        admission_posture: snapshot.admission_posture,
+        corridor_status: snapshot.corridor_status,
+        public_reason_code: snapshot.public_reason_code,
+        sponsor_display_state: snapshot.sponsor_display_state,
+    }
+}
+
+fn realm_admission_view_response(
+    snapshot: RealmAdmissionViewSnapshot,
+) -> RealmAdmissionViewResponse {
+    RealmAdmissionViewResponse {
+        realm_id: snapshot.realm_id,
+        account_id: snapshot.account_id,
+        admission_status: snapshot.admission_status,
+        admission_kind: snapshot.admission_kind,
+        public_reason_code: snapshot.public_reason_code,
+    }
+}
+
+fn realm_review_trigger_response(
+    snapshot: RealmReviewTriggerSnapshot,
+) -> RealmReviewTriggerResponse {
+    RealmReviewTriggerResponse {
+        realm_review_trigger_id: snapshot.realm_review_trigger_id,
+        realm_id: snapshot.realm_id,
+        trigger_kind: snapshot.trigger_kind,
+        trigger_state: snapshot.trigger_state,
+        redacted_reason_code: snapshot.redacted_reason_code,
+        related_account_id: snapshot.related_account_id,
+        related_realm_request_id: snapshot.related_realm_request_id,
+        related_sponsor_record_id: snapshot.related_sponsor_record_id,
+        created_at: snapshot.created_at,
+        updated_at: snapshot.updated_at,
+        resolved_at: snapshot.resolved_at,
+    }
+}
+
+fn realm_review_summary_response(
+    snapshot: RealmReviewSummarySnapshot,
+) -> RealmReviewSummaryResponse {
+    RealmReviewSummaryResponse {
+        realm_id: snapshot.realm_id,
+        realm_status: snapshot.realm_status,
+        corridor_status: snapshot.corridor_status,
+        corridor_remaining_seconds: snapshot.corridor_remaining_seconds,
+        active_sponsor_count: snapshot.active_sponsor_count,
+        sponsor_backed_admission_count: snapshot.sponsor_backed_admission_count,
+        recent_admission_count_7d: snapshot.recent_admission_count_7d,
+        open_review_trigger_count: snapshot.open_review_trigger_count,
+        open_review_case_count: snapshot.open_review_case_count,
+        latest_redacted_reason_code: snapshot.latest_redacted_reason_code,
+        source_watermark_at: snapshot.source_watermark_at,
+        source_fact_count: snapshot.source_fact_count,
+        projection_lag_ms: snapshot.projection_lag_ms,
+        rebuild_generation: snapshot.rebuild_generation,
+        last_projected_at: snapshot.last_projected_at,
+        open_review_triggers: snapshot
+            .open_review_triggers
+            .into_iter()
+            .map(realm_review_trigger_response)
+            .collect(),
+    }
+}
+
+fn realm_bootstrap_summary_response(
+    snapshot: RealmBootstrapSummarySnapshot,
+) -> RealmBootstrapSummaryResponse {
+    RealmBootstrapSummaryResponse {
+        realm_request: snapshot.realm_request.map(realm_request_response),
+        bootstrap_view: realm_bootstrap_view_response(snapshot.bootstrap_view),
+        admission_view: snapshot.admission_view.map(realm_admission_view_response),
+    }
+}
+
+fn realm_bootstrap_rebuild_response(
+    snapshot: RealmBootstrapRebuildSnapshot,
+) -> RealmBootstrapRebuildResponse {
+    RealmBootstrapRebuildResponse {
+        bootstrap_view_count: snapshot.bootstrap_view_count,
+        admission_view_count: snapshot.admission_view_count,
+        review_summary_count: snapshot.review_summary_count,
+    }
+}
+
+fn map_realm_bootstrap_happy_route_error(
+    error: crate::services::happy_route::HappyRouteError,
+) -> ApiError {
+    match error {
+        crate::services::happy_route::HappyRouteError::BadRequest(message) => bad_request(message),
+        crate::services::happy_route::HappyRouteError::Unauthorized(message) => {
+            unauthorized(message)
+        }
+        crate::services::happy_route::HappyRouteError::NotFound(message) => not_found(message),
+        crate::services::happy_route::HappyRouteError::ProviderCallbackMappingDeferred(_) => {
+            service_unavailable("temporarily unavailable")
+        }
+        crate::services::happy_route::HappyRouteError::Provider { .. } => {
+            service_unavailable("temporarily unavailable")
+        }
+        crate::services::happy_route::HappyRouteError::Database { retryable, .. } => {
+            if retryable {
+                service_unavailable("temporarily unavailable")
+            } else {
+                internal_server_error("internal server error")
+            }
+        }
+        crate::services::happy_route::HappyRouteError::Internal(_) => {
+            internal_server_error("internal server error")
+        }
+    }
+}
+
+fn map_realm_bootstrap_error(error: RealmBootstrapError) -> ApiError {
+    match error {
+        RealmBootstrapError::BadRequest(message) => bad_request(message),
+        RealmBootstrapError::Unauthorized(message) => unauthorized(message),
+        RealmBootstrapError::NotFound(message) => not_found(message),
+        RealmBootstrapError::Database { retryable, .. } => {
+            if retryable {
+                service_unavailable("temporarily unavailable")
+            } else {
+                internal_server_error("internal server error")
+            }
+        }
+        RealmBootstrapError::Internal(_) => internal_server_error("internal server error"),
+    }
+}

--- a/apps/backend/src/handlers/realm_bootstrap.rs
+++ b/apps/backend/src/handlers/realm_bootstrap.rs
@@ -10,8 +10,9 @@ use serde_json::Value;
 use crate::{
     SharedState,
     handlers::{
-        ApiError, ApiResult, bad_request, internal_server_error, not_found, require_bearer_token,
-        require_internal_bearer_token, require_operator_id, service_unavailable, unauthorized,
+        ApiError, ApiResult, bad_request, internal_server_error, map_happy_route_error, not_found,
+        require_bearer_token, require_internal_bearer_token, require_operator_id,
+        service_unavailable, unauthorized,
     },
     services::{
         happy_route::authorize_account,
@@ -243,7 +244,7 @@ pub async fn create_realm_request(
     let token = require_bearer_token(&headers)?;
     let account = authorize_account(&state, &token)
         .await
-        .map_err(map_realm_bootstrap_happy_route_error)?;
+        .map_err(map_happy_route_error)?;
     let snapshot = state
         .realm_bootstrap
         .create_realm_request(
@@ -273,7 +274,7 @@ pub async fn get_realm_request(
     let token = require_bearer_token(&headers)?;
     let account = authorize_account(&state, &token)
         .await
-        .map_err(map_realm_bootstrap_happy_route_error)?;
+        .map_err(map_happy_route_error)?;
     let snapshot = state
         .realm_bootstrap
         .get_realm_request_for_requester(&account.account_id, realm_request_id.trim())
@@ -437,7 +438,7 @@ pub async fn get_bootstrap_summary(
     let token = require_bearer_token(&headers)?;
     let account = authorize_account(&state, &token)
         .await
-        .map_err(map_realm_bootstrap_happy_route_error)?;
+        .map_err(map_happy_route_error)?;
     let snapshot = state
         .realm_bootstrap
         .get_bootstrap_summary_for_viewer(&account.account_id, realm_id.trim())
@@ -656,34 +657,6 @@ fn realm_bootstrap_rebuild_response(
         bootstrap_view_count: snapshot.bootstrap_view_count,
         admission_view_count: snapshot.admission_view_count,
         review_summary_count: snapshot.review_summary_count,
-    }
-}
-
-fn map_realm_bootstrap_happy_route_error(
-    error: crate::services::happy_route::HappyRouteError,
-) -> ApiError {
-    match error {
-        crate::services::happy_route::HappyRouteError::BadRequest(message) => bad_request(message),
-        crate::services::happy_route::HappyRouteError::Unauthorized(message) => {
-            unauthorized(message)
-        }
-        crate::services::happy_route::HappyRouteError::NotFound(message) => not_found(message),
-        crate::services::happy_route::HappyRouteError::ProviderCallbackMappingDeferred(_) => {
-            service_unavailable("temporarily unavailable")
-        }
-        crate::services::happy_route::HappyRouteError::Provider { .. } => {
-            service_unavailable("temporarily unavailable")
-        }
-        crate::services::happy_route::HappyRouteError::Database { retryable, .. } => {
-            if retryable {
-                service_unavailable("temporarily unavailable")
-            } else {
-                internal_server_error("internal server error")
-            }
-        }
-        crate::services::happy_route::HappyRouteError::Internal(_) => {
-            internal_server_error("internal server error")
-        }
     }
 }
 

--- a/apps/backend/src/handlers/realm_bootstrap.rs
+++ b/apps/backend/src/handlers/realm_bootstrap.rs
@@ -480,11 +480,8 @@ pub async fn get_review_summary(
 pub async fn rebuild_realm_bootstrap_views(
     State(state): State<SharedState>,
     headers: HeaderMap,
-    body: Bytes,
+    _body: Bytes,
 ) -> ApiResult<RealmBootstrapRebuildResponse> {
-    if !body.is_empty() {
-        return Err(bad_request("request body must be empty"));
-    }
     require_internal_bearer_token(&headers)?;
     let operator_id = require_operator_id(&headers)?;
     let snapshot = state

--- a/apps/backend/src/handlers/realm_bootstrap.rs
+++ b/apps/backend/src/handlers/realm_bootstrap.rs
@@ -1,5 +1,6 @@
 use axum::{
     Json,
+    body::Bytes,
     extract::{Path, Query, State},
     http::HeaderMap,
 };
@@ -91,7 +92,6 @@ pub struct CreateRealmAdmissionRequest {
 #[derive(Debug, Serialize)]
 pub struct RealmRequestResponse {
     pub realm_request_id: String,
-    pub requested_by_account_id: String,
     pub display_name: String,
     pub slug_candidate: String,
     pub purpose_text: String,
@@ -480,7 +480,11 @@ pub async fn get_review_summary(
 pub async fn rebuild_realm_bootstrap_views(
     State(state): State<SharedState>,
     headers: HeaderMap,
+    body: Bytes,
 ) -> ApiResult<RealmBootstrapRebuildResponse> {
+    if !body.is_empty() {
+        return Err(bad_request("request body must be empty"));
+    }
     require_internal_bearer_token(&headers)?;
     let operator_id = require_operator_id(&headers)?;
     let snapshot = state
@@ -494,7 +498,6 @@ pub async fn rebuild_realm_bootstrap_views(
 fn realm_request_response(snapshot: RealmRequestSnapshot) -> RealmRequestResponse {
     RealmRequestResponse {
         realm_request_id: snapshot.realm_request_id,
-        requested_by_account_id: snapshot.requested_by_account_id,
         display_name: snapshot.display_name,
         slug_candidate: snapshot.slug_candidate,
         purpose_text: snapshot.purpose_text,
@@ -681,9 +684,16 @@ fn map_realm_bootstrap_error(error: RealmBootstrapError) -> ApiError {
         RealmBootstrapError::Unauthorized(message) => unauthorized(message),
         RealmBootstrapError::NotFound(message) => not_found(message),
         RealmBootstrapError::Database {
-            message, retryable, ..
+            message,
+            code,
+            constraint,
+            retryable,
         } => {
-            eprintln!("database realm bootstrap error: {message}");
+            eprintln!(
+                "database realm bootstrap error: message={message}; code={}; constraint={}",
+                code.as_deref().unwrap_or("none"),
+                constraint.as_deref().unwrap_or("none")
+            );
             if retryable {
                 service_unavailable("temporarily unavailable")
             } else {

--- a/apps/backend/src/handlers/realm_bootstrap.rs
+++ b/apps/backend/src/handlers/realm_bootstrap.rs
@@ -466,9 +466,10 @@ pub async fn rebuild_realm_bootstrap_views(
     headers: HeaderMap,
 ) -> ApiResult<RealmBootstrapRebuildResponse> {
     require_internal_bearer_token(&headers)?;
+    let operator_id = require_operator_id(&headers)?;
     let snapshot = state
         .realm_bootstrap
-        .rebuild_realm_bootstrap_views()
+        .rebuild_realm_bootstrap_views(&operator_id)
         .await
         .map_err(map_realm_bootstrap_error)?;
     Ok(Json(realm_bootstrap_rebuild_response(snapshot)))

--- a/apps/backend/src/handlers/realm_bootstrap.rs
+++ b/apps/backend/src/handlers/realm_bootstrap.rs
@@ -1,6 +1,6 @@
 use axum::{
     Json,
-    extract::{Path, State},
+    extract::{Path, Query, State},
     http::HeaderMap,
 };
 use chrono::{DateTime, Utc};
@@ -18,8 +18,8 @@ use crate::{
         happy_route::authorize_account,
         realm_bootstrap::{
             CreateRealmAdmissionInput, CreateRealmRequestInput, CreateRealmSponsorRecordInput,
-            RealmAdmissionSnapshot, RealmAdmissionViewSnapshot, RealmBootstrapError,
-            RealmBootstrapRebuildSnapshot, RealmBootstrapSummarySnapshot,
+            ListRealmRequestsInput, RealmAdmissionSnapshot, RealmAdmissionViewSnapshot,
+            RealmBootstrapError, RealmBootstrapRebuildSnapshot, RealmBootstrapSummarySnapshot,
             RealmBootstrapViewSnapshot, RealmRequestSnapshot, RealmReviewSummarySnapshot,
             RealmReviewTriggerSnapshot, RealmSnapshot, RealmSponsorRecordSnapshot,
             RejectRealmRequestInput, ReviewRealmRequestInput,
@@ -60,6 +60,13 @@ pub struct ReviewRealmRequestRequest {
 pub struct RejectRealmRequestRequest {
     pub review_reason_code: String,
     pub review_decision_idempotency_key: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ListRealmRequestsQuery {
+    pub limit: Option<i64>,
+    pub before_created_at: Option<DateTime<Utc>>,
+    pub before_realm_request_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -286,12 +293,20 @@ pub async fn get_realm_request(
 pub async fn list_realm_requests(
     State(state): State<SharedState>,
     headers: HeaderMap,
+    Query(query): Query<ListRealmRequestsQuery>,
 ) -> ApiResult<Vec<RealmRequestOperatorResponse>> {
     require_internal_bearer_token(&headers)?;
     let operator_id = require_operator_id(&headers)?;
     let snapshots = state
         .realm_bootstrap
-        .list_realm_requests_for_operator(&operator_id)
+        .list_realm_requests_for_operator(
+            &operator_id,
+            ListRealmRequestsInput {
+                limit: query.limit,
+                before_created_at: query.before_created_at,
+                before_realm_request_id: query.before_realm_request_id,
+            },
+        )
         .await
         .map_err(map_realm_bootstrap_error)?;
     Ok(Json(

--- a/apps/backend/src/handlers/realm_bootstrap.rs
+++ b/apps/backend/src/handlers/realm_bootstrap.rs
@@ -127,6 +127,7 @@ pub struct RealmRequestOperatorResponse {
     pub created_realm_id: Option<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    pub open_review_triggers: Vec<RealmReviewTriggerResponse>,
 }
 
 #[derive(Debug, Serialize)]
@@ -531,6 +532,11 @@ fn realm_request_operator_response(snapshot: RealmRequestSnapshot) -> RealmReque
         created_realm_id: snapshot.created_realm_id,
         created_at: snapshot.created_at,
         updated_at: snapshot.updated_at,
+        open_review_triggers: snapshot
+            .open_review_triggers
+            .into_iter()
+            .map(realm_review_trigger_response)
+            .collect(),
     }
 }
 

--- a/apps/backend/src/handlers/realm_bootstrap.rs
+++ b/apps/backend/src/handlers/realm_bootstrap.rs
@@ -691,13 +691,19 @@ fn map_realm_bootstrap_error(error: RealmBootstrapError) -> ApiError {
         RealmBootstrapError::BadRequest(message) => bad_request(message),
         RealmBootstrapError::Unauthorized(message) => unauthorized(message),
         RealmBootstrapError::NotFound(message) => not_found(message),
-        RealmBootstrapError::Database { retryable, .. } => {
+        RealmBootstrapError::Database {
+            message, retryable, ..
+        } => {
+            eprintln!("database realm bootstrap error: {message}");
             if retryable {
                 service_unavailable("temporarily unavailable")
             } else {
                 internal_server_error("internal server error")
             }
         }
-        RealmBootstrapError::Internal(_) => internal_server_error("internal server error"),
+        RealmBootstrapError::Internal(message) => {
+            eprintln!("internal realm bootstrap error: {message}");
+            internal_server_error("internal server error")
+        }
     }
 }

--- a/apps/backend/src/handlers/realm_bootstrap.rs
+++ b/apps/backend/src/handlers/realm_bootstrap.rs
@@ -257,7 +257,7 @@ pub async fn create_realm_request(
                 bootstrap_rationale_text: payload.bootstrap_rationale_text,
                 proposed_sponsor_account_id: payload.proposed_sponsor_account_id,
                 proposed_steward_account_id: payload.proposed_steward_account_id,
-                request_idempotency_key: Some(payload.request_idempotency_key),
+                request_idempotency_key: payload.request_idempotency_key,
             },
         )
         .await
@@ -343,7 +343,7 @@ pub async fn approve_realm_request(
                 review_threshold_json: payload
                     .review_threshold_json
                     .unwrap_or_else(|| Value::Object(Default::default())),
-                review_decision_idempotency_key: Some(payload.review_decision_idempotency_key),
+                review_decision_idempotency_key: payload.review_decision_idempotency_key,
             },
         )
         .await
@@ -366,7 +366,7 @@ pub async fn reject_realm_request(
             realm_request_id.trim(),
             RejectRealmRequestInput {
                 review_reason_code: payload.review_reason_code,
-                review_decision_idempotency_key: Some(payload.review_decision_idempotency_key),
+                review_decision_idempotency_key: payload.review_decision_idempotency_key,
             },
         )
         .await
@@ -392,7 +392,7 @@ pub async fn create_realm_sponsor_record(
                 sponsor_status: payload.sponsor_status,
                 quota_total: payload.quota_total,
                 status_reason_code: payload.status_reason_code,
-                request_idempotency_key: Some(payload.request_idempotency_key),
+                request_idempotency_key: payload.request_idempotency_key,
             },
         )
         .await
@@ -421,7 +421,7 @@ pub async fn create_realm_admission(
                 source_snapshot_json: payload
                     .source_snapshot_json
                     .unwrap_or_else(|| Value::Object(Default::default())),
-                request_idempotency_key: Some(payload.request_idempotency_key),
+                request_idempotency_key: payload.request_idempotency_key,
             },
         )
         .await

--- a/apps/backend/src/handlers/realm_bootstrap.rs
+++ b/apps/backend/src/handlers/realm_bootstrap.rs
@@ -36,7 +36,7 @@ pub struct CreateRealmRequestRequest {
     pub bootstrap_rationale_text: String,
     pub proposed_sponsor_account_id: Option<String>,
     pub proposed_steward_account_id: Option<String>,
-    pub request_idempotency_key: Option<String>,
+    pub request_idempotency_key: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -52,13 +52,13 @@ pub struct ReviewRealmRequestRequest {
     pub corridor_member_cap: Option<i64>,
     pub corridor_sponsor_cap: Option<i64>,
     pub review_threshold_json: Option<Value>,
-    pub review_decision_idempotency_key: Option<String>,
+    pub review_decision_idempotency_key: String,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct RejectRealmRequestRequest {
     pub review_reason_code: String,
-    pub review_decision_idempotency_key: Option<String>,
+    pub review_decision_idempotency_key: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -67,7 +67,7 @@ pub struct CreateRealmSponsorRecordRequest {
     pub sponsor_status: String,
     pub quota_total: i64,
     pub status_reason_code: String,
-    pub request_idempotency_key: Option<String>,
+    pub request_idempotency_key: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -77,7 +77,7 @@ pub struct CreateRealmAdmissionRequest {
     pub source_fact_kind: String,
     pub source_fact_id: String,
     pub source_snapshot_json: Option<Value>,
-    pub request_idempotency_key: Option<String>,
+    pub request_idempotency_key: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -257,7 +257,7 @@ pub async fn create_realm_request(
                 bootstrap_rationale_text: payload.bootstrap_rationale_text,
                 proposed_sponsor_account_id: payload.proposed_sponsor_account_id,
                 proposed_steward_account_id: payload.proposed_steward_account_id,
-                request_idempotency_key: payload.request_idempotency_key,
+                request_idempotency_key: Some(payload.request_idempotency_key),
             },
         )
         .await
@@ -343,7 +343,7 @@ pub async fn approve_realm_request(
                 review_threshold_json: payload
                     .review_threshold_json
                     .unwrap_or_else(|| Value::Object(Default::default())),
-                review_decision_idempotency_key: payload.review_decision_idempotency_key,
+                review_decision_idempotency_key: Some(payload.review_decision_idempotency_key),
             },
         )
         .await
@@ -366,7 +366,7 @@ pub async fn reject_realm_request(
             realm_request_id.trim(),
             RejectRealmRequestInput {
                 review_reason_code: payload.review_reason_code,
-                review_decision_idempotency_key: payload.review_decision_idempotency_key,
+                review_decision_idempotency_key: Some(payload.review_decision_idempotency_key),
             },
         )
         .await
@@ -392,7 +392,7 @@ pub async fn create_realm_sponsor_record(
                 sponsor_status: payload.sponsor_status,
                 quota_total: payload.quota_total,
                 status_reason_code: payload.status_reason_code,
-                request_idempotency_key: payload.request_idempotency_key,
+                request_idempotency_key: Some(payload.request_idempotency_key),
             },
         )
         .await
@@ -421,7 +421,7 @@ pub async fn create_realm_admission(
                 source_snapshot_json: payload
                     .source_snapshot_json
                     .unwrap_or_else(|| Value::Object(Default::default())),
-                request_idempotency_key: payload.request_idempotency_key,
+                request_idempotency_key: Some(payload.request_idempotency_key),
             },
         )
         .await

--- a/apps/backend/src/lib.rs
+++ b/apps/backend/src/lib.rs
@@ -166,7 +166,8 @@ pub fn build_app(state: SharedState) -> Router {
         )
         .route(
             "/api/realms/requests",
-            post(handlers::realm_bootstrap::create_realm_request),
+            post(handlers::realm_bootstrap::create_realm_request)
+                .layer(DefaultBodyLimit::max(16 * 1024)),
         )
         .route(
             "/api/realms/requests/{realm_request_id}",
@@ -228,19 +229,23 @@ pub fn build_app(state: SharedState) -> Router {
         )
         .route(
             "/api/internal/operator/realms/requests/{realm_request_id}/approve",
-            post(handlers::realm_bootstrap::approve_realm_request),
+            post(handlers::realm_bootstrap::approve_realm_request)
+                .layer(DefaultBodyLimit::max(16 * 1024)),
         )
         .route(
             "/api/internal/operator/realms/requests/{realm_request_id}/reject",
-            post(handlers::realm_bootstrap::reject_realm_request),
+            post(handlers::realm_bootstrap::reject_realm_request)
+                .layer(DefaultBodyLimit::max(16 * 1024)),
         )
         .route(
             "/api/internal/realms/{realm_id}/sponsor-records",
-            post(handlers::realm_bootstrap::create_realm_sponsor_record),
+            post(handlers::realm_bootstrap::create_realm_sponsor_record)
+                .layer(DefaultBodyLimit::max(16 * 1024)),
         )
         .route(
             "/api/internal/realms/{realm_id}/admissions",
-            post(handlers::realm_bootstrap::create_realm_admission),
+            post(handlers::realm_bootstrap::create_realm_admission)
+                .layer(DefaultBodyLimit::max(16 * 1024)),
         )
         .route(
             "/api/internal/operator/realms/{realm_id}/review-summary",
@@ -248,7 +253,8 @@ pub fn build_app(state: SharedState) -> Router {
         )
         .route(
             "/api/internal/projection/realms/rebuild",
-            post(handlers::realm_bootstrap::rebuild_realm_bootstrap_views),
+            post(handlers::realm_bootstrap::rebuild_realm_bootstrap_views)
+                .layer(DefaultBodyLimit::max(16 * 1024)),
         )
         .route(
             "/api/internal/room-progressions",

--- a/apps/backend/src/lib.rs
+++ b/apps/backend/src/lib.rs
@@ -24,6 +24,7 @@ pub type SharedState = Arc<AppState>;
 pub struct AppState {
     pub happy_route: services::happy_route::HappyRouteStore,
     pub operator_review: services::operator_review::OperatorReviewStore,
+    pub realm_bootstrap: services::realm_bootstrap::RealmBootstrapStore,
     pub room_progression: services::room_progression::RoomProgressionStore,
     pub proof: RwLock<services::proof::ProofState>,
 }
@@ -44,6 +45,7 @@ pub async fn new_state_from_config(config: &DbConfig) -> musubi_db_runtime::Resu
     Ok(Arc::new(AppState {
         happy_route: services::happy_route::HappyRouteStore::connect(config).await?,
         operator_review: services::operator_review::OperatorReviewStore::connect(config).await?,
+        realm_bootstrap: services::realm_bootstrap::RealmBootstrapStore::connect(config).await?,
         room_progression: services::room_progression::RoomProgressionStore::connect(config).await?,
         proof: RwLock::new(services::proof::ProofState::default()),
     }))
@@ -93,6 +95,11 @@ pub async fn new_test_state() -> Result<TestState, String> {
         .map_err(|error| error.message().to_owned())?;
     state
         .operator_review
+        .reset_for_test()
+        .await
+        .map_err(|error| error.message().to_owned())?;
+    state
+        .realm_bootstrap
         .reset_for_test()
         .await
         .map_err(|error| error.message().to_owned())?;
@@ -158,8 +165,20 @@ pub fn build_app(state: SharedState) -> Router {
             get(handlers::operator_review::get_review_status),
         )
         .route(
+            "/api/realms/requests",
+            post(handlers::realm_bootstrap::create_realm_request),
+        )
+        .route(
+            "/api/realms/requests/{realm_request_id}",
+            get(handlers::realm_bootstrap::get_realm_request),
+        )
+        .route(
             "/api/projection/room-progression-views/{room_progression_id}",
             get(handlers::room_progression::get_room_progression_view),
+        )
+        .route(
+            "/api/projection/realms/{realm_id}/bootstrap-summary",
+            get(handlers::realm_bootstrap::get_bootstrap_summary),
         );
     let app = if unauthenticated_pi_callback_enabled() {
         app.route(
@@ -198,6 +217,38 @@ pub fn build_app(state: SharedState) -> Router {
         .route(
             "/api/internal/operator/review-cases/{review_case_id}/decisions",
             post(handlers::operator_review::record_operator_decision),
+        )
+        .route(
+            "/api/internal/operator/realms/requests",
+            get(handlers::realm_bootstrap::list_realm_requests),
+        )
+        .route(
+            "/api/internal/operator/realms/requests/{realm_request_id}",
+            get(handlers::realm_bootstrap::read_realm_request),
+        )
+        .route(
+            "/api/internal/operator/realms/requests/{realm_request_id}/approve",
+            post(handlers::realm_bootstrap::approve_realm_request),
+        )
+        .route(
+            "/api/internal/operator/realms/requests/{realm_request_id}/reject",
+            post(handlers::realm_bootstrap::reject_realm_request),
+        )
+        .route(
+            "/api/internal/realms/{realm_id}/sponsor-records",
+            post(handlers::realm_bootstrap::create_realm_sponsor_record),
+        )
+        .route(
+            "/api/internal/realms/{realm_id}/admissions",
+            post(handlers::realm_bootstrap::create_realm_admission),
+        )
+        .route(
+            "/api/internal/operator/realms/{realm_id}/review-summary",
+            get(handlers::realm_bootstrap::get_review_summary),
+        )
+        .route(
+            "/api/internal/projection/realms/rebuild",
+            post(handlers::realm_bootstrap::rebuild_realm_bootstrap_views),
         )
         .route(
             "/api/internal/room-progressions",

--- a/apps/backend/src/services/mod.rs
+++ b/apps/backend/src/services/mod.rs
@@ -2,4 +2,5 @@
 pub mod happy_route;
 pub mod operator_review;
 pub mod proof;
+pub mod realm_bootstrap;
 pub mod room_progression;

--- a/apps/backend/src/services/realm_bootstrap/mod.rs
+++ b/apps/backend/src/services/realm_bootstrap/mod.rs
@@ -1,0 +1,12 @@
+mod repository;
+mod types;
+
+pub use repository::RealmBootstrapStore;
+pub use types::{
+    BootstrapCorridorSnapshot, CreateRealmAdmissionInput, CreateRealmRequestInput,
+    CreateRealmSponsorRecordInput, RealmAdmissionSnapshot, RealmAdmissionViewSnapshot,
+    RealmBootstrapError, RealmBootstrapRebuildSnapshot, RealmBootstrapSummarySnapshot,
+    RealmBootstrapViewSnapshot, RealmRequestSnapshot, RealmReviewSummarySnapshot,
+    RealmReviewTriggerSnapshot, RealmSnapshot, RealmSponsorRecordSnapshot, RejectRealmRequestInput,
+    ReviewRealmRequestInput,
+};

--- a/apps/backend/src/services/realm_bootstrap/mod.rs
+++ b/apps/backend/src/services/realm_bootstrap/mod.rs
@@ -4,9 +4,9 @@ mod types;
 pub use repository::RealmBootstrapStore;
 pub use types::{
     BootstrapCorridorSnapshot, CreateRealmAdmissionInput, CreateRealmRequestInput,
-    CreateRealmSponsorRecordInput, RealmAdmissionSnapshot, RealmAdmissionViewSnapshot,
-    RealmBootstrapError, RealmBootstrapRebuildSnapshot, RealmBootstrapSummarySnapshot,
-    RealmBootstrapViewSnapshot, RealmRequestSnapshot, RealmReviewSummarySnapshot,
-    RealmReviewTriggerSnapshot, RealmSnapshot, RealmSponsorRecordSnapshot, RejectRealmRequestInput,
-    ReviewRealmRequestInput,
+    CreateRealmSponsorRecordInput, ListRealmRequestsInput, RealmAdmissionSnapshot,
+    RealmAdmissionViewSnapshot, RealmBootstrapError, RealmBootstrapRebuildSnapshot,
+    RealmBootstrapSummarySnapshot, RealmBootstrapViewSnapshot, RealmRequestSnapshot,
+    RealmReviewSummarySnapshot, RealmReviewTriggerSnapshot, RealmSnapshot,
+    RealmSponsorRecordSnapshot, RejectRealmRequestInput, ReviewRealmRequestInput,
 };

--- a/apps/backend/src/services/realm_bootstrap/repository.rs
+++ b/apps/backend/src/services/realm_bootstrap/repository.rs
@@ -642,6 +642,13 @@ impl RealmBootstrapStore {
             ensure_sponsor_record_payload_hash_matches(&existing, &payload_hash)?;
             existing
         } else {
+            ensure_sponsor_status_transition_allowed_tx(
+                &tx,
+                &realm_id,
+                &sponsor_account_id,
+                &input.sponsor_status,
+            )
+            .await?;
             let row = insert_sponsor_record_tx(
                 &tx,
                 &realm_id,
@@ -841,12 +848,16 @@ impl RealmBootstrapStore {
             .query_opt(
                 "
                 SELECT *
-                FROM dao.realm_admissions
-                WHERE realm_id = $1
-                  AND account_id = $2
-                  AND admission_status = 'admitted'
+                FROM (
+                    SELECT *
+                    FROM dao.realm_admissions
+                    WHERE realm_id = $1
+                      AND account_id = $2
+                    ORDER BY updated_at DESC, created_at DESC, realm_admission_id DESC
+                    LIMIT 1
+                ) latest_admission
+                WHERE admission_status = 'admitted'
                 ORDER BY updated_at DESC, realm_admission_id DESC
-                LIMIT 1
                 ",
                 &[&realm_id, &viewer_account_id],
             )
@@ -2484,6 +2495,42 @@ async fn lock_sponsor_lineage_for_record_tx<C: GenericClient + Sync>(
     }
     let sponsor_account_id: Uuid = sponsor_row.get("sponsor_account_id");
     lock_sponsor_lineage_tx(client, realm_id, &sponsor_account_id).await
+}
+
+async fn ensure_sponsor_status_transition_allowed_tx<C: GenericClient + Sync>(
+    client: &C,
+    realm_id: &str,
+    sponsor_account_id: &Uuid,
+    next_sponsor_status: &str,
+) -> Result<(), RealmBootstrapError> {
+    if !matches!(next_sponsor_status, "proposed" | "approved" | "active") {
+        return Ok(());
+    }
+    let current_status = client
+        .query_opt(
+            "
+            SELECT sponsor_status
+            FROM dao.realm_sponsor_records
+            WHERE realm_id = $1
+              AND sponsor_account_id = $2
+            ORDER BY updated_at DESC, created_at DESC, realm_sponsor_record_id DESC
+            LIMIT 1
+            ",
+            &[&realm_id, sponsor_account_id],
+        )
+        .await
+        .map_err(db_error)?
+        .map(|row| row.get::<_, String>("sponsor_status"));
+
+    if current_status
+        .as_deref()
+        .is_some_and(|status| matches!(status, "proposed" | "approved" | "active"))
+    {
+        return Err(RealmBootstrapError::BadRequest(
+            "sponsor account already has an open sponsor record for this realm".to_owned(),
+        ));
+    }
+    Ok(())
 }
 
 async fn ensure_slug_available_for_approval_tx<C: GenericClient + Sync>(

--- a/apps/backend/src/services/realm_bootstrap/repository.rs
+++ b/apps/backend/src/services/realm_bootstrap/repository.rs
@@ -768,8 +768,6 @@ impl RealmBootstrapStore {
         let mut client = self.client.lock().await;
         let tx = client.transaction().await.map_err(db_error)?;
         ensure_operator_role_tx(&tx, &operator_id, OPERATOR_WRITE_ROLES).await?;
-        ensure_active_account_exists_tx(&tx, &account_id).await?;
-        let granted_by_actor_kind = operator_actor_kind_tx(&tx, &operator_id).await?;
         let payload_hash = create_admission_payload_hash(&input, &account_id, &sponsor_record_id);
 
         let row = if let Some(existing) =
@@ -779,6 +777,8 @@ impl RealmBootstrapStore {
             ensure_admission_payload_hash_matches(&existing, &payload_hash)?;
             existing
         } else {
+            ensure_active_account_exists_tx(&tx, &account_id).await?;
+            let granted_by_actor_kind = operator_actor_kind_tx(&tx, &operator_id).await?;
             let realm_row = lock_realm_tx(&tx, &realm_id).await?;
             let realm_status: String = realm_row.get("realm_status");
             if matches!(realm_status.as_str(), "restricted" | "suspended") {

--- a/apps/backend/src/services/realm_bootstrap/repository.rs
+++ b/apps/backend/src/services/realm_bootstrap/repository.rs
@@ -520,7 +520,7 @@ impl RealmBootstrapStore {
                     sponsor_status: "active".to_owned(),
                     quota_total,
                     status_reason_code: input.review_reason_code.clone(),
-                    request_idempotency_key: input.review_decision_idempotency_key.clone(),
+                    request_idempotency_key: review_decision_idempotency_key.clone(),
                 },
                 sponsor_account_id,
             );
@@ -532,7 +532,7 @@ impl RealmBootstrapStore {
                 quota_total,
                 &input.review_reason_code,
                 &operator_id,
-                input.review_decision_idempotency_key.clone(),
+                review_decision_idempotency_key.clone(),
                 sponsor_payload_hash,
             )
             .await?;
@@ -3973,7 +3973,7 @@ fn db_error(error: tokio_postgres::Error) -> RealmBootstrapError {
             }
             Some("realm_admissions_active_unique") => {
                 return RealmBootstrapError::BadRequest(
-                    "account already has a pending or admitted realm admission".to_owned(),
+                    "account already has an admitted realm admission".to_owned(),
                 );
             }
             Some("realm_admissions_idempotency_unique") => {

--- a/apps/backend/src/services/realm_bootstrap/repository.rs
+++ b/apps/backend/src/services/realm_bootstrap/repository.rs
@@ -911,7 +911,7 @@ impl RealmBootstrapStore {
                     LIMIT 1
                 ) latest_admission
                 WHERE admission_status = 'admitted'
-                ORDER BY updated_at DESC, realm_admission_id DESC
+                ORDER BY updated_at DESC, created_at DESC, realm_admission_id DESC
                 ",
                 &[&realm_id, &viewer_account_id],
             )
@@ -2469,7 +2469,7 @@ async fn refresh_realm_admission_view_tx<C: GenericClient + Sync>(
                 FROM dao.realm_admissions
                 WHERE realm_id = $1
                   AND account_id = $2
-                ORDER BY updated_at DESC, realm_admission_id DESC
+                ORDER BY updated_at DESC, created_at DESC, realm_admission_id DESC
                 LIMIT 1
             ),
             source_counts AS (

--- a/apps/backend/src/services/realm_bootstrap/repository.rs
+++ b/apps/backend/src/services/realm_bootstrap/repository.rs
@@ -1241,7 +1241,7 @@ async fn maybe_open_realm_request_triggers_tx<C: GenericClient + Sync>(
             Some(realm_request_id),
             None,
             &json!({ "rejected_request_count": rejected_count }),
-            &format!("repeated-rejected-requests:{requester_account_id}"),
+            &format!("repeated-rejected-requests:{requester_account_id}:{realm_request_id}"),
         )
         .await?;
     }
@@ -1272,8 +1272,8 @@ async fn maybe_open_realm_request_triggers_tx<C: GenericClient + Sync>(
             None,
             &json!({ "matching_request_count": duplicate_count }),
             &format!(
-                "duplicate-venue-context:{}",
-                hash_json_value(venue_context_json)
+                "duplicate-venue-context:{}:{realm_request_id}",
+                hash_json_value(venue_context_json),
             ),
         )
         .await?;
@@ -1321,7 +1321,7 @@ async fn maybe_open_repeated_rejection_trigger_tx<C: GenericClient + Sync>(
             Some(realm_request_id),
             None,
             &json!({ "rejected_request_count": rejected_count }),
-            &format!("repeated-rejected-requests:{requester_account_id}"),
+            &format!("repeated-rejected-requests:{requester_account_id}:{realm_request_id}"),
         )
         .await?;
     }

--- a/apps/backend/src/services/realm_bootstrap/repository.rs
+++ b/apps/backend/src/services/realm_bootstrap/repository.rs
@@ -650,8 +650,11 @@ impl RealmBootstrapStore {
                     &review_decision_idempotency_key,
                     &decision_payload_hash,
                 )?;
+                let mut snapshot = realm_request_from_row(&request)?;
+                snapshot.open_review_triggers =
+                    read_open_realm_request_triggers_tx(&tx, &realm_request_id).await?;
                 tx.commit().await.map_err(db_error)?;
-                return realm_request_from_row(&request);
+                return Ok(snapshot);
             }
             "approved" => {
                 return Err(RealmBootstrapError::BadRequest(
@@ -690,8 +693,11 @@ impl RealmBootstrapStore {
         .map_err(db_error)?;
         maybe_open_repeated_rejection_trigger_tx(&tx, &realm_request_id).await?;
         let refreshed = lock_realm_request_tx(&tx, &realm_request_id).await?;
+        let mut snapshot = realm_request_from_row(&refreshed)?;
+        snapshot.open_review_triggers =
+            read_open_realm_request_triggers_tx(&tx, &realm_request_id).await?;
         tx.commit().await.map_err(db_error)?;
-        realm_request_from_row(&refreshed)
+        Ok(snapshot)
     }
 
     pub async fn create_realm_sponsor_record(
@@ -3751,9 +3757,7 @@ fn write_canonical_json(value: &Value, output: &mut String) {
             let _ = write!(output, "{number}");
         }
         Value::String(string) => {
-            output.push_str(
-                &serde_json::to_string(string).expect("serializing a JSON string should not fail"),
-            );
+            write_json_string(string, output);
         }
         Value::Array(values) => {
             output.push('[');
@@ -3773,16 +3777,33 @@ fn write_canonical_json(value: &Value, output: &mut String) {
                 if index > 0 {
                     output.push(',');
                 }
-                output.push_str(
-                    &serde_json::to_string(key)
-                        .expect("serializing a JSON object key should not fail"),
-                );
+                write_json_string(key, output);
                 output.push(':');
                 write_canonical_json(value, output);
             }
             output.push('}');
         }
     }
+}
+
+fn write_json_string(value: &str, output: &mut String) {
+    output.push('"');
+    for character in value.chars() {
+        match character {
+            '"' => output.push_str("\\\""),
+            '\\' => output.push_str("\\\\"),
+            '\u{08}' => output.push_str("\\b"),
+            '\u{0c}' => output.push_str("\\f"),
+            '\n' => output.push_str("\\n"),
+            '\r' => output.push_str("\\r"),
+            '\t' => output.push_str("\\t"),
+            control if control <= '\u{1f}' => {
+                let _ = write!(output, "\\u{:04x}", control as u32);
+            }
+            other => output.push(other),
+        }
+    }
+    output.push('"');
 }
 
 fn parse_uuid(value: &str, field_name: &str) -> Result<Uuid, RealmBootstrapError> {

--- a/apps/backend/src/services/realm_bootstrap/repository.rs
+++ b/apps/backend/src/services/realm_bootstrap/repository.rs
@@ -866,7 +866,8 @@ impl RealmBootstrapStore {
         }
 
         update_expired_corridors_tx(&tx, Some(&realm_id)).await?;
-        refresh_realm_projection_bundle_tx(&tx, &realm_id, Some(&viewer_account_id)).await?;
+        refresh_realm_bootstrap_view_tx(&tx, &realm_id, None).await?;
+        refresh_realm_admission_view_tx(&tx, &realm_id, &viewer_account_id, None).await?;
 
         let bootstrap_row = tx
             .query_opt(
@@ -922,7 +923,7 @@ impl RealmBootstrapStore {
         ensure_operator_role_tx(&tx, &operator_id, OPERATOR_READ_ROLES).await?;
         ensure_realm_exists_tx(&tx, &realm_id).await?;
         update_expired_corridors_tx(&tx, Some(&realm_id)).await?;
-        refresh_realm_projection_bundle_tx(&tx, &realm_id, None).await?;
+        refresh_realm_review_summary_tx(&tx, &realm_id, None).await?;
         let row = tx
             .query_opt(
                 "
@@ -1779,6 +1780,16 @@ async fn refresh_realm_bootstrap_view_tx<C: GenericClient + Sync>(
                 projection_lag_ms = EXCLUDED.projection_lag_ms,
                 rebuild_generation = COALESCE($12, projection.realm_bootstrap_views.rebuild_generation, 1::bigint),
                 last_projected_at = CURRENT_TIMESTAMP
+            WHERE projection.realm_bootstrap_views.slug IS DISTINCT FROM EXCLUDED.slug
+               OR projection.realm_bootstrap_views.display_name IS DISTINCT FROM EXCLUDED.display_name
+               OR projection.realm_bootstrap_views.realm_status IS DISTINCT FROM EXCLUDED.realm_status
+               OR projection.realm_bootstrap_views.admission_posture IS DISTINCT FROM EXCLUDED.admission_posture
+               OR projection.realm_bootstrap_views.corridor_status IS DISTINCT FROM EXCLUDED.corridor_status
+               OR projection.realm_bootstrap_views.public_reason_code IS DISTINCT FROM EXCLUDED.public_reason_code
+               OR projection.realm_bootstrap_views.sponsor_display_state IS DISTINCT FROM EXCLUDED.sponsor_display_state
+               OR projection.realm_bootstrap_views.source_watermark_at IS DISTINCT FROM EXCLUDED.source_watermark_at
+               OR projection.realm_bootstrap_views.source_fact_count IS DISTINCT FROM EXCLUDED.source_fact_count
+               OR projection.realm_bootstrap_views.rebuild_generation IS DISTINCT FROM COALESCE($12, projection.realm_bootstrap_views.rebuild_generation, 1::bigint)
             ",
             &[
                 &realm_id,
@@ -1878,6 +1889,12 @@ async fn refresh_realm_admission_view_tx<C: GenericClient + Sync>(
                 projection_lag_ms = EXCLUDED.projection_lag_ms,
                 rebuild_generation = COALESCE($9, projection.realm_admission_views.rebuild_generation, 1::bigint),
                 last_projected_at = CURRENT_TIMESTAMP
+            WHERE projection.realm_admission_views.admission_status IS DISTINCT FROM EXCLUDED.admission_status
+               OR projection.realm_admission_views.admission_kind IS DISTINCT FROM EXCLUDED.admission_kind
+               OR projection.realm_admission_views.public_reason_code IS DISTINCT FROM EXCLUDED.public_reason_code
+               OR projection.realm_admission_views.source_watermark_at IS DISTINCT FROM EXCLUDED.source_watermark_at
+               OR projection.realm_admission_views.source_fact_count IS DISTINCT FROM EXCLUDED.source_fact_count
+               OR projection.realm_admission_views.rebuild_generation IS DISTINCT FROM COALESCE($9, projection.realm_admission_views.rebuild_generation, 1::bigint)
             ",
             &[
                 &realm_id,
@@ -2042,6 +2059,18 @@ async fn refresh_realm_review_summary_tx<C: GenericClient + Sync>(
                 projection_lag_ms = EXCLUDED.projection_lag_ms,
                 rebuild_generation = COALESCE($14, projection.realm_review_summaries.rebuild_generation, 1::bigint),
                 last_projected_at = CURRENT_TIMESTAMP
+            WHERE projection.realm_review_summaries.realm_status IS DISTINCT FROM EXCLUDED.realm_status
+               OR projection.realm_review_summaries.corridor_status IS DISTINCT FROM EXCLUDED.corridor_status
+               OR projection.realm_review_summaries.corridor_remaining_seconds IS DISTINCT FROM EXCLUDED.corridor_remaining_seconds
+               OR projection.realm_review_summaries.active_sponsor_count IS DISTINCT FROM EXCLUDED.active_sponsor_count
+               OR projection.realm_review_summaries.sponsor_backed_admission_count IS DISTINCT FROM EXCLUDED.sponsor_backed_admission_count
+               OR projection.realm_review_summaries.recent_admission_count_7d IS DISTINCT FROM EXCLUDED.recent_admission_count_7d
+               OR projection.realm_review_summaries.open_review_trigger_count IS DISTINCT FROM EXCLUDED.open_review_trigger_count
+               OR projection.realm_review_summaries.open_review_case_count IS DISTINCT FROM EXCLUDED.open_review_case_count
+               OR projection.realm_review_summaries.latest_redacted_reason_code IS DISTINCT FROM EXCLUDED.latest_redacted_reason_code
+               OR projection.realm_review_summaries.source_watermark_at IS DISTINCT FROM EXCLUDED.source_watermark_at
+               OR projection.realm_review_summaries.source_fact_count IS DISTINCT FROM EXCLUDED.source_fact_count
+               OR projection.realm_review_summaries.rebuild_generation IS DISTINCT FROM COALESCE($14, projection.realm_review_summaries.rebuild_generation, 1::bigint)
             ",
             &[
                 &realm_id,

--- a/apps/backend/src/services/realm_bootstrap/repository.rs
+++ b/apps/backend/src/services/realm_bootstrap/repository.rs
@@ -10,10 +10,11 @@ use uuid::Uuid;
 
 use super::types::{
     CreateRealmAdmissionInput, CreateRealmRequestInput, CreateRealmSponsorRecordInput,
-    RealmAdmissionSnapshot, RealmAdmissionViewSnapshot, RealmBootstrapError,
-    RealmBootstrapRebuildSnapshot, RealmBootstrapSummarySnapshot, RealmBootstrapViewSnapshot,
-    RealmRequestSnapshot, RealmReviewSummarySnapshot, RealmReviewTriggerSnapshot, RealmSnapshot,
-    RealmSponsorRecordSnapshot, RejectRealmRequestInput, ReviewRealmRequestInput,
+    ListRealmRequestsInput, RealmAdmissionSnapshot, RealmAdmissionViewSnapshot,
+    RealmBootstrapError, RealmBootstrapRebuildSnapshot, RealmBootstrapSummarySnapshot,
+    RealmBootstrapViewSnapshot, RealmRequestSnapshot, RealmReviewSummarySnapshot,
+    RealmReviewTriggerSnapshot, RealmSnapshot, RealmSponsorRecordSnapshot, RejectRealmRequestInput,
+    ReviewRealmRequestInput,
 };
 
 const SPONSOR_STATUSES: &[&str] = &["proposed", "approved", "active", "rate_limited", "revoked"];
@@ -50,6 +51,8 @@ const APPROVAL_REASON_CODES: &[&str] = &["limited_bootstrap_active", "active_aft
 const REJECTION_REASON_CODES: &[&str] = &["request_rejected", "duplicate_or_invalid"];
 const OPERATOR_READ_ROLES: &[&str] = &["reviewer", "approver", "steward", "auditor", "support"];
 const OPERATOR_WRITE_ROLES: &[&str] = &["approver", "steward"];
+const REALM_REQUEST_LIST_DEFAULT_LIMIT: i64 = 50;
+const REALM_REQUEST_LIST_MAX_LIMIT: i64 = 100;
 
 #[derive(Clone)]
 pub struct RealmBootstrapStore {
@@ -296,8 +299,21 @@ impl RealmBootstrapStore {
     pub async fn list_realm_requests_for_operator(
         &self,
         operator_id: &str,
+        input: ListRealmRequestsInput,
     ) -> Result<Vec<RealmRequestSnapshot>, RealmBootstrapError> {
         let operator_id = parse_uuid(operator_id, "operator id")?;
+        let limit = normalize_realm_request_list_limit(input.limit)?;
+        let before_realm_request_id = input
+            .before_realm_request_id
+            .as_deref()
+            .map(|value| parse_uuid(value, "before realm request id"))
+            .transpose()?;
+        if input.before_created_at.is_some() != before_realm_request_id.is_some() {
+            return Err(RealmBootstrapError::BadRequest(
+                "realm request list cursor requires before_created_at and before_realm_request_id"
+                    .to_owned(),
+            ));
+        }
         let client = self.client.lock().await;
         ensure_operator_role_tx(&*client, &operator_id, OPERATOR_READ_ROLES).await?;
         let rows = client
@@ -309,9 +325,15 @@ impl RealmBootstrapStore {
                 FROM dao.realm_requests request
                 LEFT JOIN dao.realms realm
                   ON realm.created_from_realm_request_id = request.realm_request_id
+                WHERE (
+                    $1::timestamptz IS NULL
+                    OR $2::uuid IS NULL
+                    OR (request.created_at, request.realm_request_id) < ($1, $2)
+                )
                 ORDER BY request.created_at DESC, request.realm_request_id DESC
+                LIMIT $3
                 ",
-                &[],
+                &[&input.before_created_at, &before_realm_request_id, &limit],
             )
             .await
             .map_err(db_error)?;
@@ -980,17 +1002,6 @@ impl RealmBootstrapStore {
         .map_err(db_error)?;
         update_expired_corridors_tx(&tx, None).await?;
 
-        let realm_rows = tx
-            .query(
-                "
-                SELECT realm_id
-                FROM dao.realms
-                ORDER BY realm_id
-                ",
-                &[],
-            )
-            .await
-            .map_err(db_error)?;
         let rebuild_generation = current_rebuild_generation_tx(&tx).await?;
         tx.execute("DELETE FROM projection.realm_admission_views", &[])
             .await
@@ -1001,30 +1012,9 @@ impl RealmBootstrapStore {
         tx.execute("DELETE FROM projection.realm_bootstrap_views", &[])
             .await
             .map_err(db_error)?;
-
-        for row in &realm_rows {
-            let realm_id: String = row.get("realm_id");
-            refresh_realm_bootstrap_view_tx(&tx, &realm_id, Some(rebuild_generation)).await?;
-            refresh_realm_review_summary_tx(&tx, &realm_id, Some(rebuild_generation)).await?;
-        }
-
-        let admission_rows = tx
-            .query(
-                "
-                SELECT DISTINCT realm_id, account_id
-                FROM dao.realm_admissions
-                ORDER BY realm_id, account_id
-                ",
-                &[],
-            )
-            .await
-            .map_err(db_error)?;
-        for row in &admission_rows {
-            let realm_id: String = row.get("realm_id");
-            let account_id: Uuid = row.get("account_id");
-            refresh_realm_admission_view_tx(&tx, &realm_id, &account_id, Some(rebuild_generation))
-                .await?;
-        }
+        rebuild_all_realm_bootstrap_views_tx(&tx, rebuild_generation).await?;
+        rebuild_all_realm_review_summaries_tx(&tx, rebuild_generation).await?;
+        rebuild_all_realm_admission_views_tx(&tx, rebuild_generation).await?;
 
         let bootstrap_view_count = tx
             .query_one(
@@ -1862,6 +1852,438 @@ async fn refresh_realm_projection_bundle_tx<C: GenericClient + Sync>(
     if let Some(account_id) = account_id {
         refresh_realm_admission_view_tx(client, realm_id, account_id, None).await?;
     }
+    Ok(())
+}
+
+async fn rebuild_all_realm_bootstrap_views_tx<C: GenericClient + Sync>(
+    client: &C,
+    rebuild_generation: i64,
+) -> Result<(), RealmBootstrapError> {
+    client
+        .execute(
+            "
+            INSERT INTO projection.realm_bootstrap_views (
+                realm_id,
+                slug,
+                display_name,
+                realm_status,
+                admission_posture,
+                corridor_status,
+                public_reason_code,
+                sponsor_display_state,
+                source_watermark_at,
+                source_fact_count,
+                projection_lag_ms,
+                rebuild_generation,
+                last_projected_at
+            )
+            WITH latest_corridor AS (
+                SELECT DISTINCT ON (realm_id)
+                    realm_id,
+                    corridor_status,
+                    starts_at,
+                    ends_at,
+                    updated_at
+                FROM dao.bootstrap_corridors
+                ORDER BY realm_id, updated_at DESC, bootstrap_corridor_id DESC
+            ),
+            current_sponsor_lineages AS (
+                SELECT DISTINCT ON (realm_id, sponsor_account_id)
+                    realm_id,
+                    sponsor_account_id,
+                    sponsor_status
+                FROM dao.realm_sponsor_records
+                ORDER BY
+                    realm_id,
+                    sponsor_account_id,
+                    updated_at DESC,
+                    created_at DESC,
+                    realm_sponsor_record_id DESC
+            ),
+            sponsor_counts AS (
+                SELECT
+                    realm_id,
+                    COUNT(*) FILTER (
+                        WHERE sponsor_status IN ('approved', 'active', 'rate_limited')
+                    ) AS active_sponsor_count
+                FROM current_sponsor_lineages
+                GROUP BY realm_id
+            ),
+            sponsor_fact_counts AS (
+                SELECT realm_id, COUNT(*) AS fact_count, MAX(updated_at) AS watermark_at
+                FROM dao.realm_sponsor_records
+                GROUP BY realm_id
+            ),
+            admission_fact_counts AS (
+                SELECT realm_id, COUNT(*) AS fact_count, MAX(updated_at) AS watermark_at
+                FROM dao.realm_admissions
+                GROUP BY realm_id
+            ),
+            corridor_fact_counts AS (
+                SELECT realm_id, COUNT(*) AS fact_count, MAX(updated_at) AS watermark_at
+                FROM dao.bootstrap_corridors
+                GROUP BY realm_id
+            ),
+            trigger_fact_counts AS (
+                SELECT realm_id, COUNT(*) AS fact_count, MAX(updated_at) AS watermark_at
+                FROM dao.realm_review_triggers
+                GROUP BY realm_id
+            ),
+            computed AS (
+                SELECT
+                    realm.realm_id,
+                    realm.slug,
+                    realm.display_name,
+                    realm.realm_status,
+                    CASE
+                        WHEN realm.realm_status IN ('restricted', 'suspended') THEN 'closed'
+                        WHEN realm.realm_status = 'active' THEN 'open'
+                        WHEN realm.realm_status = 'limited_bootstrap'
+                             AND corridor.corridor_status = 'active'
+                             AND corridor.starts_at <= CURRENT_TIMESTAMP
+                             AND corridor.ends_at > CURRENT_TIMESTAMP THEN 'limited'
+                        ELSE 'review_required'
+                    END AS admission_posture,
+                    COALESCE(corridor.corridor_status, 'none') AS corridor_status,
+                    realm.public_reason_code,
+                    CASE
+                        WHEN COALESCE(sponsor_counts.active_sponsor_count, 0) > 0
+                             AND realm.steward_account_id IS NOT NULL THEN 'sponsor_and_steward'
+                        WHEN COALESCE(sponsor_counts.active_sponsor_count, 0) > 0 THEN 'sponsor_backed'
+                        WHEN realm.steward_account_id IS NOT NULL THEN 'steward_present'
+                        ELSE 'none'
+                    END AS sponsor_display_state,
+                    GREATEST(
+                        realm.updated_at,
+                        COALESCE(sponsor_fact_counts.watermark_at, realm.updated_at),
+                        COALESCE(admission_fact_counts.watermark_at, realm.updated_at),
+                        COALESCE(corridor_fact_counts.watermark_at, realm.updated_at),
+                        COALESCE(trigger_fact_counts.watermark_at, realm.updated_at)
+                    ) AS source_watermark_at,
+                    (
+                        1
+                        + COALESCE(sponsor_fact_counts.fact_count, 0)
+                        + COALESCE(admission_fact_counts.fact_count, 0)
+                        + COALESCE(corridor_fact_counts.fact_count, 0)
+                        + COALESCE(trigger_fact_counts.fact_count, 0)
+                    ) AS source_fact_count
+                FROM dao.realms realm
+                LEFT JOIN latest_corridor corridor
+                  ON corridor.realm_id = realm.realm_id
+                LEFT JOIN sponsor_counts
+                  ON sponsor_counts.realm_id = realm.realm_id
+                LEFT JOIN sponsor_fact_counts
+                  ON sponsor_fact_counts.realm_id = realm.realm_id
+                LEFT JOIN admission_fact_counts
+                  ON admission_fact_counts.realm_id = realm.realm_id
+                LEFT JOIN corridor_fact_counts
+                  ON corridor_fact_counts.realm_id = realm.realm_id
+                LEFT JOIN trigger_fact_counts
+                  ON trigger_fact_counts.realm_id = realm.realm_id
+            )
+            SELECT
+                realm_id,
+                slug,
+                display_name,
+                realm_status,
+                admission_posture,
+                corridor_status,
+                public_reason_code,
+                sponsor_display_state,
+                source_watermark_at,
+                source_fact_count,
+                GREATEST(
+                    FLOOR(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - source_watermark_at)) * 1000),
+                    0
+                )::bigint AS projection_lag_ms,
+                $1,
+                CURRENT_TIMESTAMP
+            FROM computed
+            ",
+            &[&rebuild_generation],
+        )
+        .await
+        .map_err(db_error)?;
+    Ok(())
+}
+
+async fn rebuild_all_realm_admission_views_tx<C: GenericClient + Sync>(
+    client: &C,
+    rebuild_generation: i64,
+) -> Result<(), RealmBootstrapError> {
+    client
+        .execute(
+            "
+            INSERT INTO projection.realm_admission_views (
+                realm_id,
+                account_id,
+                admission_status,
+                admission_kind,
+                public_reason_code,
+                source_watermark_at,
+                source_fact_count,
+                projection_lag_ms,
+                rebuild_generation,
+                last_projected_at
+            )
+            WITH latest_admission AS (
+                SELECT DISTINCT ON (realm_id, account_id)
+                    realm_id,
+                    account_id,
+                    admission_status,
+                    admission_kind,
+                    review_reason_code,
+                    updated_at
+                FROM dao.realm_admissions
+                ORDER BY
+                    realm_id,
+                    account_id,
+                    updated_at DESC,
+                    created_at DESC,
+                    realm_admission_id DESC
+            ),
+            source_counts AS (
+                SELECT realm_id, account_id, COUNT(*) AS source_fact_count
+                FROM dao.realm_admissions
+                GROUP BY realm_id, account_id
+            ),
+            computed AS (
+                SELECT
+                    latest_admission.realm_id,
+                    latest_admission.account_id,
+                    latest_admission.admission_status,
+                    latest_admission.admission_kind,
+                    latest_admission.review_reason_code AS public_reason_code,
+                    latest_admission.updated_at AS source_watermark_at,
+                    COALESCE(source_counts.source_fact_count, 0) AS source_fact_count
+                FROM latest_admission
+                LEFT JOIN source_counts
+                  ON source_counts.realm_id = latest_admission.realm_id
+                 AND source_counts.account_id = latest_admission.account_id
+            )
+            SELECT
+                realm_id,
+                account_id,
+                admission_status,
+                admission_kind,
+                public_reason_code,
+                source_watermark_at,
+                source_fact_count,
+                GREATEST(
+                    FLOOR(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - source_watermark_at)) * 1000),
+                    0
+                )::bigint AS projection_lag_ms,
+                $1,
+                CURRENT_TIMESTAMP
+            FROM computed
+            ",
+            &[&rebuild_generation],
+        )
+        .await
+        .map_err(db_error)?;
+    Ok(())
+}
+
+async fn rebuild_all_realm_review_summaries_tx<C: GenericClient + Sync>(
+    client: &C,
+    rebuild_generation: i64,
+) -> Result<(), RealmBootstrapError> {
+    client
+        .execute(
+            "
+            INSERT INTO projection.realm_review_summaries (
+                realm_id,
+                realm_status,
+                corridor_status,
+                corridor_remaining_seconds,
+                active_sponsor_count,
+                sponsor_backed_admission_count,
+                recent_admission_count_7d,
+                open_review_trigger_count,
+                open_review_case_count,
+                latest_redacted_reason_code,
+                source_watermark_at,
+                source_fact_count,
+                projection_lag_ms,
+                rebuild_generation,
+                last_projected_at
+            )
+            WITH latest_corridor AS (
+                SELECT DISTINCT ON (realm_id)
+                    realm_id,
+                    corridor_status,
+                    ends_at,
+                    updated_at
+                FROM dao.bootstrap_corridors
+                ORDER BY realm_id, updated_at DESC, bootstrap_corridor_id DESC
+            ),
+            current_sponsor_lineages AS (
+                SELECT DISTINCT ON (realm_id, sponsor_account_id)
+                    realm_id,
+                    sponsor_account_id,
+                    sponsor_status
+                FROM dao.realm_sponsor_records
+                ORDER BY
+                    realm_id,
+                    sponsor_account_id,
+                    updated_at DESC,
+                    created_at DESC,
+                    realm_sponsor_record_id DESC
+            ),
+            active_sponsors AS (
+                SELECT realm_id, COUNT(*) AS active_sponsor_count
+                FROM current_sponsor_lineages
+                WHERE sponsor_status IN ('approved', 'active', 'rate_limited')
+                GROUP BY realm_id
+            ),
+            sponsor_backed_admissions AS (
+                SELECT realm_id, COUNT(*) AS sponsor_backed_admission_count
+                FROM dao.realm_admissions
+                WHERE admission_kind = 'sponsor_backed'
+                  AND admission_status IN ('pending', 'admitted')
+                GROUP BY realm_id
+            ),
+            recent_admissions AS (
+                SELECT realm_id, COUNT(*) AS recent_admission_count_7d
+                FROM dao.realm_admissions
+                WHERE created_at >= (CURRENT_TIMESTAMP - interval '7 days')
+                GROUP BY realm_id
+            ),
+            open_triggers AS (
+                SELECT realm_id, COUNT(*) AS open_review_trigger_count
+                FROM dao.realm_review_triggers
+                WHERE trigger_state = 'open'
+                GROUP BY realm_id
+            ),
+            open_cases AS (
+                SELECT related_realm_id AS realm_id, COUNT(*) AS open_review_case_count
+                FROM dao.review_cases
+                WHERE related_realm_id IS NOT NULL
+                  AND review_status <> 'closed'
+                GROUP BY related_realm_id
+            ),
+            latest_reason AS (
+                SELECT DISTINCT ON (realm_id)
+                    realm_id,
+                    redacted_reason_code
+                FROM dao.realm_review_triggers
+                ORDER BY realm_id, updated_at DESC, realm_review_trigger_id DESC
+            ),
+            sponsor_fact_counts AS (
+                SELECT realm_id, COUNT(*) AS fact_count, MAX(updated_at) AS watermark_at
+                FROM dao.realm_sponsor_records
+                GROUP BY realm_id
+            ),
+            admission_fact_counts AS (
+                SELECT realm_id, COUNT(*) AS fact_count, MAX(updated_at) AS watermark_at
+                FROM dao.realm_admissions
+                GROUP BY realm_id
+            ),
+            corridor_fact_counts AS (
+                SELECT realm_id, COUNT(*) AS fact_count, MAX(updated_at) AS watermark_at
+                FROM dao.bootstrap_corridors
+                GROUP BY realm_id
+            ),
+            trigger_fact_counts AS (
+                SELECT realm_id, COUNT(*) AS fact_count, MAX(updated_at) AS watermark_at
+                FROM dao.realm_review_triggers
+                GROUP BY realm_id
+            ),
+            case_fact_counts AS (
+                SELECT related_realm_id AS realm_id, COUNT(*) AS fact_count, MAX(updated_at) AS watermark_at
+                FROM dao.review_cases
+                WHERE related_realm_id IS NOT NULL
+                GROUP BY related_realm_id
+            ),
+            computed AS (
+                SELECT
+                    realm.realm_id,
+                    realm.realm_status,
+                    COALESCE(corridor.corridor_status, 'none') AS corridor_status,
+                    CASE
+                        WHEN corridor.corridor_status = 'active'
+                            THEN GREATEST(EXTRACT(EPOCH FROM (corridor.ends_at - CURRENT_TIMESTAMP))::bigint, 0)
+                        ELSE 0
+                    END AS corridor_remaining_seconds,
+                    COALESCE(active_sponsors.active_sponsor_count, 0) AS active_sponsor_count,
+                    COALESCE(
+                        sponsor_backed_admissions.sponsor_backed_admission_count,
+                        0
+                    ) AS sponsor_backed_admission_count,
+                    COALESCE(recent_admissions.recent_admission_count_7d, 0) AS recent_admission_count_7d,
+                    COALESCE(open_triggers.open_review_trigger_count, 0) AS open_review_trigger_count,
+                    COALESCE(open_cases.open_review_case_count, 0) AS open_review_case_count,
+                    COALESCE(
+                        latest_reason.redacted_reason_code,
+                        realm.public_reason_code
+                    ) AS latest_redacted_reason_code,
+                    GREATEST(
+                        realm.updated_at,
+                        COALESCE(sponsor_fact_counts.watermark_at, realm.updated_at),
+                        COALESCE(admission_fact_counts.watermark_at, realm.updated_at),
+                        COALESCE(corridor_fact_counts.watermark_at, realm.updated_at),
+                        COALESCE(trigger_fact_counts.watermark_at, realm.updated_at),
+                        COALESCE(case_fact_counts.watermark_at, realm.updated_at)
+                    ) AS source_watermark_at,
+                    (
+                        1
+                        + COALESCE(sponsor_fact_counts.fact_count, 0)
+                        + COALESCE(admission_fact_counts.fact_count, 0)
+                        + COALESCE(corridor_fact_counts.fact_count, 0)
+                        + COALESCE(trigger_fact_counts.fact_count, 0)
+                        + COALESCE(case_fact_counts.fact_count, 0)
+                    ) AS source_fact_count
+                FROM dao.realms realm
+                LEFT JOIN latest_corridor corridor
+                  ON corridor.realm_id = realm.realm_id
+                LEFT JOIN active_sponsors
+                  ON active_sponsors.realm_id = realm.realm_id
+                LEFT JOIN sponsor_backed_admissions
+                  ON sponsor_backed_admissions.realm_id = realm.realm_id
+                LEFT JOIN recent_admissions
+                  ON recent_admissions.realm_id = realm.realm_id
+                LEFT JOIN open_triggers
+                  ON open_triggers.realm_id = realm.realm_id
+                LEFT JOIN open_cases
+                  ON open_cases.realm_id = realm.realm_id
+                LEFT JOIN latest_reason
+                  ON latest_reason.realm_id = realm.realm_id
+                LEFT JOIN sponsor_fact_counts
+                  ON sponsor_fact_counts.realm_id = realm.realm_id
+                LEFT JOIN admission_fact_counts
+                  ON admission_fact_counts.realm_id = realm.realm_id
+                LEFT JOIN corridor_fact_counts
+                  ON corridor_fact_counts.realm_id = realm.realm_id
+                LEFT JOIN trigger_fact_counts
+                  ON trigger_fact_counts.realm_id = realm.realm_id
+                LEFT JOIN case_fact_counts
+                  ON case_fact_counts.realm_id = realm.realm_id
+            )
+            SELECT
+                realm_id,
+                realm_status,
+                corridor_status,
+                corridor_remaining_seconds,
+                active_sponsor_count,
+                sponsor_backed_admission_count,
+                recent_admission_count_7d,
+                open_review_trigger_count,
+                open_review_case_count,
+                latest_redacted_reason_code,
+                source_watermark_at,
+                source_fact_count,
+                GREATEST(
+                    FLOOR(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - source_watermark_at)) * 1000),
+                    0
+                )::bigint AS projection_lag_ms,
+                $1,
+                CURRENT_TIMESTAMP
+            FROM computed
+            ",
+            &[&rebuild_generation],
+        )
+        .await
+        .map_err(db_error)?;
     Ok(())
 }
 
@@ -3115,6 +3537,16 @@ fn normalize_optional(value: Option<&str>) -> Option<String> {
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(str::to_owned)
+}
+
+fn normalize_realm_request_list_limit(limit: Option<i64>) -> Result<i64, RealmBootstrapError> {
+    match limit {
+        Some(value) if value <= 0 => Err(RealmBootstrapError::BadRequest(
+            "realm request list limit must be positive".to_owned(),
+        )),
+        Some(value) => Ok(value.min(REALM_REQUEST_LIST_MAX_LIMIT)),
+        None => Ok(REALM_REQUEST_LIST_DEFAULT_LIMIT),
+    }
 }
 
 fn normalize_slug_candidate(value: &str) -> Result<String, RealmBootstrapError> {

--- a/apps/backend/src/services/realm_bootstrap/repository.rs
+++ b/apps/backend/src/services/realm_bootstrap/repository.rs
@@ -171,8 +171,7 @@ impl RealmBootstrapStore {
                             'request_received',
                             $11, $12
                         )
-                        ON CONFLICT (requested_by_account_id, request_idempotency_key)
-                        DO NOTHING
+                        ON CONFLICT DO NOTHING
                         RETURNING *, NULL::text AS created_realm_id, TRUE AS was_inserted
                     )
                     SELECT *
@@ -209,9 +208,10 @@ impl RealmBootstrapStore {
                 .map_err(db_error)?
             {
                 Some(row) => row,
-                None => tx
-                    .query_opt(
-                        "
+                None => {
+                    match tx
+                        .query_opt(
+                            "
                         SELECT request.*, realm.realm_id AS created_realm_id, FALSE AS was_inserted
                         FROM dao.realm_requests request
                         LEFT JOIN dao.realms realm
@@ -219,16 +219,44 @@ impl RealmBootstrapStore {
                         WHERE request.requested_by_account_id = $1
                           AND request.request_idempotency_key = $2
                         ",
-                        &[&requester_account_id, &request_idempotency_key],
-                    )
-                    .await
-                    .map_err(db_error)?
-                    .ok_or_else(|| RealmBootstrapError::Database {
-                        message: "realm request idempotency replay was not yet visible".to_owned(),
-                        code: None,
-                        constraint: None,
-                        retryable: true,
-                    })?,
+                            &[&requester_account_id, &request_idempotency_key],
+                        )
+                        .await
+                        .map_err(db_error)?
+                    {
+                        Some(row) => row,
+                        None => {
+                            let slug_conflict = tx
+                                .query_opt(
+                                    "
+                                    SELECT 1
+                                    FROM dao.realm_requests
+                                    WHERE slug_candidate = $1
+                                      AND request_state IN (
+                                          'requested',
+                                          'pending_review',
+                                          'approved'
+                                      )
+                                    ",
+                                    &[&slug_candidate],
+                                )
+                                .await
+                                .map_err(db_error)?;
+                            if slug_conflict.is_some() {
+                                return Err(RealmBootstrapError::BadRequest(
+                                    "slug_candidate already has an open realm request".to_owned(),
+                                ));
+                            }
+                            return Err(RealmBootstrapError::Database {
+                                message: "realm request idempotency replay was not yet visible"
+                                    .to_owned(),
+                                code: None,
+                                constraint: None,
+                                retryable: true,
+                            });
+                        }
+                    }
+                }
             };
             if !request_row.get::<_, bool>("was_inserted") {
                 ensure_request_payload_hash_matches(&request_row, &request_payload_hash)?;

--- a/apps/backend/src/services/realm_bootstrap/repository.rs
+++ b/apps/backend/src/services/realm_bootstrap/repository.rs
@@ -76,6 +76,7 @@ impl RealmBootstrapStore {
                 DELETE FROM projection.realm_review_summaries;
                 DELETE FROM projection.realm_bootstrap_views;
                 DELETE FROM dao.realm_review_triggers;
+                DELETE FROM dao.realm_admission_idempotency_keys;
                 DELETE FROM dao.realm_admissions;
                 DELETE FROM dao.bootstrap_corridors;
                 DELETE FROM dao.realm_sponsor_records;
@@ -682,15 +683,6 @@ impl RealmBootstrapStore {
         let mut client = self.client.lock().await;
         let tx = client.transaction().await.map_err(db_error)?;
         ensure_operator_role_tx(&tx, &operator_id, OPERATOR_WRITE_ROLES).await?;
-        ensure_sponsor_account_state_allows_status_tx(
-            &tx,
-            &sponsor_account_id,
-            &input.sponsor_status,
-        )
-        .await?;
-        lock_realm_tx(&tx, &realm_id).await?;
-        lock_sponsor_lineage_tx(&tx, &realm_id, &sponsor_account_id).await?;
-        update_expired_corridors_tx(&tx, Some(&realm_id)).await?;
 
         let row = if let Some(existing) = find_sponsor_record_by_idempotency_tx(
             &tx,
@@ -703,29 +695,50 @@ impl RealmBootstrapStore {
             ensure_sponsor_record_payload_hash_matches(&existing, &payload_hash)?;
             existing
         } else {
-            ensure_sponsor_status_transition_allowed_tx(
+            ensure_sponsor_account_state_allows_status_tx(
                 &tx,
-                &realm_id,
                 &sponsor_account_id,
                 &input.sponsor_status,
             )
             .await?;
-            let row = insert_sponsor_record_tx(
+            lock_realm_tx(&tx, &realm_id).await?;
+            lock_sponsor_lineage_tx(&tx, &realm_id, &sponsor_account_id).await?;
+            update_expired_corridors_tx(&tx, Some(&realm_id)).await?;
+            if let Some(existing) = find_sponsor_record_by_idempotency_tx(
                 &tx,
                 &realm_id,
-                &sponsor_account_id,
-                &input.sponsor_status,
-                input.quota_total,
-                &input.status_reason_code,
                 &operator_id,
-                request_idempotency_key,
-                payload_hash.clone(),
+                &request_idempotency_key,
             )
-            .await?;
-            ensure_sponsor_record_payload_hash_matches(&row, &payload_hash)?;
-            maybe_open_sponsor_concentration_trigger_tx(&tx, &realm_id, &sponsor_account_id)
+            .await?
+            {
+                ensure_sponsor_record_payload_hash_matches(&existing, &payload_hash)?;
+                existing
+            } else {
+                ensure_sponsor_status_transition_allowed_tx(
+                    &tx,
+                    &realm_id,
+                    &sponsor_account_id,
+                    &input.sponsor_status,
+                )
                 .await?;
-            row
+                let row = insert_sponsor_record_tx(
+                    &tx,
+                    &realm_id,
+                    &sponsor_account_id,
+                    &input.sponsor_status,
+                    input.quota_total,
+                    &input.status_reason_code,
+                    &operator_id,
+                    request_idempotency_key,
+                    payload_hash.clone(),
+                )
+                .await?;
+                ensure_sponsor_record_payload_hash_matches(&row, &payload_hash)?;
+                maybe_open_sponsor_concentration_trigger_tx(&tx, &realm_id, &sponsor_account_id)
+                    .await?;
+                row
+            }
         };
 
         refresh_realm_projection_bundle_tx(&tx, &realm_id, None).await?;
@@ -797,6 +810,15 @@ impl RealmBootstrapStore {
                     .filter(|row| row.get::<_, String>("admission_status") == "admitted")
             };
             if let Some(existing) = existing_admitted {
+                let existing = record_admission_idempotency_tx(
+                    &tx,
+                    &existing,
+                    &operator_id,
+                    &request_idempotency_key,
+                    &payload_hash,
+                )
+                .await?;
+                ensure_admission_payload_hash_matches(&existing, &payload_hash)?;
                 existing
             } else {
                 if let Some(trigger) = admission_context.open_trigger.as_ref() {
@@ -895,6 +917,14 @@ impl RealmBootstrapStore {
                         retryable: true,
                     })?,
                 };
+                let row = record_admission_idempotency_tx(
+                    &tx,
+                    &row,
+                    &operator_id,
+                    &request_idempotency_key,
+                    &payload_hash,
+                )
+                .await?;
                 ensure_admission_payload_hash_matches(&row, &payload_hash)?;
                 maybe_open_member_overlap_trigger_tx(&tx, &realm_id, &account_id).await?;
                 row
@@ -3052,16 +3082,104 @@ async fn find_admission_by_idempotency_tx<C: GenericClient + Sync>(
     client
         .query_opt(
             "
-            SELECT *
-            FROM dao.realm_admissions
-            WHERE realm_id = $1
-              AND granted_by_actor_id = $2
-              AND request_idempotency_key = $3
+            WITH idempotency AS (
+                SELECT
+                    realm_admission_id,
+                    request_payload_hash,
+                    0 AS priority
+                FROM dao.realm_admission_idempotency_keys
+                WHERE realm_id = $1
+                  AND granted_by_actor_id = $2
+                  AND request_idempotency_key = $3
+                UNION ALL
+                SELECT
+                    realm_admission_id,
+                    request_payload_hash,
+                    1 AS priority
+                FROM dao.realm_admissions
+                WHERE realm_id = $1
+                  AND granted_by_actor_id = $2
+                  AND request_idempotency_key = $3
+                ORDER BY priority
+                LIMIT 1
+            )
+            SELECT
+                admission.*,
+                idempotency.request_payload_hash AS idempotency_request_payload_hash
+            FROM idempotency
+            JOIN dao.realm_admissions admission
+              ON admission.realm_admission_id = idempotency.realm_admission_id
             ",
             &[&realm_id, operator_id, &request_idempotency_key],
         )
         .await
         .map_err(db_error)
+}
+
+async fn record_admission_idempotency_tx<C: GenericClient + Sync>(
+    client: &C,
+    admission: &Row,
+    operator_id: &Uuid,
+    request_idempotency_key: &str,
+    request_payload_hash: &str,
+) -> Result<Row, RealmBootstrapError> {
+    let realm_id: String = admission.get("realm_id");
+    let realm_admission_id: Uuid = admission.get("realm_admission_id");
+    client
+        .query_opt(
+            "
+            WITH inserted AS (
+                INSERT INTO dao.realm_admission_idempotency_keys (
+                    realm_id,
+                    granted_by_actor_id,
+                    request_idempotency_key,
+                    realm_admission_id,
+                    request_payload_hash
+                )
+                VALUES ($1, $2, $3, $4, $5)
+                ON CONFLICT (
+                    realm_id,
+                    granted_by_actor_id,
+                    request_idempotency_key
+                )
+                DO NOTHING
+                RETURNING realm_admission_id, request_payload_hash
+            ),
+            idempotency AS (
+                SELECT realm_admission_id, request_payload_hash
+                FROM inserted
+                UNION ALL
+                SELECT realm_admission_id, request_payload_hash
+                FROM dao.realm_admission_idempotency_keys
+                WHERE realm_id = $1
+                  AND granted_by_actor_id = $2
+                  AND request_idempotency_key = $3
+                  AND NOT EXISTS (SELECT 1 FROM inserted)
+                LIMIT 1
+            )
+            SELECT
+                admission.*,
+                idempotency.request_payload_hash AS idempotency_request_payload_hash
+            FROM idempotency
+            JOIN dao.realm_admissions admission
+              ON admission.realm_admission_id = idempotency.realm_admission_id
+            ",
+            &[
+                &realm_id,
+                operator_id,
+                &request_idempotency_key,
+                &realm_admission_id,
+                &request_payload_hash,
+            ],
+        )
+        .await
+        .map_err(db_error)?
+        .ok_or_else(|| RealmBootstrapError::Database {
+            message: "realm admission idempotency key was not recorded".to_owned(),
+            code: None,
+            constraint: None,
+            retryable: true,
+        })
 }
 
 async fn find_latest_admission_for_account_tx<C: GenericClient + Sync>(
@@ -3515,7 +3633,9 @@ fn ensure_admission_payload_hash_matches(
     row: &Row,
     payload_hash: &str,
 ) -> Result<(), RealmBootstrapError> {
-    let existing_hash: String = row.get("request_payload_hash");
+    let existing_hash: String = row
+        .try_get("idempotency_request_payload_hash")
+        .unwrap_or_else(|_| row.get("request_payload_hash"));
     if existing_hash == payload_hash {
         Ok(())
     } else {

--- a/apps/backend/src/services/realm_bootstrap/repository.rs
+++ b/apps/backend/src/services/realm_bootstrap/repository.rs
@@ -2697,6 +2697,7 @@ async fn refresh_realm_review_summary_tx<C: GenericClient + Sync>(
                OR projection.realm_review_summaries.latest_redacted_reason_code IS DISTINCT FROM EXCLUDED.latest_redacted_reason_code
                OR projection.realm_review_summaries.source_watermark_at IS DISTINCT FROM EXCLUDED.source_watermark_at
                OR projection.realm_review_summaries.source_fact_count IS DISTINCT FROM EXCLUDED.source_fact_count
+               OR projection.realm_review_summaries.projection_lag_ms IS DISTINCT FROM EXCLUDED.projection_lag_ms
                OR projection.realm_review_summaries.rebuild_generation IS DISTINCT FROM COALESCE($14, projection.realm_review_summaries.rebuild_generation, 1::bigint)
             ",
             &[

--- a/apps/backend/src/services/realm_bootstrap/repository.rs
+++ b/apps/backend/src/services/realm_bootstrap/repository.rs
@@ -2087,6 +2087,7 @@ async fn find_current_corridor_tx<C: GenericClient + Sync>(
               AND ends_at > CURRENT_TIMESTAMP
             ORDER BY updated_at DESC, bootstrap_corridor_id DESC
             LIMIT 1
+            FOR UPDATE
             ",
             &[&realm_id],
         )
@@ -2965,6 +2966,11 @@ fn db_error(error: tokio_postgres::Error) -> RealmBootstrapError {
             Some("realm_requests_request_idempotency_unique") => {
                 return RealmBootstrapError::BadRequest(
                     "request_idempotency_key was already used by this requester".to_owned(),
+                );
+            }
+            Some("realms_slug_key") => {
+                return RealmBootstrapError::BadRequest(
+                    "approved slug is already in use".to_owned(),
                 );
             }
             Some("realm_sponsor_records_active_unique") => {

--- a/apps/backend/src/services/realm_bootstrap/repository.rs
+++ b/apps/backend/src/services/realm_bootstrap/repository.rs
@@ -896,6 +896,16 @@ impl RealmBootstrapStore {
     ) -> Result<RealmBootstrapRebuildSnapshot, RealmBootstrapError> {
         let mut client = self.client.lock().await;
         let tx = client.transaction().await.map_err(db_error)?;
+        tx.query_one(
+            "
+            SELECT pg_advisory_xact_lock(
+                hashtext('projection.realm_bootstrap_views.rebuild')::bigint
+            )
+            ",
+            &[],
+        )
+        .await
+        .map_err(db_error)?;
         update_expired_corridors_tx(&tx, None).await?;
 
         let realm_rows = tx
@@ -1646,7 +1656,7 @@ async fn refresh_realm_bootstrap_view_tx<C: GenericClient + Sync>(
                 source_watermark_at = EXCLUDED.source_watermark_at,
                 source_fact_count = EXCLUDED.source_fact_count,
                 projection_lag_ms = EXCLUDED.projection_lag_ms,
-                rebuild_generation = COALESCE($12, projection.realm_bootstrap_views.rebuild_generation),
+                rebuild_generation = COALESCE($12, projection.realm_bootstrap_views.rebuild_generation, 1::bigint),
                 last_projected_at = CURRENT_TIMESTAMP
             ",
             &[
@@ -1745,7 +1755,7 @@ async fn refresh_realm_admission_view_tx<C: GenericClient + Sync>(
                 source_watermark_at = EXCLUDED.source_watermark_at,
                 source_fact_count = EXCLUDED.source_fact_count,
                 projection_lag_ms = EXCLUDED.projection_lag_ms,
-                rebuild_generation = COALESCE($9, projection.realm_admission_views.rebuild_generation),
+                rebuild_generation = COALESCE($9, projection.realm_admission_views.rebuild_generation, 1::bigint),
                 last_projected_at = CURRENT_TIMESTAMP
             ",
             &[
@@ -1899,7 +1909,7 @@ async fn refresh_realm_review_summary_tx<C: GenericClient + Sync>(
                 source_watermark_at = EXCLUDED.source_watermark_at,
                 source_fact_count = EXCLUDED.source_fact_count,
                 projection_lag_ms = EXCLUDED.projection_lag_ms,
-                rebuild_generation = COALESCE($14, projection.realm_review_summaries.rebuild_generation),
+                rebuild_generation = COALESCE($14, projection.realm_review_summaries.rebuild_generation, 1::bigint),
                 last_projected_at = CURRENT_TIMESTAMP
             ",
             &[

--- a/apps/backend/src/services/realm_bootstrap/repository.rs
+++ b/apps/backend/src/services/realm_bootstrap/repository.rs
@@ -128,12 +128,6 @@ impl RealmBootstrapStore {
         let mut client = self.client.lock().await;
         let tx = client.transaction().await.map_err(db_error)?;
         ensure_active_account_exists_tx(&tx, &requester_account_id).await?;
-        if let Some(sponsor_account_id) = proposed_sponsor_account_id.as_ref() {
-            ensure_active_account_exists_tx(&tx, sponsor_account_id).await?;
-        }
-        if let Some(steward_account_id) = proposed_steward_account_id.as_ref() {
-            ensure_active_account_exists_tx(&tx, steward_account_id).await?;
-        }
 
         let row = if let Some(existing) = find_realm_request_by_idempotency_tx(
             &tx,
@@ -145,6 +139,12 @@ impl RealmBootstrapStore {
             ensure_request_payload_hash_matches(&existing, &request_payload_hash)?;
             existing
         } else {
+            if let Some(sponsor_account_id) = proposed_sponsor_account_id.as_ref() {
+                ensure_active_account_exists_tx(&tx, sponsor_account_id).await?;
+            }
+            if let Some(steward_account_id) = proposed_steward_account_id.as_ref() {
+                ensure_active_account_exists_tx(&tx, steward_account_id).await?;
+            }
             let request_row = match tx
                 .query_opt(
                     "

--- a/apps/backend/src/services/realm_bootstrap/repository.rs
+++ b/apps/backend/src/services/realm_bootstrap/repository.rs
@@ -775,9 +775,13 @@ impl RealmBootstrapStore {
     ) -> Result<RealmBootstrapSummarySnapshot, RealmBootstrapError> {
         let viewer_account_id = parse_uuid(viewer_account_id, "viewer account id")?;
         let realm_id = normalize_required(realm_id, "realm id")?;
-        let client = self.client.lock().await;
+        let mut client = self.client.lock().await;
+        let tx = client.transaction().await.map_err(db_error)?;
+        lock_realm_tx(&tx, &realm_id).await?;
+        update_expired_corridors_tx(&tx, Some(&realm_id)).await?;
+        refresh_realm_projection_bundle_tx(&tx, &realm_id, Some(&viewer_account_id)).await?;
 
-        let bootstrap_row = client
+        let bootstrap_row = tx
             .query_opt(
                 "
                 SELECT *
@@ -792,7 +796,7 @@ impl RealmBootstrapStore {
                 RealmBootstrapError::NotFound("realm bootstrap summary was not found".to_owned())
             })?;
 
-        let request_row = client
+        let request_row = tx
             .query_opt(
                 "
                 SELECT
@@ -808,7 +812,7 @@ impl RealmBootstrapStore {
             )
             .await
             .map_err(db_error)?;
-        let admission_row = client
+        let admission_row = tx
             .query_opt(
                 "
                 SELECT *
@@ -827,7 +831,7 @@ impl RealmBootstrapStore {
             ));
         }
 
-        Ok(RealmBootstrapSummarySnapshot {
+        let snapshot = RealmBootstrapSummarySnapshot {
             realm_request: request_row
                 .as_ref()
                 .map(realm_request_from_row)
@@ -837,7 +841,9 @@ impl RealmBootstrapStore {
                 .as_ref()
                 .map(realm_admission_view_from_row)
                 .transpose()?,
-        })
+        };
+        tx.commit().await.map_err(db_error)?;
+        Ok(snapshot)
     }
 
     pub async fn get_review_summary_for_operator(
@@ -847,9 +853,13 @@ impl RealmBootstrapStore {
     ) -> Result<RealmReviewSummarySnapshot, RealmBootstrapError> {
         let operator_id = parse_uuid(operator_id, "operator id")?;
         let realm_id = normalize_required(realm_id, "realm id")?;
-        let client = self.client.lock().await;
-        ensure_operator_role_tx(&*client, &operator_id, OPERATOR_READ_ROLES).await?;
-        let row = client
+        let mut client = self.client.lock().await;
+        let tx = client.transaction().await.map_err(db_error)?;
+        ensure_operator_role_tx(&tx, &operator_id, OPERATOR_READ_ROLES).await?;
+        lock_realm_tx(&tx, &realm_id).await?;
+        update_expired_corridors_tx(&tx, Some(&realm_id)).await?;
+        refresh_realm_projection_bundle_tx(&tx, &realm_id, None).await?;
+        let row = tx
             .query_opt(
                 "
                 SELECT *
@@ -863,7 +873,7 @@ impl RealmBootstrapStore {
             .ok_or_else(|| {
                 RealmBootstrapError::NotFound("realm review summary was not found".to_owned())
             })?;
-        let trigger_rows = client
+        let trigger_rows = tx
             .query(
                 "
                 SELECT *
@@ -876,7 +886,9 @@ impl RealmBootstrapStore {
             )
             .await
             .map_err(db_error)?;
-        realm_review_summary_from_row(&row, &trigger_rows)
+        let snapshot = realm_review_summary_from_row(&row, &trigger_rows)?;
+        tx.commit().await.map_err(db_error)?;
+        Ok(snapshot)
     }
 
     pub async fn rebuild_realm_bootstrap_views(
@@ -1634,7 +1646,7 @@ async fn refresh_realm_bootstrap_view_tx<C: GenericClient + Sync>(
                 source_watermark_at = EXCLUDED.source_watermark_at,
                 source_fact_count = EXCLUDED.source_fact_count,
                 projection_lag_ms = EXCLUDED.projection_lag_ms,
-                rebuild_generation = COALESCE($12, projection.realm_bootstrap_views.rebuild_generation + 1),
+                rebuild_generation = COALESCE($12, projection.realm_bootstrap_views.rebuild_generation),
                 last_projected_at = CURRENT_TIMESTAMP
             ",
             &[
@@ -1733,7 +1745,7 @@ async fn refresh_realm_admission_view_tx<C: GenericClient + Sync>(
                 source_watermark_at = EXCLUDED.source_watermark_at,
                 source_fact_count = EXCLUDED.source_fact_count,
                 projection_lag_ms = EXCLUDED.projection_lag_ms,
-                rebuild_generation = COALESCE($9, projection.realm_admission_views.rebuild_generation + 1),
+                rebuild_generation = COALESCE($9, projection.realm_admission_views.rebuild_generation),
                 last_projected_at = CURRENT_TIMESTAMP
             ",
             &[
@@ -1887,7 +1899,7 @@ async fn refresh_realm_review_summary_tx<C: GenericClient + Sync>(
                 source_watermark_at = EXCLUDED.source_watermark_at,
                 source_fact_count = EXCLUDED.source_fact_count,
                 projection_lag_ms = EXCLUDED.projection_lag_ms,
-                rebuild_generation = COALESCE($14, projection.realm_review_summaries.rebuild_generation + 1),
+                rebuild_generation = COALESCE($14, projection.realm_review_summaries.rebuild_generation),
                 last_projected_at = CURRENT_TIMESTAMP
             ",
             &[
@@ -2327,8 +2339,8 @@ fn create_realm_request_payload_hash(
         "display_name": normalize_optional(Some(input.display_name.as_str())),
         "slug_candidate": slug_candidate,
         "purpose_text": normalize_optional(Some(input.purpose_text.as_str())),
-        "venue_context_json": input.venue_context_json,
-        "expected_member_shape_json": input.expected_member_shape_json,
+        "venue_context_json": &input.venue_context_json,
+        "expected_member_shape_json": &input.expected_member_shape_json,
         "bootstrap_rationale_text": normalize_optional(Some(input.bootstrap_rationale_text.as_str())),
         "proposed_sponsor_account_id": optional_uuid_hash_value(proposed_sponsor_account_id),
         "proposed_steward_account_id": optional_uuid_hash_value(proposed_steward_account_id),
@@ -2343,24 +2355,24 @@ fn approve_request_payload_hash(
 ) -> String {
     hash_json_value(&json!({
         "schema_version": 1,
-        "target_realm_status": input.target_realm_status,
+        "target_realm_status": &input.target_realm_status,
         "approved_slug": approved_slug,
         "approved_display_name": approved_display_name,
-        "review_reason_code": input.review_reason_code,
+        "review_reason_code": &input.review_reason_code,
         "steward_account_id": optional_uuid_hash_value(steward_account_id),
         "sponsor_quota_total": input.sponsor_quota_total,
-        "corridor_starts_at": input.corridor_starts_at.map(|value| value.to_rfc3339()),
-        "corridor_ends_at": input.corridor_ends_at.map(|value| value.to_rfc3339()),
+        "corridor_starts_at": input.corridor_starts_at.as_ref().map(|value| value.to_rfc3339()),
+        "corridor_ends_at": input.corridor_ends_at.as_ref().map(|value| value.to_rfc3339()),
         "corridor_member_cap": input.corridor_member_cap,
         "corridor_sponsor_cap": input.corridor_sponsor_cap,
-        "review_threshold_json": input.review_threshold_json,
+        "review_threshold_json": &input.review_threshold_json,
     }))
 }
 
 fn reject_request_payload_hash(input: &RejectRealmRequestInput) -> String {
     hash_json_value(&json!({
         "schema_version": 1,
-        "review_reason_code": input.review_reason_code,
+        "review_reason_code": &input.review_reason_code,
     }))
 }
 
@@ -2371,9 +2383,9 @@ fn create_sponsor_record_payload_hash(
     hash_json_value(&json!({
         "schema_version": 1,
         "sponsor_account_id": sponsor_account_id.to_string(),
-        "sponsor_status": input.sponsor_status,
+        "sponsor_status": &input.sponsor_status,
         "quota_total": input.quota_total,
-        "status_reason_code": input.status_reason_code,
+        "status_reason_code": &input.status_reason_code,
     }))
 }
 
@@ -2387,9 +2399,9 @@ fn create_admission_payload_hash(
         "schema_version": 1,
         "account_id": account_id.to_string(),
         "sponsor_record_id": optional_uuid_hash_value(sponsor_record_id),
-        "source_fact_kind": input.source_fact_kind,
-        "source_fact_id": input.source_fact_id,
-        "source_snapshot_json": input.source_snapshot_json,
+        "source_fact_kind": &input.source_fact_kind,
+        "source_fact_id": &input.source_fact_id,
+        "source_snapshot_json": &input.source_snapshot_json,
         "granted_by_actor_kind": granted_by_actor_kind,
     }))
 }
@@ -2645,6 +2657,7 @@ async fn open_trigger_tx<C: GenericClient + Sync>(
 ) -> Result<(), RealmBootstrapError> {
     validate_allowed("trigger_kind", trigger_kind, REVIEW_TRIGGER_KINDS)?;
     validate_allowed("redacted_reason_code", redacted_reason_code, REASON_CODES)?;
+    let realm_id_param = realm_id.map(str::to_owned);
     client
         .execute(
             "
@@ -2668,7 +2681,7 @@ async fn open_trigger_tx<C: GenericClient + Sync>(
             ",
             &[
                 &Uuid::new_v4(),
-                &realm_id.map(str::to_owned),
+                &realm_id_param,
                 &trigger_kind,
                 &redacted_reason_code,
                 &related_account_id,
@@ -2916,11 +2929,32 @@ fn db_error(error: tokio_postgres::Error) -> RealmBootstrapError {
     let constraint = error
         .as_db_error()
         .and_then(|db_error| db_error.constraint().map(str::to_owned));
+    if matches!(error.code(), Some(&SqlState::UNIQUE_VIOLATION)) {
+        match constraint.as_deref() {
+            Some("realm_sponsor_records_active_unique") => {
+                return RealmBootstrapError::BadRequest(
+                    "sponsor account already has an open sponsor record for this realm".to_owned(),
+                );
+            }
+            Some("realm_admissions_active_unique") => {
+                return RealmBootstrapError::BadRequest(
+                    "account already has a pending or admitted realm admission".to_owned(),
+                );
+            }
+            _ => {}
+        }
+    }
     let retryable = matches!(
         error.code(),
         Some(&SqlState::T_R_SERIALIZATION_FAILURE)
             | Some(&SqlState::T_R_DEADLOCK_DETECTED)
             | Some(&SqlState::CONNECTION_EXCEPTION)
+            | Some(&SqlState::CONNECTION_DOES_NOT_EXIST)
+            | Some(&SqlState::CONNECTION_FAILURE)
+            | Some(&SqlState::SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION)
+            | Some(&SqlState::SQLSERVER_REJECTED_ESTABLISHMENT_OF_SQLCONNECTION)
+            | Some(&SqlState::TRANSACTION_RESOLUTION_UNKNOWN)
+            | Some(&SqlState::PROTOCOL_VIOLATION)
     );
     RealmBootstrapError::Database {
         message: error.to_string(),

--- a/apps/backend/src/services/realm_bootstrap/repository.rs
+++ b/apps/backend/src/services/realm_bootstrap/repository.rs
@@ -429,8 +429,7 @@ impl RealmBootstrapStore {
             ensure_active_account_exists_tx(&tx, sponsor_account_id).await?;
             let quota_total = input.sponsor_quota_total.ok_or_else(|| {
                 RealmBootstrapError::BadRequest(
-                    "limited bootstrap approval with a proposed sponsor requires sponsor_quota_total"
-                        .to_owned(),
+                    "approval with a proposed sponsor requires sponsor_quota_total".to_owned(),
                 )
             })?;
             let sponsor_payload_hash = create_sponsor_record_payload_hash(
@@ -652,19 +651,19 @@ impl RealmBootstrapStore {
                     "admission creation requires request_idempotency_key".to_owned(),
                 )
             })?;
-        let granted_by_actor_kind = operator_actor_kind(operator_id, self).await?;
-        let payload_hash = create_admission_payload_hash(
-            &input,
-            &account_id,
-            &sponsor_record_id,
-            &granted_by_actor_kind,
-        );
 
         let mut client = self.client.lock().await;
         let tx = client.transaction().await.map_err(db_error)?;
         ensure_operator_role_tx(&tx, &operator_id, OPERATOR_WRITE_ROLES).await?;
         ensure_active_account_exists_tx(&tx, &account_id).await?;
         update_expired_corridors_tx(&tx, Some(&realm_id)).await?;
+        let granted_by_actor_kind = operator_actor_kind_tx(&tx, &operator_id).await?;
+        let payload_hash = create_admission_payload_hash(
+            &input,
+            &account_id,
+            &sponsor_record_id,
+            &granted_by_actor_kind,
+        );
 
         let row = if let Some(existing) =
             find_admission_by_idempotency_tx(&tx, &realm_id, &operator_id, &request_idempotency_key)
@@ -777,7 +776,7 @@ impl RealmBootstrapStore {
         let realm_id = normalize_required(realm_id, "realm id")?;
         let mut client = self.client.lock().await;
         let tx = client.transaction().await.map_err(db_error)?;
-        lock_realm_tx(&tx, &realm_id).await?;
+        ensure_realm_exists_tx(&tx, &realm_id).await?;
         update_expired_corridors_tx(&tx, Some(&realm_id)).await?;
         refresh_realm_projection_bundle_tx(&tx, &realm_id, Some(&viewer_account_id)).await?;
 
@@ -856,7 +855,7 @@ impl RealmBootstrapStore {
         let mut client = self.client.lock().await;
         let tx = client.transaction().await.map_err(db_error)?;
         ensure_operator_role_tx(&tx, &operator_id, OPERATOR_READ_ROLES).await?;
-        lock_realm_tx(&tx, &realm_id).await?;
+        ensure_realm_exists_tx(&tx, &realm_id).await?;
         update_expired_corridors_tx(&tx, Some(&realm_id)).await?;
         refresh_realm_projection_bundle_tx(&tx, &realm_id, None).await?;
         let row = tx
@@ -919,6 +918,7 @@ impl RealmBootstrapStore {
             )
             .await
             .map_err(db_error)?;
+        let rebuild_generation = current_rebuild_generation_tx(&tx).await?;
         tx.execute("DELETE FROM projection.realm_admission_views", &[])
             .await
             .map_err(db_error)?;
@@ -929,7 +929,6 @@ impl RealmBootstrapStore {
             .await
             .map_err(db_error)?;
 
-        let rebuild_generation = current_rebuild_generation_tx(&tx).await?;
         for row in &realm_rows {
             let realm_id: String = row.get("realm_id");
             refresh_realm_bootstrap_view_tx(&tx, &realm_id, Some(rebuild_generation)).await?;
@@ -2222,6 +2221,24 @@ async fn lock_realm_tx<C: GenericClient + Sync>(
         .ok_or_else(|| RealmBootstrapError::NotFound("realm was not found".to_owned()))
 }
 
+async fn ensure_realm_exists_tx<C: GenericClient + Sync>(
+    client: &C,
+    realm_id: &str,
+) -> Result<(), RealmBootstrapError> {
+    if client
+        .query_opt("SELECT 1 FROM dao.realms WHERE realm_id = $1", &[&realm_id])
+        .await
+        .map_err(db_error)?
+        .is_some()
+    {
+        Ok(())
+    } else {
+        Err(RealmBootstrapError::NotFound(
+            "realm was not found".to_owned(),
+        ))
+    }
+}
+
 async fn lock_sponsor_record_tx<C: GenericClient + Sync>(
     client: &C,
     sponsor_record_id: &Uuid,
@@ -2725,11 +2742,10 @@ async fn current_rebuild_generation_tx<C: GenericClient + Sync>(
         .get("rebuild_generation"))
 }
 
-async fn operator_actor_kind(
-    operator_id: Uuid,
-    store: &RealmBootstrapStore,
+async fn operator_actor_kind_tx<C: GenericClient + Sync>(
+    client: &C,
+    operator_id: &Uuid,
 ) -> Result<String, RealmBootstrapError> {
-    let client = store.client.lock().await;
     let row = client
         .query_one(
             "
@@ -2741,7 +2757,7 @@ async fn operator_actor_kind(
                   AND revoked_at IS NULL
             ) AS is_steward
             ",
-            &[&operator_id],
+            &[operator_id],
         )
         .await
         .map_err(db_error)?;
@@ -2941,14 +2957,36 @@ fn db_error(error: tokio_postgres::Error) -> RealmBootstrapError {
         .and_then(|db_error| db_error.constraint().map(str::to_owned));
     if matches!(error.code(), Some(&SqlState::UNIQUE_VIOLATION)) {
         match constraint.as_deref() {
+            Some("realm_requests_open_slug_candidate_unique") => {
+                return RealmBootstrapError::BadRequest(
+                    "slug_candidate already has an open realm request".to_owned(),
+                );
+            }
+            Some("realm_requests_request_idempotency_unique") => {
+                return RealmBootstrapError::BadRequest(
+                    "request_idempotency_key was already used by this requester".to_owned(),
+                );
+            }
             Some("realm_sponsor_records_active_unique") => {
                 return RealmBootstrapError::BadRequest(
                     "sponsor account already has an open sponsor record for this realm".to_owned(),
                 );
             }
+            Some("realm_sponsor_records_idempotency_unique") => {
+                return RealmBootstrapError::BadRequest(
+                    "request_idempotency_key was already used by this operator for this realm"
+                        .to_owned(),
+                );
+            }
             Some("realm_admissions_active_unique") => {
                 return RealmBootstrapError::BadRequest(
                     "account already has a pending or admitted realm admission".to_owned(),
+                );
+            }
+            Some("realm_admissions_idempotency_unique") => {
+                return RealmBootstrapError::BadRequest(
+                    "request_idempotency_key was already used by this operator for this realm"
+                        .to_owned(),
                 );
             }
             _ => {}

--- a/apps/backend/src/services/realm_bootstrap/repository.rs
+++ b/apps/backend/src/services/realm_bootstrap/repository.rs
@@ -820,10 +820,9 @@ impl RealmBootstrapStore {
     ) -> Result<RealmBootstrapSummarySnapshot, RealmBootstrapError> {
         let viewer_account_id = parse_uuid(viewer_account_id, "viewer account id")?;
         let realm_id = normalize_required(realm_id, "realm id")?;
-        let mut client = self.client.lock().await;
-        let tx = client.transaction().await.map_err(db_error)?;
+        let client = self.client.lock().await;
 
-        let request_row = tx
+        let request_row = client
             .query_opt(
                 "
                 SELECT
@@ -839,7 +838,7 @@ impl RealmBootstrapStore {
             )
             .await
             .map_err(db_error)?;
-        let admitted_row = tx
+        let admitted_row = client
             .query_opt(
                 "
                 SELECT *
@@ -865,49 +864,19 @@ impl RealmBootstrapStore {
             ));
         }
 
-        update_expired_corridors_tx(&tx, Some(&realm_id)).await?;
-        refresh_realm_bootstrap_view_tx(&tx, &realm_id, None).await?;
-        refresh_realm_admission_view_tx(&tx, &realm_id, &viewer_account_id, None).await?;
-
-        let bootstrap_row = tx
-            .query_opt(
-                "
-                SELECT *
-                FROM projection.realm_bootstrap_views
-                WHERE realm_id = $1
-                ",
-                &[&realm_id],
-            )
-            .await
-            .map_err(db_error)?
-            .ok_or_else(|| {
-                RealmBootstrapError::NotFound("realm bootstrap summary was not found".to_owned())
-            })?;
-        let admission_row = tx
-            .query_opt(
-                "
-                SELECT *
-                FROM projection.realm_admission_views
-                WHERE realm_id = $1
-                  AND account_id = $2
-                ",
-                &[&realm_id, &viewer_account_id],
-            )
-            .await
-            .map_err(db_error)?;
-
         let snapshot = RealmBootstrapSummarySnapshot {
             realm_request: request_row
                 .as_ref()
                 .map(realm_request_from_row)
                 .transpose()?,
-            bootstrap_view: realm_bootstrap_view_from_row(&bootstrap_row)?,
-            admission_view: admission_row
-                .as_ref()
-                .map(realm_admission_view_from_row)
-                .transpose()?,
+            bootstrap_view: read_current_realm_bootstrap_view(&*client, &realm_id).await?,
+            admission_view: read_current_realm_admission_view(
+                &*client,
+                &realm_id,
+                &viewer_account_id,
+            )
+            .await?,
         };
-        tx.commit().await.map_err(db_error)?;
         Ok(snapshot)
     }
 
@@ -1645,6 +1614,172 @@ async fn insert_bootstrap_corridor_tx<C: GenericClient + Sync>(
         .await
         .map_err(db_error)?;
     Ok(())
+}
+
+async fn read_current_realm_bootstrap_view<C: GenericClient + Sync>(
+    client: &C,
+    realm_id: &str,
+) -> Result<RealmBootstrapViewSnapshot, RealmBootstrapError> {
+    let row = client
+        .query_opt(
+            "
+            WITH latest_corridor AS (
+                SELECT *
+                FROM dao.bootstrap_corridors
+                WHERE realm_id = $1
+                ORDER BY updated_at DESC, bootstrap_corridor_id DESC
+                LIMIT 1
+            ),
+            current_corridor AS (
+                SELECT
+                    CASE
+                        WHEN corridor_status IN ('active', 'cooling_down')
+                             AND ends_at <= CURRENT_TIMESTAMP THEN 'expired'
+                        ELSE corridor_status
+                    END AS corridor_status
+                FROM latest_corridor
+            ),
+            sponsor_counts AS (
+                SELECT
+                    COUNT(*) FILTER (WHERE sponsor_status IN ('approved', 'active', 'rate_limited')) AS active_sponsor_count
+                FROM (
+                    SELECT DISTINCT ON (sponsor_account_id)
+                        sponsor_account_id,
+                        sponsor_status
+                    FROM dao.realm_sponsor_records
+                    WHERE realm_id = $1
+                    ORDER BY
+                        sponsor_account_id,
+                        updated_at DESC,
+                        created_at DESC,
+                        realm_sponsor_record_id DESC
+                ) current_sponsor_lineages
+            ),
+            source_counts AS (
+                SELECT
+                    1
+                    + COALESCE((SELECT COUNT(*) FROM dao.realm_sponsor_records WHERE realm_id = $1), 0)
+                    + COALESCE((SELECT COUNT(*) FROM dao.realm_admissions WHERE realm_id = $1), 0)
+                    + COALESCE((SELECT COUNT(*) FROM dao.bootstrap_corridors WHERE realm_id = $1), 0)
+                    + COALESCE((SELECT COUNT(*) FROM dao.realm_review_triggers WHERE realm_id = $1), 0)
+                    AS source_fact_count
+            ),
+            watermarks AS (
+                SELECT GREATEST(
+                    realm.updated_at,
+                    COALESCE((SELECT MAX(updated_at) FROM dao.realm_sponsor_records WHERE realm_id = $1), realm.updated_at),
+                    COALESCE((SELECT MAX(updated_at) FROM dao.realm_admissions WHERE realm_id = $1), realm.updated_at),
+                    COALESCE((SELECT MAX(updated_at) FROM dao.bootstrap_corridors WHERE realm_id = $1), realm.updated_at),
+                    COALESCE((SELECT MAX(updated_at) FROM dao.realm_review_triggers WHERE realm_id = $1), realm.updated_at)
+                ) AS source_watermark_at
+                FROM dao.realms realm
+                WHERE realm.realm_id = $1
+            ),
+            computed AS (
+                SELECT
+                    realm.realm_id,
+                    realm.slug,
+                    realm.display_name,
+                    realm.realm_status,
+                    CASE
+                        WHEN realm.realm_status IN ('restricted', 'suspended') THEN 'closed'
+                        WHEN realm.realm_status = 'active' THEN 'open'
+                        WHEN realm.realm_status = 'limited_bootstrap' AND EXISTS (
+                            SELECT 1
+                            FROM latest_corridor
+                            WHERE corridor_status = 'active'
+                              AND starts_at <= CURRENT_TIMESTAMP
+                              AND ends_at > CURRENT_TIMESTAMP
+                        ) THEN 'limited'
+                        ELSE 'review_required'
+                    END AS admission_posture,
+                    COALESCE((SELECT corridor_status FROM current_corridor), 'none') AS corridor_status,
+                    realm.public_reason_code,
+                    CASE
+                        WHEN COALESCE((SELECT active_sponsor_count FROM sponsor_counts), 0) > 0
+                             AND realm.steward_account_id IS NOT NULL THEN 'sponsor_and_steward'
+                        WHEN COALESCE((SELECT active_sponsor_count FROM sponsor_counts), 0) > 0 THEN 'sponsor_backed'
+                        WHEN realm.steward_account_id IS NOT NULL THEN 'steward_present'
+                        ELSE 'none'
+                    END AS sponsor_display_state,
+                    (SELECT source_watermark_at FROM watermarks) AS source_watermark_at,
+                    (SELECT source_fact_count FROM source_counts) AS source_fact_count
+                FROM dao.realms realm
+                WHERE realm.realm_id = $1
+            )
+            SELECT
+                computed.*,
+                GREATEST(
+                    FLOOR(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - computed.source_watermark_at)) * 1000),
+                    0
+                )::bigint AS projection_lag_ms,
+                COALESCE(projection.rebuild_generation, 1::bigint) AS rebuild_generation,
+                COALESCE(projection.last_projected_at, CURRENT_TIMESTAMP) AS last_projected_at
+            FROM computed
+            LEFT JOIN projection.realm_bootstrap_views projection
+              ON projection.realm_id = computed.realm_id
+            ",
+            &[&realm_id],
+        )
+        .await
+        .map_err(db_error)?
+        .ok_or_else(|| {
+            RealmBootstrapError::NotFound("realm bootstrap summary was not found".to_owned())
+        })?;
+    realm_bootstrap_view_from_row(&row)
+}
+
+async fn read_current_realm_admission_view<C: GenericClient + Sync>(
+    client: &C,
+    realm_id: &str,
+    account_id: &Uuid,
+) -> Result<Option<RealmAdmissionViewSnapshot>, RealmBootstrapError> {
+    let row = client
+        .query_opt(
+            "
+            WITH latest_admission AS (
+                SELECT *
+                FROM dao.realm_admissions
+                WHERE realm_id = $1
+                  AND account_id = $2
+                ORDER BY updated_at DESC, created_at DESC, realm_admission_id DESC
+                LIMIT 1
+            ),
+            source_counts AS (
+                SELECT COUNT(*) AS source_fact_count
+                FROM dao.realm_admissions
+                WHERE realm_id = $1
+                  AND account_id = $2
+            ),
+            computed AS (
+                SELECT
+                    latest_admission.realm_id,
+                    latest_admission.account_id,
+                    latest_admission.admission_status,
+                    latest_admission.admission_kind,
+                    latest_admission.review_reason_code AS public_reason_code,
+                    latest_admission.updated_at AS source_watermark_at,
+                    (SELECT source_fact_count FROM source_counts) AS source_fact_count
+                FROM latest_admission
+            )
+            SELECT
+                computed.*,
+                GREATEST(
+                    FLOOR(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - computed.source_watermark_at)) * 1000),
+                    0
+                )::bigint AS projection_lag_ms,
+                COALESCE(projection.rebuild_generation, 1::bigint) AS rebuild_generation,
+                COALESCE(projection.last_projected_at, CURRENT_TIMESTAMP) AS last_projected_at
+            FROM computed
+            LEFT JOIN projection.realm_admission_views projection
+              ON projection.realm_id = computed.realm_id
+             AND projection.account_id = computed.account_id
+            ",
+            &[&realm_id, account_id],
+        )
+        .await
+        .map_err(db_error)?;
+    row.as_ref().map(realm_admission_view_from_row).transpose()
 }
 
 async fn refresh_realm_projection_bundle_tx<C: GenericClient + Sync>(
@@ -2626,8 +2761,8 @@ async fn ensure_active_account_exists_tx<C: GenericClient + Sync>(
     if row.get::<_, bool>("exists") {
         Ok(())
     } else {
-        Err(RealmBootstrapError::NotFound(
-            "account was not found".to_owned(),
+        Err(RealmBootstrapError::BadRequest(
+            "account id must reference an active account".to_owned(),
         ))
     }
 }

--- a/apps/backend/src/services/realm_bootstrap/repository.rs
+++ b/apps/backend/src/services/realm_bootstrap/repository.rs
@@ -814,38 +814,49 @@ impl RealmBootstrapStore {
                     .await?;
                 }
 
-                let row = tx
-                    .query_one(
+                let row = match tx
+                    .query_opt(
                         "
-                        INSERT INTO dao.realm_admissions (
-                            realm_admission_id,
-                            realm_id,
-                            account_id,
-                            admission_kind,
-                            admission_status,
-                            sponsor_record_id,
-                            bootstrap_corridor_id,
-                            granted_by_actor_kind,
-                            granted_by_actor_id,
-                            review_reason_code,
-                            source_fact_kind,
-                            source_fact_id,
-                            source_snapshot_json,
-                            request_idempotency_key,
-                            request_payload_hash
+                        WITH inserted AS (
+                            INSERT INTO dao.realm_admissions (
+                                realm_admission_id,
+                                realm_id,
+                                account_id,
+                                admission_kind,
+                                admission_status,
+                                sponsor_record_id,
+                                bootstrap_corridor_id,
+                                granted_by_actor_kind,
+                                granted_by_actor_id,
+                                review_reason_code,
+                                source_fact_kind,
+                                source_fact_id,
+                                source_snapshot_json,
+                                request_idempotency_key,
+                                request_payload_hash
+                            )
+                            VALUES (
+                                $1, $2, $3, $4, $5, $6, $7,
+                                $8, $9, $10, $11, $12, $13, $14, $15
+                            )
+                            ON CONFLICT (
+                                realm_id,
+                                granted_by_actor_id,
+                                request_idempotency_key
+                            )
+                            DO NOTHING
+                            RETURNING *
                         )
-                        VALUES (
-                            $1, $2, $3, $4, $5, $6, $7,
-                            $8, $9, $10, $11, $12, $13, $14, $15
-                        )
-                        ON CONFLICT (
-                            realm_id,
-                            granted_by_actor_id,
-                            request_idempotency_key
-                        )
-                        DO UPDATE
-                        SET request_payload_hash = dao.realm_admissions.request_payload_hash
-                        RETURNING *
+                        SELECT *
+                        FROM inserted
+                        UNION ALL
+                        SELECT existing.*
+                        FROM dao.realm_admissions existing
+                        WHERE NOT EXISTS (SELECT 1 FROM inserted)
+                          AND existing.realm_id = $2
+                          AND existing.granted_by_actor_id = $9
+                          AND existing.request_idempotency_key = $14
+                        LIMIT 1
                         ",
                         &[
                             &Uuid::new_v4(),
@@ -866,7 +877,24 @@ impl RealmBootstrapStore {
                         ],
                     )
                     .await
-                    .map_err(db_error)?;
+                    .map_err(db_error)?
+                {
+                    Some(row) => row,
+                    None => find_admission_by_idempotency_tx(
+                        &tx,
+                        &realm_id,
+                        &operator_id,
+                        &request_idempotency_key,
+                    )
+                    .await?
+                    .ok_or_else(|| RealmBootstrapError::Database {
+                        message: "realm admission idempotency replay was not yet visible"
+                            .to_owned(),
+                        code: None,
+                        constraint: None,
+                        retryable: true,
+                    })?,
+                };
                 ensure_admission_payload_hash_matches(&row, &payload_hash)?;
                 maybe_open_member_overlap_trigger_tx(&tx, &realm_id, &account_id).await?;
                 row
@@ -2330,6 +2358,15 @@ async fn refresh_realm_bootstrap_view_tx<C: GenericClient + Sync>(
                 ORDER BY updated_at DESC, bootstrap_corridor_id DESC
                 LIMIT 1
             ),
+            current_corridor AS (
+                SELECT
+                    CASE
+                        WHEN corridor_status IN ('active', 'cooling_down')
+                             AND ends_at <= CURRENT_TIMESTAMP THEN 'expired'
+                        ELSE corridor_status
+                    END AS corridor_status
+                FROM latest_corridor
+            ),
             sponsor_counts AS (
                 SELECT
                     COUNT(*) FILTER (WHERE sponsor_status IN ('approved', 'active', 'rate_limited')) AS active_sponsor_count
@@ -2371,7 +2408,7 @@ async fn refresh_realm_bootstrap_view_tx<C: GenericClient + Sync>(
                 realm.display_name,
                 realm.realm_status,
                 realm.public_reason_code,
-                COALESCE((SELECT corridor_status FROM latest_corridor), 'none') AS corridor_status,
+                COALESCE((SELECT corridor_status FROM current_corridor), 'none') AS corridor_status,
                 CASE
                     WHEN realm.realm_status IN ('restricted', 'suspended') THEN 'closed'
                     WHEN realm.realm_status = 'active' THEN 'open'

--- a/apps/backend/src/services/realm_bootstrap/repository.rs
+++ b/apps/backend/src/services/realm_bootstrap/repository.rs
@@ -840,7 +840,11 @@ impl RealmBootstrapStore {
             .await
             .map_err(db_error)?;
 
-        if request_row.is_none() && admission_row.is_none() {
+        let admission_is_admitted = admission_row
+            .as_ref()
+            .map(|row| row.get::<_, String>("admission_status") == "admitted")
+            .unwrap_or(false);
+        if request_row.is_none() && !admission_is_admitted {
             return Err(RealmBootstrapError::NotFound(
                 "realm bootstrap summary was not found".to_owned(),
             ));

--- a/apps/backend/src/services/realm_bootstrap/repository.rs
+++ b/apps/backend/src/services/realm_bootstrap/repository.rs
@@ -127,7 +127,6 @@ impl RealmBootstrapStore {
 
         let mut client = self.client.lock().await;
         let tx = client.transaction().await.map_err(db_error)?;
-        ensure_active_account_exists_tx(&tx, &requester_account_id).await?;
 
         let row = if let Some(existing) = find_realm_request_by_idempotency_tx(
             &tx,
@@ -139,6 +138,7 @@ impl RealmBootstrapStore {
             ensure_request_payload_hash_matches(&existing, &request_payload_hash)?;
             existing
         } else {
+            ensure_active_account_exists_tx(&tx, &requester_account_id).await?;
             if let Some(sponsor_account_id) = proposed_sponsor_account_id.as_ref() {
                 ensure_active_realm_request_candidate_account_exists_tx(&tx, sponsor_account_id)
                     .await?;

--- a/apps/backend/src/services/realm_bootstrap/repository.rs
+++ b/apps/backend/src/services/realm_bootstrap/repository.rs
@@ -171,7 +171,6 @@ impl RealmBootstrapStore {
                             $11, $12
                         )
                         ON CONFLICT (requested_by_account_id, request_idempotency_key)
-                            WHERE request_idempotency_key IS NOT NULL
                         DO NOTHING
                         RETURNING *, NULL::text AS created_realm_id, TRUE AS was_inserted
                     )
@@ -201,7 +200,7 @@ impl RealmBootstrapStore {
                         )?,
                         &proposed_sponsor_account_id,
                         &proposed_steward_account_id,
-                        &Some(request_idempotency_key.clone()),
+                        &request_idempotency_key,
                         &request_payload_hash,
                     ],
                 )
@@ -533,7 +532,7 @@ impl RealmBootstrapStore {
                 quota_total,
                 &input.review_reason_code,
                 &operator_id,
-                None,
+                input.review_decision_idempotency_key.clone(),
                 sponsor_payload_hash,
             )
             .await?;
@@ -683,7 +682,12 @@ impl RealmBootstrapStore {
         let mut client = self.client.lock().await;
         let tx = client.transaction().await.map_err(db_error)?;
         ensure_operator_role_tx(&tx, &operator_id, OPERATOR_WRITE_ROLES).await?;
-        ensure_active_account_exists_tx(&tx, &sponsor_account_id).await?;
+        ensure_sponsor_account_state_allows_status_tx(
+            &tx,
+            &sponsor_account_id,
+            &input.sponsor_status,
+        )
+        .await?;
         lock_realm_tx(&tx, &realm_id).await?;
         lock_sponsor_lineage_tx(&tx, &realm_id, &sponsor_account_id).await?;
         update_expired_corridors_tx(&tx, Some(&realm_id)).await?;
@@ -714,7 +718,7 @@ impl RealmBootstrapStore {
                 input.quota_total,
                 &input.status_reason_code,
                 &operator_id,
-                Some(request_idempotency_key),
+                request_idempotency_key,
                 payload_hash.clone(),
             )
             .await?;
@@ -829,7 +833,6 @@ impl RealmBootstrapStore {
                         granted_by_actor_id,
                         request_idempotency_key
                     )
-                    WHERE request_idempotency_key IS NOT NULL
                     DO UPDATE
                     SET request_payload_hash = dao.realm_admissions.request_payload_hash
                     RETURNING *
@@ -848,7 +851,7 @@ impl RealmBootstrapStore {
                         &input.source_fact_kind,
                         &input.source_fact_id,
                         &input.source_snapshot_json,
-                        &Some(request_idempotency_key),
+                        &request_idempotency_key,
                         &payload_hash,
                     ],
                 )
@@ -1322,6 +1325,29 @@ async fn derive_admission_context_tx<C: GenericClient + Sync>(
             return Ok(context);
         }
         let sponsor_status: String = sponsor_row.get("sponsor_status");
+        let sponsor_account_state = find_account_state_tx(client, &sponsor_account_id)
+            .await?
+            .ok_or_else(|| {
+                RealmBootstrapError::BadRequest("sponsor account was not found".to_owned())
+            })?;
+        if sponsor_account_state != "active" {
+            return Ok(AdmissionContext {
+                admission_kind: "review_required",
+                admission_status: "pending",
+                reason_code: "sponsor_revoked",
+                sponsor_record_id: Some(current_sponsor_record_id),
+                bootstrap_corridor_id: active_corridor_id,
+                open_trigger: Some(trigger_intent(
+                    "revoked_sponsor_lineage",
+                    "sponsor_revoked",
+                    json!({
+                        "sponsor_account_state": sponsor_account_state,
+                        "sponsor_record_id": current_sponsor_record_id.to_string()
+                    }),
+                    format!("inactive-sponsor:{realm_id}:{sponsor_account_id}"),
+                )),
+            });
+        }
         let sponsor_quota_total: i64 = sponsor_row.get("quota_total");
         let sponsor_used_count =
             count_sponsor_backed_admissions_tx(client, realm_id, &sponsor_account_id).await?;
@@ -1526,7 +1552,7 @@ async fn insert_sponsor_record_tx<C: GenericClient + Sync>(
     quota_total: i64,
     status_reason_code: &str,
     approved_by_operator_id: &Uuid,
-    request_idempotency_key: Option<String>,
+    request_idempotency_key: String,
     request_payload_hash: String,
 ) -> Result<Row, RealmBootstrapError> {
     let row = client
@@ -1550,7 +1576,6 @@ async fn insert_sponsor_record_tx<C: GenericClient + Sync>(
                     approved_by_operator_id,
                     request_idempotency_key
                 )
-                WHERE request_idempotency_key IS NOT NULL
                 DO NOTHING
                 RETURNING *
             )
@@ -1581,27 +1606,19 @@ async fn insert_sponsor_record_tx<C: GenericClient + Sync>(
         .map_err(db_error)?;
     match row {
         Some(row) => Ok(row),
-        None => match request_idempotency_key.as_deref() {
-            Some(key) => find_sponsor_record_by_idempotency_tx(
-                client,
-                realm_id,
-                approved_by_operator_id,
-                key,
-            )
-            .await?
-            .ok_or_else(|| RealmBootstrapError::Database {
-                message: "realm sponsor record idempotency replay was not yet visible".to_owned(),
-                code: None,
-                constraint: None,
-                retryable: true,
-            }),
-            None => Err(RealmBootstrapError::Database {
-                message: "realm sponsor record insert did not return a row".to_owned(),
-                code: None,
-                constraint: None,
-                retryable: true,
-            }),
-        },
+        None => find_sponsor_record_by_idempotency_tx(
+            client,
+            realm_id,
+            approved_by_operator_id,
+            &request_idempotency_key,
+        )
+        .await?
+        .ok_or_else(|| RealmBootstrapError::Database {
+            message: "realm sponsor record idempotency replay was not yet visible".to_owned(),
+            code: None,
+            constraint: None,
+            retryable: true,
+        }),
     }
 }
 
@@ -3237,27 +3254,52 @@ async fn ensure_active_account_exists_tx<C: GenericClient + Sync>(
     client: &C,
     account_id: &Uuid,
 ) -> Result<(), RealmBootstrapError> {
-    let row = client
-        .query_one(
-            "
-            SELECT EXISTS (
-                SELECT 1
-                FROM core.accounts
-                WHERE account_id = $1
-                  AND account_state = 'active'
-            ) AS exists
-            ",
-            &[account_id],
-        )
-        .await
-        .map_err(db_error)?;
-    if row.get::<_, bool>("exists") {
+    if find_account_state_tx(client, account_id).await?.as_deref() == Some("active") {
         Ok(())
     } else {
         Err(RealmBootstrapError::BadRequest(
             "account id must reference an active account".to_owned(),
         ))
     }
+}
+
+async fn ensure_sponsor_account_state_allows_status_tx<C: GenericClient + Sync>(
+    client: &C,
+    sponsor_account_id: &Uuid,
+    sponsor_status: &str,
+) -> Result<(), RealmBootstrapError> {
+    let account_state = find_account_state_tx(client, sponsor_account_id)
+        .await?
+        .ok_or_else(|| {
+            RealmBootstrapError::BadRequest(
+                "sponsor account id must reference an account".to_owned(),
+            )
+        })?;
+    if account_state == "active" || matches!(sponsor_status, "rate_limited" | "revoked") {
+        Ok(())
+    } else {
+        Err(RealmBootstrapError::BadRequest(
+            "sponsor account must be active for this sponsor status".to_owned(),
+        ))
+    }
+}
+
+async fn find_account_state_tx<C: GenericClient + Sync>(
+    client: &C,
+    account_id: &Uuid,
+) -> Result<Option<String>, RealmBootstrapError> {
+    Ok(client
+        .query_opt(
+            "
+            SELECT account_state
+            FROM core.accounts
+            WHERE account_id = $1
+            ",
+            &[account_id],
+        )
+        .await
+        .map_err(db_error)?
+        .map(|row| row.get("account_state")))
 }
 
 async fn ensure_operator_role_tx<C: GenericClient + Sync>(
@@ -3650,6 +3692,11 @@ async fn open_trigger_tx<C: GenericClient + Sync>(
             ON CONFLICT (trigger_fingerprint)
                 WHERE trigger_state = 'open'
             DO UPDATE SET
+                redacted_reason_code = EXCLUDED.redacted_reason_code,
+                related_account_id = EXCLUDED.related_account_id,
+                related_realm_request_id = EXCLUDED.related_realm_request_id,
+                related_sponsor_record_id = EXCLUDED.related_sponsor_record_id,
+                context_json = EXCLUDED.context_json,
                 updated_at = CURRENT_TIMESTAMP
             ",
             &[

--- a/apps/backend/src/services/realm_bootstrap/repository.rs
+++ b/apps/backend/src/services/realm_bootstrap/repository.rs
@@ -1815,7 +1815,7 @@ async fn read_current_realm_bootstrap_view<C: GenericClient + Sync>(
             ),
             sponsor_counts AS (
                 SELECT
-                    COUNT(*) FILTER (WHERE sponsor_status IN ('approved', 'active', 'rate_limited')) AS active_sponsor_count
+                    COUNT(*) FILTER (WHERE sponsor_status IN ('approved', 'active', 'rate_limited')) AS eligible_sponsor_count
                 FROM (
                     SELECT DISTINCT ON (sponsor_account_id)
                         sponsor_account_id,
@@ -1870,9 +1870,9 @@ async fn read_current_realm_bootstrap_view<C: GenericClient + Sync>(
                     COALESCE((SELECT corridor_status FROM current_corridor), 'none') AS corridor_status,
                     realm.public_reason_code,
                     CASE
-                        WHEN COALESCE((SELECT active_sponsor_count FROM sponsor_counts), 0) > 0
+                        WHEN COALESCE((SELECT eligible_sponsor_count FROM sponsor_counts), 0) > 0
                              AND realm.steward_account_id IS NOT NULL THEN 'sponsor_and_steward'
-                        WHEN COALESCE((SELECT active_sponsor_count FROM sponsor_counts), 0) > 0 THEN 'sponsor_backed'
+                        WHEN COALESCE((SELECT eligible_sponsor_count FROM sponsor_counts), 0) > 0 THEN 'sponsor_backed'
                         WHEN realm.steward_account_id IS NOT NULL THEN 'steward_present'
                         ELSE 'none'
                     END AS sponsor_display_state,
@@ -2019,7 +2019,7 @@ async fn rebuild_all_realm_bootstrap_views_tx<C: GenericClient + Sync>(
                     realm_id,
                     COUNT(*) FILTER (
                         WHERE sponsor_status IN ('approved', 'active', 'rate_limited')
-                    ) AS active_sponsor_count
+                    ) AS eligible_sponsor_count
                 FROM current_sponsor_lineages
                 GROUP BY realm_id
             ),
@@ -2061,9 +2061,9 @@ async fn rebuild_all_realm_bootstrap_views_tx<C: GenericClient + Sync>(
                     COALESCE(corridor.corridor_status, 'none') AS corridor_status,
                     realm.public_reason_code,
                     CASE
-                        WHEN COALESCE(sponsor_counts.active_sponsor_count, 0) > 0
+                        WHEN COALESCE(sponsor_counts.eligible_sponsor_count, 0) > 0
                              AND realm.steward_account_id IS NOT NULL THEN 'sponsor_and_steward'
-                        WHEN COALESCE(sponsor_counts.active_sponsor_count, 0) > 0 THEN 'sponsor_backed'
+                        WHEN COALESCE(sponsor_counts.eligible_sponsor_count, 0) > 0 THEN 'sponsor_backed'
                         WHEN realm.steward_account_id IS NOT NULL THEN 'steward_present'
                         ELSE 'none'
                     END AS sponsor_display_state,
@@ -2244,8 +2244,8 @@ async fn rebuild_all_realm_review_summaries_tx<C: GenericClient + Sync>(
                     created_at DESC,
                     realm_sponsor_record_id DESC
             ),
-            active_sponsors AS (
-                SELECT realm_id, COUNT(*) AS active_sponsor_count
+            eligible_sponsors AS (
+                SELECT realm_id, COUNT(*) AS eligible_sponsor_count
                 FROM current_sponsor_lineages
                 WHERE sponsor_status IN ('approved', 'active', 'rate_limited')
                 GROUP BY realm_id
@@ -2319,7 +2319,7 @@ async fn rebuild_all_realm_review_summaries_tx<C: GenericClient + Sync>(
                             THEN GREATEST(EXTRACT(EPOCH FROM (corridor.ends_at - CURRENT_TIMESTAMP))::bigint, 0)
                         ELSE 0
                     END AS corridor_remaining_seconds,
-                    COALESCE(active_sponsors.active_sponsor_count, 0) AS active_sponsor_count,
+                    COALESCE(eligible_sponsors.eligible_sponsor_count, 0) AS active_sponsor_count,
                     COALESCE(
                         sponsor_backed_admissions.sponsor_backed_admission_count,
                         0
@@ -2350,8 +2350,8 @@ async fn rebuild_all_realm_review_summaries_tx<C: GenericClient + Sync>(
                 FROM dao.realms realm
                 LEFT JOIN latest_corridor corridor
                   ON corridor.realm_id = realm.realm_id
-                LEFT JOIN active_sponsors
-                  ON active_sponsors.realm_id = realm.realm_id
+                LEFT JOIN eligible_sponsors
+                  ON eligible_sponsors.realm_id = realm.realm_id
                 LEFT JOIN sponsor_backed_admissions
                   ON sponsor_backed_admissions.realm_id = realm.realm_id
                 LEFT JOIN recent_admissions
@@ -2427,7 +2427,7 @@ async fn refresh_realm_bootstrap_view_tx<C: GenericClient + Sync>(
             ),
             sponsor_counts AS (
                 SELECT
-                    COUNT(*) FILTER (WHERE sponsor_status IN ('approved', 'active', 'rate_limited')) AS active_sponsor_count
+                    COUNT(*) FILTER (WHERE sponsor_status IN ('approved', 'active', 'rate_limited')) AS eligible_sponsor_count
                 FROM (
                     SELECT DISTINCT ON (sponsor_account_id)
                         sponsor_account_id,
@@ -2480,9 +2480,9 @@ async fn refresh_realm_bootstrap_view_tx<C: GenericClient + Sync>(
                     ELSE 'review_required'
                 END AS admission_posture,
                 CASE
-                    WHEN COALESCE((SELECT active_sponsor_count FROM sponsor_counts), 0) > 0
+                    WHEN COALESCE((SELECT eligible_sponsor_count FROM sponsor_counts), 0) > 0
                          AND realm.steward_account_id IS NOT NULL THEN 'sponsor_and_steward'
-                    WHEN COALESCE((SELECT active_sponsor_count FROM sponsor_counts), 0) > 0 THEN 'sponsor_backed'
+                    WHEN COALESCE((SELECT eligible_sponsor_count FROM sponsor_counts), 0) > 0 THEN 'sponsor_backed'
                     WHEN realm.steward_account_id IS NOT NULL THEN 'steward_present'
                     ELSE 'none'
                 END AS sponsor_display_state,
@@ -2678,8 +2678,8 @@ async fn refresh_realm_review_summary_tx<C: GenericClient + Sync>(
                 ORDER BY updated_at DESC, bootstrap_corridor_id DESC
                 LIMIT 1
             ),
-            active_sponsors AS (
-                SELECT COUNT(*) AS active_sponsor_count
+            eligible_sponsors AS (
+                SELECT COUNT(*) AS eligible_sponsor_count
                 FROM (
                     SELECT DISTINCT ON (sponsor_account_id)
                         sponsor_account_id,
@@ -2756,7 +2756,7 @@ async fn refresh_realm_review_summary_tx<C: GenericClient + Sync>(
                         THEN GREATEST(EXTRACT(EPOCH FROM ((SELECT ends_at FROM latest_corridor) - CURRENT_TIMESTAMP))::bigint, 0)
                     ELSE 0
                 END AS corridor_remaining_seconds,
-                (SELECT active_sponsor_count FROM active_sponsors) AS active_sponsor_count,
+                (SELECT eligible_sponsor_count FROM eligible_sponsors) AS active_sponsor_count,
                 (SELECT sponsor_backed_admission_count FROM sponsor_backed_admissions) AS sponsor_backed_admission_count,
                 (SELECT recent_admission_count_7d FROM recent_admissions) AS recent_admission_count_7d,
                 (SELECT open_review_trigger_count FROM open_triggers) AS open_review_trigger_count,
@@ -3424,9 +3424,18 @@ async fn ensure_sponsor_status_transition_allowed_tx<C: GenericClient + Sync>(
         _ => false,
     };
     if !transition_allowed {
-        return Err(RealmBootstrapError::BadRequest(
-            "sponsor account already has an open sponsor record for this realm".to_owned(),
-        ));
+        let message = match current_status.as_deref() {
+            None => format!(
+                "cannot transition sponsor status to '{next_sponsor_status}' because no sponsor record exists for this realm"
+            ),
+            Some(current) if current == next_sponsor_status => {
+                format!("sponsor account is already in status '{next_sponsor_status}'")
+            }
+            Some(current) => format!(
+                "sponsor status transition from '{current}' to '{next_sponsor_status}' is not allowed"
+            ),
+        };
+        return Err(RealmBootstrapError::BadRequest(message));
     }
     Ok(())
 }

--- a/apps/backend/src/services/realm_bootstrap/repository.rs
+++ b/apps/backend/src/services/realm_bootstrap/repository.rs
@@ -1985,7 +1985,7 @@ async fn refresh_realm_review_summary_tx<C: GenericClient + Sync>(
                 realm.realm_status,
                 COALESCE((SELECT corridor_status FROM latest_corridor), 'none') AS corridor_status,
                 CASE
-                    WHEN EXISTS (SELECT 1 FROM latest_corridor)
+                    WHEN (SELECT corridor_status FROM latest_corridor) = 'active'
                         THEN GREATEST(EXTRACT(EPOCH FROM ((SELECT ends_at FROM latest_corridor) - CURRENT_TIMESTAMP))::bigint, 0)
                     ELSE 0
                 END AS corridor_remaining_seconds,

--- a/apps/backend/src/services/realm_bootstrap/repository.rs
+++ b/apps/backend/src/services/realm_bootstrap/repository.rs
@@ -650,9 +650,10 @@ impl RealmBootstrapStore {
                 &input.status_reason_code,
                 &operator_id,
                 Some(request_idempotency_key),
-                Some(payload_hash),
+                Some(payload_hash.clone()),
             )
             .await?;
+            ensure_sponsor_record_payload_hash_matches(&row, &payload_hash)?;
             maybe_open_sponsor_concentration_trigger_tx(&tx, &realm_id, &sponsor_account_id)
                 .await?;
             row
@@ -760,6 +761,14 @@ impl RealmBootstrapStore {
                         $1, $2, $3, $4, $5, $6, $7,
                         $8, $9, $10, $11, $12, $13, $14, $15
                     )
+                    ON CONFLICT (
+                        realm_id,
+                        granted_by_actor_id,
+                        request_idempotency_key
+                    )
+                    WHERE request_idempotency_key IS NOT NULL
+                    DO UPDATE
+                    SET request_payload_hash = dao.realm_admissions.request_payload_hash
                     RETURNING *
                     ",
                     &[
@@ -782,6 +791,7 @@ impl RealmBootstrapStore {
                 )
                 .await
                 .map_err(db_error)?;
+            ensure_admission_payload_hash_matches(&row, &payload_hash)?;
             maybe_open_member_overlap_trigger_tx(&tx, &realm_id, &account_id).await?;
             row
         };
@@ -1218,10 +1228,23 @@ async fn maybe_open_sponsor_concentration_trigger_tx<C: GenericClient + Sync>(
     let count = client
         .query_one(
             "
+            WITH current_sponsor_lineages AS (
+                SELECT DISTINCT ON (realm_id, sponsor_account_id)
+                    realm_id,
+                    sponsor_account_id,
+                    sponsor_status
+                FROM dao.realm_sponsor_records
+                WHERE sponsor_account_id = $1
+                ORDER BY
+                    realm_id,
+                    sponsor_account_id,
+                    updated_at DESC,
+                    created_at DESC,
+                    realm_sponsor_record_id DESC
+            )
             SELECT COUNT(*) AS count
-            FROM dao.realm_sponsor_records
-            WHERE sponsor_account_id = $1
-              AND sponsor_status IN ('approved', 'active', 'rate_limited')
+            FROM current_sponsor_lineages
+            WHERE sponsor_status IN ('approved', 'active', 'rate_limited')
             ",
             &[sponsor_account_id],
         )
@@ -1237,7 +1260,7 @@ async fn maybe_open_sponsor_concentration_trigger_tx<C: GenericClient + Sync>(
             Some(sponsor_account_id),
             None,
             None,
-            &json!({ "active_sponsor_record_count": count }),
+            &json!({ "active_sponsor_realm_count": count }),
             &format!("sponsor-concentration:{realm_id}:{sponsor_account_id}"),
         )
         .await?;
@@ -1373,7 +1396,7 @@ async fn derive_admission_context_tx<C: GenericClient + Sync>(
                 corridor_row,
             )
             .await?;
-            let sponsor_already_present = corridor_contains_sponsor_record_tx(
+            let sponsor_already_present = corridor_contains_sponsor_account_tx(
                 client,
                 &current_sponsor_record_id,
                 corridor_row,
@@ -1502,6 +1525,14 @@ async fn insert_sponsor_record_tx<C: GenericClient + Sync>(
                 request_payload_hash
             )
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, COALESCE($9, repeat('0', 64)))
+            ON CONFLICT (
+                realm_id,
+                approved_by_operator_id,
+                request_idempotency_key
+            )
+            WHERE request_idempotency_key IS NOT NULL
+            DO UPDATE
+            SET request_payload_hash = dao.realm_sponsor_records.request_payload_hash
             RETURNING *
             ",
             &[
@@ -1622,8 +1653,18 @@ async fn refresh_realm_bootstrap_view_tx<C: GenericClient + Sync>(
             sponsor_counts AS (
                 SELECT
                     COUNT(*) FILTER (WHERE sponsor_status IN ('approved', 'active', 'rate_limited')) AS active_sponsor_count
-                FROM dao.realm_sponsor_records
-                WHERE realm_id = $1
+                FROM (
+                    SELECT DISTINCT ON (sponsor_account_id)
+                        sponsor_account_id,
+                        sponsor_status
+                    FROM dao.realm_sponsor_records
+                    WHERE realm_id = $1
+                    ORDER BY
+                        sponsor_account_id,
+                        updated_at DESC,
+                        created_at DESC,
+                        realm_sponsor_record_id DESC
+                ) current_sponsor_lineages
             ),
             source_counts AS (
                 SELECT
@@ -1848,9 +1889,19 @@ async fn refresh_realm_review_summary_tx<C: GenericClient + Sync>(
             ),
             active_sponsors AS (
                 SELECT COUNT(*) AS active_sponsor_count
-                FROM dao.realm_sponsor_records
-                WHERE realm_id = $1
-                  AND sponsor_status IN ('approved', 'active', 'rate_limited')
+                FROM (
+                    SELECT DISTINCT ON (sponsor_account_id)
+                        sponsor_account_id,
+                        sponsor_status
+                    FROM dao.realm_sponsor_records
+                    WHERE realm_id = $1
+                    ORDER BY
+                        sponsor_account_id,
+                        updated_at DESC,
+                        created_at DESC,
+                        realm_sponsor_record_id DESC
+                ) current_sponsor_lineages
+                WHERE sponsor_status IN ('approved', 'active', 'rate_limited')
             ),
             sponsor_backed_admissions AS (
                 SELECT COUNT(*) AS sponsor_backed_admission_count
@@ -2055,37 +2106,61 @@ async fn count_distinct_corridor_sponsors_tx<C: GenericClient + Sync>(
     Ok(client
         .query_one(
             "
-            SELECT COUNT(DISTINCT sponsor_record_id) AS count
-            FROM dao.realm_admissions
-            WHERE bootstrap_corridor_id = $1
-              AND sponsor_record_id IS NOT NULL
-              AND admission_status IN ('pending', 'admitted')
+            SELECT COUNT(DISTINCT sponsor.sponsor_account_id) AS count
+            FROM dao.realm_admissions admission
+            JOIN dao.realm_sponsor_records sponsor
+              ON sponsor.realm_sponsor_record_id = admission.sponsor_record_id
+            WHERE admission.bootstrap_corridor_id = $1
+              AND sponsor.realm_id = $2
+              AND admission.admission_status IN ('pending', 'admitted')
             ",
-            &[&corridor_id],
+            &[&corridor_id, &sponsor_realm_id],
         )
         .await
         .map_err(db_error)?
         .get("count"))
 }
 
-async fn corridor_contains_sponsor_record_tx<C: GenericClient + Sync>(
+async fn corridor_contains_sponsor_account_tx<C: GenericClient + Sync>(
     client: &C,
     sponsor_record_id: &Uuid,
     corridor_row: &Row,
 ) -> Result<bool, RealmBootstrapError> {
     let corridor_id: Uuid = corridor_row.get("bootstrap_corridor_id");
+    let sponsor_realm_id: String = corridor_row.get("realm_id");
+    let sponsor_row = client
+        .query_one(
+            "
+            SELECT realm_id, sponsor_account_id
+            FROM dao.realm_sponsor_records
+            WHERE realm_sponsor_record_id = $1
+            ",
+            &[sponsor_record_id],
+        )
+        .await
+        .map_err(db_error)?;
+    let current_sponsor_realm_id: String = sponsor_row.get("realm_id");
+    if current_sponsor_realm_id != sponsor_realm_id {
+        return Err(RealmBootstrapError::BadRequest(
+            "sponsor record does not belong to the same realm".to_owned(),
+        ));
+    }
+    let sponsor_account_id: Uuid = sponsor_row.get("sponsor_account_id");
     Ok(client
         .query_one(
             "
             SELECT EXISTS (
                 SELECT 1
-                FROM dao.realm_admissions
-                WHERE bootstrap_corridor_id = $1
-                  AND sponsor_record_id = $2
-                  AND admission_status IN ('pending', 'admitted')
+                FROM dao.realm_admissions admission
+                JOIN dao.realm_sponsor_records sponsor
+                  ON sponsor.realm_sponsor_record_id = admission.sponsor_record_id
+                WHERE admission.bootstrap_corridor_id = $1
+                  AND sponsor.realm_id = $2
+                  AND sponsor.sponsor_account_id = $3
+                  AND admission.admission_status IN ('pending', 'admitted')
             ) AS sponsor_present
             ",
-            &[&corridor_id, sponsor_record_id],
+            &[&corridor_id, &sponsor_realm_id, &sponsor_account_id],
         )
         .await
         .map_err(db_error)?

--- a/apps/backend/src/services/realm_bootstrap/repository.rs
+++ b/apps/backend/src/services/realm_bootstrap/repository.rs
@@ -3247,9 +3247,6 @@ async fn ensure_sponsor_status_transition_allowed_tx<C: GenericClient + Sync>(
     sponsor_account_id: &Uuid,
     next_sponsor_status: &str,
 ) -> Result<(), RealmBootstrapError> {
-    if !matches!(next_sponsor_status, "proposed" | "approved" | "active") {
-        return Ok(());
-    }
     let current_status = client
         .query_opt(
             "
@@ -3266,16 +3263,20 @@ async fn ensure_sponsor_status_transition_allowed_tx<C: GenericClient + Sync>(
         .map_err(db_error)?
         .map(|row| row.get::<_, String>("sponsor_status"));
 
-    let transition_allowed = matches!(
-        (current_status.as_deref(), next_sponsor_status),
-        (None, _)
-            | (Some("proposed"), "approved" | "active")
-            | (Some("approved"), "active")
-            | (
-                Some("rate_limited" | "revoked"),
-                "proposed" | "approved" | "active"
-            )
-    );
+    let transition_allowed = match next_sponsor_status {
+        "proposed" | "approved" | "active" => matches!(
+            (current_status.as_deref(), next_sponsor_status),
+            (None, _)
+                | (Some("proposed"), "approved" | "active")
+                | (Some("approved"), "active")
+                | (
+                    Some("rate_limited" | "revoked"),
+                    "proposed" | "approved" | "active"
+                )
+        ),
+        "rate_limited" | "revoked" => current_status.is_some(),
+        _ => false,
+    };
     if !transition_allowed {
         return Err(RealmBootstrapError::BadRequest(
             "sponsor account already has an open sponsor record for this realm".to_owned(),

--- a/apps/backend/src/services/realm_bootstrap/repository.rs
+++ b/apps/backend/src/services/realm_bootstrap/repository.rs
@@ -2257,7 +2257,7 @@ async fn rebuild_all_realm_review_summaries_tx<C: GenericClient + Sync>(
                 GROUP BY realm_id
             ),
             sponsor_backed_admissions AS (
-                SELECT realm_id, COUNT(*) AS sponsor_backed_admission_count
+                SELECT realm_id, COUNT(DISTINCT account_id) AS sponsor_backed_admission_count
                 FROM dao.realm_admissions
                 WHERE admission_kind = 'sponsor_backed'
                   AND admission_status IN ('pending', 'admitted')
@@ -2701,7 +2701,7 @@ async fn refresh_realm_review_summary_tx<C: GenericClient + Sync>(
                 WHERE sponsor_status IN ('approved', 'active', 'rate_limited')
             ),
             sponsor_backed_admissions AS (
-                SELECT COUNT(*) AS sponsor_backed_admission_count
+                SELECT COUNT(DISTINCT account_id) AS sponsor_backed_admission_count
                 FROM dao.realm_admissions
                 WHERE realm_id = $1
                   AND admission_kind = 'sponsor_backed'

--- a/apps/backend/src/services/realm_bootstrap/repository.rs
+++ b/apps/backend/src/services/realm_bootstrap/repository.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Write as _, sync::Arc};
+use std::{collections::HashMap, fmt::Write as _, sync::Arc};
 
 use chrono::{DateTime, Utc};
 use musubi_db_runtime::{DbConfig, connect_writer};
@@ -367,12 +367,17 @@ impl RealmBootstrapStore {
             )
             .await
             .map_err(db_error)?;
+        let realm_request_ids: Vec<Uuid> =
+            rows.iter().map(|row| row.get("realm_request_id")).collect();
+        let mut triggers_by_request =
+            read_open_realm_request_triggers_by_request_tx(&*client, &realm_request_ids).await?;
         let mut snapshots = Vec::with_capacity(rows.len());
         for row in rows {
             let realm_request_id: Uuid = row.get("realm_request_id");
             let mut snapshot = realm_request_from_row(&row)?;
-            snapshot.open_review_triggers =
-                read_open_realm_request_triggers_tx(&*client, &realm_request_id).await?;
+            snapshot.open_review_triggers = triggers_by_request
+                .remove(&realm_request_id)
+                .unwrap_or_default();
             snapshots.push(snapshot);
         }
         Ok(snapshots)
@@ -1848,26 +1853,6 @@ async fn read_current_realm_bootstrap_view<C: GenericClient + Sync>(
                         realm_sponsor_record_id DESC
                 ) current_sponsor_lineages
             ),
-            source_counts AS (
-                SELECT
-                    1
-                    + COALESCE((SELECT COUNT(*) FROM dao.realm_sponsor_records WHERE realm_id = $1), 0)
-                    + COALESCE((SELECT COUNT(*) FROM dao.realm_admissions WHERE realm_id = $1), 0)
-                    + COALESCE((SELECT COUNT(*) FROM dao.bootstrap_corridors WHERE realm_id = $1), 0)
-                    + COALESCE((SELECT COUNT(*) FROM dao.realm_review_triggers WHERE realm_id = $1), 0)
-                    AS source_fact_count
-            ),
-            watermarks AS (
-                SELECT GREATEST(
-                    realm.updated_at,
-                    COALESCE((SELECT MAX(updated_at) FROM dao.realm_sponsor_records WHERE realm_id = $1), realm.updated_at),
-                    COALESCE((SELECT MAX(updated_at) FROM dao.realm_admissions WHERE realm_id = $1), realm.updated_at),
-                    COALESCE((SELECT MAX(updated_at) FROM dao.bootstrap_corridors WHERE realm_id = $1), realm.updated_at),
-                    COALESCE((SELECT MAX(updated_at) FROM dao.realm_review_triggers WHERE realm_id = $1), realm.updated_at)
-                ) AS source_watermark_at
-                FROM dao.realms realm
-                WHERE realm.realm_id = $1
-            ),
             computed AS (
                 SELECT
                     realm.realm_id,
@@ -1895,9 +1880,13 @@ async fn read_current_realm_bootstrap_view<C: GenericClient + Sync>(
                         WHEN realm.steward_account_id IS NOT NULL THEN 'steward_present'
                         ELSE 'none'
                     END AS sponsor_display_state,
-                    (SELECT source_watermark_at FROM watermarks) AS source_watermark_at,
-                    (SELECT source_fact_count FROM source_counts) AS source_fact_count
+                    COALESCE(projection.source_watermark_at, realm.updated_at) AS source_watermark_at,
+                    COALESCE(projection.source_fact_count, 1::bigint) AS source_fact_count,
+                    COALESCE(projection.rebuild_generation, 1::bigint) AS rebuild_generation,
+                    COALESCE(projection.last_projected_at, CURRENT_TIMESTAMP) AS last_projected_at
                 FROM dao.realms realm
+                LEFT JOIN projection.realm_bootstrap_views projection
+                  ON projection.realm_id = realm.realm_id
                 WHERE realm.realm_id = $1
             )
             SELECT
@@ -1906,11 +1895,9 @@ async fn read_current_realm_bootstrap_view<C: GenericClient + Sync>(
                     FLOOR(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - computed.source_watermark_at)) * 1000),
                     0
                 )::bigint AS projection_lag_ms,
-                COALESCE(projection.rebuild_generation, 1::bigint) AS rebuild_generation,
-                COALESCE(projection.last_projected_at, CURRENT_TIMESTAMP) AS last_projected_at
+                computed.rebuild_generation,
+                computed.last_projected_at
             FROM computed
-            LEFT JOIN projection.realm_bootstrap_views projection
-              ON projection.realm_id = computed.realm_id
             ",
             &[&realm_id],
         )
@@ -4053,6 +4040,37 @@ async fn read_open_realm_request_triggers_tx<C: GenericClient + Sync>(
         .await
         .map_err(db_error)?;
     rows.iter().map(realm_review_trigger_from_row).collect()
+}
+
+async fn read_open_realm_request_triggers_by_request_tx<C: GenericClient + Sync>(
+    client: &C,
+    realm_request_ids: &[Uuid],
+) -> Result<HashMap<Uuid, Vec<RealmReviewTriggerSnapshot>>, RealmBootstrapError> {
+    if realm_request_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let rows = client
+        .query(
+            "
+            SELECT *
+            FROM dao.realm_review_triggers
+            WHERE related_realm_request_id = ANY($1::uuid[])
+              AND trigger_state = 'open'
+            ORDER BY related_realm_request_id, created_at DESC, realm_review_trigger_id DESC
+            ",
+            &[&realm_request_ids],
+        )
+        .await
+        .map_err(db_error)?;
+    let mut triggers_by_request: HashMap<Uuid, Vec<RealmReviewTriggerSnapshot>> = HashMap::new();
+    for row in rows {
+        let realm_request_id: Uuid = row.get("related_realm_request_id");
+        triggers_by_request
+            .entry(realm_request_id)
+            .or_default()
+            .push(realm_review_trigger_from_row(&row)?);
+    }
+    Ok(triggers_by_request)
 }
 
 fn realm_request_from_row(row: &Row) -> Result<RealmRequestSnapshot, RealmBootstrapError> {

--- a/apps/backend/src/services/realm_bootstrap/repository.rs
+++ b/apps/backend/src/services/realm_bootstrap/repository.rs
@@ -816,24 +816,6 @@ impl RealmBootstrapStore {
         let realm_id = normalize_required(realm_id, "realm id")?;
         let mut client = self.client.lock().await;
         let tx = client.transaction().await.map_err(db_error)?;
-        ensure_realm_exists_tx(&tx, &realm_id).await?;
-        update_expired_corridors_tx(&tx, Some(&realm_id)).await?;
-        refresh_realm_projection_bundle_tx(&tx, &realm_id, Some(&viewer_account_id)).await?;
-
-        let bootstrap_row = tx
-            .query_opt(
-                "
-                SELECT *
-                FROM projection.realm_bootstrap_views
-                WHERE realm_id = $1
-                ",
-                &[&realm_id],
-            )
-            .await
-            .map_err(db_error)?
-            .ok_or_else(|| {
-                RealmBootstrapError::NotFound("realm bootstrap summary was not found".to_owned())
-            })?;
 
         let request_row = tx
             .query_opt(
@@ -851,6 +833,45 @@ impl RealmBootstrapStore {
             )
             .await
             .map_err(db_error)?;
+        let admitted_row = tx
+            .query_opt(
+                "
+                SELECT *
+                FROM dao.realm_admissions
+                WHERE realm_id = $1
+                  AND account_id = $2
+                  AND admission_status = 'admitted'
+                ORDER BY updated_at DESC, realm_admission_id DESC
+                LIMIT 1
+                ",
+                &[&realm_id, &viewer_account_id],
+            )
+            .await
+            .map_err(db_error)?;
+
+        if request_row.is_none() && admitted_row.is_none() {
+            return Err(RealmBootstrapError::NotFound(
+                "realm bootstrap summary was not found".to_owned(),
+            ));
+        }
+
+        update_expired_corridors_tx(&tx, Some(&realm_id)).await?;
+        refresh_realm_projection_bundle_tx(&tx, &realm_id, Some(&viewer_account_id)).await?;
+
+        let bootstrap_row = tx
+            .query_opt(
+                "
+                SELECT *
+                FROM projection.realm_bootstrap_views
+                WHERE realm_id = $1
+                ",
+                &[&realm_id],
+            )
+            .await
+            .map_err(db_error)?
+            .ok_or_else(|| {
+                RealmBootstrapError::NotFound("realm bootstrap summary was not found".to_owned())
+            })?;
         let admission_row = tx
             .query_opt(
                 "
@@ -863,16 +884,6 @@ impl RealmBootstrapStore {
             )
             .await
             .map_err(db_error)?;
-
-        let admission_is_admitted = admission_row
-            .as_ref()
-            .map(|row| row.get::<_, String>("admission_status") == "admitted")
-            .unwrap_or(false);
-        if request_row.is_none() && !admission_is_admitted {
-            return Err(RealmBootstrapError::NotFound(
-                "realm bootstrap summary was not found".to_owned(),
-            ));
-        }
 
         let snapshot = RealmBootstrapSummarySnapshot {
             realm_request: request_row

--- a/apps/backend/src/services/realm_bootstrap/repository.rs
+++ b/apps/backend/src/services/realm_bootstrap/repository.rs
@@ -1330,7 +1330,7 @@ async fn derive_admission_context_tx<C: GenericClient + Sync>(
         let sponsor_status: String = sponsor_row.get("sponsor_status");
         let sponsor_quota_total: i64 = sponsor_row.get("quota_total");
         let sponsor_used_count =
-            count_sponsor_backed_admissions_tx(client, &current_sponsor_record_id).await?;
+            count_sponsor_backed_admissions_tx(client, realm_id, &sponsor_account_id).await?;
         if sponsor_status == "revoked" {
             return Ok(AdmissionContext {
                 admission_kind: "review_required",
@@ -2115,17 +2115,23 @@ async fn count_corridor_admissions_tx<C: GenericClient + Sync>(
 
 async fn count_sponsor_backed_admissions_tx<C: GenericClient + Sync>(
     client: &C,
-    sponsor_record_id: &Uuid,
+    realm_id: &str,
+    sponsor_account_id: &Uuid,
 ) -> Result<i64, RealmBootstrapError> {
     Ok(client
         .query_one(
             "
             SELECT COUNT(*) AS count
-            FROM dao.realm_admissions
-            WHERE sponsor_record_id = $1
-              AND admission_status IN ('pending', 'admitted')
+            FROM dao.realm_admissions admission
+            JOIN dao.realm_sponsor_records sponsor
+              ON sponsor.realm_sponsor_record_id = admission.sponsor_record_id
+             AND sponsor.realm_id = admission.realm_id
+            WHERE sponsor.realm_id = $1
+              AND sponsor.sponsor_account_id = $2
+              AND admission.admission_kind = 'sponsor_backed'
+              AND admission.admission_status IN ('pending', 'admitted')
             ",
-            &[sponsor_record_id],
+            &[&realm_id, sponsor_account_id],
         )
         .await
         .map_err(db_error)?

--- a/apps/backend/src/services/realm_bootstrap/repository.rs
+++ b/apps/backend/src/services/realm_bootstrap/repository.rs
@@ -789,77 +789,88 @@ impl RealmBootstrapStore {
             )
             .await?;
 
-            if let Some(trigger) = admission_context.open_trigger.as_ref() {
-                open_trigger_tx(
-                    &tx,
-                    Some(&realm_id),
-                    trigger.kind,
-                    trigger.reason_code,
-                    Some(&account_id),
-                    None,
-                    admission_context.sponsor_record_id.as_ref(),
-                    &trigger.context_json,
-                    &trigger.fingerprint,
-                )
-                .await?;
-            }
+            let existing_admitted = if admission_context.admission_status == "admitted" {
+                None
+            } else {
+                find_latest_admission_for_account_tx(&tx, &realm_id, &account_id)
+                    .await?
+                    .filter(|row| row.get::<_, String>("admission_status") == "admitted")
+            };
+            if let Some(existing) = existing_admitted {
+                existing
+            } else {
+                if let Some(trigger) = admission_context.open_trigger.as_ref() {
+                    open_trigger_tx(
+                        &tx,
+                        Some(&realm_id),
+                        trigger.kind,
+                        trigger.reason_code,
+                        Some(&account_id),
+                        None,
+                        admission_context.sponsor_record_id.as_ref(),
+                        &trigger.context_json,
+                        &trigger.fingerprint,
+                    )
+                    .await?;
+                }
 
-            let row = tx
-                .query_one(
-                    "
-                    INSERT INTO dao.realm_admissions (
-                        realm_admission_id,
-                        realm_id,
-                        account_id,
-                        admission_kind,
-                        admission_status,
-                        sponsor_record_id,
-                        bootstrap_corridor_id,
-                        granted_by_actor_kind,
-                        granted_by_actor_id,
-                        review_reason_code,
-                        source_fact_kind,
-                        source_fact_id,
-                        source_snapshot_json,
-                        request_idempotency_key,
-                        request_payload_hash
+                let row = tx
+                    .query_one(
+                        "
+                        INSERT INTO dao.realm_admissions (
+                            realm_admission_id,
+                            realm_id,
+                            account_id,
+                            admission_kind,
+                            admission_status,
+                            sponsor_record_id,
+                            bootstrap_corridor_id,
+                            granted_by_actor_kind,
+                            granted_by_actor_id,
+                            review_reason_code,
+                            source_fact_kind,
+                            source_fact_id,
+                            source_snapshot_json,
+                            request_idempotency_key,
+                            request_payload_hash
+                        )
+                        VALUES (
+                            $1, $2, $3, $4, $5, $6, $7,
+                            $8, $9, $10, $11, $12, $13, $14, $15
+                        )
+                        ON CONFLICT (
+                            realm_id,
+                            granted_by_actor_id,
+                            request_idempotency_key
+                        )
+                        DO UPDATE
+                        SET request_payload_hash = dao.realm_admissions.request_payload_hash
+                        RETURNING *
+                        ",
+                        &[
+                            &Uuid::new_v4(),
+                            &realm_id,
+                            &account_id,
+                            &admission_context.admission_kind,
+                            &admission_context.admission_status,
+                            &admission_context.sponsor_record_id,
+                            &admission_context.bootstrap_corridor_id,
+                            &granted_by_actor_kind,
+                            &operator_id,
+                            &admission_context.reason_code,
+                            &input.source_fact_kind,
+                            &input.source_fact_id,
+                            &input.source_snapshot_json,
+                            &request_idempotency_key,
+                            &payload_hash,
+                        ],
                     )
-                    VALUES (
-                        $1, $2, $3, $4, $5, $6, $7,
-                        $8, $9, $10, $11, $12, $13, $14, $15
-                    )
-                    ON CONFLICT (
-                        realm_id,
-                        granted_by_actor_id,
-                        request_idempotency_key
-                    )
-                    DO UPDATE
-                    SET request_payload_hash = dao.realm_admissions.request_payload_hash
-                    RETURNING *
-                    ",
-                    &[
-                        &Uuid::new_v4(),
-                        &realm_id,
-                        &account_id,
-                        &admission_context.admission_kind,
-                        &admission_context.admission_status,
-                        &admission_context.sponsor_record_id,
-                        &admission_context.bootstrap_corridor_id,
-                        &granted_by_actor_kind,
-                        &operator_id,
-                        &admission_context.reason_code,
-                        &input.source_fact_kind,
-                        &input.source_fact_id,
-                        &input.source_snapshot_json,
-                        &request_idempotency_key,
-                        &payload_hash,
-                    ],
-                )
-                .await
-                .map_err(db_error)?;
-            ensure_admission_payload_hash_matches(&row, &payload_hash)?;
-            maybe_open_member_overlap_trigger_tx(&tx, &realm_id, &account_id).await?;
-            row
+                    .await
+                    .map_err(db_error)?;
+                ensure_admission_payload_hash_matches(&row, &payload_hash)?;
+                maybe_open_member_overlap_trigger_tx(&tx, &realm_id, &account_id).await?;
+                row
+            }
         };
 
         let refreshed_admission: RealmAdmissionSnapshot = realm_admission_from_row(&row)?;
@@ -3011,6 +3022,27 @@ async fn find_admission_by_idempotency_tx<C: GenericClient + Sync>(
               AND request_idempotency_key = $3
             ",
             &[&realm_id, operator_id, &request_idempotency_key],
+        )
+        .await
+        .map_err(db_error)
+}
+
+async fn find_latest_admission_for_account_tx<C: GenericClient + Sync>(
+    client: &C,
+    realm_id: &str,
+    account_id: &Uuid,
+) -> Result<Option<Row>, RealmBootstrapError> {
+    client
+        .query_opt(
+            "
+            SELECT *
+            FROM dao.realm_admissions
+            WHERE realm_id = $1
+              AND account_id = $2
+            ORDER BY updated_at DESC, created_at DESC, realm_admission_id DESC
+            LIMIT 1
+            ",
+            &[&realm_id, account_id],
         )
         .await
         .map_err(db_error)

--- a/apps/backend/src/services/realm_bootstrap/repository.rs
+++ b/apps/backend/src/services/realm_bootstrap/repository.rs
@@ -108,8 +108,8 @@ impl RealmBootstrapStore {
             &input.proposed_steward_account_id,
             "proposed steward account id",
         )?;
-        let request_idempotency_key = normalize_optional(input.request_idempotency_key.as_deref())
-            .ok_or_else(|| {
+        let request_idempotency_key =
+            normalize_optional(Some(input.request_idempotency_key.as_str())).ok_or_else(|| {
                 RealmBootstrapError::BadRequest(
                     "realm request requires request_idempotency_key".to_owned(),
                 )
@@ -376,9 +376,9 @@ impl RealmBootstrapStore {
                 "review_reason_code must match target_realm_status".to_owned(),
             ));
         }
-        let review_decision_idempotency_key = normalize_optional(
-            input.review_decision_idempotency_key.as_deref(),
-        )
+        let review_decision_idempotency_key = normalize_optional(Some(
+            input.review_decision_idempotency_key.as_str(),
+        ))
         .ok_or_else(|| {
             RealmBootstrapError::BadRequest(
                 "approve realm request requires review_decision_idempotency_key".to_owned(),
@@ -499,7 +499,7 @@ impl RealmBootstrapStore {
                     sponsor_status: "active".to_owned(),
                     quota_total,
                     status_reason_code: input.review_reason_code.clone(),
-                    request_idempotency_key: None,
+                    request_idempotency_key: input.review_decision_idempotency_key.clone(),
                 },
                 sponsor_account_id,
             );
@@ -566,9 +566,9 @@ impl RealmBootstrapStore {
             &input.review_reason_code,
             REJECTION_REASON_CODES,
         )?;
-        let review_decision_idempotency_key = normalize_optional(
-            input.review_decision_idempotency_key.as_deref(),
-        )
+        let review_decision_idempotency_key = normalize_optional(Some(
+            input.review_decision_idempotency_key.as_str(),
+        ))
         .ok_or_else(|| {
             RealmBootstrapError::BadRequest(
                 "reject realm request requires review_decision_idempotency_key".to_owned(),
@@ -651,8 +651,8 @@ impl RealmBootstrapStore {
                 "quota_total must be positive".to_owned(),
             ));
         }
-        let request_idempotency_key = normalize_optional(input.request_idempotency_key.as_deref())
-            .ok_or_else(|| {
+        let request_idempotency_key =
+            normalize_optional(Some(input.request_idempotency_key.as_str())).ok_or_else(|| {
                 RealmBootstrapError::BadRequest(
                     "sponsor record creation requires request_idempotency_key".to_owned(),
                 )
@@ -719,8 +719,8 @@ impl RealmBootstrapStore {
         ensure_non_empty("source_fact_kind", &input.source_fact_kind)?;
         ensure_non_empty("source_fact_id", &input.source_fact_id)?;
         let sponsor_record_id = parse_optional_uuid(&input.sponsor_record_id, "sponsor record id")?;
-        let request_idempotency_key = normalize_optional(input.request_idempotency_key.as_deref())
-            .ok_or_else(|| {
+        let request_idempotency_key =
+            normalize_optional(Some(input.request_idempotency_key.as_str())).ok_or_else(|| {
                 RealmBootstrapError::BadRequest(
                     "admission creation requires request_idempotency_key".to_owned(),
                 )

--- a/apps/backend/src/services/realm_bootstrap/repository.rs
+++ b/apps/backend/src/services/realm_bootstrap/repository.rs
@@ -628,6 +628,7 @@ impl RealmBootstrapStore {
         ensure_operator_role_tx(&tx, &operator_id, OPERATOR_WRITE_ROLES).await?;
         ensure_active_account_exists_tx(&tx, &sponsor_account_id).await?;
         lock_realm_tx(&tx, &realm_id).await?;
+        lock_sponsor_lineage_tx(&tx, &realm_id, &sponsor_account_id).await?;
         update_expired_corridors_tx(&tx, Some(&realm_id)).await?;
 
         let row = if let Some(existing) = find_sponsor_record_by_idempotency_tx(
@@ -687,7 +688,6 @@ impl RealmBootstrapStore {
         let tx = client.transaction().await.map_err(db_error)?;
         ensure_operator_role_tx(&tx, &operator_id, OPERATOR_WRITE_ROLES).await?;
         ensure_active_account_exists_tx(&tx, &account_id).await?;
-        update_expired_corridors_tx(&tx, Some(&realm_id)).await?;
         let granted_by_actor_kind = operator_actor_kind_tx(&tx, &operator_id).await?;
         let payload_hash = create_admission_payload_hash(
             &input,
@@ -710,6 +710,10 @@ impl RealmBootstrapStore {
                     "restricted or suspended realms cannot admit new members".to_owned(),
                 ));
             }
+            if let Some(sponsor_record_id) = sponsor_record_id.as_ref() {
+                lock_sponsor_lineage_for_record_tx(&tx, &realm_id, sponsor_record_id).await?;
+            }
+            update_expired_corridors_tx(&tx, Some(&realm_id)).await?;
             let active_corridor = find_current_corridor_tx(&tx, &realm_id).await?;
             let latest_corridor_status = find_latest_corridor_status_tx(&tx, &realm_id).await?;
             let admission_context = derive_admission_context_tx(
@@ -947,9 +951,12 @@ impl RealmBootstrapStore {
 
     pub async fn rebuild_realm_bootstrap_views(
         &self,
+        operator_id: &str,
     ) -> Result<RealmBootstrapRebuildSnapshot, RealmBootstrapError> {
+        let operator_id = parse_uuid(operator_id, "operator id")?;
         let mut client = self.client.lock().await;
         let tx = client.transaction().await.map_err(db_error)?;
+        ensure_operator_role_tx(&tx, &operator_id, OPERATOR_WRITE_ROLES).await?;
         tx.query_one(
             "
             SELECT pg_advisory_xact_lock(
@@ -2427,6 +2434,56 @@ async fn lock_current_sponsor_record_tx<C: GenericClient + Sync>(
         .ok_or_else(|| {
             RealmBootstrapError::NotFound("realm sponsor record was not found".to_owned())
         })
+}
+
+async fn lock_sponsor_lineage_tx<C: GenericClient + Sync>(
+    client: &C,
+    realm_id: &str,
+    sponsor_account_id: &Uuid,
+) -> Result<(), RealmBootstrapError> {
+    let sponsor_account_id_text = sponsor_account_id.to_string();
+    client
+        .query_one(
+            "
+            SELECT pg_advisory_xact_lock(
+                hashtext('realm_bootstrap.sponsor_lineage'),
+                hashtext($1 || ':' || $2::text)
+            )
+            ",
+            &[&realm_id, &sponsor_account_id_text],
+        )
+        .await
+        .map_err(db_error)?;
+    Ok(())
+}
+
+async fn lock_sponsor_lineage_for_record_tx<C: GenericClient + Sync>(
+    client: &C,
+    realm_id: &str,
+    sponsor_record_id: &Uuid,
+) -> Result<(), RealmBootstrapError> {
+    let sponsor_row = client
+        .query_opt(
+            "
+            SELECT realm_id, sponsor_account_id
+            FROM dao.realm_sponsor_records
+            WHERE realm_sponsor_record_id = $1
+            ",
+            &[sponsor_record_id],
+        )
+        .await
+        .map_err(db_error)?
+        .ok_or_else(|| {
+            RealmBootstrapError::NotFound("realm sponsor record was not found".to_owned())
+        })?;
+    let sponsor_realm_id: String = sponsor_row.get("realm_id");
+    if sponsor_realm_id != realm_id {
+        return Err(RealmBootstrapError::BadRequest(
+            "sponsor record does not belong to the same realm".to_owned(),
+        ));
+    }
+    let sponsor_account_id: Uuid = sponsor_row.get("sponsor_account_id");
+    lock_sponsor_lineage_tx(client, realm_id, &sponsor_account_id).await
 }
 
 async fn ensure_slug_available_for_approval_tx<C: GenericClient + Sync>(

--- a/apps/backend/src/services/realm_bootstrap/repository.rs
+++ b/apps/backend/src/services/realm_bootstrap/repository.rs
@@ -3245,11 +3245,6 @@ fn db_error(error: tokio_postgres::Error) -> RealmBootstrapError {
                     "approved slug is already in use".to_owned(),
                 );
             }
-            Some("realm_sponsor_records_active_unique") => {
-                return RealmBootstrapError::BadRequest(
-                    "sponsor account already has an open sponsor record for this realm".to_owned(),
-                );
-            }
             Some("realm_sponsor_records_idempotency_unique") => {
                 return RealmBootstrapError::BadRequest(
                     "request_idempotency_key was already used by this operator for this realm"

--- a/apps/backend/src/services/realm_bootstrap/repository.rs
+++ b/apps/backend/src/services/realm_bootstrap/repository.rs
@@ -140,10 +140,12 @@ impl RealmBootstrapStore {
             existing
         } else {
             if let Some(sponsor_account_id) = proposed_sponsor_account_id.as_ref() {
-                ensure_active_account_exists_tx(&tx, sponsor_account_id).await?;
+                ensure_active_realm_request_candidate_account_exists_tx(&tx, sponsor_account_id)
+                    .await?;
             }
             if let Some(steward_account_id) = proposed_steward_account_id.as_ref() {
-                ensure_active_account_exists_tx(&tx, steward_account_id).await?;
+                ensure_active_realm_request_candidate_account_exists_tx(&tx, steward_account_id)
+                    .await?;
             }
             let request_row = match tx
                 .query_opt(
@@ -365,7 +367,15 @@ impl RealmBootstrapStore {
             )
             .await
             .map_err(db_error)?;
-        rows.iter().map(realm_request_from_row).collect()
+        let mut snapshots = Vec::with_capacity(rows.len());
+        for row in rows {
+            let realm_request_id: Uuid = row.get("realm_request_id");
+            let mut snapshot = realm_request_from_row(&row)?;
+            snapshot.open_review_triggers =
+                read_open_realm_request_triggers_tx(&*client, &realm_request_id).await?;
+            snapshots.push(snapshot);
+        }
+        Ok(snapshots)
     }
 
     pub async fn read_realm_request_for_operator(
@@ -395,7 +405,10 @@ impl RealmBootstrapStore {
             .ok_or_else(|| {
                 RealmBootstrapError::NotFound("realm request was not found".to_owned())
             })?;
-        realm_request_from_row(&row)
+        let mut snapshot = realm_request_from_row(&row)?;
+        snapshot.open_review_triggers =
+            read_open_realm_request_triggers_tx(&*client, &realm_request_id).await?;
+        Ok(snapshot)
     }
 
     pub async fn approve_realm_request(
@@ -3488,6 +3501,19 @@ async fn ensure_active_account_exists_tx<C: GenericClient + Sync>(
     }
 }
 
+async fn ensure_active_realm_request_candidate_account_exists_tx<C: GenericClient + Sync>(
+    client: &C,
+    account_id: &Uuid,
+) -> Result<(), RealmBootstrapError> {
+    if find_account_state_tx(client, account_id).await?.as_deref() == Some("active") {
+        Ok(())
+    } else {
+        Err(RealmBootstrapError::BadRequest(
+            "provided sponsor/steward account id is invalid".to_owned(),
+        ))
+    }
+}
+
 async fn ensure_sponsor_account_state_allows_status_tx<C: GenericClient + Sync>(
     client: &C,
     sponsor_account_id: &Uuid,
@@ -3988,6 +4014,26 @@ async fn operator_actor_kind_tx<C: GenericClient + Sync>(
     }
 }
 
+async fn read_open_realm_request_triggers_tx<C: GenericClient + Sync>(
+    client: &C,
+    realm_request_id: &Uuid,
+) -> Result<Vec<RealmReviewTriggerSnapshot>, RealmBootstrapError> {
+    let rows = client
+        .query(
+            "
+            SELECT *
+            FROM dao.realm_review_triggers
+            WHERE related_realm_request_id = $1
+              AND trigger_state = 'open'
+            ORDER BY created_at DESC, realm_review_trigger_id DESC
+            ",
+            &[realm_request_id],
+        )
+        .await
+        .map_err(db_error)?;
+    rows.iter().map(realm_review_trigger_from_row).collect()
+}
+
 fn realm_request_from_row(row: &Row) -> Result<RealmRequestSnapshot, RealmBootstrapError> {
     let created_realm_id = if row
         .columns()
@@ -4022,6 +4068,7 @@ fn realm_request_from_row(row: &Row) -> Result<RealmRequestSnapshot, RealmBootst
         created_realm_id,
         created_at: row.get("created_at"),
         updated_at: row.get("updated_at"),
+        open_review_triggers: Vec::new(),
     })
 }
 

--- a/apps/backend/src/services/realm_bootstrap/repository.rs
+++ b/apps/backend/src/services/realm_bootstrap/repository.rs
@@ -464,6 +464,7 @@ impl RealmBootstrapStore {
             "
             UPDATE dao.realm_requests
             SET request_state = 'approved',
+                slug_candidate = $6,
                 review_reason_code = $2,
                 reviewed_by_operator_id = $3,
                 review_decision_idempotency_key = $4,
@@ -478,6 +479,7 @@ impl RealmBootstrapStore {
                 &operator_id,
                 &Some(review_decision_idempotency_key),
                 &Some(decision_payload_hash),
+                &approved_slug,
             ],
         )
         .await
@@ -699,7 +701,7 @@ impl RealmBootstrapStore {
                     trigger.reason_code,
                     Some(&account_id),
                     None,
-                    sponsor_record_id.as_ref(),
+                    admission_context.sponsor_record_id.as_ref(),
                     &trigger.context_json,
                     &trigger.fingerprint,
                 )
@@ -738,7 +740,7 @@ impl RealmBootstrapStore {
                         &account_id,
                         &admission_context.admission_kind,
                         &admission_context.admission_status,
-                        &sponsor_record_id,
+                        &admission_context.sponsor_record_id,
                         &admission_context.bootstrap_corridor_id,
                         &granted_by_actor_kind,
                         &operator_id,
@@ -1000,6 +1002,7 @@ struct AdmissionContext {
     admission_kind: &'static str,
     admission_status: &'static str,
     reason_code: &'static str,
+    sponsor_record_id: Option<Uuid>,
     bootstrap_corridor_id: Option<Uuid>,
     open_trigger: Option<TriggerIntent>,
 }
@@ -1016,6 +1019,7 @@ fn limited_bootstrap_without_active_corridor_context(
         admission_kind: "review_required",
         admission_status: "pending",
         reason_code,
+        sponsor_record_id: None,
         bootstrap_corridor_id: None,
         open_trigger: None,
     }
@@ -1226,33 +1230,39 @@ async fn derive_admission_context_tx<C: GenericClient + Sync>(
     };
 
     if let Some(sponsor_record_id) = sponsor_record_id {
-        let sponsor_row = lock_sponsor_record_tx(client, sponsor_record_id).await?;
-        let sponsor_realm_id: String = sponsor_row.get("realm_id");
+        let requested_sponsor_row = lock_sponsor_record_tx(client, sponsor_record_id).await?;
+        let sponsor_realm_id: String = requested_sponsor_row.get("realm_id");
         if sponsor_realm_id != realm_id {
             return Err(RealmBootstrapError::BadRequest(
                 "sponsor record does not belong to this realm".to_owned(),
             ));
         }
+        let sponsor_account_id: Uuid = requested_sponsor_row.get("sponsor_account_id");
+        let sponsor_row =
+            lock_current_sponsor_record_tx(client, realm_id, &sponsor_account_id).await?;
+        let current_sponsor_record_id: Uuid = sponsor_row.get("realm_sponsor_record_id");
         if realm_status == "limited_bootstrap" && active_corridor.is_none() {
-            return Ok(limited_bootstrap_without_active_corridor_context(
-                latest_corridor_status,
-            ));
+            let mut context =
+                limited_bootstrap_without_active_corridor_context(latest_corridor_status);
+            context.sponsor_record_id = Some(current_sponsor_record_id);
+            return Ok(context);
         }
         let sponsor_status: String = sponsor_row.get("sponsor_status");
         let sponsor_quota_total: i64 = sponsor_row.get("quota_total");
         let sponsor_used_count =
-            count_sponsor_backed_admissions_tx(client, sponsor_record_id).await?;
+            count_sponsor_backed_admissions_tx(client, &current_sponsor_record_id).await?;
         if sponsor_status == "revoked" {
             return Ok(AdmissionContext {
                 admission_kind: "review_required",
                 admission_status: "pending",
                 reason_code: "sponsor_revoked",
+                sponsor_record_id: Some(current_sponsor_record_id),
                 bootstrap_corridor_id: active_corridor_id,
                 open_trigger: Some(trigger_intent(
                     "revoked_sponsor_lineage",
                     "sponsor_revoked",
-                    json!({ "sponsor_record_id": sponsor_record_id.to_string() }),
-                    format!("revoked-sponsor:{sponsor_record_id}"),
+                    json!({ "sponsor_record_id": current_sponsor_record_id.to_string() }),
+                    format!("revoked-sponsor:{current_sponsor_record_id}"),
                 )),
             });
         }
@@ -1261,12 +1271,13 @@ async fn derive_admission_context_tx<C: GenericClient + Sync>(
                 admission_kind: "review_required",
                 admission_status: "pending",
                 reason_code: "sponsor_rate_limited",
+                sponsor_record_id: Some(current_sponsor_record_id),
                 bootstrap_corridor_id: active_corridor_id,
                 open_trigger: Some(trigger_intent(
                     "quota_abuse",
                     "sponsor_rate_limited",
-                    json!({ "sponsor_record_id": sponsor_record_id.to_string() }),
-                    format!("quota-abuse:{sponsor_record_id}"),
+                    json!({ "sponsor_record_id": current_sponsor_record_id.to_string() }),
+                    format!("quota-abuse:{current_sponsor_record_id}"),
                 )),
             });
         }
@@ -1275,6 +1286,7 @@ async fn derive_admission_context_tx<C: GenericClient + Sync>(
                 admission_kind: "review_required",
                 admission_status: "pending",
                 reason_code: "review_required",
+                sponsor_record_id: Some(current_sponsor_record_id),
                 bootstrap_corridor_id: active_corridor_id,
                 open_trigger: None,
             });
@@ -1284,16 +1296,17 @@ async fn derive_admission_context_tx<C: GenericClient + Sync>(
                 admission_kind: "review_required",
                 admission_status: "pending",
                 reason_code: "bootstrap_capacity_reached",
+                sponsor_record_id: Some(current_sponsor_record_id),
                 bootstrap_corridor_id: active_corridor_id,
                 open_trigger: Some(trigger_intent(
                     "quota_exceeded",
                     "bootstrap_capacity_reached",
                     json!({
-                        "sponsor_record_id": sponsor_record_id.to_string(),
+                        "sponsor_record_id": current_sponsor_record_id.to_string(),
                         "quota_total": sponsor_quota_total,
                         "used_count": sponsor_used_count,
                     }),
-                    format!("quota-exceeded:{sponsor_record_id}"),
+                    format!("quota-exceeded:{current_sponsor_record_id}"),
                 )),
             });
         }
@@ -1304,6 +1317,7 @@ async fn derive_admission_context_tx<C: GenericClient + Sync>(
                     admission_kind: "review_required",
                     admission_status: "pending",
                     reason_code: "bootstrap_capacity_reached",
+                    sponsor_record_id: Some(current_sponsor_record_id),
                     bootstrap_corridor_id: active_corridor_id,
                     open_trigger: Some(trigger_intent(
                         "corridor_cap_pressure",
@@ -1321,17 +1335,24 @@ async fn derive_admission_context_tx<C: GenericClient + Sync>(
                 });
             }
             let sponsor_cap: i64 = corridor_row.get("sponsor_cap");
-            let sponsor_slots =
-                count_distinct_corridor_sponsors_tx(client, sponsor_record_id, corridor_row)
-                    .await?;
-            let sponsor_already_present =
-                corridor_contains_sponsor_record_tx(client, sponsor_record_id, corridor_row)
-                    .await?;
+            let sponsor_slots = count_distinct_corridor_sponsors_tx(
+                client,
+                &current_sponsor_record_id,
+                corridor_row,
+            )
+            .await?;
+            let sponsor_already_present = corridor_contains_sponsor_record_tx(
+                client,
+                &current_sponsor_record_id,
+                corridor_row,
+            )
+            .await?;
             if !sponsor_already_present && sponsor_slots >= sponsor_cap {
                 return Ok(AdmissionContext {
                     admission_kind: "review_required",
                     admission_status: "pending",
                     reason_code: "bootstrap_capacity_reached",
+                    sponsor_record_id: Some(current_sponsor_record_id),
                     bootstrap_corridor_id: active_corridor_id,
                     open_trigger: Some(trigger_intent(
                         "corridor_cap_pressure",
@@ -1358,6 +1379,7 @@ async fn derive_admission_context_tx<C: GenericClient + Sync>(
             admission_kind: "sponsor_backed",
             admission_status: "admitted",
             reason_code,
+            sponsor_record_id: Some(current_sponsor_record_id),
             bootstrap_corridor_id: active_corridor_id,
             open_trigger: None,
         });
@@ -1370,6 +1392,7 @@ async fn derive_admission_context_tx<C: GenericClient + Sync>(
                 admission_kind: "review_required",
                 admission_status: "pending",
                 reason_code: "bootstrap_capacity_reached",
+                sponsor_record_id: None,
                 bootstrap_corridor_id: active_corridor_id,
                 open_trigger: Some(trigger_intent(
                     "corridor_cap_pressure",
@@ -1390,6 +1413,7 @@ async fn derive_admission_context_tx<C: GenericClient + Sync>(
             admission_kind: "corridor",
             admission_status: "admitted",
             reason_code: "limited_bootstrap_active",
+            sponsor_record_id: None,
             bootstrap_corridor_id: active_corridor_id,
             open_trigger: None,
         });
@@ -1414,6 +1438,7 @@ async fn derive_admission_context_tx<C: GenericClient + Sync>(
             "pending"
         },
         reason_code,
+        sponsor_record_id: None,
         bootstrap_corridor_id: None,
         open_trigger: None,
     })
@@ -2253,6 +2278,31 @@ async fn lock_sponsor_record_tx<C: GenericClient + Sync>(
             FOR UPDATE
             ",
             &[sponsor_record_id],
+        )
+        .await
+        .map_err(db_error)?
+        .ok_or_else(|| {
+            RealmBootstrapError::NotFound("realm sponsor record was not found".to_owned())
+        })
+}
+
+async fn lock_current_sponsor_record_tx<C: GenericClient + Sync>(
+    client: &C,
+    realm_id: &str,
+    sponsor_account_id: &Uuid,
+) -> Result<Row, RealmBootstrapError> {
+    client
+        .query_opt(
+            "
+            SELECT *
+            FROM dao.realm_sponsor_records
+            WHERE realm_id = $1
+              AND sponsor_account_id = $2
+            ORDER BY updated_at DESC, created_at DESC, realm_sponsor_record_id DESC
+            LIMIT 1
+            FOR UPDATE
+            ",
+            &[&realm_id, sponsor_account_id],
         )
         .await
         .map_err(db_error)?

--- a/apps/backend/src/services/realm_bootstrap/repository.rs
+++ b/apps/backend/src/services/realm_bootstrap/repository.rs
@@ -696,12 +696,7 @@ impl RealmBootstrapStore {
         ensure_operator_role_tx(&tx, &operator_id, OPERATOR_WRITE_ROLES).await?;
         ensure_active_account_exists_tx(&tx, &account_id).await?;
         let granted_by_actor_kind = operator_actor_kind_tx(&tx, &operator_id).await?;
-        let payload_hash = create_admission_payload_hash(
-            &input,
-            &account_id,
-            &sponsor_record_id,
-            &granted_by_actor_kind,
-        );
+        let payload_hash = create_admission_payload_hash(&input, &account_id, &sponsor_record_id);
 
         let row = if let Some(existing) =
             find_admission_by_idempotency_tx(&tx, &realm_id, &operator_id, &request_idempotency_key)
@@ -2522,10 +2517,17 @@ async fn ensure_sponsor_status_transition_allowed_tx<C: GenericClient + Sync>(
         .map_err(db_error)?
         .map(|row| row.get::<_, String>("sponsor_status"));
 
-    if current_status
-        .as_deref()
-        .is_some_and(|status| matches!(status, "proposed" | "approved" | "active"))
-    {
+    let transition_allowed = matches!(
+        (current_status.as_deref(), next_sponsor_status),
+        (None, _)
+            | (Some("proposed"), "approved" | "active")
+            | (Some("approved"), "active")
+            | (
+                Some("rate_limited" | "revoked"),
+                "proposed" | "approved" | "active"
+            )
+    );
+    if !transition_allowed {
         return Err(RealmBootstrapError::BadRequest(
             "sponsor account already has an open sponsor record for this realm".to_owned(),
         ));
@@ -2693,7 +2695,6 @@ fn create_admission_payload_hash(
     input: &CreateRealmAdmissionInput,
     account_id: &Uuid,
     sponsor_record_id: &Option<Uuid>,
-    granted_by_actor_kind: &str,
 ) -> String {
     hash_json_value(&json!({
         "schema_version": 1,
@@ -2702,7 +2703,6 @@ fn create_admission_payload_hash(
         "source_fact_kind": &input.source_fact_kind,
         "source_fact_id": &input.source_fact_id,
         "source_snapshot_json": &input.source_snapshot_json,
-        "granted_by_actor_kind": granted_by_actor_kind,
     }))
 }
 

--- a/apps/backend/src/services/realm_bootstrap/repository.rs
+++ b/apps/backend/src/services/realm_bootstrap/repository.rs
@@ -1,0 +1,2931 @@
+use std::{fmt::Write as _, sync::Arc};
+
+use chrono::{DateTime, Utc};
+use musubi_db_runtime::{DbConfig, connect_writer};
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+use tokio::sync::Mutex;
+use tokio_postgres::{Client, GenericClient, Row, error::SqlState};
+use uuid::Uuid;
+
+use super::types::{
+    CreateRealmAdmissionInput, CreateRealmRequestInput, CreateRealmSponsorRecordInput,
+    RealmAdmissionSnapshot, RealmAdmissionViewSnapshot, RealmBootstrapError,
+    RealmBootstrapRebuildSnapshot, RealmBootstrapSummarySnapshot, RealmBootstrapViewSnapshot,
+    RealmRequestSnapshot, RealmReviewSummarySnapshot, RealmReviewTriggerSnapshot, RealmSnapshot,
+    RealmSponsorRecordSnapshot, RejectRealmRequestInput, ReviewRealmRequestInput,
+};
+
+const SPONSOR_STATUSES: &[&str] = &["proposed", "approved", "active", "rate_limited", "revoked"];
+const REVIEW_TRIGGER_KINDS: &[&str] = &[
+    "sponsor_concentration",
+    "duplicate_venue_context",
+    "suspicious_member_overlap",
+    "proof_failure_rate",
+    "safety_case_concentration",
+    "operator_restriction",
+    "quota_exceeded",
+    "quota_abuse",
+    "corridor_cap_pressure",
+    "revoked_sponsor_lineage",
+    "repeated_rejected_requests",
+];
+const REASON_CODES: &[&str] = &[
+    "request_received",
+    "review_required",
+    "limited_bootstrap_active",
+    "active_after_review",
+    "request_rejected",
+    "duplicate_or_invalid",
+    "sponsor_required",
+    "bootstrap_capacity_reached",
+    "bootstrap_expired",
+    "sponsor_rate_limited",
+    "sponsor_revoked",
+    "restricted_after_review",
+    "suspended_after_review",
+    "operator_restriction",
+];
+const OPERATOR_READ_ROLES: &[&str] = &["reviewer", "approver", "steward", "auditor", "support"];
+const OPERATOR_WRITE_ROLES: &[&str] = &["approver", "steward"];
+
+#[derive(Clone)]
+pub struct RealmBootstrapStore {
+    client: Arc<Mutex<Client>>,
+}
+
+impl RealmBootstrapStore {
+    pub(crate) async fn connect(config: &DbConfig) -> musubi_db_runtime::Result<Self> {
+        let client = connect_writer(config, "musubi-backend realm-bootstrap").await?;
+        Ok(Self {
+            client: Arc::new(Mutex::new(client)),
+        })
+    }
+
+    pub(crate) async fn reset_for_test(&self) -> Result<(), RealmBootstrapError> {
+        let client = self.client.lock().await;
+        client
+            .batch_execute(
+                "
+                DELETE FROM projection.realm_admission_views;
+                DELETE FROM projection.realm_review_summaries;
+                DELETE FROM projection.realm_bootstrap_views;
+                DELETE FROM dao.realm_review_triggers;
+                DELETE FROM dao.realm_admissions;
+                DELETE FROM dao.bootstrap_corridors;
+                DELETE FROM dao.realm_sponsor_records;
+                DELETE FROM dao.realms;
+                DELETE FROM dao.realm_requests;
+                ",
+            )
+            .await
+            .map_err(db_error)?;
+        Ok(())
+    }
+
+    pub async fn create_realm_request(
+        &self,
+        requester_account_id: &str,
+        input: CreateRealmRequestInput,
+    ) -> Result<RealmRequestSnapshot, RealmBootstrapError> {
+        let requester_account_id = parse_uuid(requester_account_id, "requester account id")?;
+        ensure_non_empty("display_name", &input.display_name)?;
+        let slug_candidate = normalize_slug_candidate(&input.slug_candidate)?;
+        ensure_non_empty("purpose_text", &input.purpose_text)?;
+        ensure_non_empty_json_object("venue_context_json", &input.venue_context_json)?;
+        ensure_non_empty_json_object(
+            "expected_member_shape_json",
+            &input.expected_member_shape_json,
+        )?;
+        ensure_non_empty("bootstrap_rationale_text", &input.bootstrap_rationale_text)?;
+        let proposed_sponsor_account_id = parse_optional_uuid(
+            &input.proposed_sponsor_account_id,
+            "proposed sponsor account id",
+        )?;
+        let proposed_steward_account_id = parse_optional_uuid(
+            &input.proposed_steward_account_id,
+            "proposed steward account id",
+        )?;
+        let request_idempotency_key = normalize_optional(input.request_idempotency_key.as_deref())
+            .ok_or_else(|| {
+                RealmBootstrapError::BadRequest(
+                    "realm request requires request_idempotency_key".to_owned(),
+                )
+            })?;
+        let request_payload_hash = create_realm_request_payload_hash(
+            &input,
+            &slug_candidate,
+            &proposed_sponsor_account_id,
+            &proposed_steward_account_id,
+        );
+
+        let mut client = self.client.lock().await;
+        let tx = client.transaction().await.map_err(db_error)?;
+        ensure_active_account_exists_tx(&tx, &requester_account_id).await?;
+        if let Some(sponsor_account_id) = proposed_sponsor_account_id.as_ref() {
+            ensure_active_account_exists_tx(&tx, sponsor_account_id).await?;
+        }
+        if let Some(steward_account_id) = proposed_steward_account_id.as_ref() {
+            ensure_active_account_exists_tx(&tx, steward_account_id).await?;
+        }
+
+        let row = if let Some(existing) = find_realm_request_by_idempotency_tx(
+            &tx,
+            &requester_account_id,
+            &request_idempotency_key,
+        )
+        .await?
+        {
+            ensure_request_payload_hash_matches(&existing, &request_payload_hash)?;
+            existing
+        } else {
+            let request_row = tx
+                .query_one(
+                    "
+                    INSERT INTO dao.realm_requests (
+                        realm_request_id,
+                        requested_by_account_id,
+                        display_name,
+                        slug_candidate,
+                        purpose_text,
+                        venue_context_json,
+                        expected_member_shape_json,
+                        bootstrap_rationale_text,
+                        proposed_sponsor_account_id,
+                        proposed_steward_account_id,
+                        request_state,
+                        review_reason_code,
+                        request_idempotency_key,
+                        request_payload_hash
+                    )
+                    VALUES (
+                        $1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
+                        'requested',
+                        'request_received',
+                        $11, $12
+                    )
+                    RETURNING *
+                    ",
+                    &[
+                        &Uuid::new_v4(),
+                        &requester_account_id,
+                        &normalize_required(&input.display_name, "display_name")?,
+                        &slug_candidate,
+                        &normalize_required(&input.purpose_text, "purpose_text")?,
+                        &input.venue_context_json,
+                        &input.expected_member_shape_json,
+                        &normalize_required(
+                            &input.bootstrap_rationale_text,
+                            "bootstrap_rationale_text",
+                        )?,
+                        &proposed_sponsor_account_id,
+                        &proposed_steward_account_id,
+                        &Some(request_idempotency_key.clone()),
+                        &request_payload_hash,
+                    ],
+                )
+                .await
+                .map_err(db_error)?;
+            let realm_request_id: Uuid = request_row.get("realm_request_id");
+            let requires_review = maybe_open_realm_request_triggers_tx(
+                &tx,
+                &realm_request_id,
+                &requester_account_id,
+                &input.venue_context_json,
+            )
+            .await?;
+            if requires_review {
+                tx.execute(
+                    "
+                    UPDATE dao.realm_requests
+                    SET request_state = 'pending_review',
+                        review_reason_code = 'review_required',
+                        updated_at = CURRENT_TIMESTAMP
+                    WHERE realm_request_id = $1
+                    ",
+                    &[&realm_request_id],
+                )
+                .await
+                .map_err(db_error)?;
+                lock_realm_request_tx(&tx, &realm_request_id).await?
+            } else {
+                request_row
+            }
+        };
+
+        tx.commit().await.map_err(db_error)?;
+        realm_request_from_row(&row)
+    }
+
+    pub async fn get_realm_request_for_requester(
+        &self,
+        requester_account_id: &str,
+        realm_request_id: &str,
+    ) -> Result<RealmRequestSnapshot, RealmBootstrapError> {
+        let requester_account_id = parse_uuid(requester_account_id, "requester account id")?;
+        let realm_request_id = parse_uuid(realm_request_id, "realm request id")?;
+        let client = self.client.lock().await;
+        let row = client
+            .query_opt(
+                "
+                SELECT
+                    request.*,
+                    realm.realm_id AS created_realm_id
+                FROM dao.realm_requests request
+                LEFT JOIN dao.realms realm
+                  ON realm.created_from_realm_request_id = request.realm_request_id
+                WHERE request.realm_request_id = $1
+                  AND request.requested_by_account_id = $2
+                ",
+                &[&realm_request_id, &requester_account_id],
+            )
+            .await
+            .map_err(db_error)?
+            .ok_or_else(|| {
+                RealmBootstrapError::NotFound("realm request was not found".to_owned())
+            })?;
+        realm_request_from_row(&row)
+    }
+
+    pub async fn list_realm_requests_for_operator(
+        &self,
+        operator_id: &str,
+    ) -> Result<Vec<RealmRequestSnapshot>, RealmBootstrapError> {
+        let operator_id = parse_uuid(operator_id, "operator id")?;
+        let client = self.client.lock().await;
+        ensure_operator_role_tx(&*client, &operator_id, OPERATOR_READ_ROLES).await?;
+        let rows = client
+            .query(
+                "
+                SELECT
+                    request.*,
+                    realm.realm_id AS created_realm_id
+                FROM dao.realm_requests request
+                LEFT JOIN dao.realms realm
+                  ON realm.created_from_realm_request_id = request.realm_request_id
+                ORDER BY request.created_at DESC, request.realm_request_id DESC
+                ",
+                &[],
+            )
+            .await
+            .map_err(db_error)?;
+        rows.iter().map(realm_request_from_row).collect()
+    }
+
+    pub async fn read_realm_request_for_operator(
+        &self,
+        operator_id: &str,
+        realm_request_id: &str,
+    ) -> Result<RealmRequestSnapshot, RealmBootstrapError> {
+        let operator_id = parse_uuid(operator_id, "operator id")?;
+        let realm_request_id = parse_uuid(realm_request_id, "realm request id")?;
+        let client = self.client.lock().await;
+        ensure_operator_role_tx(&*client, &operator_id, OPERATOR_READ_ROLES).await?;
+        let row = client
+            .query_opt(
+                "
+                SELECT
+                    request.*,
+                    realm.realm_id AS created_realm_id
+                FROM dao.realm_requests request
+                LEFT JOIN dao.realms realm
+                  ON realm.created_from_realm_request_id = request.realm_request_id
+                WHERE request.realm_request_id = $1
+                ",
+                &[&realm_request_id],
+            )
+            .await
+            .map_err(db_error)?
+            .ok_or_else(|| {
+                RealmBootstrapError::NotFound("realm request was not found".to_owned())
+            })?;
+        realm_request_from_row(&row)
+    }
+
+    pub async fn approve_realm_request(
+        &self,
+        operator_id: &str,
+        realm_request_id: &str,
+        input: ReviewRealmRequestInput,
+    ) -> Result<RealmSnapshot, RealmBootstrapError> {
+        let operator_id = parse_uuid(operator_id, "operator id")?;
+        let realm_request_id = parse_uuid(realm_request_id, "realm request id")?;
+        validate_allowed(
+            "target_realm_status",
+            &input.target_realm_status,
+            &["limited_bootstrap", "active"],
+        )?;
+        validate_allowed(
+            "review_reason_code",
+            &input.review_reason_code,
+            REASON_CODES,
+        )?;
+        let review_decision_idempotency_key = normalize_optional(
+            input.review_decision_idempotency_key.as_deref(),
+        )
+        .ok_or_else(|| {
+            RealmBootstrapError::BadRequest(
+                "approve realm request requires review_decision_idempotency_key".to_owned(),
+            )
+        })?;
+        let steward_account_id =
+            parse_optional_uuid(&input.steward_account_id, "steward account id")?;
+        let mut client = self.client.lock().await;
+        let tx = client.transaction().await.map_err(db_error)?;
+        ensure_operator_role_tx(&tx, &operator_id, OPERATOR_WRITE_ROLES).await?;
+
+        let request = lock_realm_request_tx(&tx, &realm_request_id).await?;
+        let existing_realm_id: Option<String> = request.get("created_realm_id");
+        let approved_slug = input
+            .approved_slug
+            .as_deref()
+            .map(normalize_slug_candidate)
+            .transpose()?
+            .unwrap_or_else(|| request.get::<_, String>("slug_candidate"));
+        let approved_display_name = input
+            .approved_display_name
+            .as_deref()
+            .map(|value| normalize_required(value, "approved_display_name"))
+            .transpose()?
+            .unwrap_or_else(|| request.get::<_, String>("display_name"));
+        let decision_payload_hash = approve_request_payload_hash(
+            &input,
+            &approved_slug,
+            &approved_display_name,
+            &steward_account_id,
+        );
+
+        match request.get::<_, String>("request_state").as_str() {
+            "approved" => {
+                ensure_request_review_replay_matches(
+                    &request,
+                    &review_decision_idempotency_key,
+                    &decision_payload_hash,
+                )?;
+                let existing_realm_id = existing_realm_id.ok_or_else(|| {
+                    RealmBootstrapError::Internal(
+                        "approved realm request is missing created realm linkage".to_owned(),
+                    )
+                })?;
+                refresh_realm_projection_bundle_tx(&tx, &existing_realm_id, None).await?;
+                let realm_row = lock_realm_tx(&tx, &existing_realm_id).await?;
+                tx.commit().await.map_err(db_error)?;
+                return realm_from_row(&realm_row);
+            }
+            "rejected" => {
+                return Err(RealmBootstrapError::BadRequest(
+                    "rejected realm requests cannot be approved".to_owned(),
+                ));
+            }
+            "requested" | "pending_review" => {}
+            other => {
+                return Err(RealmBootstrapError::BadRequest(format!(
+                    "realm request cannot be approved from state {other}"
+                )));
+            }
+        }
+
+        if input.target_realm_status == "limited_bootstrap" {
+            require_corridor_fields(&input)?;
+        }
+        if let Some(steward_account_id) = steward_account_id.as_ref() {
+            ensure_active_account_exists_tx(&tx, steward_account_id).await?;
+        }
+        ensure_slug_available_for_approval_tx(&tx, &approved_slug, &realm_request_id).await?;
+
+        let created_realm_id = format!("realm-{}", Uuid::new_v4());
+        let realm_row = tx
+            .query_one(
+                "
+                INSERT INTO dao.realms (
+                    realm_id,
+                    slug,
+                    display_name,
+                    realm_status,
+                    public_reason_code,
+                    created_from_realm_request_id,
+                    steward_account_id,
+                    created_by_operator_id
+                )
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+                RETURNING *
+                ",
+                &[
+                    &created_realm_id,
+                    &approved_slug,
+                    &approved_display_name,
+                    &input.target_realm_status,
+                    &input.review_reason_code,
+                    &realm_request_id,
+                    &steward_account_id,
+                    &operator_id,
+                ],
+            )
+            .await
+            .map_err(db_error)?;
+
+        let proposed_sponsor_account_id: Option<Uuid> = request.get("proposed_sponsor_account_id");
+        if let Some(sponsor_account_id) = proposed_sponsor_account_id.as_ref() {
+            ensure_active_account_exists_tx(&tx, sponsor_account_id).await?;
+            let quota_total = input.sponsor_quota_total.ok_or_else(|| {
+                RealmBootstrapError::BadRequest(
+                    "limited bootstrap approval with a proposed sponsor requires sponsor_quota_total"
+                        .to_owned(),
+                )
+            })?;
+            let sponsor_payload_hash = create_sponsor_record_payload_hash(
+                &CreateRealmSponsorRecordInput {
+                    sponsor_account_id: sponsor_account_id.to_string(),
+                    sponsor_status: "active".to_owned(),
+                    quota_total,
+                    status_reason_code: input.review_reason_code.clone(),
+                    request_idempotency_key: None,
+                },
+                sponsor_account_id,
+            );
+            insert_sponsor_record_tx(
+                &tx,
+                &created_realm_id,
+                sponsor_account_id,
+                "active",
+                quota_total,
+                &input.review_reason_code,
+                &operator_id,
+                None,
+                Some(sponsor_payload_hash),
+            )
+            .await?;
+        }
+
+        if input.target_realm_status == "limited_bootstrap" {
+            insert_bootstrap_corridor_tx(&tx, &created_realm_id, &input, &operator_id).await?;
+        }
+
+        tx.execute(
+            "
+            UPDATE dao.realm_requests
+            SET request_state = 'approved',
+                review_reason_code = $2,
+                reviewed_by_operator_id = $3,
+                review_decision_idempotency_key = $4,
+                review_decision_payload_hash = $5,
+                reviewed_at = CURRENT_TIMESTAMP,
+                updated_at = CURRENT_TIMESTAMP
+            WHERE realm_request_id = $1
+            ",
+            &[
+                &realm_request_id,
+                &input.review_reason_code,
+                &operator_id,
+                &Some(review_decision_idempotency_key),
+                &Some(decision_payload_hash),
+            ],
+        )
+        .await
+        .map_err(db_error)?;
+
+        refresh_realm_projection_bundle_tx(&tx, &created_realm_id, None).await?;
+        tx.commit().await.map_err(db_error)?;
+        realm_from_row(&realm_row)
+    }
+
+    pub async fn reject_realm_request(
+        &self,
+        operator_id: &str,
+        realm_request_id: &str,
+        input: RejectRealmRequestInput,
+    ) -> Result<RealmRequestSnapshot, RealmBootstrapError> {
+        let operator_id = parse_uuid(operator_id, "operator id")?;
+        let realm_request_id = parse_uuid(realm_request_id, "realm request id")?;
+        validate_allowed(
+            "review_reason_code",
+            &input.review_reason_code,
+            REASON_CODES,
+        )?;
+        let review_decision_idempotency_key = normalize_optional(
+            input.review_decision_idempotency_key.as_deref(),
+        )
+        .ok_or_else(|| {
+            RealmBootstrapError::BadRequest(
+                "reject realm request requires review_decision_idempotency_key".to_owned(),
+            )
+        })?;
+        let decision_payload_hash = reject_request_payload_hash(&input);
+        let mut client = self.client.lock().await;
+        let tx = client.transaction().await.map_err(db_error)?;
+        ensure_operator_role_tx(&tx, &operator_id, OPERATOR_WRITE_ROLES).await?;
+        let request = lock_realm_request_tx(&tx, &realm_request_id).await?;
+
+        match request.get::<_, String>("request_state").as_str() {
+            "rejected" => {
+                ensure_request_review_replay_matches(
+                    &request,
+                    &review_decision_idempotency_key,
+                    &decision_payload_hash,
+                )?;
+                tx.commit().await.map_err(db_error)?;
+                return realm_request_from_row(&request);
+            }
+            "approved" => {
+                return Err(RealmBootstrapError::BadRequest(
+                    "approved realm requests cannot be rejected".to_owned(),
+                ));
+            }
+            "requested" | "pending_review" => {}
+            other => {
+                return Err(RealmBootstrapError::BadRequest(format!(
+                    "realm request cannot be rejected from state {other}"
+                )));
+            }
+        }
+
+        tx.execute(
+            "
+            UPDATE dao.realm_requests
+            SET request_state = 'rejected',
+                review_reason_code = $2,
+                reviewed_by_operator_id = $3,
+                review_decision_idempotency_key = $4,
+                review_decision_payload_hash = $5,
+                reviewed_at = CURRENT_TIMESTAMP,
+                updated_at = CURRENT_TIMESTAMP
+            WHERE realm_request_id = $1
+            ",
+            &[
+                &realm_request_id,
+                &input.review_reason_code,
+                &operator_id,
+                &Some(review_decision_idempotency_key),
+                &Some(decision_payload_hash),
+            ],
+        )
+        .await
+        .map_err(db_error)?;
+        maybe_open_repeated_rejection_trigger_tx(&tx, &realm_request_id).await?;
+        let refreshed = lock_realm_request_tx(&tx, &realm_request_id).await?;
+        tx.commit().await.map_err(db_error)?;
+        realm_request_from_row(&refreshed)
+    }
+
+    pub async fn create_realm_sponsor_record(
+        &self,
+        operator_id: &str,
+        realm_id: &str,
+        input: CreateRealmSponsorRecordInput,
+    ) -> Result<RealmSponsorRecordSnapshot, RealmBootstrapError> {
+        let operator_id = parse_uuid(operator_id, "operator id")?;
+        let realm_id = normalize_required(realm_id, "realm id")?;
+        validate_allowed("sponsor_status", &input.sponsor_status, SPONSOR_STATUSES)?;
+        validate_allowed(
+            "status_reason_code",
+            &input.status_reason_code,
+            REASON_CODES,
+        )?;
+        let sponsor_account_id = parse_uuid(&input.sponsor_account_id, "sponsor account id")?;
+        if input.quota_total <= 0 {
+            return Err(RealmBootstrapError::BadRequest(
+                "quota_total must be positive".to_owned(),
+            ));
+        }
+        let request_idempotency_key = normalize_optional(input.request_idempotency_key.as_deref())
+            .ok_or_else(|| {
+                RealmBootstrapError::BadRequest(
+                    "sponsor record creation requires request_idempotency_key".to_owned(),
+                )
+            })?;
+        let payload_hash = create_sponsor_record_payload_hash(&input, &sponsor_account_id);
+        let mut client = self.client.lock().await;
+        let tx = client.transaction().await.map_err(db_error)?;
+        ensure_operator_role_tx(&tx, &operator_id, OPERATOR_WRITE_ROLES).await?;
+        ensure_active_account_exists_tx(&tx, &sponsor_account_id).await?;
+        lock_realm_tx(&tx, &realm_id).await?;
+        update_expired_corridors_tx(&tx, Some(&realm_id)).await?;
+
+        let row = if let Some(existing) = find_sponsor_record_by_idempotency_tx(
+            &tx,
+            &realm_id,
+            &operator_id,
+            &request_idempotency_key,
+        )
+        .await?
+        {
+            ensure_sponsor_record_payload_hash_matches(&existing, &payload_hash)?;
+            existing
+        } else {
+            let row = insert_sponsor_record_tx(
+                &tx,
+                &realm_id,
+                &sponsor_account_id,
+                &input.sponsor_status,
+                input.quota_total,
+                &input.status_reason_code,
+                &operator_id,
+                Some(request_idempotency_key),
+                Some(payload_hash),
+            )
+            .await?;
+            maybe_open_sponsor_concentration_trigger_tx(&tx, &realm_id, &sponsor_account_id)
+                .await?;
+            row
+        };
+
+        refresh_realm_projection_bundle_tx(&tx, &realm_id, None).await?;
+        tx.commit().await.map_err(db_error)?;
+        realm_sponsor_record_from_row(&row)
+    }
+
+    pub async fn create_realm_admission(
+        &self,
+        operator_id: &str,
+        realm_id: &str,
+        input: CreateRealmAdmissionInput,
+    ) -> Result<RealmAdmissionSnapshot, RealmBootstrapError> {
+        let operator_id = parse_uuid(operator_id, "operator id")?;
+        let realm_id = normalize_required(realm_id, "realm id")?;
+        let account_id = parse_uuid(&input.account_id, "account id")?;
+        ensure_non_empty("source_fact_kind", &input.source_fact_kind)?;
+        ensure_non_empty("source_fact_id", &input.source_fact_id)?;
+        let sponsor_record_id = parse_optional_uuid(&input.sponsor_record_id, "sponsor record id")?;
+        let request_idempotency_key = normalize_optional(input.request_idempotency_key.as_deref())
+            .ok_or_else(|| {
+                RealmBootstrapError::BadRequest(
+                    "admission creation requires request_idempotency_key".to_owned(),
+                )
+            })?;
+        let granted_by_actor_kind = operator_actor_kind(operator_id, self).await?;
+        let payload_hash = create_admission_payload_hash(
+            &input,
+            &account_id,
+            &sponsor_record_id,
+            &granted_by_actor_kind,
+        );
+
+        let mut client = self.client.lock().await;
+        let tx = client.transaction().await.map_err(db_error)?;
+        ensure_operator_role_tx(&tx, &operator_id, OPERATOR_WRITE_ROLES).await?;
+        ensure_active_account_exists_tx(&tx, &account_id).await?;
+        update_expired_corridors_tx(&tx, Some(&realm_id)).await?;
+
+        let row = if let Some(existing) =
+            find_admission_by_idempotency_tx(&tx, &realm_id, &operator_id, &request_idempotency_key)
+                .await?
+        {
+            ensure_admission_payload_hash_matches(&existing, &payload_hash)?;
+            existing
+        } else {
+            let realm_row = lock_realm_tx(&tx, &realm_id).await?;
+            let realm_status: String = realm_row.get("realm_status");
+            if matches!(realm_status.as_str(), "restricted" | "suspended") {
+                return Err(RealmBootstrapError::BadRequest(
+                    "restricted or suspended realms cannot admit new members".to_owned(),
+                ));
+            }
+            let active_corridor = find_current_corridor_tx(&tx, &realm_id).await?;
+            let latest_corridor_status = find_latest_corridor_status_tx(&tx, &realm_id).await?;
+            let admission_context = derive_admission_context_tx(
+                &tx,
+                &realm_id,
+                &realm_status,
+                sponsor_record_id.as_ref(),
+                active_corridor.as_ref(),
+                latest_corridor_status.as_deref(),
+            )
+            .await?;
+
+            if let Some(trigger) = admission_context.open_trigger.as_ref() {
+                open_trigger_tx(
+                    &tx,
+                    Some(&realm_id),
+                    trigger.kind,
+                    trigger.reason_code,
+                    Some(&account_id),
+                    None,
+                    sponsor_record_id.as_ref(),
+                    &trigger.context_json,
+                    &trigger.fingerprint,
+                )
+                .await?;
+            }
+
+            let row = tx
+                .query_one(
+                    "
+                    INSERT INTO dao.realm_admissions (
+                        realm_admission_id,
+                        realm_id,
+                        account_id,
+                        admission_kind,
+                        admission_status,
+                        sponsor_record_id,
+                        bootstrap_corridor_id,
+                        granted_by_actor_kind,
+                        granted_by_actor_id,
+                        review_reason_code,
+                        source_fact_kind,
+                        source_fact_id,
+                        source_snapshot_json,
+                        request_idempotency_key,
+                        request_payload_hash
+                    )
+                    VALUES (
+                        $1, $2, $3, $4, $5, $6, $7,
+                        $8, $9, $10, $11, $12, $13, $14, $15
+                    )
+                    RETURNING *
+                    ",
+                    &[
+                        &Uuid::new_v4(),
+                        &realm_id,
+                        &account_id,
+                        &admission_context.admission_kind,
+                        &admission_context.admission_status,
+                        &sponsor_record_id,
+                        &admission_context.bootstrap_corridor_id,
+                        &granted_by_actor_kind,
+                        &operator_id,
+                        &admission_context.reason_code,
+                        &input.source_fact_kind,
+                        &input.source_fact_id,
+                        &input.source_snapshot_json,
+                        &Some(request_idempotency_key),
+                        &payload_hash,
+                    ],
+                )
+                .await
+                .map_err(db_error)?;
+            maybe_open_member_overlap_trigger_tx(&tx, &realm_id, &account_id).await?;
+            row
+        };
+
+        let refreshed_admission: RealmAdmissionSnapshot = realm_admission_from_row(&row)?;
+        refresh_realm_projection_bundle_tx(
+            &tx,
+            &realm_id,
+            Some(&parse_uuid(&refreshed_admission.account_id, "account id")?),
+        )
+        .await?;
+        tx.commit().await.map_err(db_error)?;
+        Ok(refreshed_admission)
+    }
+
+    pub async fn get_bootstrap_summary_for_viewer(
+        &self,
+        viewer_account_id: &str,
+        realm_id: &str,
+    ) -> Result<RealmBootstrapSummarySnapshot, RealmBootstrapError> {
+        let viewer_account_id = parse_uuid(viewer_account_id, "viewer account id")?;
+        let realm_id = normalize_required(realm_id, "realm id")?;
+        let client = self.client.lock().await;
+
+        let bootstrap_row = client
+            .query_opt(
+                "
+                SELECT *
+                FROM projection.realm_bootstrap_views
+                WHERE realm_id = $1
+                ",
+                &[&realm_id],
+            )
+            .await
+            .map_err(db_error)?
+            .ok_or_else(|| {
+                RealmBootstrapError::NotFound("realm bootstrap summary was not found".to_owned())
+            })?;
+
+        let request_row = client
+            .query_opt(
+                "
+                SELECT
+                    request.*,
+                    realm.realm_id AS created_realm_id
+                FROM dao.realms realm
+                JOIN dao.realm_requests request
+                  ON request.realm_request_id = realm.created_from_realm_request_id
+                WHERE realm.realm_id = $1
+                  AND request.requested_by_account_id = $2
+                ",
+                &[&realm_id, &viewer_account_id],
+            )
+            .await
+            .map_err(db_error)?;
+        let admission_row = client
+            .query_opt(
+                "
+                SELECT *
+                FROM projection.realm_admission_views
+                WHERE realm_id = $1
+                  AND account_id = $2
+                ",
+                &[&realm_id, &viewer_account_id],
+            )
+            .await
+            .map_err(db_error)?;
+
+        if request_row.is_none() && admission_row.is_none() {
+            return Err(RealmBootstrapError::NotFound(
+                "realm bootstrap summary was not found".to_owned(),
+            ));
+        }
+
+        Ok(RealmBootstrapSummarySnapshot {
+            realm_request: request_row
+                .as_ref()
+                .map(realm_request_from_row)
+                .transpose()?,
+            bootstrap_view: realm_bootstrap_view_from_row(&bootstrap_row)?,
+            admission_view: admission_row
+                .as_ref()
+                .map(realm_admission_view_from_row)
+                .transpose()?,
+        })
+    }
+
+    pub async fn get_review_summary_for_operator(
+        &self,
+        operator_id: &str,
+        realm_id: &str,
+    ) -> Result<RealmReviewSummarySnapshot, RealmBootstrapError> {
+        let operator_id = parse_uuid(operator_id, "operator id")?;
+        let realm_id = normalize_required(realm_id, "realm id")?;
+        let client = self.client.lock().await;
+        ensure_operator_role_tx(&*client, &operator_id, OPERATOR_READ_ROLES).await?;
+        let row = client
+            .query_opt(
+                "
+                SELECT *
+                FROM projection.realm_review_summaries
+                WHERE realm_id = $1
+                ",
+                &[&realm_id],
+            )
+            .await
+            .map_err(db_error)?
+            .ok_or_else(|| {
+                RealmBootstrapError::NotFound("realm review summary was not found".to_owned())
+            })?;
+        let trigger_rows = client
+            .query(
+                "
+                SELECT *
+                FROM dao.realm_review_triggers
+                WHERE realm_id = $1
+                  AND trigger_state = 'open'
+                ORDER BY created_at DESC, realm_review_trigger_id DESC
+                ",
+                &[&realm_id],
+            )
+            .await
+            .map_err(db_error)?;
+        realm_review_summary_from_row(&row, &trigger_rows)
+    }
+
+    pub async fn rebuild_realm_bootstrap_views(
+        &self,
+    ) -> Result<RealmBootstrapRebuildSnapshot, RealmBootstrapError> {
+        let mut client = self.client.lock().await;
+        let tx = client.transaction().await.map_err(db_error)?;
+        update_expired_corridors_tx(&tx, None).await?;
+
+        let realm_rows = tx
+            .query(
+                "
+                SELECT realm_id
+                FROM dao.realms
+                ORDER BY realm_id
+                ",
+                &[],
+            )
+            .await
+            .map_err(db_error)?;
+        tx.execute("DELETE FROM projection.realm_admission_views", &[])
+            .await
+            .map_err(db_error)?;
+        tx.execute("DELETE FROM projection.realm_review_summaries", &[])
+            .await
+            .map_err(db_error)?;
+        tx.execute("DELETE FROM projection.realm_bootstrap_views", &[])
+            .await
+            .map_err(db_error)?;
+
+        let rebuild_generation = current_rebuild_generation_tx(&tx).await?;
+        for row in &realm_rows {
+            let realm_id: String = row.get("realm_id");
+            refresh_realm_bootstrap_view_tx(&tx, &realm_id, Some(rebuild_generation)).await?;
+            refresh_realm_review_summary_tx(&tx, &realm_id, Some(rebuild_generation)).await?;
+        }
+
+        let admission_rows = tx
+            .query(
+                "
+                SELECT DISTINCT realm_id, account_id
+                FROM dao.realm_admissions
+                ORDER BY realm_id, account_id
+                ",
+                &[],
+            )
+            .await
+            .map_err(db_error)?;
+        for row in &admission_rows {
+            let realm_id: String = row.get("realm_id");
+            let account_id: Uuid = row.get("account_id");
+            refresh_realm_admission_view_tx(&tx, &realm_id, &account_id, Some(rebuild_generation))
+                .await?;
+        }
+
+        let bootstrap_view_count = tx
+            .query_one(
+                "SELECT COUNT(*) AS count FROM projection.realm_bootstrap_views",
+                &[],
+            )
+            .await
+            .map_err(db_error)?
+            .get::<_, i64>("count");
+        let admission_view_count = tx
+            .query_one(
+                "SELECT COUNT(*) AS count FROM projection.realm_admission_views",
+                &[],
+            )
+            .await
+            .map_err(db_error)?
+            .get::<_, i64>("count");
+        let review_summary_count = tx
+            .query_one(
+                "SELECT COUNT(*) AS count FROM projection.realm_review_summaries",
+                &[],
+            )
+            .await
+            .map_err(db_error)?
+            .get::<_, i64>("count");
+
+        tx.commit().await.map_err(db_error)?;
+        Ok(RealmBootstrapRebuildSnapshot {
+            bootstrap_view_count,
+            admission_view_count,
+            review_summary_count,
+        })
+    }
+}
+
+#[derive(Debug)]
+struct TriggerIntent {
+    kind: &'static str,
+    reason_code: &'static str,
+    context_json: Value,
+    fingerprint: String,
+}
+
+#[derive(Debug)]
+struct AdmissionContext {
+    admission_kind: &'static str,
+    admission_status: &'static str,
+    reason_code: &'static str,
+    bootstrap_corridor_id: Option<Uuid>,
+    open_trigger: Option<TriggerIntent>,
+}
+
+fn limited_bootstrap_without_active_corridor_context(
+    latest_corridor_status: Option<&str>,
+) -> AdmissionContext {
+    let reason_code = match latest_corridor_status {
+        Some("expired") => "bootstrap_expired",
+        Some("disabled_by_operator") => "operator_restriction",
+        _ => "review_required",
+    };
+    AdmissionContext {
+        admission_kind: "review_required",
+        admission_status: "pending",
+        reason_code,
+        bootstrap_corridor_id: None,
+        open_trigger: None,
+    }
+}
+
+async fn maybe_open_realm_request_triggers_tx<C: GenericClient + Sync>(
+    client: &C,
+    realm_request_id: &Uuid,
+    requester_account_id: &Uuid,
+    venue_context_json: &Value,
+) -> Result<bool, RealmBootstrapError> {
+    let mut requires_review = false;
+    let rejected_count = client
+        .query_one(
+            "
+            SELECT COUNT(*) AS count
+            FROM dao.realm_requests
+            WHERE requested_by_account_id = $1
+              AND request_state = 'rejected'
+            ",
+            &[requester_account_id],
+        )
+        .await
+        .map_err(db_error)?
+        .get::<_, i64>("count");
+    if rejected_count >= 2 {
+        requires_review = true;
+        open_trigger_tx(
+            client,
+            None,
+            "repeated_rejected_requests",
+            "review_required",
+            Some(requester_account_id),
+            Some(realm_request_id),
+            None,
+            &json!({ "rejected_request_count": rejected_count }),
+            &format!("repeated-rejected-requests:{requester_account_id}"),
+        )
+        .await?;
+    }
+
+    let duplicate_count = client
+        .query_one(
+            "
+            SELECT COUNT(*) AS count
+            FROM dao.realm_requests
+            WHERE realm_request_id <> $1
+              AND venue_context_json = $2
+              AND request_state IN ('requested', 'pending_review', 'approved')
+            ",
+            &[realm_request_id, venue_context_json],
+        )
+        .await
+        .map_err(db_error)?
+        .get::<_, i64>("count");
+    if duplicate_count > 0 {
+        requires_review = true;
+        open_trigger_tx(
+            client,
+            None,
+            "duplicate_venue_context",
+            "duplicate_or_invalid",
+            Some(requester_account_id),
+            Some(realm_request_id),
+            None,
+            &json!({ "matching_request_count": duplicate_count }),
+            &format!(
+                "duplicate-venue-context:{}",
+                hash_json_value(venue_context_json)
+            ),
+        )
+        .await?;
+    }
+
+    Ok(requires_review)
+}
+
+async fn maybe_open_repeated_rejection_trigger_tx<C: GenericClient + Sync>(
+    client: &C,
+    realm_request_id: &Uuid,
+) -> Result<(), RealmBootstrapError> {
+    let row = client
+        .query_one(
+            "
+            SELECT requested_by_account_id
+            FROM dao.realm_requests
+            WHERE realm_request_id = $1
+            ",
+            &[realm_request_id],
+        )
+        .await
+        .map_err(db_error)?;
+    let requester_account_id: Uuid = row.get("requested_by_account_id");
+    let rejected_count = client
+        .query_one(
+            "
+            SELECT COUNT(*) AS count
+            FROM dao.realm_requests
+            WHERE requested_by_account_id = $1
+              AND request_state = 'rejected'
+            ",
+            &[&requester_account_id],
+        )
+        .await
+        .map_err(db_error)?
+        .get::<_, i64>("count");
+    if rejected_count >= 2 {
+        open_trigger_tx(
+            client,
+            None,
+            "repeated_rejected_requests",
+            "review_required",
+            Some(&requester_account_id),
+            Some(realm_request_id),
+            None,
+            &json!({ "rejected_request_count": rejected_count }),
+            &format!("repeated-rejected-requests:{requester_account_id}"),
+        )
+        .await?;
+    }
+    Ok(())
+}
+
+async fn maybe_open_member_overlap_trigger_tx<C: GenericClient + Sync>(
+    client: &C,
+    realm_id: &str,
+    account_id: &Uuid,
+) -> Result<(), RealmBootstrapError> {
+    let count = client
+        .query_one(
+            "
+            SELECT COUNT(DISTINCT realm_id) AS count
+            FROM dao.realm_admissions
+            WHERE account_id = $1
+              AND admission_status IN ('pending', 'admitted')
+            ",
+            &[account_id],
+        )
+        .await
+        .map_err(db_error)?
+        .get::<_, i64>("count");
+    if count >= 3 {
+        open_trigger_tx(
+            client,
+            Some(realm_id),
+            "suspicious_member_overlap",
+            "review_required",
+            Some(account_id),
+            None,
+            None,
+            &json!({ "active_realm_count": count }),
+            &format!("member-overlap:{account_id}"),
+        )
+        .await?;
+    }
+    Ok(())
+}
+
+async fn maybe_open_sponsor_concentration_trigger_tx<C: GenericClient + Sync>(
+    client: &C,
+    realm_id: &str,
+    sponsor_account_id: &Uuid,
+) -> Result<(), RealmBootstrapError> {
+    let count = client
+        .query_one(
+            "
+            SELECT COUNT(*) AS count
+            FROM dao.realm_sponsor_records
+            WHERE sponsor_account_id = $1
+              AND sponsor_status IN ('approved', 'active', 'rate_limited')
+            ",
+            &[sponsor_account_id],
+        )
+        .await
+        .map_err(db_error)?
+        .get::<_, i64>("count");
+    if count >= 3 {
+        open_trigger_tx(
+            client,
+            Some(realm_id),
+            "sponsor_concentration",
+            "review_required",
+            Some(sponsor_account_id),
+            None,
+            None,
+            &json!({ "active_sponsor_record_count": count }),
+            &format!("sponsor-concentration:{sponsor_account_id}"),
+        )
+        .await?;
+    }
+    Ok(())
+}
+
+async fn derive_admission_context_tx<C: GenericClient + Sync>(
+    client: &C,
+    realm_id: &str,
+    realm_status: &str,
+    sponsor_record_id: Option<&Uuid>,
+    active_corridor: Option<&Row>,
+    latest_corridor_status: Option<&str>,
+) -> Result<AdmissionContext, RealmBootstrapError> {
+    let active_corridor_id = active_corridor.map(|row| row.get::<_, Uuid>("bootstrap_corridor_id"));
+    let corridor_status = latest_corridor_status.unwrap_or("none");
+    let active_corridor_member_count = if let Some(corridor_id) = active_corridor_id.as_ref() {
+        count_corridor_admissions_tx(client, corridor_id).await?
+    } else {
+        0
+    };
+
+    if let Some(sponsor_record_id) = sponsor_record_id {
+        let sponsor_row = lock_sponsor_record_tx(client, sponsor_record_id).await?;
+        let sponsor_realm_id: String = sponsor_row.get("realm_id");
+        if sponsor_realm_id != realm_id {
+            return Err(RealmBootstrapError::BadRequest(
+                "sponsor record does not belong to this realm".to_owned(),
+            ));
+        }
+        if realm_status == "limited_bootstrap" && active_corridor.is_none() {
+            return Ok(limited_bootstrap_without_active_corridor_context(
+                latest_corridor_status,
+            ));
+        }
+        let sponsor_status: String = sponsor_row.get("sponsor_status");
+        let sponsor_quota_total: i64 = sponsor_row.get("quota_total");
+        let sponsor_used_count =
+            count_sponsor_backed_admissions_tx(client, sponsor_record_id).await?;
+        if sponsor_status == "revoked" {
+            return Ok(AdmissionContext {
+                admission_kind: "review_required",
+                admission_status: "pending",
+                reason_code: "sponsor_revoked",
+                bootstrap_corridor_id: active_corridor_id,
+                open_trigger: Some(trigger_intent(
+                    "revoked_sponsor_lineage",
+                    "sponsor_revoked",
+                    json!({ "sponsor_record_id": sponsor_record_id.to_string() }),
+                    format!("revoked-sponsor:{sponsor_record_id}"),
+                )),
+            });
+        }
+        if sponsor_status == "rate_limited" {
+            return Ok(AdmissionContext {
+                admission_kind: "review_required",
+                admission_status: "pending",
+                reason_code: "sponsor_rate_limited",
+                bootstrap_corridor_id: active_corridor_id,
+                open_trigger: Some(trigger_intent(
+                    "quota_abuse",
+                    "sponsor_rate_limited",
+                    json!({ "sponsor_record_id": sponsor_record_id.to_string() }),
+                    format!("quota-abuse:{sponsor_record_id}"),
+                )),
+            });
+        }
+        if !matches!(sponsor_status.as_str(), "approved" | "active") {
+            return Ok(AdmissionContext {
+                admission_kind: "review_required",
+                admission_status: "pending",
+                reason_code: "review_required",
+                bootstrap_corridor_id: active_corridor_id,
+                open_trigger: None,
+            });
+        }
+        if sponsor_used_count >= sponsor_quota_total {
+            return Ok(AdmissionContext {
+                admission_kind: "review_required",
+                admission_status: "pending",
+                reason_code: "bootstrap_capacity_reached",
+                bootstrap_corridor_id: active_corridor_id,
+                open_trigger: Some(trigger_intent(
+                    "quota_exceeded",
+                    "bootstrap_capacity_reached",
+                    json!({
+                        "sponsor_record_id": sponsor_record_id.to_string(),
+                        "quota_total": sponsor_quota_total,
+                        "used_count": sponsor_used_count,
+                    }),
+                    format!("quota-exceeded:{sponsor_record_id}"),
+                )),
+            });
+        }
+        if let Some(corridor_row) = active_corridor {
+            let member_cap: i64 = corridor_row.get("member_cap");
+            if active_corridor_member_count >= member_cap {
+                return Ok(AdmissionContext {
+                    admission_kind: "review_required",
+                    admission_status: "pending",
+                    reason_code: "bootstrap_capacity_reached",
+                    bootstrap_corridor_id: active_corridor_id,
+                    open_trigger: Some(trigger_intent(
+                        "corridor_cap_pressure",
+                        "bootstrap_capacity_reached",
+                        json!({
+                            "bootstrap_corridor_id": corridor_row.get::<_, Uuid>("bootstrap_corridor_id").to_string(),
+                            "member_cap": member_cap,
+                            "active_corridor_member_count": active_corridor_member_count,
+                        }),
+                        format!(
+                            "corridor-member-cap:{}",
+                            corridor_row.get::<_, Uuid>("bootstrap_corridor_id")
+                        ),
+                    )),
+                });
+            }
+            let sponsor_cap: i64 = corridor_row.get("sponsor_cap");
+            let sponsor_slots =
+                count_distinct_corridor_sponsors_tx(client, sponsor_record_id, corridor_row)
+                    .await?;
+            let sponsor_already_present =
+                corridor_contains_sponsor_record_tx(client, sponsor_record_id, corridor_row)
+                    .await?;
+            if !sponsor_already_present && sponsor_slots >= sponsor_cap {
+                return Ok(AdmissionContext {
+                    admission_kind: "review_required",
+                    admission_status: "pending",
+                    reason_code: "bootstrap_capacity_reached",
+                    bootstrap_corridor_id: active_corridor_id,
+                    open_trigger: Some(trigger_intent(
+                        "corridor_cap_pressure",
+                        "bootstrap_capacity_reached",
+                        json!({
+                            "bootstrap_corridor_id": corridor_row.get::<_, Uuid>("bootstrap_corridor_id").to_string(),
+                            "sponsor_cap": sponsor_cap,
+                            "distinct_sponsor_count": sponsor_slots,
+                        }),
+                        format!(
+                            "corridor-sponsor-cap:{}",
+                            corridor_row.get::<_, Uuid>("bootstrap_corridor_id")
+                        ),
+                    )),
+                });
+            }
+        }
+        let reason_code = if realm_status == "active" {
+            "active_after_review"
+        } else {
+            "limited_bootstrap_active"
+        };
+        return Ok(AdmissionContext {
+            admission_kind: "sponsor_backed",
+            admission_status: "admitted",
+            reason_code,
+            bootstrap_corridor_id: active_corridor_id,
+            open_trigger: None,
+        });
+    }
+
+    if let Some(corridor_row) = active_corridor {
+        let member_cap: i64 = corridor_row.get("member_cap");
+        if active_corridor_member_count >= member_cap {
+            return Ok(AdmissionContext {
+                admission_kind: "review_required",
+                admission_status: "pending",
+                reason_code: "bootstrap_capacity_reached",
+                bootstrap_corridor_id: active_corridor_id,
+                open_trigger: Some(trigger_intent(
+                    "corridor_cap_pressure",
+                    "bootstrap_capacity_reached",
+                    json!({
+                        "bootstrap_corridor_id": corridor_row.get::<_, Uuid>("bootstrap_corridor_id").to_string(),
+                        "member_cap": member_cap,
+                        "active_corridor_member_count": active_corridor_member_count,
+                    }),
+                    format!(
+                        "corridor-member-cap:{}",
+                        corridor_row.get::<_, Uuid>("bootstrap_corridor_id")
+                    ),
+                )),
+            });
+        }
+        return Ok(AdmissionContext {
+            admission_kind: "corridor",
+            admission_status: "admitted",
+            reason_code: "limited_bootstrap_active",
+            bootstrap_corridor_id: active_corridor_id,
+            open_trigger: None,
+        });
+    }
+
+    let (admission_kind, reason_code) = match realm_status {
+        "active" => ("normal", "active_after_review"),
+        "limited_bootstrap" if corridor_status == "expired" => {
+            ("review_required", "bootstrap_expired")
+        }
+        "limited_bootstrap" if corridor_status == "disabled_by_operator" => {
+            ("review_required", "operator_restriction")
+        }
+        "limited_bootstrap" => ("review_required", "review_required"),
+        _ => ("review_required", "review_required"),
+    };
+    Ok(AdmissionContext {
+        admission_kind,
+        admission_status: if realm_status == "active" {
+            "admitted"
+        } else {
+            "pending"
+        },
+        reason_code,
+        bootstrap_corridor_id: None,
+        open_trigger: None,
+    })
+}
+
+async fn insert_sponsor_record_tx<C: GenericClient + Sync>(
+    client: &C,
+    realm_id: &str,
+    sponsor_account_id: &Uuid,
+    sponsor_status: &str,
+    quota_total: i64,
+    status_reason_code: &str,
+    approved_by_operator_id: &Uuid,
+    request_idempotency_key: Option<String>,
+    request_payload_hash: Option<String>,
+) -> Result<Row, RealmBootstrapError> {
+    client
+        .query_one(
+            "
+            INSERT INTO dao.realm_sponsor_records (
+                realm_sponsor_record_id,
+                realm_id,
+                sponsor_account_id,
+                sponsor_status,
+                quota_total,
+                status_reason_code,
+                approved_by_operator_id,
+                request_idempotency_key,
+                request_payload_hash
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, COALESCE($9, repeat('0', 64)))
+            RETURNING *
+            ",
+            &[
+                &Uuid::new_v4(),
+                &realm_id,
+                sponsor_account_id,
+                &sponsor_status,
+                &quota_total,
+                &status_reason_code,
+                approved_by_operator_id,
+                &request_idempotency_key,
+                &request_payload_hash,
+            ],
+        )
+        .await
+        .map_err(db_error)
+}
+
+async fn insert_bootstrap_corridor_tx<C: GenericClient + Sync>(
+    client: &C,
+    realm_id: &str,
+    input: &ReviewRealmRequestInput,
+    operator_id: &Uuid,
+) -> Result<(), RealmBootstrapError> {
+    let starts_at = input.corridor_starts_at.ok_or_else(|| {
+        RealmBootstrapError::BadRequest("corridor_starts_at is required".to_owned())
+    })?;
+    let ends_at = input.corridor_ends_at.ok_or_else(|| {
+        RealmBootstrapError::BadRequest("corridor_ends_at is required".to_owned())
+    })?;
+    let member_cap = input.corridor_member_cap.ok_or_else(|| {
+        RealmBootstrapError::BadRequest("corridor_member_cap is required".to_owned())
+    })?;
+    let sponsor_cap = input.corridor_sponsor_cap.ok_or_else(|| {
+        RealmBootstrapError::BadRequest("corridor_sponsor_cap is required".to_owned())
+    })?;
+    if member_cap <= 0 || sponsor_cap <= 0 {
+        return Err(RealmBootstrapError::BadRequest(
+            "corridor caps must be positive".to_owned(),
+        ));
+    }
+    if starts_at >= ends_at {
+        return Err(RealmBootstrapError::BadRequest(
+            "corridor_starts_at must be earlier than corridor_ends_at".to_owned(),
+        ));
+    }
+    if starts_at > Utc::now() {
+        return Err(RealmBootstrapError::BadRequest(
+            "corridor_starts_at must not be in the future for Day 1 bootstrap activation"
+                .to_owned(),
+        ));
+    }
+    if ends_at <= Utc::now() {
+        return Err(RealmBootstrapError::BadRequest(
+            "corridor_ends_at must be in the future for Day 1 bootstrap activation".to_owned(),
+        ));
+    }
+    client
+        .execute(
+            "
+            INSERT INTO dao.bootstrap_corridors (
+                bootstrap_corridor_id,
+                realm_id,
+                corridor_status,
+                starts_at,
+                ends_at,
+                member_cap,
+                sponsor_cap,
+                review_threshold_json,
+                created_by_operator_id
+            )
+            VALUES ($1, $2, 'active', $3, $4, $5, $6, $7, $8)
+            ",
+            &[
+                &Uuid::new_v4(),
+                &realm_id,
+                &starts_at,
+                &ends_at,
+                &member_cap,
+                &sponsor_cap,
+                &input.review_threshold_json,
+                operator_id,
+            ],
+        )
+        .await
+        .map_err(db_error)?;
+    Ok(())
+}
+
+async fn refresh_realm_projection_bundle_tx<C: GenericClient + Sync>(
+    client: &C,
+    realm_id: &str,
+    account_id: Option<&Uuid>,
+) -> Result<(), RealmBootstrapError> {
+    refresh_realm_bootstrap_view_tx(client, realm_id, None).await?;
+    refresh_realm_review_summary_tx(client, realm_id, None).await?;
+    if let Some(account_id) = account_id {
+        refresh_realm_admission_view_tx(client, realm_id, account_id, None).await?;
+    }
+    Ok(())
+}
+
+async fn refresh_realm_bootstrap_view_tx<C: GenericClient + Sync>(
+    client: &C,
+    realm_id: &str,
+    rebuild_generation: Option<i64>,
+) -> Result<(), RealmBootstrapError> {
+    let row = client
+        .query_one(
+            "
+            WITH latest_corridor AS (
+                SELECT *
+                FROM dao.bootstrap_corridors
+                WHERE realm_id = $1
+                ORDER BY updated_at DESC, bootstrap_corridor_id DESC
+                LIMIT 1
+            ),
+            sponsor_counts AS (
+                SELECT
+                    COUNT(*) FILTER (WHERE sponsor_status IN ('approved', 'active', 'rate_limited')) AS active_sponsor_count
+                FROM dao.realm_sponsor_records
+                WHERE realm_id = $1
+            ),
+            source_counts AS (
+                SELECT
+                    1
+                    + COALESCE((SELECT COUNT(*) FROM dao.realm_sponsor_records WHERE realm_id = $1), 0)
+                    + COALESCE((SELECT COUNT(*) FROM dao.realm_admissions WHERE realm_id = $1), 0)
+                    + COALESCE((SELECT COUNT(*) FROM dao.bootstrap_corridors WHERE realm_id = $1), 0)
+                    + COALESCE((SELECT COUNT(*) FROM dao.realm_review_triggers WHERE realm_id = $1), 0)
+                    AS source_fact_count
+            ),
+            watermarks AS (
+                SELECT GREATEST(
+                    realm.updated_at,
+                    COALESCE((SELECT MAX(updated_at) FROM dao.realm_sponsor_records WHERE realm_id = $1), realm.updated_at),
+                    COALESCE((SELECT MAX(updated_at) FROM dao.realm_admissions WHERE realm_id = $1), realm.updated_at),
+                    COALESCE((SELECT MAX(updated_at) FROM dao.bootstrap_corridors WHERE realm_id = $1), realm.updated_at),
+                    COALESCE((SELECT MAX(updated_at) FROM dao.realm_review_triggers WHERE realm_id = $1), realm.updated_at)
+                ) AS source_watermark_at
+                FROM dao.realms realm
+                WHERE realm.realm_id = $1
+            )
+            SELECT
+                realm.slug,
+                realm.display_name,
+                realm.realm_status,
+                realm.public_reason_code,
+                COALESCE((SELECT corridor_status FROM latest_corridor), 'none') AS corridor_status,
+                CASE
+                    WHEN realm.realm_status IN ('restricted', 'suspended') THEN 'closed'
+                    WHEN realm.realm_status = 'active' THEN 'open'
+                    WHEN realm.realm_status = 'limited_bootstrap' AND EXISTS (
+                        SELECT 1
+                        FROM latest_corridor
+                        WHERE corridor_status = 'active'
+                          AND starts_at <= CURRENT_TIMESTAMP
+                          AND ends_at > CURRENT_TIMESTAMP
+                    ) THEN 'limited'
+                    ELSE 'review_required'
+                END AS admission_posture,
+                CASE
+                    WHEN COALESCE((SELECT active_sponsor_count FROM sponsor_counts), 0) > 0
+                         AND realm.steward_account_id IS NOT NULL THEN 'sponsor_and_steward'
+                    WHEN COALESCE((SELECT active_sponsor_count FROM sponsor_counts), 0) > 0 THEN 'sponsor_backed'
+                    WHEN realm.steward_account_id IS NOT NULL THEN 'steward_present'
+                    ELSE 'none'
+                END AS sponsor_display_state,
+                (SELECT source_watermark_at FROM watermarks) AS source_watermark_at,
+                (SELECT source_fact_count FROM source_counts) AS source_fact_count
+            FROM dao.realms realm
+            WHERE realm.realm_id = $1
+            ",
+            &[&realm_id],
+        )
+        .await
+        .map_err(db_error)?;
+
+    let source_watermark_at: DateTime<Utc> = row.get("source_watermark_at");
+    let projection_lag_ms = (Utc::now() - source_watermark_at).num_milliseconds().max(0);
+    client
+        .execute(
+            "
+            INSERT INTO projection.realm_bootstrap_views (
+                realm_id,
+                slug,
+                display_name,
+                realm_status,
+                admission_posture,
+                corridor_status,
+                public_reason_code,
+                sponsor_display_state,
+                source_watermark_at,
+                source_fact_count,
+                projection_lag_ms,
+                rebuild_generation,
+                last_projected_at
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, COALESCE($12, 1::bigint), CURRENT_TIMESTAMP)
+            ON CONFLICT (realm_id) DO UPDATE
+            SET slug = EXCLUDED.slug,
+                display_name = EXCLUDED.display_name,
+                realm_status = EXCLUDED.realm_status,
+                admission_posture = EXCLUDED.admission_posture,
+                corridor_status = EXCLUDED.corridor_status,
+                public_reason_code = EXCLUDED.public_reason_code,
+                sponsor_display_state = EXCLUDED.sponsor_display_state,
+                source_watermark_at = EXCLUDED.source_watermark_at,
+                source_fact_count = EXCLUDED.source_fact_count,
+                projection_lag_ms = EXCLUDED.projection_lag_ms,
+                rebuild_generation = COALESCE($12, projection.realm_bootstrap_views.rebuild_generation + 1),
+                last_projected_at = CURRENT_TIMESTAMP
+            ",
+            &[
+                &realm_id,
+                &row.get::<_, String>("slug"),
+                &row.get::<_, String>("display_name"),
+                &row.get::<_, String>("realm_status"),
+                &row.get::<_, String>("admission_posture"),
+                &row.get::<_, String>("corridor_status"),
+                &row.get::<_, String>("public_reason_code"),
+                &row.get::<_, String>("sponsor_display_state"),
+                &source_watermark_at,
+                &row.get::<_, i64>("source_fact_count"),
+                &projection_lag_ms,
+                &rebuild_generation,
+            ],
+        )
+        .await
+        .map_err(db_error)?;
+    Ok(())
+}
+
+async fn refresh_realm_admission_view_tx<C: GenericClient + Sync>(
+    client: &C,
+    realm_id: &str,
+    account_id: &Uuid,
+    rebuild_generation: Option<i64>,
+) -> Result<(), RealmBootstrapError> {
+    let row = client
+        .query_opt(
+            "
+            WITH latest_admission AS (
+                SELECT *
+                FROM dao.realm_admissions
+                WHERE realm_id = $1
+                  AND account_id = $2
+                ORDER BY updated_at DESC, realm_admission_id DESC
+                LIMIT 1
+            ),
+            source_counts AS (
+                SELECT COUNT(*) AS source_fact_count
+                FROM dao.realm_admissions
+                WHERE realm_id = $1
+                  AND account_id = $2
+            )
+            SELECT
+                latest_admission.admission_status,
+                latest_admission.admission_kind,
+                latest_admission.review_reason_code AS public_reason_code,
+                latest_admission.updated_at AS source_watermark_at,
+                (SELECT source_fact_count FROM source_counts) AS source_fact_count
+            FROM latest_admission
+            ",
+            &[&realm_id, account_id],
+        )
+        .await
+        .map_err(db_error)?;
+
+    let Some(row) = row else {
+        client
+            .execute(
+                "
+                DELETE FROM projection.realm_admission_views
+                WHERE realm_id = $1
+                  AND account_id = $2
+                ",
+                &[&realm_id, account_id],
+            )
+            .await
+            .map_err(db_error)?;
+        return Ok(());
+    };
+
+    let source_watermark_at: DateTime<Utc> = row.get("source_watermark_at");
+    let projection_lag_ms = (Utc::now() - source_watermark_at).num_milliseconds().max(0);
+    client
+        .execute(
+            "
+            INSERT INTO projection.realm_admission_views (
+                realm_id,
+                account_id,
+                admission_status,
+                admission_kind,
+                public_reason_code,
+                source_watermark_at,
+                source_fact_count,
+                projection_lag_ms,
+                rebuild_generation,
+                last_projected_at
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, COALESCE($9, 1::bigint), CURRENT_TIMESTAMP)
+            ON CONFLICT (realm_id, account_id) DO UPDATE
+            SET admission_status = EXCLUDED.admission_status,
+                admission_kind = EXCLUDED.admission_kind,
+                public_reason_code = EXCLUDED.public_reason_code,
+                source_watermark_at = EXCLUDED.source_watermark_at,
+                source_fact_count = EXCLUDED.source_fact_count,
+                projection_lag_ms = EXCLUDED.projection_lag_ms,
+                rebuild_generation = COALESCE($9, projection.realm_admission_views.rebuild_generation + 1),
+                last_projected_at = CURRENT_TIMESTAMP
+            ",
+            &[
+                &realm_id,
+                account_id,
+                &row.get::<_, String>("admission_status"),
+                &row.get::<_, String>("admission_kind"),
+                &row.get::<_, String>("public_reason_code"),
+                &source_watermark_at,
+                &row.get::<_, i64>("source_fact_count"),
+                &projection_lag_ms,
+                &rebuild_generation,
+            ],
+        )
+        .await
+        .map_err(db_error)?;
+    Ok(())
+}
+
+async fn refresh_realm_review_summary_tx<C: GenericClient + Sync>(
+    client: &C,
+    realm_id: &str,
+    rebuild_generation: Option<i64>,
+) -> Result<(), RealmBootstrapError> {
+    let row = client
+        .query_one(
+            "
+            WITH latest_corridor AS (
+                SELECT *
+                FROM dao.bootstrap_corridors
+                WHERE realm_id = $1
+                ORDER BY updated_at DESC, bootstrap_corridor_id DESC
+                LIMIT 1
+            ),
+            active_sponsors AS (
+                SELECT COUNT(*) AS active_sponsor_count
+                FROM dao.realm_sponsor_records
+                WHERE realm_id = $1
+                  AND sponsor_status IN ('approved', 'active', 'rate_limited')
+            ),
+            sponsor_backed_admissions AS (
+                SELECT COUNT(*) AS sponsor_backed_admission_count
+                FROM dao.realm_admissions
+                WHERE realm_id = $1
+                  AND admission_kind = 'sponsor_backed'
+                  AND admission_status IN ('pending', 'admitted')
+            ),
+            recent_admissions AS (
+                SELECT COUNT(*) AS recent_admission_count_7d
+                FROM dao.realm_admissions
+                WHERE realm_id = $1
+                  AND created_at >= (CURRENT_TIMESTAMP - interval '7 days')
+            ),
+            open_triggers AS (
+                SELECT COUNT(*) AS open_review_trigger_count
+                FROM dao.realm_review_triggers
+                WHERE realm_id = $1
+                  AND trigger_state = 'open'
+            ),
+            open_cases AS (
+                SELECT COUNT(*) AS open_review_case_count
+                FROM dao.review_cases
+                WHERE related_realm_id = $1
+                  AND review_status <> 'closed'
+            ),
+            source_counts AS (
+                SELECT
+                    1
+                    + COALESCE((SELECT COUNT(*) FROM dao.realm_sponsor_records WHERE realm_id = $1), 0)
+                    + COALESCE((SELECT COUNT(*) FROM dao.realm_admissions WHERE realm_id = $1), 0)
+                    + COALESCE((SELECT COUNT(*) FROM dao.bootstrap_corridors WHERE realm_id = $1), 0)
+                    + COALESCE((SELECT COUNT(*) FROM dao.realm_review_triggers WHERE realm_id = $1), 0)
+                    + COALESCE((SELECT COUNT(*) FROM dao.review_cases WHERE related_realm_id = $1), 0)
+                    AS source_fact_count
+            ),
+            latest_reason AS (
+                SELECT redacted_reason_code
+                FROM dao.realm_review_triggers
+                WHERE realm_id = $1
+                ORDER BY updated_at DESC, realm_review_trigger_id DESC
+                LIMIT 1
+            ),
+            watermarks AS (
+                SELECT GREATEST(
+                    realm.updated_at,
+                    COALESCE((SELECT MAX(updated_at) FROM dao.realm_sponsor_records WHERE realm_id = $1), realm.updated_at),
+                    COALESCE((SELECT MAX(updated_at) FROM dao.realm_admissions WHERE realm_id = $1), realm.updated_at),
+                    COALESCE((SELECT MAX(updated_at) FROM dao.bootstrap_corridors WHERE realm_id = $1), realm.updated_at),
+                    COALESCE((SELECT MAX(updated_at) FROM dao.realm_review_triggers WHERE realm_id = $1), realm.updated_at),
+                    COALESCE((SELECT MAX(updated_at) FROM dao.review_cases WHERE related_realm_id = $1), realm.updated_at)
+                ) AS source_watermark_at
+                FROM dao.realms realm
+                WHERE realm.realm_id = $1
+            )
+            SELECT
+                realm.realm_status,
+                COALESCE((SELECT corridor_status FROM latest_corridor), 'none') AS corridor_status,
+                CASE
+                    WHEN EXISTS (SELECT 1 FROM latest_corridor)
+                        THEN GREATEST(EXTRACT(EPOCH FROM ((SELECT ends_at FROM latest_corridor) - CURRENT_TIMESTAMP))::bigint, 0)
+                    ELSE 0
+                END AS corridor_remaining_seconds,
+                (SELECT active_sponsor_count FROM active_sponsors) AS active_sponsor_count,
+                (SELECT sponsor_backed_admission_count FROM sponsor_backed_admissions) AS sponsor_backed_admission_count,
+                (SELECT recent_admission_count_7d FROM recent_admissions) AS recent_admission_count_7d,
+                (SELECT open_review_trigger_count FROM open_triggers) AS open_review_trigger_count,
+                (SELECT open_review_case_count FROM open_cases) AS open_review_case_count,
+                COALESCE((SELECT redacted_reason_code FROM latest_reason), realm.public_reason_code) AS latest_redacted_reason_code,
+                (SELECT source_watermark_at FROM watermarks) AS source_watermark_at,
+                (SELECT source_fact_count FROM source_counts) AS source_fact_count
+            FROM dao.realms realm
+            WHERE realm.realm_id = $1
+            ",
+            &[&realm_id],
+        )
+        .await
+        .map_err(db_error)?;
+    let source_watermark_at: DateTime<Utc> = row.get("source_watermark_at");
+    let projection_lag_ms = (Utc::now() - source_watermark_at).num_milliseconds().max(0);
+    client
+        .execute(
+            "
+            INSERT INTO projection.realm_review_summaries (
+                realm_id,
+                realm_status,
+                corridor_status,
+                corridor_remaining_seconds,
+                active_sponsor_count,
+                sponsor_backed_admission_count,
+                recent_admission_count_7d,
+                open_review_trigger_count,
+                open_review_case_count,
+                latest_redacted_reason_code,
+                source_watermark_at,
+                source_fact_count,
+                projection_lag_ms,
+                rebuild_generation,
+                last_projected_at
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, COALESCE($14, 1::bigint), CURRENT_TIMESTAMP)
+            ON CONFLICT (realm_id) DO UPDATE
+            SET realm_status = EXCLUDED.realm_status,
+                corridor_status = EXCLUDED.corridor_status,
+                corridor_remaining_seconds = EXCLUDED.corridor_remaining_seconds,
+                active_sponsor_count = EXCLUDED.active_sponsor_count,
+                sponsor_backed_admission_count = EXCLUDED.sponsor_backed_admission_count,
+                recent_admission_count_7d = EXCLUDED.recent_admission_count_7d,
+                open_review_trigger_count = EXCLUDED.open_review_trigger_count,
+                open_review_case_count = EXCLUDED.open_review_case_count,
+                latest_redacted_reason_code = EXCLUDED.latest_redacted_reason_code,
+                source_watermark_at = EXCLUDED.source_watermark_at,
+                source_fact_count = EXCLUDED.source_fact_count,
+                projection_lag_ms = EXCLUDED.projection_lag_ms,
+                rebuild_generation = COALESCE($14, projection.realm_review_summaries.rebuild_generation + 1),
+                last_projected_at = CURRENT_TIMESTAMP
+            ",
+            &[
+                &realm_id,
+                &row.get::<_, String>("realm_status"),
+                &row.get::<_, String>("corridor_status"),
+                &row.get::<_, i64>("corridor_remaining_seconds"),
+                &row.get::<_, i64>("active_sponsor_count"),
+                &row.get::<_, i64>("sponsor_backed_admission_count"),
+                &row.get::<_, i64>("recent_admission_count_7d"),
+                &row.get::<_, i64>("open_review_trigger_count"),
+                &row.get::<_, i64>("open_review_case_count"),
+                &row.get::<_, String>("latest_redacted_reason_code"),
+                &source_watermark_at,
+                &row.get::<_, i64>("source_fact_count"),
+                &projection_lag_ms,
+                &rebuild_generation,
+            ],
+        )
+        .await
+        .map_err(db_error)?;
+    Ok(())
+}
+
+async fn count_corridor_admissions_tx<C: GenericClient + Sync>(
+    client: &C,
+    corridor_id: &Uuid,
+) -> Result<i64, RealmBootstrapError> {
+    Ok(client
+        .query_one(
+            "
+            SELECT COUNT(*) AS count
+            FROM dao.realm_admissions
+            WHERE bootstrap_corridor_id = $1
+              AND admission_status IN ('pending', 'admitted')
+            ",
+            &[corridor_id],
+        )
+        .await
+        .map_err(db_error)?
+        .get("count"))
+}
+
+async fn count_sponsor_backed_admissions_tx<C: GenericClient + Sync>(
+    client: &C,
+    sponsor_record_id: &Uuid,
+) -> Result<i64, RealmBootstrapError> {
+    Ok(client
+        .query_one(
+            "
+            SELECT COUNT(*) AS count
+            FROM dao.realm_admissions
+            WHERE sponsor_record_id = $1
+              AND admission_status IN ('pending', 'admitted')
+            ",
+            &[sponsor_record_id],
+        )
+        .await
+        .map_err(db_error)?
+        .get("count"))
+}
+
+async fn count_distinct_corridor_sponsors_tx<C: GenericClient + Sync>(
+    client: &C,
+    sponsor_record_id: &Uuid,
+    corridor_row: &Row,
+) -> Result<i64, RealmBootstrapError> {
+    let corridor_id: Uuid = corridor_row.get("bootstrap_corridor_id");
+    let sponsor_realm_id: String = corridor_row.get("realm_id");
+    let current_sponsor_realm_id = client
+        .query_one(
+            "
+            SELECT realm_id
+            FROM dao.realm_sponsor_records
+            WHERE realm_sponsor_record_id = $1
+            ",
+            &[sponsor_record_id],
+        )
+        .await
+        .map_err(db_error)?
+        .get::<_, String>("realm_id");
+    if current_sponsor_realm_id != sponsor_realm_id {
+        return Err(RealmBootstrapError::BadRequest(
+            "sponsor record does not belong to the same realm".to_owned(),
+        ));
+    }
+    Ok(client
+        .query_one(
+            "
+            SELECT COUNT(DISTINCT sponsor_record_id) AS count
+            FROM dao.realm_admissions
+            WHERE bootstrap_corridor_id = $1
+              AND sponsor_record_id IS NOT NULL
+              AND admission_status IN ('pending', 'admitted')
+            ",
+            &[&corridor_id],
+        )
+        .await
+        .map_err(db_error)?
+        .get("count"))
+}
+
+async fn corridor_contains_sponsor_record_tx<C: GenericClient + Sync>(
+    client: &C,
+    sponsor_record_id: &Uuid,
+    corridor_row: &Row,
+) -> Result<bool, RealmBootstrapError> {
+    let corridor_id: Uuid = corridor_row.get("bootstrap_corridor_id");
+    Ok(client
+        .query_one(
+            "
+            SELECT EXISTS (
+                SELECT 1
+                FROM dao.realm_admissions
+                WHERE bootstrap_corridor_id = $1
+                  AND sponsor_record_id = $2
+                  AND admission_status IN ('pending', 'admitted')
+            ) AS sponsor_present
+            ",
+            &[&corridor_id, sponsor_record_id],
+        )
+        .await
+        .map_err(db_error)?
+        .get("sponsor_present"))
+}
+
+async fn update_expired_corridors_tx<C: GenericClient + Sync>(
+    client: &C,
+    realm_id: Option<&str>,
+) -> Result<(), RealmBootstrapError> {
+    if let Some(realm_id) = realm_id {
+        client
+            .execute(
+                "
+                UPDATE dao.bootstrap_corridors
+                SET corridor_status = 'expired',
+                    updated_at = CURRENT_TIMESTAMP
+                WHERE realm_id = $1
+                  AND corridor_status IN ('active', 'cooling_down')
+                  AND ends_at <= CURRENT_TIMESTAMP
+                ",
+                &[&realm_id],
+            )
+            .await
+            .map_err(db_error)?;
+    } else {
+        client
+            .execute(
+                "
+                UPDATE dao.bootstrap_corridors
+                SET corridor_status = 'expired',
+                    updated_at = CURRENT_TIMESTAMP
+                WHERE corridor_status IN ('active', 'cooling_down')
+                  AND ends_at <= CURRENT_TIMESTAMP
+                ",
+                &[],
+            )
+            .await
+            .map_err(db_error)?;
+    }
+    Ok(())
+}
+
+async fn find_current_corridor_tx<C: GenericClient + Sync>(
+    client: &C,
+    realm_id: &str,
+) -> Result<Option<Row>, RealmBootstrapError> {
+    client
+        .query_opt(
+            "
+            SELECT *
+            FROM dao.bootstrap_corridors
+            WHERE realm_id = $1
+              AND corridor_status = 'active'
+              AND starts_at <= CURRENT_TIMESTAMP
+              AND ends_at > CURRENT_TIMESTAMP
+            ORDER BY updated_at DESC, bootstrap_corridor_id DESC
+            LIMIT 1
+            ",
+            &[&realm_id],
+        )
+        .await
+        .map_err(db_error)
+}
+
+async fn find_latest_corridor_status_tx<C: GenericClient + Sync>(
+    client: &C,
+    realm_id: &str,
+) -> Result<Option<String>, RealmBootstrapError> {
+    client
+        .query_opt(
+            "
+            SELECT corridor_status
+            FROM dao.bootstrap_corridors
+            WHERE realm_id = $1
+            ORDER BY updated_at DESC, bootstrap_corridor_id DESC
+            LIMIT 1
+            ",
+            &[&realm_id],
+        )
+        .await
+        .map_err(db_error)
+        .map(|row| row.map(|value| value.get("corridor_status")))
+}
+
+async fn find_realm_request_by_idempotency_tx<C: GenericClient + Sync>(
+    client: &C,
+    requester_account_id: &Uuid,
+    request_idempotency_key: &str,
+) -> Result<Option<Row>, RealmBootstrapError> {
+    client
+        .query_opt(
+            "
+            SELECT
+                request.*,
+                realm.realm_id AS created_realm_id
+            FROM dao.realm_requests request
+            LEFT JOIN dao.realms realm
+              ON realm.created_from_realm_request_id = request.realm_request_id
+            WHERE request.requested_by_account_id = $1
+              AND request.request_idempotency_key = $2
+            ",
+            &[requester_account_id, &request_idempotency_key],
+        )
+        .await
+        .map_err(db_error)
+}
+
+async fn find_sponsor_record_by_idempotency_tx<C: GenericClient + Sync>(
+    client: &C,
+    realm_id: &str,
+    operator_id: &Uuid,
+    request_idempotency_key: &str,
+) -> Result<Option<Row>, RealmBootstrapError> {
+    client
+        .query_opt(
+            "
+            SELECT *
+            FROM dao.realm_sponsor_records
+            WHERE realm_id = $1
+              AND approved_by_operator_id = $2
+              AND request_idempotency_key = $3
+            ",
+            &[&realm_id, operator_id, &request_idempotency_key],
+        )
+        .await
+        .map_err(db_error)
+}
+
+async fn find_admission_by_idempotency_tx<C: GenericClient + Sync>(
+    client: &C,
+    realm_id: &str,
+    operator_id: &Uuid,
+    request_idempotency_key: &str,
+) -> Result<Option<Row>, RealmBootstrapError> {
+    client
+        .query_opt(
+            "
+            SELECT *
+            FROM dao.realm_admissions
+            WHERE realm_id = $1
+              AND granted_by_actor_id = $2
+              AND request_idempotency_key = $3
+            ",
+            &[&realm_id, operator_id, &request_idempotency_key],
+        )
+        .await
+        .map_err(db_error)
+}
+
+async fn lock_realm_request_tx<C: GenericClient + Sync>(
+    client: &C,
+    realm_request_id: &Uuid,
+) -> Result<Row, RealmBootstrapError> {
+    client
+        .query_opt(
+            "
+            SELECT
+                request.*,
+                realm.realm_id AS created_realm_id
+            FROM dao.realm_requests request
+            LEFT JOIN dao.realms realm
+              ON realm.created_from_realm_request_id = request.realm_request_id
+            WHERE request.realm_request_id = $1
+            FOR UPDATE OF request
+            ",
+            &[realm_request_id],
+        )
+        .await
+        .map_err(db_error)?
+        .ok_or_else(|| RealmBootstrapError::NotFound("realm request was not found".to_owned()))
+}
+
+async fn lock_realm_tx<C: GenericClient + Sync>(
+    client: &C,
+    realm_id: &str,
+) -> Result<Row, RealmBootstrapError> {
+    client
+        .query_opt(
+            "
+            SELECT *
+            FROM dao.realms
+            WHERE realm_id = $1
+            FOR UPDATE
+            ",
+            &[&realm_id],
+        )
+        .await
+        .map_err(db_error)?
+        .ok_or_else(|| RealmBootstrapError::NotFound("realm was not found".to_owned()))
+}
+
+async fn lock_sponsor_record_tx<C: GenericClient + Sync>(
+    client: &C,
+    sponsor_record_id: &Uuid,
+) -> Result<Row, RealmBootstrapError> {
+    client
+        .query_opt(
+            "
+            SELECT *
+            FROM dao.realm_sponsor_records
+            WHERE realm_sponsor_record_id = $1
+            FOR UPDATE
+            ",
+            &[sponsor_record_id],
+        )
+        .await
+        .map_err(db_error)?
+        .ok_or_else(|| {
+            RealmBootstrapError::NotFound("realm sponsor record was not found".to_owned())
+        })
+}
+
+async fn ensure_slug_available_for_approval_tx<C: GenericClient + Sync>(
+    client: &C,
+    slug: &str,
+    realm_request_id: &Uuid,
+) -> Result<(), RealmBootstrapError> {
+    let realm_exists = client
+        .query_opt("SELECT 1 FROM dao.realms WHERE slug = $1", &[&slug])
+        .await
+        .map_err(db_error)?;
+    if realm_exists.is_some() {
+        return Err(RealmBootstrapError::BadRequest(
+            "approved slug is already in use".to_owned(),
+        ));
+    }
+    let request_exists = client
+        .query_opt(
+            "
+            SELECT 1
+            FROM dao.realm_requests
+            WHERE slug_candidate = $1
+              AND realm_request_id <> $2
+              AND request_state IN ('requested', 'pending_review', 'approved')
+            ",
+            &[&slug, realm_request_id],
+        )
+        .await
+        .map_err(db_error)?;
+    if request_exists.is_some() {
+        return Err(RealmBootstrapError::BadRequest(
+            "approved slug is already reserved by another realm request".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+async fn ensure_active_account_exists_tx<C: GenericClient + Sync>(
+    client: &C,
+    account_id: &Uuid,
+) -> Result<(), RealmBootstrapError> {
+    let row = client
+        .query_one(
+            "
+            SELECT EXISTS (
+                SELECT 1
+                FROM core.accounts
+                WHERE account_id = $1
+                  AND account_state = 'active'
+            ) AS exists
+            ",
+            &[account_id],
+        )
+        .await
+        .map_err(db_error)?;
+    if row.get::<_, bool>("exists") {
+        Ok(())
+    } else {
+        Err(RealmBootstrapError::NotFound(
+            "account was not found".to_owned(),
+        ))
+    }
+}
+
+async fn ensure_operator_role_tx<C: GenericClient + Sync>(
+    client: &C,
+    operator_id: &Uuid,
+    allowed_roles: &[&str],
+) -> Result<(), RealmBootstrapError> {
+    let row = client
+        .query_one(
+            "
+            SELECT EXISTS (
+                SELECT 1
+                FROM core.operator_role_assignments
+                JOIN core.accounts
+                  ON core.accounts.account_id = core.operator_role_assignments.operator_account_id
+                WHERE operator_account_id = $1
+                  AND operator_role = ANY($2::text[])
+                  AND revoked_at IS NULL
+                  AND core.accounts.account_class = 'Controlled Exceptional Account'
+                  AND core.accounts.account_state = 'active'
+            ) AS has_role
+            ",
+            &[operator_id, &allowed_roles],
+        )
+        .await
+        .map_err(db_error)?;
+    if row.get::<_, bool>("has_role") {
+        Ok(())
+    } else {
+        Err(RealmBootstrapError::Unauthorized(
+            "operator role is not allowed for realm bootstrap actions".to_owned(),
+        ))
+    }
+}
+
+fn create_realm_request_payload_hash(
+    input: &CreateRealmRequestInput,
+    slug_candidate: &str,
+    proposed_sponsor_account_id: &Option<Uuid>,
+    proposed_steward_account_id: &Option<Uuid>,
+) -> String {
+    hash_json_value(&json!({
+        "schema_version": 1,
+        "display_name": normalize_optional(Some(input.display_name.as_str())),
+        "slug_candidate": slug_candidate,
+        "purpose_text": normalize_optional(Some(input.purpose_text.as_str())),
+        "venue_context_json": input.venue_context_json,
+        "expected_member_shape_json": input.expected_member_shape_json,
+        "bootstrap_rationale_text": normalize_optional(Some(input.bootstrap_rationale_text.as_str())),
+        "proposed_sponsor_account_id": optional_uuid_hash_value(proposed_sponsor_account_id),
+        "proposed_steward_account_id": optional_uuid_hash_value(proposed_steward_account_id),
+    }))
+}
+
+fn approve_request_payload_hash(
+    input: &ReviewRealmRequestInput,
+    approved_slug: &str,
+    approved_display_name: &str,
+    steward_account_id: &Option<Uuid>,
+) -> String {
+    hash_json_value(&json!({
+        "schema_version": 1,
+        "target_realm_status": input.target_realm_status,
+        "approved_slug": approved_slug,
+        "approved_display_name": approved_display_name,
+        "review_reason_code": input.review_reason_code,
+        "steward_account_id": optional_uuid_hash_value(steward_account_id),
+        "sponsor_quota_total": input.sponsor_quota_total,
+        "corridor_starts_at": input.corridor_starts_at.map(|value| value.to_rfc3339()),
+        "corridor_ends_at": input.corridor_ends_at.map(|value| value.to_rfc3339()),
+        "corridor_member_cap": input.corridor_member_cap,
+        "corridor_sponsor_cap": input.corridor_sponsor_cap,
+        "review_threshold_json": input.review_threshold_json,
+    }))
+}
+
+fn reject_request_payload_hash(input: &RejectRealmRequestInput) -> String {
+    hash_json_value(&json!({
+        "schema_version": 1,
+        "review_reason_code": input.review_reason_code,
+    }))
+}
+
+fn create_sponsor_record_payload_hash(
+    input: &CreateRealmSponsorRecordInput,
+    sponsor_account_id: &Uuid,
+) -> String {
+    hash_json_value(&json!({
+        "schema_version": 1,
+        "sponsor_account_id": sponsor_account_id.to_string(),
+        "sponsor_status": input.sponsor_status,
+        "quota_total": input.quota_total,
+        "status_reason_code": input.status_reason_code,
+    }))
+}
+
+fn create_admission_payload_hash(
+    input: &CreateRealmAdmissionInput,
+    account_id: &Uuid,
+    sponsor_record_id: &Option<Uuid>,
+    granted_by_actor_kind: &str,
+) -> String {
+    hash_json_value(&json!({
+        "schema_version": 1,
+        "account_id": account_id.to_string(),
+        "sponsor_record_id": optional_uuid_hash_value(sponsor_record_id),
+        "source_fact_kind": input.source_fact_kind,
+        "source_fact_id": input.source_fact_id,
+        "source_snapshot_json": input.source_snapshot_json,
+        "granted_by_actor_kind": granted_by_actor_kind,
+    }))
+}
+
+fn ensure_request_payload_hash_matches(
+    row: &Row,
+    request_payload_hash: &str,
+) -> Result<(), RealmBootstrapError> {
+    let existing_hash: String = row.get("request_payload_hash");
+    if existing_hash == request_payload_hash {
+        Ok(())
+    } else {
+        Err(RealmBootstrapError::BadRequest(
+            "request_idempotency_key was already used with a different realm request payload"
+                .to_owned(),
+        ))
+    }
+}
+
+fn ensure_sponsor_record_payload_hash_matches(
+    row: &Row,
+    payload_hash: &str,
+) -> Result<(), RealmBootstrapError> {
+    let existing_hash: String = row.get("request_payload_hash");
+    if existing_hash == payload_hash {
+        Ok(())
+    } else {
+        Err(RealmBootstrapError::BadRequest(
+            "request_idempotency_key was already used with a different sponsor record payload"
+                .to_owned(),
+        ))
+    }
+}
+
+fn ensure_admission_payload_hash_matches(
+    row: &Row,
+    payload_hash: &str,
+) -> Result<(), RealmBootstrapError> {
+    let existing_hash: String = row.get("request_payload_hash");
+    if existing_hash == payload_hash {
+        Ok(())
+    } else {
+        Err(RealmBootstrapError::BadRequest(
+            "request_idempotency_key was already used with a different realm admission payload"
+                .to_owned(),
+        ))
+    }
+}
+
+fn ensure_request_review_replay_matches(
+    row: &Row,
+    review_decision_idempotency_key: &str,
+    payload_hash: &str,
+) -> Result<(), RealmBootstrapError> {
+    let existing_key: Option<String> = row.get("review_decision_idempotency_key");
+    let existing_hash: Option<String> = row.get("review_decision_payload_hash");
+    if existing_key.as_deref() == Some(review_decision_idempotency_key)
+        && existing_hash.as_deref() == Some(payload_hash)
+    {
+        Ok(())
+    } else {
+        Err(RealmBootstrapError::BadRequest(
+            "review_decision_idempotency_key was already used with a different realm review payload"
+                .to_owned(),
+        ))
+    }
+}
+
+fn hash_json_value(value: &Value) -> String {
+    let digest = Sha256::digest(canonical_json_text(value).as_bytes());
+    let mut encoded = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        let _ = write!(&mut encoded, "{byte:02x}");
+    }
+    encoded
+}
+
+fn canonical_json_text(value: &Value) -> String {
+    let mut output = String::new();
+    write_canonical_json(value, &mut output);
+    output
+}
+
+fn write_canonical_json(value: &Value, output: &mut String) {
+    match value {
+        Value::Null => output.push_str("null"),
+        Value::Bool(boolean) => output.push_str(if *boolean { "true" } else { "false" }),
+        Value::Number(number) => {
+            let _ = write!(output, "{number}");
+        }
+        Value::String(string) => {
+            output.push_str(
+                &serde_json::to_string(string).expect("serializing a JSON string should not fail"),
+            );
+        }
+        Value::Array(values) => {
+            output.push('[');
+            for (index, value) in values.iter().enumerate() {
+                if index > 0 {
+                    output.push(',');
+                }
+                write_canonical_json(value, output);
+            }
+            output.push(']');
+        }
+        Value::Object(map) => {
+            output.push('{');
+            let mut entries = map.iter().collect::<Vec<_>>();
+            entries.sort_by(|left, right| left.0.cmp(right.0));
+            for (index, (key, value)) in entries.into_iter().enumerate() {
+                if index > 0 {
+                    output.push(',');
+                }
+                output.push_str(
+                    &serde_json::to_string(key)
+                        .expect("serializing a JSON object key should not fail"),
+                );
+                output.push(':');
+                write_canonical_json(value, output);
+            }
+            output.push('}');
+        }
+    }
+}
+
+fn parse_uuid(value: &str, field_name: &str) -> Result<Uuid, RealmBootstrapError> {
+    Uuid::parse_str(value.trim())
+        .map_err(|_| RealmBootstrapError::BadRequest(format!("{field_name} must be a UUID")))
+}
+
+fn parse_optional_uuid(
+    value: &Option<String>,
+    field_name: &str,
+) -> Result<Option<Uuid>, RealmBootstrapError> {
+    match normalize_optional(value.as_deref()) {
+        Some(value) => Ok(Some(parse_uuid(&value, field_name)?)),
+        None => Ok(None),
+    }
+}
+
+fn normalize_required(value: &str, field_name: &str) -> Result<String, RealmBootstrapError> {
+    let value = value.trim();
+    if value.is_empty() {
+        Err(RealmBootstrapError::BadRequest(format!(
+            "{field_name} is required"
+        )))
+    } else {
+        Ok(value.to_owned())
+    }
+}
+
+fn ensure_non_empty(field_name: &str, value: &str) -> Result<(), RealmBootstrapError> {
+    let _ = normalize_required(value, field_name)?;
+    Ok(())
+}
+
+fn ensure_non_empty_json_object(
+    field_name: &str,
+    value: &Value,
+) -> Result<(), RealmBootstrapError> {
+    match value {
+        Value::Object(map) if !map.is_empty() => Ok(()),
+        _ => Err(RealmBootstrapError::BadRequest(format!(
+            "{field_name} must be a non-empty JSON object"
+        ))),
+    }
+}
+
+fn normalize_optional(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+}
+
+fn normalize_slug_candidate(value: &str) -> Result<String, RealmBootstrapError> {
+    let raw = value.trim().to_ascii_lowercase().replace('_', "-");
+    let raw = raw.split_whitespace().collect::<Vec<_>>().join("-");
+    if raw.is_empty() || raw.len() > 64 {
+        return Err(RealmBootstrapError::BadRequest(
+            "slug_candidate must be between 1 and 64 characters".to_owned(),
+        ));
+    }
+    if !raw.chars().all(|character| {
+        character.is_ascii_lowercase() || character.is_ascii_digit() || character == '-'
+    }) || raw.starts_with('-')
+        || raw.ends_with('-')
+        || raw.contains("--")
+    {
+        return Err(RealmBootstrapError::BadRequest(
+            "slug_candidate must use lowercase letters, digits, and single hyphens".to_owned(),
+        ));
+    }
+    Ok(raw)
+}
+
+fn validate_allowed(
+    field_name: &str,
+    value: &str,
+    allowed: &[&str],
+) -> Result<(), RealmBootstrapError> {
+    if allowed.iter().any(|candidate| candidate == &value) {
+        Ok(())
+    } else {
+        Err(RealmBootstrapError::BadRequest(format!(
+            "{field_name} must be one of: {}",
+            allowed.join(", ")
+        )))
+    }
+}
+
+fn optional_uuid_hash_value(value: &Option<Uuid>) -> Option<String> {
+    value.map(|value| value.to_string())
+}
+
+fn require_corridor_fields(input: &ReviewRealmRequestInput) -> Result<(), RealmBootstrapError> {
+    if input.corridor_starts_at.is_none()
+        || input.corridor_ends_at.is_none()
+        || input.corridor_member_cap.is_none()
+        || input.corridor_sponsor_cap.is_none()
+    {
+        return Err(RealmBootstrapError::BadRequest(
+            "limited bootstrap approval requires corridor fields".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn trigger_intent(
+    kind: &'static str,
+    reason_code: &'static str,
+    context_json: Value,
+    fingerprint: String,
+) -> TriggerIntent {
+    TriggerIntent {
+        kind,
+        reason_code,
+        context_json,
+        fingerprint,
+    }
+}
+
+async fn open_trigger_tx<C: GenericClient + Sync>(
+    client: &C,
+    realm_id: Option<&str>,
+    trigger_kind: &str,
+    redacted_reason_code: &str,
+    related_account_id: Option<&Uuid>,
+    related_realm_request_id: Option<&Uuid>,
+    related_sponsor_record_id: Option<&Uuid>,
+    context_json: &Value,
+    trigger_fingerprint: &str,
+) -> Result<(), RealmBootstrapError> {
+    validate_allowed("trigger_kind", trigger_kind, REVIEW_TRIGGER_KINDS)?;
+    validate_allowed("redacted_reason_code", redacted_reason_code, REASON_CODES)?;
+    client
+        .execute(
+            "
+            INSERT INTO dao.realm_review_triggers (
+                realm_review_trigger_id,
+                realm_id,
+                trigger_kind,
+                trigger_state,
+                redacted_reason_code,
+                related_account_id,
+                related_realm_request_id,
+                related_sponsor_record_id,
+                context_json,
+                trigger_fingerprint
+            )
+            VALUES ($1, $2, $3, 'open', $4, $5, $6, $7, $8, $9)
+            ON CONFLICT (trigger_fingerprint)
+                WHERE trigger_state = 'open'
+            DO UPDATE SET
+                updated_at = CURRENT_TIMESTAMP
+            ",
+            &[
+                &Uuid::new_v4(),
+                &realm_id.map(str::to_owned),
+                &trigger_kind,
+                &redacted_reason_code,
+                &related_account_id,
+                &related_realm_request_id,
+                &related_sponsor_record_id,
+                context_json,
+                &trigger_fingerprint,
+            ],
+        )
+        .await
+        .map_err(db_error)?;
+    Ok(())
+}
+
+async fn current_rebuild_generation_tx<C: GenericClient + Sync>(
+    client: &C,
+) -> Result<i64, RealmBootstrapError> {
+    Ok(client
+        .query_one(
+            "
+            SELECT GREATEST(
+                COALESCE((SELECT MAX(rebuild_generation) FROM projection.realm_bootstrap_views), 0),
+                COALESCE((SELECT MAX(rebuild_generation) FROM projection.realm_admission_views), 0),
+                COALESCE((SELECT MAX(rebuild_generation) FROM projection.realm_review_summaries), 0)
+            ) + 1 AS rebuild_generation
+            ",
+            &[],
+        )
+        .await
+        .map_err(db_error)?
+        .get("rebuild_generation"))
+}
+
+async fn operator_actor_kind(
+    operator_id: Uuid,
+    store: &RealmBootstrapStore,
+) -> Result<String, RealmBootstrapError> {
+    let client = store.client.lock().await;
+    let row = client
+        .query_one(
+            "
+            SELECT EXISTS (
+                SELECT 1
+                FROM core.operator_role_assignments
+                WHERE operator_account_id = $1
+                  AND operator_role = 'steward'
+                  AND revoked_at IS NULL
+            ) AS is_steward
+            ",
+            &[&operator_id],
+        )
+        .await
+        .map_err(db_error)?;
+    if row.get::<_, bool>("is_steward") {
+        Ok("steward".to_owned())
+    } else {
+        Ok("operator".to_owned())
+    }
+}
+
+fn realm_request_from_row(row: &Row) -> Result<RealmRequestSnapshot, RealmBootstrapError> {
+    let created_realm_id = if row
+        .columns()
+        .iter()
+        .any(|column| column.name() == "created_realm_id")
+    {
+        row.get("created_realm_id")
+    } else {
+        None
+    };
+    Ok(RealmRequestSnapshot {
+        realm_request_id: row.get::<_, Uuid>("realm_request_id").to_string(),
+        requested_by_account_id: row.get::<_, Uuid>("requested_by_account_id").to_string(),
+        display_name: row.get("display_name"),
+        slug_candidate: row.get("slug_candidate"),
+        purpose_text: row.get("purpose_text"),
+        venue_context_json: row.get("venue_context_json"),
+        expected_member_shape_json: row.get("expected_member_shape_json"),
+        bootstrap_rationale_text: row.get("bootstrap_rationale_text"),
+        proposed_sponsor_account_id: row
+            .get::<_, Option<Uuid>>("proposed_sponsor_account_id")
+            .map(|value| value.to_string()),
+        proposed_steward_account_id: row
+            .get::<_, Option<Uuid>>("proposed_steward_account_id")
+            .map(|value| value.to_string()),
+        request_state: row.get("request_state"),
+        review_reason_code: row.get("review_reason_code"),
+        reviewed_by_operator_id: row
+            .get::<_, Option<Uuid>>("reviewed_by_operator_id")
+            .map(|value| value.to_string()),
+        reviewed_at: row.get("reviewed_at"),
+        created_realm_id,
+        created_at: row.get("created_at"),
+        updated_at: row.get("updated_at"),
+    })
+}
+
+fn realm_from_row(row: &Row) -> Result<RealmSnapshot, RealmBootstrapError> {
+    Ok(RealmSnapshot {
+        realm_id: row.get("realm_id"),
+        slug: row.get("slug"),
+        display_name: row.get("display_name"),
+        realm_status: row.get("realm_status"),
+        public_reason_code: row.get("public_reason_code"),
+        created_from_realm_request_id: row
+            .get::<_, Uuid>("created_from_realm_request_id")
+            .to_string(),
+        steward_account_id: row
+            .get::<_, Option<Uuid>>("steward_account_id")
+            .map(|value| value.to_string()),
+        created_at: row.get("created_at"),
+        updated_at: row.get("updated_at"),
+    })
+}
+
+fn realm_sponsor_record_from_row(
+    row: &Row,
+) -> Result<RealmSponsorRecordSnapshot, RealmBootstrapError> {
+    Ok(RealmSponsorRecordSnapshot {
+        realm_sponsor_record_id: row.get::<_, Uuid>("realm_sponsor_record_id").to_string(),
+        realm_id: row.get("realm_id"),
+        sponsor_account_id: row.get::<_, Uuid>("sponsor_account_id").to_string(),
+        sponsor_status: row.get("sponsor_status"),
+        quota_total: row.get("quota_total"),
+        status_reason_code: row.get("status_reason_code"),
+        approved_by_operator_id: row.get::<_, Uuid>("approved_by_operator_id").to_string(),
+        created_at: row.get("created_at"),
+        updated_at: row.get("updated_at"),
+    })
+}
+
+fn realm_admission_from_row(row: &Row) -> Result<RealmAdmissionSnapshot, RealmBootstrapError> {
+    Ok(RealmAdmissionSnapshot {
+        realm_admission_id: row.get::<_, Uuid>("realm_admission_id").to_string(),
+        realm_id: row.get("realm_id"),
+        account_id: row.get::<_, Uuid>("account_id").to_string(),
+        admission_kind: row.get("admission_kind"),
+        admission_status: row.get("admission_status"),
+        sponsor_record_id: row
+            .get::<_, Option<Uuid>>("sponsor_record_id")
+            .map(|value| value.to_string()),
+        bootstrap_corridor_id: row
+            .get::<_, Option<Uuid>>("bootstrap_corridor_id")
+            .map(|value| value.to_string()),
+        granted_by_actor_kind: row.get("granted_by_actor_kind"),
+        granted_by_actor_id: row.get::<_, Uuid>("granted_by_actor_id").to_string(),
+        review_reason_code: row.get("review_reason_code"),
+        source_fact_kind: row.get("source_fact_kind"),
+        source_fact_id: row.get("source_fact_id"),
+        created_at: row.get("created_at"),
+        updated_at: row.get("updated_at"),
+    })
+}
+
+fn realm_bootstrap_view_from_row(
+    row: &Row,
+) -> Result<RealmBootstrapViewSnapshot, RealmBootstrapError> {
+    Ok(RealmBootstrapViewSnapshot {
+        realm_id: row.get("realm_id"),
+        slug: row.get("slug"),
+        display_name: row.get("display_name"),
+        realm_status: row.get("realm_status"),
+        admission_posture: row.get("admission_posture"),
+        corridor_status: row.get("corridor_status"),
+        public_reason_code: row.get("public_reason_code"),
+        sponsor_display_state: row.get("sponsor_display_state"),
+        source_watermark_at: row.get("source_watermark_at"),
+        source_fact_count: row.get("source_fact_count"),
+        projection_lag_ms: row.get("projection_lag_ms"),
+        rebuild_generation: row.get("rebuild_generation"),
+        last_projected_at: row.get("last_projected_at"),
+    })
+}
+
+fn realm_admission_view_from_row(
+    row: &Row,
+) -> Result<RealmAdmissionViewSnapshot, RealmBootstrapError> {
+    Ok(RealmAdmissionViewSnapshot {
+        realm_id: row.get("realm_id"),
+        account_id: row.get::<_, Uuid>("account_id").to_string(),
+        admission_status: row.get("admission_status"),
+        admission_kind: row.get("admission_kind"),
+        public_reason_code: row.get("public_reason_code"),
+        source_watermark_at: row.get("source_watermark_at"),
+        source_fact_count: row.get("source_fact_count"),
+        projection_lag_ms: row.get("projection_lag_ms"),
+        rebuild_generation: row.get("rebuild_generation"),
+        last_projected_at: row.get("last_projected_at"),
+    })
+}
+
+fn realm_review_trigger_from_row(
+    row: &Row,
+) -> Result<RealmReviewTriggerSnapshot, RealmBootstrapError> {
+    Ok(RealmReviewTriggerSnapshot {
+        realm_review_trigger_id: row.get::<_, Uuid>("realm_review_trigger_id").to_string(),
+        realm_id: row.get("realm_id"),
+        trigger_kind: row.get("trigger_kind"),
+        trigger_state: row.get("trigger_state"),
+        redacted_reason_code: row.get("redacted_reason_code"),
+        related_account_id: row
+            .get::<_, Option<Uuid>>("related_account_id")
+            .map(|value| value.to_string()),
+        related_realm_request_id: row
+            .get::<_, Option<Uuid>>("related_realm_request_id")
+            .map(|value| value.to_string()),
+        related_sponsor_record_id: row
+            .get::<_, Option<Uuid>>("related_sponsor_record_id")
+            .map(|value| value.to_string()),
+        created_at: row.get("created_at"),
+        updated_at: row.get("updated_at"),
+        resolved_at: row.get("resolved_at"),
+    })
+}
+
+fn realm_review_summary_from_row(
+    row: &Row,
+    trigger_rows: &[Row],
+) -> Result<RealmReviewSummarySnapshot, RealmBootstrapError> {
+    Ok(RealmReviewSummarySnapshot {
+        realm_id: row.get("realm_id"),
+        realm_status: row.get("realm_status"),
+        corridor_status: row.get("corridor_status"),
+        corridor_remaining_seconds: row.get("corridor_remaining_seconds"),
+        active_sponsor_count: row.get("active_sponsor_count"),
+        sponsor_backed_admission_count: row.get("sponsor_backed_admission_count"),
+        recent_admission_count_7d: row.get("recent_admission_count_7d"),
+        open_review_trigger_count: row.get("open_review_trigger_count"),
+        open_review_case_count: row.get("open_review_case_count"),
+        latest_redacted_reason_code: row.get("latest_redacted_reason_code"),
+        source_watermark_at: row.get("source_watermark_at"),
+        source_fact_count: row.get("source_fact_count"),
+        projection_lag_ms: row.get("projection_lag_ms"),
+        rebuild_generation: row.get("rebuild_generation"),
+        last_projected_at: row.get("last_projected_at"),
+        open_review_triggers: trigger_rows
+            .iter()
+            .map(realm_review_trigger_from_row)
+            .collect::<Result<Vec<_>, _>>()?,
+    })
+}
+
+fn db_error(error: tokio_postgres::Error) -> RealmBootstrapError {
+    let code = error.code().map(|code| code.code().to_owned());
+    let constraint = error
+        .as_db_error()
+        .and_then(|db_error| db_error.constraint().map(str::to_owned));
+    let retryable = matches!(
+        error.code(),
+        Some(&SqlState::T_R_SERIALIZATION_FAILURE)
+            | Some(&SqlState::T_R_DEADLOCK_DETECTED)
+            | Some(&SqlState::CONNECTION_EXCEPTION)
+    );
+    RealmBootstrapError::Database {
+        message: error.to_string(),
+        code,
+        constraint,
+        retryable,
+    }
+}

--- a/apps/backend/src/services/realm_bootstrap/repository.rs
+++ b/apps/backend/src/services/realm_bootstrap/repository.rs
@@ -1167,7 +1167,7 @@ async fn maybe_open_member_overlap_trigger_tx<C: GenericClient + Sync>(
             None,
             None,
             &json!({ "active_realm_count": count }),
-            &format!("member-overlap:{account_id}"),
+            &format!("member-overlap:{realm_id}:{account_id}"),
         )
         .await?;
     }
@@ -1202,7 +1202,7 @@ async fn maybe_open_sponsor_concentration_trigger_tx<C: GenericClient + Sync>(
             None,
             None,
             &json!({ "active_sponsor_record_count": count }),
-            &format!("sponsor-concentration:{sponsor_account_id}"),
+            &format!("sponsor-concentration:{realm_id}:{sponsor_account_id}"),
         )
         .await?;
     }

--- a/apps/backend/src/services/realm_bootstrap/repository.rs
+++ b/apps/backend/src/services/realm_bootstrap/repository.rs
@@ -819,16 +819,20 @@ impl RealmBootstrapStore {
 
         let mut client = self.client.lock().await;
         let tx = client.transaction().await.map_err(db_error)?;
-        ensure_operator_role_tx(&tx, &operator_id, OPERATOR_WRITE_ROLES).await?;
         let payload_hash = create_admission_payload_hash(&input, &account_id, &sponsor_record_id);
 
-        let row = if let Some(existing) =
+        if let Some(existing) =
             find_admission_by_idempotency_tx(&tx, &realm_id, &operator_id, &request_idempotency_key)
                 .await?
         {
             ensure_admission_payload_hash_matches(&existing, &payload_hash)?;
-            existing
-        } else {
+            tx.commit().await.map_err(db_error)?;
+            return realm_admission_from_row(&existing);
+        }
+
+        ensure_operator_role_tx(&tx, &operator_id, OPERATOR_WRITE_ROLES).await?;
+
+        let row = {
             ensure_active_account_exists_tx(&tx, &account_id).await?;
             let granted_by_actor_kind = operator_actor_kind_tx(&tx, &operator_id).await?;
             let realm_row = lock_realm_tx(&tx, &realm_id).await?;

--- a/apps/backend/src/services/realm_bootstrap/repository.rs
+++ b/apps/backend/src/services/realm_bootstrap/repository.rs
@@ -46,6 +46,8 @@ const REASON_CODES: &[&str] = &[
     "suspended_after_review",
     "operator_restriction",
 ];
+const APPROVAL_REASON_CODES: &[&str] = &["limited_bootstrap_active", "active_after_review"];
+const REJECTION_REASON_CODES: &[&str] = &["request_rejected", "duplicate_or_invalid"];
 const OPERATOR_READ_ROLES: &[&str] = &["reviewer", "approver", "steward", "auditor", "support"];
 const OPERATOR_WRITE_ROLES: &[&str] = &["approver", "steward"];
 
@@ -327,8 +329,18 @@ impl RealmBootstrapStore {
         validate_allowed(
             "review_reason_code",
             &input.review_reason_code,
-            REASON_CODES,
+            APPROVAL_REASON_CODES,
         )?;
+        let expected_reason_code = if input.target_realm_status == "active" {
+            "active_after_review"
+        } else {
+            "limited_bootstrap_active"
+        };
+        if input.review_reason_code != expected_reason_code {
+            return Err(RealmBootstrapError::BadRequest(
+                "review_reason_code must match target_realm_status".to_owned(),
+            ));
+        }
         let review_decision_idempotency_key = normalize_optional(
             input.review_decision_idempotency_key.as_deref(),
         )
@@ -479,6 +491,7 @@ impl RealmBootstrapStore {
             UPDATE dao.realm_requests
             SET request_state = 'approved',
                 slug_candidate = $6,
+                display_name = $7,
                 review_reason_code = $2,
                 reviewed_by_operator_id = $3,
                 review_decision_idempotency_key = $4,
@@ -494,6 +507,7 @@ impl RealmBootstrapStore {
                 &Some(review_decision_idempotency_key),
                 &Some(decision_payload_hash),
                 &approved_slug,
+                &approved_display_name,
             ],
         )
         .await
@@ -515,7 +529,7 @@ impl RealmBootstrapStore {
         validate_allowed(
             "review_reason_code",
             &input.review_reason_code,
-            REASON_CODES,
+            REJECTION_REASON_CODES,
         )?;
         let review_decision_idempotency_key = normalize_optional(
             input.review_decision_idempotency_key.as_deref(),

--- a/apps/backend/src/services/realm_bootstrap/repository.rs
+++ b/apps/backend/src/services/realm_bootstrap/repository.rs
@@ -164,7 +164,11 @@ impl RealmBootstrapStore {
                         'request_received',
                         $11, $12
                     )
-                    RETURNING *
+                    ON CONFLICT (requested_by_account_id, request_idempotency_key)
+                        WHERE request_idempotency_key IS NOT NULL
+                    DO UPDATE SET
+                        request_payload_hash = dao.realm_requests.request_payload_hash
+                    RETURNING *, (xmax = 0) AS was_inserted
                     ",
                     &[
                         &Uuid::new_v4(),
@@ -186,6 +190,11 @@ impl RealmBootstrapStore {
                 )
                 .await
                 .map_err(db_error)?;
+            if !request_row.get::<_, bool>("was_inserted") {
+                ensure_request_payload_hash_matches(&request_row, &request_payload_hash)?;
+                tx.commit().await.map_err(db_error)?;
+                return realm_request_from_row(&request_row);
+            }
             let realm_request_id: Uuid = request_row.get("realm_request_id");
             let requires_review = maybe_open_realm_request_triggers_tx(
                 &tx,
@@ -432,6 +441,11 @@ impl RealmBootstrapStore {
                     "approval with a proposed sponsor requires sponsor_quota_total".to_owned(),
                 )
             })?;
+            if quota_total <= 0 {
+                return Err(RealmBootstrapError::BadRequest(
+                    "sponsor_quota_total must be positive".to_owned(),
+                ));
+            }
             let sponsor_payload_hash = create_sponsor_record_payload_hash(
                 &CreateRealmSponsorRecordInput {
                     sponsor_account_id: sponsor_account_id.to_string(),

--- a/apps/backend/src/services/realm_bootstrap/repository.rs
+++ b/apps/backend/src/services/realm_bootstrap/repository.rs
@@ -2746,7 +2746,7 @@ async fn count_corridor_admissions_tx<C: GenericClient + Sync>(
     Ok(client
         .query_one(
             "
-            SELECT COUNT(*) AS count
+            SELECT COUNT(DISTINCT account_id) AS count
             FROM dao.realm_admissions
             WHERE bootstrap_corridor_id = $1
               AND admission_status IN ('pending', 'admitted')
@@ -2766,7 +2766,7 @@ async fn count_sponsor_backed_admissions_tx<C: GenericClient + Sync>(
     Ok(client
         .query_one(
             "
-            SELECT COUNT(*) AS count
+            SELECT COUNT(DISTINCT admission.account_id) AS count
             FROM dao.realm_admissions admission
             JOIN dao.realm_sponsor_records sponsor
               ON sponsor.realm_sponsor_record_id = admission.sponsor_record_id

--- a/apps/backend/src/services/realm_bootstrap/repository.rs
+++ b/apps/backend/src/services/realm_bootstrap/repository.rs
@@ -141,36 +141,48 @@ impl RealmBootstrapStore {
             ensure_request_payload_hash_matches(&existing, &request_payload_hash)?;
             existing
         } else {
-            let request_row = tx
-                .query_one(
+            let request_row = match tx
+                .query_opt(
                     "
-                    INSERT INTO dao.realm_requests (
-                        realm_request_id,
-                        requested_by_account_id,
-                        display_name,
-                        slug_candidate,
-                        purpose_text,
-                        venue_context_json,
-                        expected_member_shape_json,
-                        bootstrap_rationale_text,
-                        proposed_sponsor_account_id,
-                        proposed_steward_account_id,
-                        request_state,
-                        review_reason_code,
-                        request_idempotency_key,
-                        request_payload_hash
+                    WITH inserted AS (
+                        INSERT INTO dao.realm_requests (
+                            realm_request_id,
+                            requested_by_account_id,
+                            display_name,
+                            slug_candidate,
+                            purpose_text,
+                            venue_context_json,
+                            expected_member_shape_json,
+                            bootstrap_rationale_text,
+                            proposed_sponsor_account_id,
+                            proposed_steward_account_id,
+                            request_state,
+                            review_reason_code,
+                            request_idempotency_key,
+                            request_payload_hash
+                        )
+                        VALUES (
+                            $1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
+                            'requested',
+                            'request_received',
+                            $11, $12
+                        )
+                        ON CONFLICT (requested_by_account_id, request_idempotency_key)
+                            WHERE request_idempotency_key IS NOT NULL
+                        DO NOTHING
+                        RETURNING *, NULL::text AS created_realm_id, TRUE AS was_inserted
                     )
-                    VALUES (
-                        $1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
-                        'requested',
-                        'request_received',
-                        $11, $12
-                    )
-                    ON CONFLICT (requested_by_account_id, request_idempotency_key)
-                        WHERE request_idempotency_key IS NOT NULL
-                    DO UPDATE SET
-                        request_payload_hash = dao.realm_requests.request_payload_hash
-                    RETURNING *, (xmax = 0) AS was_inserted
+                    SELECT *
+                    FROM inserted
+                    UNION ALL
+                    SELECT request.*, realm.realm_id AS created_realm_id, FALSE AS was_inserted
+                    FROM dao.realm_requests request
+                    LEFT JOIN dao.realms realm
+                      ON realm.created_from_realm_request_id = request.realm_request_id
+                    WHERE request.requested_by_account_id = $2
+                      AND request.request_idempotency_key = $11
+                      AND NOT EXISTS (SELECT 1 FROM inserted)
+                    LIMIT 1
                     ",
                     &[
                         &Uuid::new_v4(),
@@ -191,7 +203,30 @@ impl RealmBootstrapStore {
                     ],
                 )
                 .await
-                .map_err(db_error)?;
+                .map_err(db_error)?
+            {
+                Some(row) => row,
+                None => tx
+                    .query_opt(
+                        "
+                        SELECT request.*, realm.realm_id AS created_realm_id, FALSE AS was_inserted
+                        FROM dao.realm_requests request
+                        LEFT JOIN dao.realms realm
+                          ON realm.created_from_realm_request_id = request.realm_request_id
+                        WHERE request.requested_by_account_id = $1
+                          AND request.request_idempotency_key = $2
+                        ",
+                        &[&requester_account_id, &request_idempotency_key],
+                    )
+                    .await
+                    .map_err(db_error)?
+                    .ok_or_else(|| RealmBootstrapError::Database {
+                        message: "realm request idempotency replay was not yet visible".to_owned(),
+                        code: None,
+                        constraint: None,
+                        retryable: true,
+                    })?,
+            };
             if !request_row.get::<_, bool>("was_inserted") {
                 ensure_request_payload_hash_matches(&request_row, &request_payload_hash)?;
                 tx.commit().await.map_err(db_error)?;
@@ -477,7 +512,7 @@ impl RealmBootstrapStore {
                 &input.review_reason_code,
                 &operator_id,
                 None,
-                Some(sponsor_payload_hash),
+                sponsor_payload_hash,
             )
             .await?;
         }
@@ -658,7 +693,7 @@ impl RealmBootstrapStore {
                 &input.status_reason_code,
                 &operator_id,
                 Some(request_idempotency_key),
-                Some(payload_hash.clone()),
+                payload_hash.clone(),
             )
             .await?;
             ensure_sponsor_record_payload_hash_matches(&row, &payload_hash)?;
@@ -1502,32 +1537,43 @@ async fn insert_sponsor_record_tx<C: GenericClient + Sync>(
     status_reason_code: &str,
     approved_by_operator_id: &Uuid,
     request_idempotency_key: Option<String>,
-    request_payload_hash: Option<String>,
+    request_payload_hash: String,
 ) -> Result<Row, RealmBootstrapError> {
-    client
-        .query_one(
+    let row = client
+        .query_opt(
             "
-            INSERT INTO dao.realm_sponsor_records (
-                realm_sponsor_record_id,
-                realm_id,
-                sponsor_account_id,
-                sponsor_status,
-                quota_total,
-                status_reason_code,
-                approved_by_operator_id,
-                request_idempotency_key,
-                request_payload_hash
+            WITH inserted AS (
+                INSERT INTO dao.realm_sponsor_records (
+                    realm_sponsor_record_id,
+                    realm_id,
+                    sponsor_account_id,
+                    sponsor_status,
+                    quota_total,
+                    status_reason_code,
+                    approved_by_operator_id,
+                    request_idempotency_key,
+                    request_payload_hash
+                )
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+                ON CONFLICT (
+                    realm_id,
+                    approved_by_operator_id,
+                    request_idempotency_key
+                )
+                WHERE request_idempotency_key IS NOT NULL
+                DO NOTHING
+                RETURNING *
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, COALESCE($9, repeat('0', 64)))
-            ON CONFLICT (
-                realm_id,
-                approved_by_operator_id,
-                request_idempotency_key
-            )
-            WHERE request_idempotency_key IS NOT NULL
-            DO UPDATE
-            SET request_payload_hash = dao.realm_sponsor_records.request_payload_hash
-            RETURNING *
+            SELECT *
+            FROM inserted
+            UNION ALL
+            SELECT existing.*
+            FROM dao.realm_sponsor_records existing
+            WHERE NOT EXISTS (SELECT 1 FROM inserted)
+              AND existing.realm_id = $2
+              AND existing.approved_by_operator_id = $7
+              AND existing.request_idempotency_key = $8
+            LIMIT 1
             ",
             &[
                 &Uuid::new_v4(),
@@ -1542,7 +1588,31 @@ async fn insert_sponsor_record_tx<C: GenericClient + Sync>(
             ],
         )
         .await
-        .map_err(db_error)
+        .map_err(db_error)?;
+    match row {
+        Some(row) => Ok(row),
+        None => match request_idempotency_key.as_deref() {
+            Some(key) => find_sponsor_record_by_idempotency_tx(
+                client,
+                realm_id,
+                approved_by_operator_id,
+                key,
+            )
+            .await?
+            .ok_or_else(|| RealmBootstrapError::Database {
+                message: "realm sponsor record idempotency replay was not yet visible".to_owned(),
+                code: None,
+                constraint: None,
+                retryable: true,
+            }),
+            None => Err(RealmBootstrapError::Database {
+                message: "realm sponsor record insert did not return a row".to_owned(),
+                code: None,
+                constraint: None,
+                retryable: true,
+            }),
+        },
+    }
 }
 
 async fn insert_bootstrap_corridor_tx<C: GenericClient + Sync>(

--- a/apps/backend/src/services/realm_bootstrap/types.rs
+++ b/apps/backend/src/services/realm_bootstrap/types.rs
@@ -1,0 +1,241 @@
+use chrono::{DateTime, Utc};
+use serde_json::Value;
+
+#[derive(Debug)]
+pub enum RealmBootstrapError {
+    BadRequest(String),
+    Unauthorized(String),
+    NotFound(String),
+    Database {
+        message: String,
+        code: Option<String>,
+        constraint: Option<String>,
+        retryable: bool,
+    },
+    Internal(String),
+}
+
+impl RealmBootstrapError {
+    pub fn message(&self) -> &str {
+        match self {
+            Self::BadRequest(message)
+            | Self::Unauthorized(message)
+            | Self::NotFound(message)
+            | Self::Database { message, .. }
+            | Self::Internal(message) => message,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct CreateRealmRequestInput {
+    pub display_name: String,
+    pub slug_candidate: String,
+    pub purpose_text: String,
+    pub venue_context_json: Value,
+    pub expected_member_shape_json: Value,
+    pub bootstrap_rationale_text: String,
+    pub proposed_sponsor_account_id: Option<String>,
+    pub proposed_steward_account_id: Option<String>,
+    pub request_idempotency_key: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct ReviewRealmRequestInput {
+    pub target_realm_status: String,
+    pub approved_slug: Option<String>,
+    pub approved_display_name: Option<String>,
+    pub review_reason_code: String,
+    pub steward_account_id: Option<String>,
+    pub sponsor_quota_total: Option<i64>,
+    pub corridor_starts_at: Option<DateTime<Utc>>,
+    pub corridor_ends_at: Option<DateTime<Utc>>,
+    pub corridor_member_cap: Option<i64>,
+    pub corridor_sponsor_cap: Option<i64>,
+    pub review_threshold_json: Value,
+    pub review_decision_idempotency_key: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct RejectRealmRequestInput {
+    pub review_reason_code: String,
+    pub review_decision_idempotency_key: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct CreateRealmSponsorRecordInput {
+    pub sponsor_account_id: String,
+    pub sponsor_status: String,
+    pub quota_total: i64,
+    pub status_reason_code: String,
+    pub request_idempotency_key: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct CreateRealmAdmissionInput {
+    pub account_id: String,
+    pub sponsor_record_id: Option<String>,
+    pub source_fact_kind: String,
+    pub source_fact_id: String,
+    pub source_snapshot_json: Value,
+    pub request_idempotency_key: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct RealmRequestSnapshot {
+    pub realm_request_id: String,
+    pub requested_by_account_id: String,
+    pub display_name: String,
+    pub slug_candidate: String,
+    pub purpose_text: String,
+    pub venue_context_json: Value,
+    pub expected_member_shape_json: Value,
+    pub bootstrap_rationale_text: String,
+    pub proposed_sponsor_account_id: Option<String>,
+    pub proposed_steward_account_id: Option<String>,
+    pub request_state: String,
+    pub review_reason_code: String,
+    pub reviewed_by_operator_id: Option<String>,
+    pub reviewed_at: Option<DateTime<Utc>>,
+    pub created_realm_id: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Clone, Debug)]
+pub struct RealmSnapshot {
+    pub realm_id: String,
+    pub slug: String,
+    pub display_name: String,
+    pub realm_status: String,
+    pub public_reason_code: String,
+    pub created_from_realm_request_id: String,
+    pub steward_account_id: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Clone, Debug)]
+pub struct RealmSponsorRecordSnapshot {
+    pub realm_sponsor_record_id: String,
+    pub realm_id: String,
+    pub sponsor_account_id: String,
+    pub sponsor_status: String,
+    pub quota_total: i64,
+    pub status_reason_code: String,
+    pub approved_by_operator_id: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Clone, Debug)]
+pub struct BootstrapCorridorSnapshot {
+    pub bootstrap_corridor_id: String,
+    pub realm_id: String,
+    pub corridor_status: String,
+    pub starts_at: DateTime<Utc>,
+    pub ends_at: DateTime<Utc>,
+    pub member_cap: i64,
+    pub sponsor_cap: i64,
+    pub created_by_operator_id: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Clone, Debug)]
+pub struct RealmAdmissionSnapshot {
+    pub realm_admission_id: String,
+    pub realm_id: String,
+    pub account_id: String,
+    pub admission_kind: String,
+    pub admission_status: String,
+    pub sponsor_record_id: Option<String>,
+    pub bootstrap_corridor_id: Option<String>,
+    pub granted_by_actor_kind: String,
+    pub granted_by_actor_id: String,
+    pub review_reason_code: String,
+    pub source_fact_kind: String,
+    pub source_fact_id: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Clone, Debug)]
+pub struct RealmReviewTriggerSnapshot {
+    pub realm_review_trigger_id: String,
+    pub realm_id: Option<String>,
+    pub trigger_kind: String,
+    pub trigger_state: String,
+    pub redacted_reason_code: String,
+    pub related_account_id: Option<String>,
+    pub related_realm_request_id: Option<String>,
+    pub related_sponsor_record_id: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub resolved_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Clone, Debug)]
+pub struct RealmBootstrapViewSnapshot {
+    pub realm_id: String,
+    pub slug: String,
+    pub display_name: String,
+    pub realm_status: String,
+    pub admission_posture: String,
+    pub corridor_status: String,
+    pub public_reason_code: String,
+    pub sponsor_display_state: String,
+    pub source_watermark_at: DateTime<Utc>,
+    pub source_fact_count: i64,
+    pub projection_lag_ms: i64,
+    pub rebuild_generation: i64,
+    pub last_projected_at: DateTime<Utc>,
+}
+
+#[derive(Clone, Debug)]
+pub struct RealmAdmissionViewSnapshot {
+    pub realm_id: String,
+    pub account_id: String,
+    pub admission_status: String,
+    pub admission_kind: String,
+    pub public_reason_code: String,
+    pub source_watermark_at: DateTime<Utc>,
+    pub source_fact_count: i64,
+    pub projection_lag_ms: i64,
+    pub rebuild_generation: i64,
+    pub last_projected_at: DateTime<Utc>,
+}
+
+#[derive(Clone, Debug)]
+pub struct RealmReviewSummarySnapshot {
+    pub realm_id: String,
+    pub realm_status: String,
+    pub corridor_status: String,
+    pub corridor_remaining_seconds: i64,
+    pub active_sponsor_count: i64,
+    pub sponsor_backed_admission_count: i64,
+    pub recent_admission_count_7d: i64,
+    pub open_review_trigger_count: i64,
+    pub open_review_case_count: i64,
+    pub latest_redacted_reason_code: String,
+    pub source_watermark_at: DateTime<Utc>,
+    pub source_fact_count: i64,
+    pub projection_lag_ms: i64,
+    pub rebuild_generation: i64,
+    pub last_projected_at: DateTime<Utc>,
+    pub open_review_triggers: Vec<RealmReviewTriggerSnapshot>,
+}
+
+#[derive(Clone, Debug)]
+pub struct RealmBootstrapSummarySnapshot {
+    pub realm_request: Option<RealmRequestSnapshot>,
+    pub bootstrap_view: RealmBootstrapViewSnapshot,
+    pub admission_view: Option<RealmAdmissionViewSnapshot>,
+}
+
+#[derive(Clone, Debug)]
+pub struct RealmBootstrapRebuildSnapshot {
+    pub bootstrap_view_count: i64,
+    pub admission_view_count: i64,
+    pub review_summary_count: i64,
+}

--- a/apps/backend/src/services/realm_bootstrap/types.rs
+++ b/apps/backend/src/services/realm_bootstrap/types.rs
@@ -62,6 +62,13 @@ pub struct RejectRealmRequestInput {
     pub review_decision_idempotency_key: String,
 }
 
+#[derive(Clone, Debug, Default)]
+pub struct ListRealmRequestsInput {
+    pub limit: Option<i64>,
+    pub before_created_at: Option<DateTime<Utc>>,
+    pub before_realm_request_id: Option<String>,
+}
+
 #[derive(Clone, Debug)]
 pub struct CreateRealmSponsorRecordInput {
     pub sponsor_account_id: String,

--- a/apps/backend/src/services/realm_bootstrap/types.rs
+++ b/apps/backend/src/services/realm_bootstrap/types.rs
@@ -37,7 +37,7 @@ pub struct CreateRealmRequestInput {
     pub bootstrap_rationale_text: String,
     pub proposed_sponsor_account_id: Option<String>,
     pub proposed_steward_account_id: Option<String>,
-    pub request_idempotency_key: Option<String>,
+    pub request_idempotency_key: String,
 }
 
 #[derive(Clone, Debug)]
@@ -53,13 +53,13 @@ pub struct ReviewRealmRequestInput {
     pub corridor_member_cap: Option<i64>,
     pub corridor_sponsor_cap: Option<i64>,
     pub review_threshold_json: Value,
-    pub review_decision_idempotency_key: Option<String>,
+    pub review_decision_idempotency_key: String,
 }
 
 #[derive(Clone, Debug)]
 pub struct RejectRealmRequestInput {
     pub review_reason_code: String,
-    pub review_decision_idempotency_key: Option<String>,
+    pub review_decision_idempotency_key: String,
 }
 
 #[derive(Clone, Debug)]
@@ -68,7 +68,7 @@ pub struct CreateRealmSponsorRecordInput {
     pub sponsor_status: String,
     pub quota_total: i64,
     pub status_reason_code: String,
-    pub request_idempotency_key: Option<String>,
+    pub request_idempotency_key: String,
 }
 
 #[derive(Clone, Debug)]
@@ -78,7 +78,7 @@ pub struct CreateRealmAdmissionInput {
     pub source_fact_kind: String,
     pub source_fact_id: String,
     pub source_snapshot_json: Value,
-    pub request_idempotency_key: Option<String>,
+    pub request_idempotency_key: String,
 }
 
 #[derive(Clone, Debug)]

--- a/apps/backend/src/services/realm_bootstrap/types.rs
+++ b/apps/backend/src/services/realm_bootstrap/types.rs
@@ -107,6 +107,7 @@ pub struct RealmRequestSnapshot {
     pub created_realm_id: Option<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    pub open_review_triggers: Vec<RealmReviewTriggerSnapshot>,
 }
 
 #[derive(Clone, Debug)]

--- a/apps/backend/tests/realm_bootstrap.rs
+++ b/apps/backend/tests/realm_bootstrap.rs
@@ -7,6 +7,7 @@ use chrono::{DateTime, Duration, Utc};
 use musubi_backend::{build_app, new_state_from_config, new_test_state};
 use musubi_db_runtime::DbConfig;
 use serde_json::{Value, json};
+use tokio_postgres::error::SqlState;
 use tower::ServiceExt;
 use uuid::Uuid;
 
@@ -46,6 +47,7 @@ async fn realm_request_can_be_approved_into_limited_bootstrap_and_participant_su
     .await;
     assert_eq!(request.status, StatusCode::OK);
     assert_eq!(request.body["request_state"], "requested");
+    assert!(request.body.get("requested_by_account_id").is_none());
     assert!(request.body.get("reviewed_by_operator_id").is_none());
     let realm_request_id = request.body["realm_request_id"]
         .as_str()
@@ -90,6 +92,7 @@ async fn realm_request_can_be_approved_into_limited_bootstrap_and_participant_su
     assert_eq!(requester_view.status, StatusCode::OK);
     assert_eq!(requester_view.body["request_state"], "approved");
     assert_eq!(requester_view.body["created_realm_id"], realm_id);
+    assert!(requester_view.body.get("requested_by_account_id").is_none());
     assert!(requester_view.body.get("reviewed_by_operator_id").is_none());
 
     let summary = get_json(
@@ -113,6 +116,11 @@ async fn realm_request_can_be_approved_into_limited_bootstrap_and_participant_su
     );
     assert!(
         summary.body["realm_request"]
+            .get("requested_by_account_id")
+            .is_none()
+    );
+    assert!(
+        summary.body["realm_request"]
             .get("reviewed_by_operator_id")
             .is_none()
     );
@@ -131,6 +139,36 @@ async fn realm_request_can_be_approved_into_limited_bootstrap_and_participant_su
             .get("rebuild_generation")
             .is_none()
     );
+}
+
+#[tokio::test]
+async fn realm_request_body_size_is_bounded() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let requester = sign_in(&app, "pi-user-realm-large-body", "realm-large-body").await;
+
+    let oversized = post_json(
+        &app,
+        "/api/realms/requests",
+        Some(requester.token.as_str()),
+        json!({
+            "display_name": "Large body Realm",
+            "slug_candidate": "large-body-realm",
+            "purpose_text": "x".repeat(17 * 1024),
+            "venue_context_json": {
+                "city": "Tokyo",
+                "venue_type": "cafe"
+            },
+            "expected_member_shape_json": {
+                "pace": "quiet"
+            },
+            "bootstrap_rationale_text": "The route must reject oversized JSON before deserialization.",
+            "request_idempotency_key": "large-body-realm"
+        }),
+    )
+    .await;
+
+    assert_eq!(oversized.status, StatusCode::PAYLOAD_TOO_LARGE);
 }
 
 #[tokio::test]
@@ -722,6 +760,34 @@ async fn realm_request_requires_venue_context_and_expected_member_shape() {
     )
     .await;
     assert_eq!(empty_shape.status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn realm_bootstrap_internal_json_posts_reject_oversized_bodies() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+
+    for path in [
+        "/api/internal/operator/realms/requests/request-id/approve",
+        "/api/internal/operator/realms/requests/request-id/reject",
+        "/api/internal/realms/realm-id/sponsor-records",
+        "/api/internal/realms/realm-id/admissions",
+    ] {
+        let request = Request::builder()
+            .method("POST")
+            .uri(path)
+            .header("content-type", "application/json")
+            .body(Body::from(vec![b'a'; 20_000]))
+            .expect("request must build");
+
+        let response = app
+            .clone()
+            .oneshot(request)
+            .await
+            .expect("app should respond");
+
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE, "{path}");
+    }
 }
 
 #[tokio::test]
@@ -3054,6 +3120,196 @@ async fn request_and_admission_idempotency_replay_mismatch_is_rejected() {
     assert_eq!(duplicate_admission.status, StatusCode::BAD_REQUEST);
 }
 
+#[tokio::test]
+async fn realm_bootstrap_idempotency_keys_reject_blank_values_at_db_layer() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let requester = sign_in(&app, "pi-user-realm-db-key-a", "realm-db-key-a").await;
+    let sponsor = sign_in(&app, "pi-user-realm-db-key-b", "realm-db-key-b").await;
+    let member = sign_in(&app, "pi-user-realm-db-key-c", "realm-db-key-c").await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let requester_id = Uuid::parse_str(&requester.account_id).expect("requester id must be uuid");
+    let sponsor_id = Uuid::parse_str(&sponsor.account_id).expect("sponsor id must be uuid");
+    let member_id = Uuid::parse_str(&member.account_id).expect("member id must be uuid");
+    let approver_uuid = Uuid::parse_str(&approver_id).expect("approver id must be uuid");
+    let blank_request_id = Uuid::new_v4();
+    let blank_review_request_id = Uuid::new_v4();
+    let blank_sponsor_record_id = Uuid::new_v4();
+    let blank_admission_id = Uuid::new_v4();
+
+    assert_check_violation(
+        client
+            .execute(
+                "
+                INSERT INTO dao.realm_requests (
+                    realm_request_id,
+                    requested_by_account_id,
+                    display_name,
+                    slug_candidate,
+                    purpose_text,
+                    venue_context_json,
+                    expected_member_shape_json,
+                    bootstrap_rationale_text,
+                    request_state,
+                    review_reason_code,
+                    request_idempotency_key,
+                    request_payload_hash
+                )
+                VALUES (
+                    $1,
+                    $2,
+                    'Blank key realm',
+                    'blank-key-realm-request',
+                    'A blank request key must fail.',
+                    '{\"city\":\"Tokyo\"}'::jsonb,
+                    '{\"size\":\"small\"}'::jsonb,
+                    'The database owns the idempotency contract.',
+                    'requested',
+                    'request_received',
+                    '   ',
+                    repeat('0', 64)
+                )
+                ",
+                &[&blank_request_id, &requester_id],
+            )
+            .await,
+    );
+
+    assert_check_violation(
+        client
+            .execute(
+                "
+                INSERT INTO dao.realm_requests (
+                    realm_request_id,
+                    requested_by_account_id,
+                    display_name,
+                    slug_candidate,
+                    purpose_text,
+                    venue_context_json,
+                    expected_member_shape_json,
+                    bootstrap_rationale_text,
+                    request_state,
+                    review_reason_code,
+                    request_idempotency_key,
+                    request_payload_hash,
+                    reviewed_by_operator_id,
+                    review_decision_idempotency_key,
+                    review_decision_payload_hash,
+                    reviewed_at
+                )
+                VALUES (
+                    $1,
+                    $2,
+                    'Blank review key realm',
+                    'blank-review-key-realm-request',
+                    'A blank review key must fail.',
+                    '{\"city\":\"Tokyo\"}'::jsonb,
+                    '{\"size\":\"small\"}'::jsonb,
+                    'The database owns review idempotency too.',
+                    'approved',
+                    'active_after_review',
+                    'db-valid-request-key',
+                    repeat('1', 64),
+                    $3,
+                    '   ',
+                    repeat('2', 64),
+                    CURRENT_TIMESTAMP
+                )
+                ",
+                &[&blank_review_request_id, &requester_id, &approver_uuid],
+            )
+            .await,
+    );
+
+    let (realm_id, _) = create_realm(
+        &app,
+        &requester,
+        None,
+        None,
+        &approver_id,
+        "active",
+        "db-key-blank",
+    )
+    .await;
+
+    assert_check_violation(
+        client
+            .execute(
+                "
+                INSERT INTO dao.realm_sponsor_records (
+                    realm_sponsor_record_id,
+                    realm_id,
+                    sponsor_account_id,
+                    sponsor_status,
+                    quota_total,
+                    status_reason_code,
+                    approved_by_operator_id,
+                    request_idempotency_key,
+                    request_payload_hash
+                )
+                VALUES (
+                    $1,
+                    $2,
+                    $3,
+                    'approved',
+                    1,
+                    'active_after_review',
+                    $4,
+                    '   ',
+                    repeat('3', 64)
+                )
+                ",
+                &[
+                    &blank_sponsor_record_id,
+                    &realm_id,
+                    &sponsor_id,
+                    &approver_uuid,
+                ],
+            )
+            .await,
+    );
+
+    assert_check_violation(
+        client
+            .execute(
+                "
+                INSERT INTO dao.realm_admissions (
+                    realm_admission_id,
+                    realm_id,
+                    account_id,
+                    admission_kind,
+                    admission_status,
+                    granted_by_actor_kind,
+                    granted_by_actor_id,
+                    review_reason_code,
+                    source_fact_kind,
+                    source_fact_id,
+                    request_idempotency_key,
+                    request_payload_hash
+                )
+                VALUES (
+                    $1,
+                    $2,
+                    $3,
+                    'normal',
+                    'admitted',
+                    'operator',
+                    $4,
+                    'active_after_review',
+                    'db_test',
+                    'blank-admission-key',
+                    '   ',
+                    repeat('4', 64)
+                )
+                ",
+                &[&blank_admission_id, &realm_id, &member_id, &approver_uuid],
+            )
+            .await,
+    );
+}
+
 async fn create_realm(
     app: &Router,
     requester: &SignedInUser,
@@ -3131,6 +3387,11 @@ async fn create_realm(
             .to_owned(),
         realm_request_id,
     )
+}
+
+fn assert_check_violation(result: Result<u64, tokio_postgres::Error>) {
+    let error = result.expect_err("blank idempotency key must fail a database check");
+    assert_eq!(error.code(), Some(&SqlState::CHECK_VIOLATION));
 }
 
 async fn sponsor_record_id_for_realm(client: &tokio_postgres::Client, realm_id: &str) -> String {

--- a/apps/backend/tests/realm_bootstrap.rs
+++ b/apps/backend/tests/realm_bootstrap.rs
@@ -661,6 +661,12 @@ async fn suspicious_requests_enter_review_even_when_trigger_is_already_open() {
         )
         .await;
         assert_eq!(rejected.status, StatusCode::OK);
+        if index == 1 {
+            assert_eq!(
+                rejected.body["open_review_triggers"][0]["trigger_kind"],
+                "repeated_rejected_requests"
+            );
+        }
     }
 
     let repeated_request = post_json(
@@ -3348,8 +3354,19 @@ async fn operator_review_summary_read_refreshes_lag_metadata() {
         "realm-summary-lag",
     )
     .await;
+    client
+        .execute(
+            "
+            UPDATE projection.realm_review_summaries
+            SET projection_lag_ms = 999999,
+                last_projected_at = last_projected_at - interval '1 second'
+            WHERE realm_id = $1
+            ",
+            &[&realm_id],
+        )
+        .await
+        .expect("review summary lag fixture must update");
     let projected_at = current_review_summary_last_projected_at(&client, &realm_id).await;
-    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
 
     let review_summary = operator_get_json(
         &app,

--- a/apps/backend/tests/realm_bootstrap.rs
+++ b/apps/backend/tests/realm_bootstrap.rs
@@ -762,6 +762,98 @@ async fn sponsor_backed_admission_respects_corridor_member_cap() {
 }
 
 #[tokio::test]
+async fn realm_scoped_review_trigger_fingerprints_do_not_collapse_across_realms() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let requester = sign_in(
+        &app,
+        "pi-user-realm-scoped-trigger-requester",
+        "realm-scoped-trigger-requester",
+    )
+    .await;
+    let sponsor = sign_in(
+        &app,
+        "pi-user-realm-scoped-trigger-sponsor",
+        "realm-scoped-trigger-sponsor",
+    )
+    .await;
+    let member = sign_in(
+        &app,
+        "pi-user-realm-scoped-trigger-member",
+        "realm-scoped-trigger-member",
+    )
+    .await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let mut realm_ids = Vec::new();
+    for index in 1..=4 {
+        let (realm_id, _) = create_realm(
+            &app,
+            &requester,
+            None,
+            None,
+            &approver_id,
+            "active",
+            &format!("realm-scoped-trigger-{index}"),
+        )
+        .await;
+        let sponsor_record = operator_post_json(
+            &app,
+            &format!("/api/internal/realms/{realm_id}/sponsor-records"),
+            &approver_id,
+            json!({
+                "sponsor_account_id": sponsor.account_id,
+                "sponsor_status": "active",
+                "quota_total": 4,
+                "status_reason_code": "active_after_review",
+                "request_idempotency_key": format!("realm-scoped-trigger-sponsor-{index}")
+            }),
+        )
+        .await;
+        assert_eq!(sponsor_record.status, StatusCode::OK);
+        let admission = operator_post_json(
+            &app,
+            &format!("/api/internal/realms/{realm_id}/admissions"),
+            &approver_id,
+            json!({
+                "account_id": member.account_id,
+                "source_fact_kind": "manual_review",
+                "source_fact_id": format!("realm-scoped-trigger-admission-{index}"),
+                "source_snapshot_json": {},
+                "request_idempotency_key": format!("realm-scoped-trigger-admission-{index}")
+            }),
+        )
+        .await;
+        assert_eq!(admission.status, StatusCode::OK);
+        realm_ids.push(realm_id);
+    }
+
+    for realm_id in &realm_ids[2..] {
+        let review_summary = operator_get_json(
+            &app,
+            &format!("/api/internal/operator/realms/{realm_id}/review-summary"),
+            &approver_id,
+        )
+        .await;
+        assert_eq!(review_summary.status, StatusCode::OK);
+        assert_eq!(review_summary.body["open_review_trigger_count"], 2);
+        let trigger_kinds = review_summary.body["open_review_triggers"]
+            .as_array()
+            .expect("open review triggers must be an array")
+            .iter()
+            .map(|value| {
+                value["trigger_kind"]
+                    .as_str()
+                    .expect("trigger kind must be present")
+            })
+            .collect::<Vec<_>>();
+        assert!(trigger_kinds.contains(&"sponsor_concentration"));
+        assert!(trigger_kinds.contains(&"suspicious_member_overlap"));
+    }
+}
+
+#[tokio::test]
 async fn cross_realm_sponsor_record_cannot_grant_admission() {
     let test_state = new_test_state().await.expect("test database state");
     let app = build_app(test_state.state.clone());

--- a/apps/backend/tests/realm_bootstrap.rs
+++ b/apps/backend/tests/realm_bootstrap.rs
@@ -1721,6 +1721,74 @@ async fn stale_sponsor_record_id_uses_latest_sponsor_status() {
 }
 
 #[tokio::test]
+async fn sponsor_backed_admission_waits_for_sponsor_lineage_lock() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let requester = sign_in(&app, "pi-user-realm-sponsor-lock-a", "realm-sponsor-lock-a").await;
+    let sponsor = sign_in(&app, "pi-user-realm-sponsor-lock-b", "realm-sponsor-lock-b").await;
+    let member = sign_in(&app, "pi-user-realm-sponsor-lock-c", "realm-sponsor-lock-c").await;
+    let mut lock_client = test_db_client().await;
+    let approver_id = insert_operator_account(&lock_client, "approver").await;
+
+    let (realm_id, _) = create_realm(
+        &app,
+        &requester,
+        Some(&sponsor),
+        None,
+        &approver_id,
+        "active",
+        "realm-sponsor-lock",
+    )
+    .await;
+    let active_sponsor_record_id = sponsor_record_id_for_realm(&lock_client, &realm_id).await;
+    let sponsor_account_id =
+        Uuid::parse_str(&sponsor.account_id).expect("sponsor account id must be a uuid");
+
+    let lock_tx = lock_client
+        .transaction()
+        .await
+        .expect("lock transaction must start");
+    lock_sponsor_lineage_for_test(&lock_tx, &realm_id, &sponsor_account_id).await;
+
+    let admission_app = app.clone();
+    let admission_path = format!("/api/internal/realms/{realm_id}/admissions");
+    let admission_operator_id = approver_id.clone();
+    let admission_member_id = member.account_id.clone();
+    let admission_sponsor_record_id = active_sponsor_record_id.clone();
+    let mut admission_task = tokio::spawn(async move {
+        operator_post_json(
+            &admission_app,
+            &admission_path,
+            &admission_operator_id,
+            json!({
+                "account_id": admission_member_id,
+                "sponsor_record_id": admission_sponsor_record_id,
+                "source_fact_kind": "sponsor_invite",
+                "source_fact_id": "realm-sponsor-lock-admission",
+                "source_snapshot_json": {},
+                "request_idempotency_key": "realm-sponsor-lock-admission"
+            }),
+        )
+        .await
+    });
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(200), &mut admission_task)
+            .await
+            .is_err()
+    );
+
+    lock_tx
+        .commit()
+        .await
+        .expect("lock transaction must commit");
+
+    let admission = admission_task.await.expect("admission task must complete");
+    assert_eq!(admission.status, StatusCode::OK);
+    assert_eq!(admission.body["admission_kind"], "sponsor_backed");
+    assert_eq!(admission.body["admission_status"], "admitted");
+}
+
+#[tokio::test]
 async fn expired_and_disabled_corridor_do_not_grant_corridor_benefits_even_if_projection_is_stale()
 {
     let test_state = new_test_state().await.expect("test database state");
@@ -1953,6 +2021,53 @@ async fn unauthorized_summary_read_does_not_expire_corridor_or_refresh_projectio
         requester_summary.body["bootstrap_view"]["corridor_status"],
         "expired"
     );
+}
+
+#[tokio::test]
+async fn realm_bootstrap_rebuild_requires_operator_role() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let ordinary = sign_in(
+        &app,
+        "pi-user-realm-rebuild-ordinary",
+        "realm-rebuild-ordinary",
+    )
+    .await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let missing_operator = request_json(
+        &app,
+        "POST",
+        "/api/internal/projection/realms/rebuild",
+        None,
+        None,
+        None,
+    )
+    .await;
+    assert_eq!(missing_operator.status, StatusCode::BAD_REQUEST);
+
+    let ordinary_operator = request_json(
+        &app,
+        "POST",
+        "/api/internal/projection/realms/rebuild",
+        None,
+        Some(&ordinary.account_id),
+        None,
+    )
+    .await;
+    assert_eq!(ordinary_operator.status, StatusCode::UNAUTHORIZED);
+
+    let rebuild = request_json(
+        &app,
+        "POST",
+        "/api/internal/projection/realms/rebuild",
+        None,
+        Some(&approver_id),
+        None,
+    )
+    .await;
+    assert_eq!(rebuild.status, StatusCode::OK);
 }
 
 #[tokio::test]
@@ -2585,6 +2700,25 @@ async fn current_corridor_status(client: &tokio_postgres::Client, realm_id: &str
         .await
         .expect("corridor row must exist")
         .get("corridor_status")
+}
+
+async fn lock_sponsor_lineage_for_test(
+    tx: &tokio_postgres::Transaction<'_>,
+    realm_id: &str,
+    sponsor_account_id: &Uuid,
+) {
+    let sponsor_account_id_text = sponsor_account_id.to_string();
+    tx.query_one(
+        "
+        SELECT pg_advisory_xact_lock(
+            hashtext('realm_bootstrap.sponsor_lineage'),
+            hashtext($1 || ':' || $2::text)
+        )
+        ",
+        &[&realm_id, &sponsor_account_id_text],
+    )
+    .await
+    .expect("sponsor lineage lock must be acquired");
 }
 
 async fn current_projection_rebuild_generation(

--- a/apps/backend/tests/realm_bootstrap.rs
+++ b/apps/backend/tests/realm_bootstrap.rs
@@ -3,7 +3,7 @@ use axum::{
     body::{Body, to_bytes},
     http::{Request, StatusCode},
 };
-use chrono::{Duration, Utc};
+use chrono::{DateTime, Duration, Utc};
 use musubi_backend::{build_app, new_state_from_config, new_test_state};
 use musubi_db_runtime::DbConfig;
 use serde_json::{Value, json};
@@ -2168,6 +2168,45 @@ async fn summary_reads_refresh_expired_corridor_without_unrelated_write() {
 }
 
 #[tokio::test]
+async fn participant_summary_read_skips_noop_operator_projection_refresh() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let requester = sign_in(&app, "pi-user-realm-summary-noop-a", "realm-summary-noop-a").await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let (realm_id, _) = create_realm(
+        &app,
+        &requester,
+        None,
+        None,
+        &approver_id,
+        "limited_bootstrap",
+        "realm-summary-noop",
+    )
+    .await;
+    let bootstrap_projected_at = current_bootstrap_last_projected_at(&client, &realm_id).await;
+    let review_projected_at = current_review_summary_last_projected_at(&client, &realm_id).await;
+    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+    let summary = get_json(
+        &app,
+        &format!("/api/projection/realms/{realm_id}/bootstrap-summary"),
+        Some(requester.token.as_str()),
+    )
+    .await;
+    assert_eq!(summary.status, StatusCode::OK);
+    assert_eq!(
+        current_bootstrap_last_projected_at(&client, &realm_id).await,
+        bootstrap_projected_at
+    );
+    assert_eq!(
+        current_review_summary_last_projected_at(&client, &realm_id).await,
+        review_projected_at
+    );
+}
+
+#[tokio::test]
 async fn unauthorized_summary_read_does_not_expire_corridor_or_refresh_projection() {
     let test_state = new_test_state().await.expect("test database state");
     let app = build_app(test_state.state.clone());
@@ -3019,6 +3058,42 @@ async fn current_projection_rebuild_generation(
         .await
         .expect("projection row must exist")
         .get("rebuild_generation")
+}
+
+async fn current_bootstrap_last_projected_at(
+    client: &tokio_postgres::Client,
+    realm_id: &str,
+) -> DateTime<Utc> {
+    client
+        .query_one(
+            "
+            SELECT last_projected_at
+            FROM projection.realm_bootstrap_views
+            WHERE realm_id = $1
+            ",
+            &[&realm_id],
+        )
+        .await
+        .expect("bootstrap projection row must exist")
+        .get("last_projected_at")
+}
+
+async fn current_review_summary_last_projected_at(
+    client: &tokio_postgres::Client,
+    realm_id: &str,
+) -> DateTime<Utc> {
+    client
+        .query_one(
+            "
+            SELECT last_projected_at
+            FROM projection.realm_review_summaries
+            WHERE realm_id = $1
+            ",
+            &[&realm_id],
+        )
+        .await
+        .expect("review summary projection row must exist")
+        .get("last_projected_at")
 }
 
 async fn set_realm_status(

--- a/apps/backend/tests/realm_bootstrap.rs
+++ b/apps/backend/tests/realm_bootstrap.rs
@@ -1416,6 +1416,266 @@ async fn pending_admission_can_be_superseded_by_operator_admission_after_review(
 }
 
 #[tokio::test]
+async fn corridor_member_cap_counts_distinct_accounts_when_pending_rows_repeat() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let requester = sign_in(
+        &app,
+        "pi-user-realm-corridor-distinct-a",
+        "realm-corridor-distinct-a",
+    )
+    .await;
+    let repeated_member = sign_in(
+        &app,
+        "pi-user-realm-corridor-distinct-b",
+        "realm-corridor-distinct-b",
+    )
+    .await;
+    let next_member = sign_in(
+        &app,
+        "pi-user-realm-corridor-distinct-c",
+        "realm-corridor-distinct-c",
+    )
+    .await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let (realm_id, _) = create_realm(
+        &app,
+        &requester,
+        None,
+        None,
+        &approver_id,
+        "limited_bootstrap",
+        "realm-corridor-distinct-001",
+    )
+    .await;
+    let corridor_id: Uuid = client
+        .query_one(
+            "
+            SELECT bootstrap_corridor_id
+            FROM dao.bootstrap_corridors
+            WHERE realm_id = $1
+            ",
+            &[&realm_id],
+        )
+        .await
+        .expect("bootstrap corridor must query")
+        .get("bootstrap_corridor_id");
+    let repeated_member_id =
+        Uuid::parse_str(&repeated_member.account_id).expect("member id must be uuid");
+    let approver_uuid = Uuid::parse_str(&approver_id).expect("operator id must be uuid");
+
+    for index in 0..2 {
+        let source_fact_id = format!("realm-corridor-distinct-pending-{index}");
+        let request_idempotency_key = format!("realm-corridor-distinct-pending-{index}");
+        client
+            .execute(
+                "
+                INSERT INTO dao.realm_admissions (
+                    realm_admission_id,
+                    realm_id,
+                    account_id,
+                    admission_kind,
+                    admission_status,
+                    sponsor_record_id,
+                    bootstrap_corridor_id,
+                    granted_by_actor_kind,
+                    granted_by_actor_id,
+                    review_reason_code,
+                    source_fact_kind,
+                    source_fact_id,
+                    source_snapshot_json,
+                    request_idempotency_key,
+                    request_payload_hash
+                )
+                VALUES (
+                    $1,
+                    $2,
+                    $3,
+                    'review_required',
+                    'pending',
+                    NULL,
+                    $4,
+                    'operator',
+                    $5,
+                    'review_required',
+                    'operator_review',
+                    $6,
+                    '{}'::jsonb,
+                    $7,
+                    repeat('7', 64)
+                )
+                ",
+                &[
+                    &Uuid::new_v4(),
+                    &realm_id,
+                    &repeated_member_id,
+                    &corridor_id,
+                    &approver_uuid,
+                    &source_fact_id,
+                    &request_idempotency_key,
+                ],
+            )
+            .await
+            .expect("pending corridor admission must insert");
+    }
+
+    let next = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_id}/admissions"),
+        &approver_id,
+        json!({
+            "account_id": next_member.account_id,
+            "source_fact_kind": "operator_review",
+            "source_fact_id": "realm-corridor-distinct-next",
+            "source_snapshot_json": {
+                "review_outcome": "approved"
+            },
+            "request_idempotency_key": "realm-corridor-distinct-next"
+        }),
+    )
+    .await;
+    assert_eq!(next.status, StatusCode::OK);
+    assert_eq!(next.body["admission_kind"], "corridor");
+    assert_eq!(next.body["admission_status"], "admitted");
+}
+
+#[tokio::test]
+async fn sponsor_quota_counts_distinct_accounts_when_pending_rows_repeat() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let requester = sign_in(
+        &app,
+        "pi-user-realm-sponsor-distinct-a",
+        "realm-sponsor-distinct-a",
+    )
+    .await;
+    let sponsor = sign_in(
+        &app,
+        "pi-user-realm-sponsor-distinct-b",
+        "realm-sponsor-distinct-b",
+    )
+    .await;
+    let repeated_member = sign_in(
+        &app,
+        "pi-user-realm-sponsor-distinct-c",
+        "realm-sponsor-distinct-c",
+    )
+    .await;
+    let next_member = sign_in(
+        &app,
+        "pi-user-realm-sponsor-distinct-d",
+        "realm-sponsor-distinct-d",
+    )
+    .await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let (realm_id, _) = create_realm(
+        &app,
+        &requester,
+        Some(&sponsor),
+        None,
+        &approver_id,
+        "active",
+        "realm-sponsor-distinct-001",
+    )
+    .await;
+    let sponsor_record_id = sponsor_record_id_for_realm(&client, &realm_id).await;
+    client
+        .execute(
+            "
+            UPDATE dao.realm_sponsor_records
+            SET quota_total = 2
+            WHERE realm_sponsor_record_id::text = $1
+            ",
+            &[&sponsor_record_id],
+        )
+        .await
+        .expect("sponsor quota must update");
+
+    let sponsor_record_uuid =
+        Uuid::parse_str(&sponsor_record_id).expect("sponsor record id must be uuid");
+    let repeated_member_id =
+        Uuid::parse_str(&repeated_member.account_id).expect("member id must be uuid");
+    let approver_uuid = Uuid::parse_str(&approver_id).expect("operator id must be uuid");
+
+    for index in 0..2 {
+        let source_fact_id = format!("realm-sponsor-distinct-pending-{index}");
+        let request_idempotency_key = format!("realm-sponsor-distinct-pending-{index}");
+        client
+            .execute(
+                "
+                INSERT INTO dao.realm_admissions (
+                    realm_admission_id,
+                    realm_id,
+                    account_id,
+                    admission_kind,
+                    admission_status,
+                    sponsor_record_id,
+                    bootstrap_corridor_id,
+                    granted_by_actor_kind,
+                    granted_by_actor_id,
+                    review_reason_code,
+                    source_fact_kind,
+                    source_fact_id,
+                    source_snapshot_json,
+                    request_idempotency_key,
+                    request_payload_hash
+                )
+                VALUES (
+                    $1,
+                    $2,
+                    $3,
+                    'sponsor_backed',
+                    'pending',
+                    $4,
+                    NULL,
+                    'operator',
+                    $5,
+                    'active_after_review',
+                    'operator_review',
+                    $6,
+                    '{}'::jsonb,
+                    $7,
+                    repeat('8', 64)
+                )
+                ",
+                &[
+                    &Uuid::new_v4(),
+                    &realm_id,
+                    &repeated_member_id,
+                    &sponsor_record_uuid,
+                    &approver_uuid,
+                    &source_fact_id,
+                    &request_idempotency_key,
+                ],
+            )
+            .await
+            .expect("pending sponsor admission must insert");
+    }
+
+    let next = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_id}/admissions"),
+        &approver_id,
+        json!({
+            "account_id": next_member.account_id,
+            "sponsor_record_id": sponsor_record_id,
+            "source_fact_kind": "sponsor_invite",
+            "source_fact_id": "realm-sponsor-distinct-next",
+            "source_snapshot_json": {},
+            "request_idempotency_key": "realm-sponsor-distinct-next"
+        }),
+    )
+    .await;
+    assert_eq!(next.status, StatusCode::OK);
+    assert_eq!(next.body["admission_kind"], "sponsor_backed");
+    assert_eq!(next.body["admission_status"], "admitted");
+}
+
+#[tokio::test]
 async fn sponsor_backed_admission_respects_corridor_member_cap() {
     let test_state = new_test_state().await.expect("test database state");
     let app = build_app(test_state.state.clone());

--- a/apps/backend/tests/realm_bootstrap.rs
+++ b/apps/backend/tests/realm_bootstrap.rs
@@ -837,6 +837,14 @@ async fn sponsor_backed_admission_respects_quota_and_review_summary_is_redacted(
         "bootstrap_capacity_reached"
     );
 
+    let pending_member_summary = get_json(
+        &app,
+        &format!("/api/projection/realms/{realm_id}/bootstrap-summary"),
+        Some(second_member.token.as_str()),
+    )
+    .await;
+    assert_eq!(pending_member_summary.status, StatusCode::NOT_FOUND);
+
     let review_summary = operator_get_json(
         &app,
         &format!("/api/internal/operator/realms/{realm_id}/review-summary"),
@@ -1288,13 +1296,23 @@ async fn rate_limited_and_revoked_sponsor_do_not_auto_admit() {
     .await;
     let rate_limited_sponsor_record_id =
         sponsor_record_id_for_realm(&client, &rate_limited_realm_id).await;
-    set_sponsor_status(
-        &client,
-        &rate_limited_sponsor_record_id,
-        "rate_limited",
-        "sponsor_rate_limited",
+    let rate_limit_record = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{rate_limited_realm_id}/sponsor-records"),
+        &approver_id,
+        json!({
+            "sponsor_account_id": sponsor.account_id,
+            "sponsor_status": "rate_limited",
+            "quota_total": 1,
+            "status_reason_code": "sponsor_rate_limited",
+            "request_idempotency_key": "realm-sponsor-rate-limited-record"
+        }),
     )
     .await;
+    assert_eq!(rate_limit_record.status, StatusCode::OK);
+    let latest_rate_limited_sponsor_record_id = rate_limit_record.body["realm_sponsor_record_id"]
+        .as_str()
+        .expect("rate-limited sponsor record id must exist");
 
     let rate_limited = operator_post_json(
         &app,
@@ -1316,6 +1334,10 @@ async fn rate_limited_and_revoked_sponsor_do_not_auto_admit() {
     assert_eq!(
         rate_limited.body["review_reason_code"],
         "sponsor_rate_limited"
+    );
+    assert_eq!(
+        rate_limited.body["sponsor_record_id"],
+        latest_rate_limited_sponsor_record_id
     );
 
     let (revoked_realm_id, _) = create_realm(

--- a/apps/backend/tests/realm_bootstrap.rs
+++ b/apps/backend/tests/realm_bootstrap.rs
@@ -4,7 +4,10 @@ use axum::{
     http::{Request, StatusCode},
 };
 use chrono::{DateTime, Duration, Utc};
-use musubi_backend::{build_app, new_state_from_config, new_test_state};
+use musubi_backend::{
+    build_app, new_state_from_config, new_test_state,
+    services::realm_bootstrap::CreateRealmRequestInput,
+};
 use musubi_db_runtime::DbConfig;
 use serde_json::{Value, json};
 use tokio_postgres::error::SqlState;
@@ -3838,6 +3841,34 @@ async fn request_and_admission_idempotency_replay_mismatch_is_rejected() {
         inactive_candidate_replay.body["realm_request_id"],
         realm_request_id
     );
+
+    set_account_state(&client, &requester.account_id, "suspended").await;
+    let inactive_requester_replay = test_state
+        .state
+        .realm_bootstrap
+        .create_realm_request(
+            &requester.account_id,
+            CreateRealmRequestInput {
+                display_name: "神戸読書会".to_owned(),
+                slug_candidate: "kobe-reading-room".to_owned(),
+                purpose_text: "静かな読書と対話です。".to_owned(),
+                venue_context_json: json!({
+                    "city": "Kobe",
+                    "venue_type": "bookstore"
+                }),
+                expected_member_shape_json: json!({
+                    "size": "small"
+                }),
+                bootstrap_rationale_text: "まずは小さく始めます。".to_owned(),
+                proposed_sponsor_account_id: Some(proposed_sponsor.account_id.clone()),
+                proposed_steward_account_id: Some(proposed_steward.account_id.clone()),
+                request_idempotency_key: "realm-idem-request".to_owned(),
+            },
+        )
+        .await
+        .expect("request replay should bypass mutable account-state gates");
+    assert_eq!(inactive_requester_replay.realm_request_id, realm_request_id);
+    set_account_state(&client, &requester.account_id, "active").await;
 
     let mismatched_request = post_json(
         &app,

--- a/apps/backend/tests/realm_bootstrap.rs
+++ b/apps/backend/tests/realm_bootstrap.rs
@@ -1039,6 +1039,67 @@ async fn expired_and_disabled_corridor_do_not_grant_corridor_benefits_even_if_pr
 }
 
 #[tokio::test]
+async fn summary_reads_refresh_expired_corridor_without_unrelated_write() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let requester = sign_in(
+        &app,
+        "pi-user-realm-summary-expiry-a",
+        "realm-summary-expiry-a",
+    )
+    .await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let (realm_id, _) = create_realm(
+        &app,
+        &requester,
+        None,
+        None,
+        &approver_id,
+        "limited_bootstrap",
+        "realm-summary-expiry",
+    )
+    .await;
+    let rebuild_generation = current_projection_rebuild_generation(&client, &realm_id).await;
+    assert_eq!(
+        current_projection_corridor_status(&client, &realm_id).await,
+        "active"
+    );
+    expire_corridor_without_rebuild(&client, &realm_id).await;
+
+    let participant_summary = get_json(
+        &app,
+        &format!("/api/projection/realms/{realm_id}/bootstrap-summary"),
+        Some(requester.token.as_str()),
+    )
+    .await;
+    assert_eq!(participant_summary.status, StatusCode::OK);
+    assert_eq!(
+        participant_summary.body["bootstrap_view"]["corridor_status"],
+        "expired"
+    );
+    assert_eq!(
+        participant_summary.body["bootstrap_view"]["admission_posture"],
+        "review_required"
+    );
+    assert_eq!(
+        current_projection_rebuild_generation(&client, &realm_id).await,
+        rebuild_generation
+    );
+
+    let review_summary = operator_get_json(
+        &app,
+        &format!("/api/internal/operator/realms/{realm_id}/review-summary"),
+        &approver_id,
+    )
+    .await;
+    assert_eq!(review_summary.status, StatusCode::OK);
+    assert_eq!(review_summary.body["corridor_status"], "expired");
+    assert_eq!(review_summary.body["corridor_remaining_seconds"], 0);
+}
+
+#[tokio::test]
 async fn expired_or_disabled_corridor_blocks_sponsor_backed_auto_admission() {
     let test_state = new_test_state().await.expect("test database state");
     let app = build_app(test_state.state.clone());
@@ -1208,6 +1269,42 @@ async fn restricted_and_suspended_realms_block_new_admissions() {
 }
 
 #[tokio::test]
+async fn duplicate_sponsor_record_conflict_is_bad_request() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let requester = sign_in(&app, "pi-user-realm-sponsor-dup-a", "realm-sponsor-dup-a").await;
+    let sponsor = sign_in(&app, "pi-user-realm-sponsor-dup-b", "realm-sponsor-dup-b").await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let (realm_id, _) = create_realm(
+        &app,
+        &requester,
+        Some(&sponsor),
+        None,
+        &approver_id,
+        "limited_bootstrap",
+        "realm-sponsor-duplicate",
+    )
+    .await;
+
+    let duplicate = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_id}/sponsor-records"),
+        &approver_id,
+        json!({
+            "sponsor_account_id": sponsor.account_id,
+            "sponsor_status": "active",
+            "quota_total": 1,
+            "status_reason_code": "limited_bootstrap_active",
+            "request_idempotency_key": "realm-sponsor-duplicate-second-key"
+        }),
+    )
+    .await;
+    assert_eq!(duplicate.status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
 async fn request_and_admission_idempotency_replay_mismatch_is_rejected() {
     let test_state = new_test_state().await.expect("test database state");
     let app = build_app(test_state.state.clone());
@@ -1343,6 +1440,21 @@ async fn request_and_admission_idempotency_replay_mismatch_is_rejected() {
     )
     .await;
     assert_eq!(mismatched_admission.status, StatusCode::BAD_REQUEST);
+
+    let duplicate_admission = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_id}/admissions"),
+        &approver_id,
+        json!({
+            "account_id": member.account_id,
+            "source_fact_kind": "realm_admin_invite",
+            "source_fact_id": "realm-idem-admission-second-key",
+            "source_snapshot_json": {},
+            "request_idempotency_key": "realm-idem-admission-second-key"
+        }),
+    )
+    .await;
+    assert_eq!(duplicate_admission.status, StatusCode::BAD_REQUEST);
 }
 
 async fn create_realm(
@@ -1529,6 +1641,24 @@ async fn current_projection_corridor_status(
         .await
         .expect("projection row must exist")
         .get("corridor_status")
+}
+
+async fn current_projection_rebuild_generation(
+    client: &tokio_postgres::Client,
+    realm_id: &str,
+) -> i64 {
+    client
+        .query_one(
+            "
+            SELECT rebuild_generation
+            FROM projection.realm_bootstrap_views
+            WHERE realm_id = $1
+            ",
+            &[&realm_id],
+        )
+        .await
+        .expect("projection row must exist")
+        .get("rebuild_generation")
 }
 
 async fn set_realm_status(

--- a/apps/backend/tests/realm_bootstrap.rs
+++ b/apps/backend/tests/realm_bootstrap.rs
@@ -1893,6 +1893,69 @@ async fn summary_reads_refresh_expired_corridor_without_unrelated_write() {
 }
 
 #[tokio::test]
+async fn unauthorized_summary_read_does_not_expire_corridor_or_refresh_projection() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let requester = sign_in(
+        &app,
+        "pi-user-realm-summary-unauthorized-a",
+        "realm-summary-unauthorized-a",
+    )
+    .await;
+    let outsider = sign_in(
+        &app,
+        "pi-user-realm-summary-unauthorized-b",
+        "realm-summary-unauthorized-b",
+    )
+    .await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let (realm_id, _) = create_realm(
+        &app,
+        &requester,
+        None,
+        None,
+        &approver_id,
+        "limited_bootstrap",
+        "realm-summary-unauthorized",
+    )
+    .await;
+    expire_corridor_without_rebuild(&client, &realm_id).await;
+    assert_eq!(current_corridor_status(&client, &realm_id).await, "active");
+    assert_eq!(
+        current_projection_corridor_status(&client, &realm_id).await,
+        "active"
+    );
+
+    let unauthorized_summary = get_json(
+        &app,
+        &format!("/api/projection/realms/{realm_id}/bootstrap-summary"),
+        Some(outsider.token.as_str()),
+    )
+    .await;
+    assert_eq!(unauthorized_summary.status, StatusCode::NOT_FOUND);
+    assert_eq!(current_corridor_status(&client, &realm_id).await, "active");
+    assert_eq!(
+        current_projection_corridor_status(&client, &realm_id).await,
+        "active"
+    );
+
+    let requester_summary = get_json(
+        &app,
+        &format!("/api/projection/realms/{realm_id}/bootstrap-summary"),
+        Some(requester.token.as_str()),
+    )
+    .await;
+    assert_eq!(requester_summary.status, StatusCode::OK);
+    assert_eq!(current_corridor_status(&client, &realm_id).await, "expired");
+    assert_eq!(
+        requester_summary.body["bootstrap_view"]["corridor_status"],
+        "expired"
+    );
+}
+
+#[tokio::test]
 async fn expired_or_disabled_corridor_blocks_sponsor_backed_auto_admission() {
     let test_state = new_test_state().await.expect("test database state");
     let app = build_app(test_state.state.clone());
@@ -2504,6 +2567,23 @@ async fn current_projection_corridor_status(
         )
         .await
         .expect("projection row must exist")
+        .get("corridor_status")
+}
+
+async fn current_corridor_status(client: &tokio_postgres::Client, realm_id: &str) -> String {
+    client
+        .query_one(
+            "
+            SELECT corridor_status
+            FROM dao.bootstrap_corridors
+            WHERE realm_id = $1
+            ORDER BY updated_at DESC, bootstrap_corridor_id DESC
+            LIMIT 1
+            ",
+            &[&realm_id],
+        )
+        .await
+        .expect("corridor row must exist")
         .get("corridor_status")
 }
 

--- a/apps/backend/tests/realm_bootstrap.rs
+++ b/apps/backend/tests/realm_bootstrap.rs
@@ -1110,6 +1110,97 @@ async fn approval_rejects_non_positive_sponsor_quota_total() {
 }
 
 #[tokio::test]
+async fn approval_sponsor_record_uses_normalized_review_idempotency_key() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let requester = sign_in(
+        &app,
+        "pi-user-realm-normalized-review-a",
+        "realm-normalized-review-a",
+    )
+    .await;
+    let sponsor = sign_in(
+        &app,
+        "pi-user-realm-normalized-review-b",
+        "realm-normalized-review-b",
+    )
+    .await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let request = post_json(
+        &app,
+        "/api/realms/requests",
+        Some(requester.token.as_str()),
+        json!({
+            "display_name": "Normalized review key realm",
+            "slug_candidate": "normalized-review-key-realm",
+            "purpose_text": "Sponsor lineage should use normalized review keys.",
+            "venue_context_json": {
+                "city": "Tokyo",
+                "venue_type": "community_space"
+            },
+            "expected_member_shape_json": {
+                "pace": "quiet"
+            },
+            "bootstrap_rationale_text": "Keep approval replay keys stable.",
+            "proposed_sponsor_account_id": sponsor.account_id,
+            "request_idempotency_key": "realm-normalized-review-request"
+        }),
+    )
+    .await;
+    assert_eq!(request.status, StatusCode::OK);
+    let realm_request_id = request.body["realm_request_id"]
+        .as_str()
+        .expect("realm request id must exist");
+
+    let approval = operator_post_json(
+        &app,
+        &format!("/api/internal/operator/realms/requests/{realm_request_id}/approve"),
+        &approver_id,
+        json!({
+            "target_realm_status": "active",
+            "review_reason_code": "active_after_review",
+            "sponsor_quota_total": 1,
+            "review_decision_idempotency_key": "  realm-normalized-review-approve  "
+        }),
+    )
+    .await;
+    assert_eq!(approval.status, StatusCode::OK);
+    let realm_id = approval.body["realm_id"]
+        .as_str()
+        .expect("realm id must exist");
+
+    let row = client
+        .query_one(
+            "
+            SELECT
+                request.review_decision_idempotency_key,
+                sponsor.request_idempotency_key AS sponsor_request_idempotency_key
+            FROM dao.realm_requests request
+            JOIN dao.realms realm
+              ON realm.created_from_realm_request_id = request.realm_request_id
+            JOIN dao.realm_sponsor_records sponsor
+              ON sponsor.realm_id = realm.realm_id
+            WHERE request.realm_request_id::text = $1
+              AND realm.realm_id = $2
+            ",
+            &[&realm_request_id, &realm_id],
+        )
+        .await
+        .expect("approval sponsor record must query");
+    assert_eq!(
+        row.get::<_, Option<String>>("review_decision_idempotency_key")
+            .as_deref(),
+        Some("realm-normalized-review-approve")
+    );
+    assert_eq!(
+        row.get::<_, String>("sponsor_request_idempotency_key"),
+        "realm-normalized-review-approve"
+    );
+}
+
+#[tokio::test]
 async fn sponsor_backed_admission_respects_quota_and_review_summary_is_redacted() {
     let test_state = new_test_state().await.expect("test database state");
     let app = build_app(test_state.state.clone());
@@ -1231,6 +1322,96 @@ async fn sponsor_backed_admission_respects_quota_and_review_summary_is_redacted(
             .body
             .to_string()
             .contains("internal_trigger_context")
+    );
+}
+
+#[tokio::test]
+async fn pending_admission_can_be_superseded_by_operator_admission_after_review() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let requester = sign_in(&app, "pi-user-realm-supersede-a", "realm-supersede-a").await;
+    let sponsor = sign_in(&app, "pi-user-realm-supersede-b", "realm-supersede-b").await;
+    let first_member = sign_in(&app, "pi-user-realm-supersede-c", "realm-supersede-c").await;
+    let reviewed_member = sign_in(&app, "pi-user-realm-supersede-d", "realm-supersede-d").await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let (realm_id, _) = create_realm(
+        &app,
+        &requester,
+        Some(&sponsor),
+        None,
+        &approver_id,
+        "active",
+        "realm-supersede-001",
+    )
+    .await;
+    let sponsor_record_id = sponsor_record_id_for_realm(&client, &realm_id).await;
+
+    let first = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_id}/admissions"),
+        &approver_id,
+        json!({
+            "account_id": first_member.account_id,
+            "sponsor_record_id": sponsor_record_id,
+            "source_fact_kind": "sponsor_invite",
+            "source_fact_id": "realm-supersede-first",
+            "source_snapshot_json": {},
+            "request_idempotency_key": "realm-supersede-first"
+        }),
+    )
+    .await;
+    assert_eq!(first.status, StatusCode::OK);
+    assert_eq!(first.body["admission_status"], "admitted");
+
+    let pending = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_id}/admissions"),
+        &approver_id,
+        json!({
+            "account_id": reviewed_member.account_id,
+            "sponsor_record_id": sponsor_record_id,
+            "source_fact_kind": "sponsor_invite",
+            "source_fact_id": "realm-supersede-pending",
+            "source_snapshot_json": {},
+            "request_idempotency_key": "realm-supersede-pending"
+        }),
+    )
+    .await;
+    assert_eq!(pending.status, StatusCode::OK);
+    assert_eq!(pending.body["admission_kind"], "review_required");
+    assert_eq!(pending.body["admission_status"], "pending");
+
+    let approved_after_review = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_id}/admissions"),
+        &approver_id,
+        json!({
+            "account_id": reviewed_member.account_id,
+            "source_fact_kind": "operator_review",
+            "source_fact_id": "realm-supersede-approved",
+            "source_snapshot_json": {
+                "review_outcome": "approved"
+            },
+            "request_idempotency_key": "realm-supersede-approved"
+        }),
+    )
+    .await;
+    assert_eq!(approved_after_review.status, StatusCode::OK);
+    assert_eq!(approved_after_review.body["admission_kind"], "normal");
+    assert_eq!(approved_after_review.body["admission_status"], "admitted");
+
+    let member_summary = get_json(
+        &app,
+        &format!("/api/projection/realms/{realm_id}/bootstrap-summary"),
+        Some(reviewed_member.token.as_str()),
+    )
+    .await;
+    assert_eq!(member_summary.status, StatusCode::OK);
+    assert_eq!(
+        member_summary.body["admission_view"]["admission_status"],
+        "admitted"
     );
 }
 

--- a/apps/backend/tests/realm_bootstrap.rs
+++ b/apps/backend/tests/realm_bootstrap.rs
@@ -274,6 +274,7 @@ async fn approval_with_changed_slug_releases_original_slug_candidate() {
         json!({
             "target_realm_status": "active",
             "approved_slug": "approved-slug-candidate",
+            "approved_display_name": "Approved display realm",
             "review_reason_code": "active_after_review",
             "review_decision_idempotency_key": "realm-approved-slug-approve"
         }),
@@ -281,6 +282,7 @@ async fn approval_with_changed_slug_releases_original_slug_candidate() {
     .await;
     assert_eq!(approval.status, StatusCode::OK);
     assert_eq!(approval.body["slug"], "approved-slug-candidate");
+    assert_eq!(approval.body["display_name"], "Approved display realm");
 
     let requester_view = get_json(
         &app,
@@ -292,6 +294,10 @@ async fn approval_with_changed_slug_releases_original_slug_candidate() {
     assert_eq!(
         requester_view.body["slug_candidate"],
         "approved-slug-candidate"
+    );
+    assert_eq!(
+        requester_view.body["display_name"],
+        "Approved display realm"
     );
 
     let second_request = post_json(
@@ -516,6 +522,74 @@ async fn suspicious_requests_enter_review_even_when_trigger_is_already_open() {
     .await;
     assert_eq!(repeated_request.status, StatusCode::OK);
     assert_eq!(repeated_request.body["request_state"], "pending_review");
+}
+
+#[tokio::test]
+async fn realm_review_decision_reason_codes_are_path_specific() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let requester = sign_in(
+        &app,
+        "pi-user-realm-review-reason-a",
+        "realm-review-reason-a",
+    )
+    .await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let request = post_json(
+        &app,
+        "/api/realms/requests",
+        Some(requester.token.as_str()),
+        json!({
+            "display_name": "Review reason realm",
+            "slug_candidate": "review-reason-realm",
+            "purpose_text": "Decision reason validation.",
+            "venue_context_json": {
+                "city": "Tokyo",
+                "venue_type": "gallery"
+            },
+            "expected_member_shape_json": {
+                "pace": "slow"
+            },
+            "bootstrap_rationale_text": "Keep decision paths semantically narrow.",
+            "request_idempotency_key": "realm-review-reason-request"
+        }),
+    )
+    .await;
+    assert_eq!(request.status, StatusCode::OK);
+    let realm_request_id = request.body["realm_request_id"]
+        .as_str()
+        .expect("realm request id must exist")
+        .to_owned();
+
+    let mismatched_approval_reason = operator_post_json(
+        &app,
+        &format!("/api/internal/operator/realms/requests/{realm_request_id}/approve"),
+        &approver_id,
+        json!({
+            "target_realm_status": "active",
+            "review_reason_code": "limited_bootstrap_active",
+            "review_decision_idempotency_key": "realm-review-reason-bad-approve"
+        }),
+    )
+    .await;
+    assert_eq!(mismatched_approval_reason.status, StatusCode::BAD_REQUEST);
+
+    let rejected_with_activation_reason = operator_post_json(
+        &app,
+        &format!("/api/internal/operator/realms/requests/{realm_request_id}/reject"),
+        &approver_id,
+        json!({
+            "review_reason_code": "active_after_review",
+            "review_decision_idempotency_key": "realm-review-reason-bad-reject"
+        }),
+    )
+    .await;
+    assert_eq!(
+        rejected_with_activation_reason.status,
+        StatusCode::BAD_REQUEST
+    );
 }
 
 #[tokio::test]

--- a/apps/backend/tests/realm_bootstrap.rs
+++ b/apps/backend/tests/realm_bootstrap.rs
@@ -593,6 +593,28 @@ async fn suspicious_requests_enter_review_even_when_trigger_is_already_open() {
     .await;
     assert_eq!(third_duplicate.status, StatusCode::OK);
     assert_eq!(third_duplicate.body["request_state"], "pending_review");
+    let third_duplicate_request_id = third_duplicate.body["realm_request_id"]
+        .as_str()
+        .expect("third duplicate request id must exist");
+    let duplicate_trigger = client
+        .query_one(
+            "
+            SELECT related_realm_request_id::text AS related_realm_request_id,
+                   context_json
+            FROM dao.realm_review_triggers
+            WHERE trigger_kind = 'duplicate_venue_context'
+              AND trigger_state = 'open'
+            ",
+            &[],
+        )
+        .await
+        .expect("duplicate trigger must query");
+    assert_eq!(
+        duplicate_trigger.get::<_, String>("related_realm_request_id"),
+        third_duplicate_request_id
+    );
+    let duplicate_context: Value = duplicate_trigger.get("context_json");
+    assert_eq!(duplicate_context["matching_request_count"], 2);
 
     for index in 0..2 {
         let request = post_json(
@@ -2219,6 +2241,108 @@ async fn stale_sponsor_record_id_uses_latest_sponsor_status() {
 }
 
 #[tokio::test]
+async fn inactive_sponsor_account_blocks_auto_admission_and_can_be_revoked() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let requester = sign_in(
+        &app,
+        "pi-user-realm-inactive-sponsor-a",
+        "realm-inactive-sponsor-a",
+    )
+    .await;
+    let sponsor = sign_in(
+        &app,
+        "pi-user-realm-inactive-sponsor-b",
+        "realm-inactive-sponsor-b",
+    )
+    .await;
+    let first_member = sign_in(
+        &app,
+        "pi-user-realm-inactive-sponsor-c",
+        "realm-inactive-sponsor-c",
+    )
+    .await;
+    let second_member = sign_in(
+        &app,
+        "pi-user-realm-inactive-sponsor-d",
+        "realm-inactive-sponsor-d",
+    )
+    .await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let (realm_id, _) = create_realm(
+        &app,
+        &requester,
+        Some(&sponsor),
+        None,
+        &approver_id,
+        "active",
+        "realm-inactive-sponsor",
+    )
+    .await;
+    let stale_active_sponsor_record_id = sponsor_record_id_for_realm(&client, &realm_id).await;
+    set_account_state(&client, &sponsor.account_id, "suspended").await;
+
+    let blocked = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_id}/admissions"),
+        &approver_id,
+        json!({
+            "account_id": first_member.account_id,
+            "sponsor_record_id": stale_active_sponsor_record_id,
+            "source_fact_kind": "sponsor_invite",
+            "source_fact_id": "realm-inactive-sponsor-blocked",
+            "source_snapshot_json": {},
+            "request_idempotency_key": "realm-inactive-sponsor-blocked"
+        }),
+    )
+    .await;
+    assert_eq!(blocked.status, StatusCode::OK);
+    assert_eq!(blocked.body["admission_kind"], "review_required");
+    assert_eq!(blocked.body["admission_status"], "pending");
+    assert_eq!(blocked.body["review_reason_code"], "sponsor_revoked");
+
+    let revoked_sponsor_record = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_id}/sponsor-records"),
+        &approver_id,
+        json!({
+            "sponsor_account_id": sponsor.account_id,
+            "sponsor_status": "revoked",
+            "quota_total": 1,
+            "status_reason_code": "sponsor_revoked",
+            "request_idempotency_key": "realm-inactive-sponsor-revoked"
+        }),
+    )
+    .await;
+    assert_eq!(revoked_sponsor_record.status, StatusCode::OK);
+    let revoked_sponsor_record_id = revoked_sponsor_record.body["realm_sponsor_record_id"]
+        .as_str()
+        .expect("revoked sponsor record id must exist");
+
+    let revoked = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_id}/admissions"),
+        &approver_id,
+        json!({
+            "account_id": second_member.account_id,
+            "sponsor_record_id": stale_active_sponsor_record_id,
+            "source_fact_kind": "sponsor_invite",
+            "source_fact_id": "realm-inactive-sponsor-revoked-admission",
+            "source_snapshot_json": {},
+            "request_idempotency_key": "realm-inactive-sponsor-revoked-admission"
+        }),
+    )
+    .await;
+    assert_eq!(revoked.status, StatusCode::OK);
+    assert_eq!(revoked.body["admission_kind"], "review_required");
+    assert_eq!(revoked.body["admission_status"], "pending");
+    assert_eq!(revoked.body["review_reason_code"], "sponsor_revoked");
+    assert_eq!(revoked.body["sponsor_record_id"], revoked_sponsor_record_id);
+}
+
+#[tokio::test]
 async fn sponsor_backed_admission_waits_for_sponsor_lineage_lock() {
     let test_state = new_test_state().await.expect("test database state");
     let app = build_app(test_state.state.clone());
@@ -3451,6 +3575,21 @@ async fn set_sponsor_status(
         )
         .await
         .expect("sponsor status must update");
+}
+
+async fn set_account_state(client: &tokio_postgres::Client, account_id: &str, account_state: &str) {
+    let account_id = Uuid::parse_str(account_id).expect("account id must be uuid");
+    client
+        .execute(
+            "
+            UPDATE core.accounts
+            SET account_state = $2
+            WHERE account_id = $1
+            ",
+            &[&account_id, &account_state],
+        )
+        .await
+        .expect("account state must update");
 }
 
 async fn expire_corridor_without_rebuild(client: &tokio_postgres::Client, realm_id: &str) {

--- a/apps/backend/tests/realm_bootstrap.rs
+++ b/apps/backend/tests/realm_bootstrap.rs
@@ -709,6 +709,79 @@ async fn active_realm_uses_normal_admission_kind_and_open_posture() {
 }
 
 #[tokio::test]
+async fn bootstrap_summary_authorizes_against_latest_admission_status() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let requester = sign_in(
+        &app,
+        "pi-user-realm-summary-latest-a",
+        "realm-summary-latest-a",
+    )
+    .await;
+    let member = sign_in(
+        &app,
+        "pi-user-realm-summary-latest-b",
+        "realm-summary-latest-b",
+    )
+    .await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let (realm_id, _) = create_realm(
+        &app,
+        &requester,
+        None,
+        None,
+        &approver_id,
+        "active",
+        "realm-summary-latest",
+    )
+    .await;
+    let admission = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_id}/admissions"),
+        &approver_id,
+        json!({
+            "account_id": member.account_id,
+            "source_fact_kind": "realm_admin_invite",
+            "source_fact_id": "realm-summary-latest-admission",
+            "source_snapshot_json": {},
+            "request_idempotency_key": "realm-summary-latest-admission"
+        }),
+    )
+    .await;
+    assert_eq!(admission.status, StatusCode::OK);
+    assert_eq!(admission.body["admission_status"], "admitted");
+
+    let admitted_summary = get_json(
+        &app,
+        &format!("/api/projection/realms/{realm_id}/bootstrap-summary"),
+        Some(member.token.as_str()),
+    )
+    .await;
+    assert_eq!(admitted_summary.status, StatusCode::OK);
+
+    append_admission_status_for_test(
+        &client,
+        &realm_id,
+        &member.account_id,
+        &approver_id,
+        "revoked",
+        "operator_restriction",
+        "realm-summary-latest-revoked",
+    )
+    .await;
+
+    let revoked_summary = get_json(
+        &app,
+        &format!("/api/projection/realms/{realm_id}/bootstrap-summary"),
+        Some(member.token.as_str()),
+    )
+    .await;
+    assert_eq!(revoked_summary.status, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
 async fn approval_rejects_already_expired_corridor() {
     let test_state = new_test_state().await.expect("test database state");
     let app = build_app(test_state.state.clone());
@@ -1544,6 +1617,7 @@ async fn rate_limited_and_revoked_sponsor_do_not_auto_admit() {
     let sponsor = sign_in(&app, "pi-user-realm-sponsor-b", "realm-sponsor-b").await;
     let first_member = sign_in(&app, "pi-user-realm-sponsor-c", "realm-sponsor-c").await;
     let second_member = sign_in(&app, "pi-user-realm-sponsor-d", "realm-sponsor-d").await;
+    let third_member = sign_in(&app, "pi-user-realm-sponsor-e", "realm-sponsor-e").await;
     let client = test_db_client().await;
     let approver_id = insert_operator_account(&client, "approver").await;
 
@@ -1601,6 +1675,46 @@ async fn rate_limited_and_revoked_sponsor_do_not_auto_admit() {
     assert_eq!(
         rate_limited.body["sponsor_record_id"],
         latest_rate_limited_sponsor_record_id
+    );
+
+    let active_record = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{rate_limited_realm_id}/sponsor-records"),
+        &approver_id,
+        json!({
+            "sponsor_account_id": sponsor.account_id,
+            "sponsor_status": "active",
+            "quota_total": 2,
+            "status_reason_code": "limited_bootstrap_active",
+            "request_idempotency_key": "realm-sponsor-reactivated-record"
+        }),
+    )
+    .await;
+    assert_eq!(active_record.status, StatusCode::OK);
+    let active_sponsor_record_id = active_record.body["realm_sponsor_record_id"]
+        .as_str()
+        .expect("active sponsor record id must exist");
+
+    let reactivated = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{rate_limited_realm_id}/admissions"),
+        &approver_id,
+        json!({
+            "account_id": third_member.account_id,
+            "sponsor_record_id": rate_limited_sponsor_record_id,
+            "source_fact_kind": "sponsor_invite",
+            "source_fact_id": "realm-reactivated-admission",
+            "source_snapshot_json": {},
+            "request_idempotency_key": "realm-reactivated-admission"
+        }),
+    )
+    .await;
+    assert_eq!(reactivated.status, StatusCode::OK);
+    assert_eq!(reactivated.body["admission_kind"], "sponsor_backed");
+    assert_eq!(reactivated.body["admission_status"], "admitted");
+    assert_eq!(
+        reactivated.body["sponsor_record_id"],
+        active_sponsor_record_id
     );
 
     let (revoked_realm_id, _) = create_realm(
@@ -2700,6 +2814,59 @@ async fn current_corridor_status(client: &tokio_postgres::Client, realm_id: &str
         .await
         .expect("corridor row must exist")
         .get("corridor_status")
+}
+
+async fn append_admission_status_for_test(
+    client: &tokio_postgres::Client,
+    realm_id: &str,
+    account_id: &str,
+    operator_id: &str,
+    admission_status: &str,
+    review_reason_code: &str,
+    request_idempotency_key: &str,
+) {
+    let account_uuid = Uuid::parse_str(account_id).expect("account id must be a uuid");
+    let operator_uuid = Uuid::parse_str(operator_id).expect("operator id must be a uuid");
+    client
+        .execute(
+            "
+            INSERT INTO dao.realm_admissions (
+                realm_admission_id,
+                realm_id,
+                account_id,
+                admission_kind,
+                admission_status,
+                granted_by_actor_kind,
+                granted_by_actor_id,
+                review_reason_code,
+                source_fact_kind,
+                source_fact_id,
+                source_snapshot_json,
+                request_idempotency_key,
+                request_payload_hash,
+                created_at,
+                updated_at
+            )
+            VALUES (
+                $1, $2, $3, 'normal', $4, 'operator', $5, $6,
+                'realm_admin_invite', $7, '{}'::jsonb, $8, repeat('0', 64),
+                CURRENT_TIMESTAMP + interval '1 minute',
+                CURRENT_TIMESTAMP + interval '1 minute'
+            )
+            ",
+            &[
+                &Uuid::new_v4(),
+                &realm_id,
+                &account_uuid,
+                &admission_status,
+                &operator_uuid,
+                &review_reason_code,
+                &request_idempotency_key,
+                &request_idempotency_key,
+            ],
+        )
+        .await
+        .expect("admission status row must insert");
 }
 
 async fn lock_sponsor_lineage_for_test(

--- a/apps/backend/tests/realm_bootstrap.rs
+++ b/apps/backend/tests/realm_bootstrap.rs
@@ -1,0 +1,1707 @@
+use axum::{
+    Router,
+    body::{Body, to_bytes},
+    http::{Request, StatusCode},
+};
+use chrono::{Duration, Utc};
+use musubi_backend::{build_app, new_test_state};
+use serde_json::{Value, json};
+use tower::ServiceExt;
+use uuid::Uuid;
+
+#[tokio::test]
+async fn realm_request_can_be_approved_into_limited_bootstrap_and_participant_summary_is_redacted()
+{
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let requester = sign_in(&app, "pi-user-realm-request-a", "realm-request-a").await;
+    let sponsor = sign_in(&app, "pi-user-realm-request-b", "realm-request-b").await;
+    let steward = sign_in(&app, "pi-user-realm-request-c", "realm-request-c").await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let request = post_json(
+        &app,
+        "/api/realms/requests",
+        Some(requester.token.as_str()),
+        json!({
+            "display_name": "東京コーヒー散歩",
+            "slug_candidate": "tokyo-coffee-walks",
+            "purpose_text": "落ち着いて会える小さな集まりを始めます。",
+            "venue_context_json": {
+                "city": "Tokyo",
+                "venue_type": "cafe"
+            },
+            "expected_member_shape_json": {
+                "pace": "slow",
+                "size": "small"
+            },
+            "bootstrap_rationale_text": "立ち上がりだけ段階的に進めます。",
+            "proposed_sponsor_account_id": sponsor.account_id,
+            "proposed_steward_account_id": steward.account_id,
+            "request_idempotency_key": "realm-request-approve-001"
+        }),
+    )
+    .await;
+    assert_eq!(request.status, StatusCode::OK);
+    assert_eq!(request.body["request_state"], "requested");
+    assert!(request.body.get("reviewed_by_operator_id").is_none());
+    let realm_request_id = request.body["realm_request_id"]
+        .as_str()
+        .expect("realm request id must exist")
+        .to_owned();
+
+    let approval = operator_post_json(
+        &app,
+        &format!("/api/internal/operator/realms/requests/{realm_request_id}/approve"),
+        &approver_id,
+        json!({
+            "target_realm_status": "limited_bootstrap",
+            "approved_slug": "tokyo-coffee-walks",
+            "approved_display_name": "東京コーヒー散歩",
+            "review_reason_code": "limited_bootstrap_active",
+            "steward_account_id": steward.account_id,
+            "sponsor_quota_total": 2,
+            "corridor_starts_at": (Utc::now() - Duration::minutes(5)).to_rfc3339(),
+            "corridor_ends_at": (Utc::now() + Duration::days(7)).to_rfc3339(),
+            "corridor_member_cap": 5,
+            "corridor_sponsor_cap": 2,
+            "review_threshold_json": {
+                "quota_review_threshold": 2
+            },
+            "review_decision_idempotency_key": "realm-request-approve-001"
+        }),
+    )
+    .await;
+    assert_eq!(approval.status, StatusCode::OK);
+    assert_eq!(approval.body["realm_status"], "limited_bootstrap");
+    let realm_id = approval.body["realm_id"]
+        .as_str()
+        .expect("realm id must exist")
+        .to_owned();
+
+    let requester_view = get_json(
+        &app,
+        &format!("/api/realms/requests/{realm_request_id}"),
+        Some(requester.token.as_str()),
+    )
+    .await;
+    assert_eq!(requester_view.status, StatusCode::OK);
+    assert_eq!(requester_view.body["request_state"], "approved");
+    assert_eq!(requester_view.body["created_realm_id"], realm_id);
+    assert!(requester_view.body.get("reviewed_by_operator_id").is_none());
+
+    let summary = get_json(
+        &app,
+        &format!("/api/projection/realms/{realm_id}/bootstrap-summary"),
+        Some(requester.token.as_str()),
+    )
+    .await;
+    assert_eq!(summary.status, StatusCode::OK);
+    assert_eq!(
+        summary.body["bootstrap_view"]["realm_status"],
+        "limited_bootstrap"
+    );
+    assert_eq!(
+        summary.body["bootstrap_view"]["admission_posture"],
+        "limited"
+    );
+    assert_eq!(
+        summary.body["bootstrap_view"]["sponsor_display_state"],
+        "sponsor_and_steward"
+    );
+    assert!(
+        summary.body["realm_request"]
+            .get("reviewed_by_operator_id")
+            .is_none()
+    );
+    assert!(
+        summary.body["bootstrap_view"]
+            .get("source_fact_count")
+            .is_none()
+    );
+    assert!(
+        summary.body["bootstrap_view"]
+            .get("projection_lag_ms")
+            .is_none()
+    );
+    assert!(
+        summary.body["bootstrap_view"]
+            .get("rebuild_generation")
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn duplicate_venue_request_enters_pending_review_and_rejected_request_creates_no_realm() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let requester_a = sign_in(&app, "pi-user-realm-duplicate-a", "realm-duplicate-a").await;
+    let requester_b = sign_in(&app, "pi-user-realm-duplicate-b", "realm-duplicate-b").await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let venue_context = json!({
+        "city": "Kyoto",
+        "venue_type": "tea_house"
+    });
+    let first = post_json(
+        &app,
+        "/api/realms/requests",
+        Some(requester_a.token.as_str()),
+        json!({
+            "display_name": "京都茶会",
+            "slug_candidate": "kyoto-tea-circle",
+            "purpose_text": "静かな対話を大切にします。",
+            "venue_context_json": venue_context,
+            "expected_member_shape_json": { "size": "small" },
+            "bootstrap_rationale_text": "まずは少人数で始めます。",
+            "request_idempotency_key": "realm-duplicate-first"
+        }),
+    )
+    .await;
+    assert_eq!(first.status, StatusCode::OK);
+
+    let second = post_json(
+        &app,
+        "/api/realms/requests",
+        Some(requester_b.token.as_str()),
+        json!({
+            "display_name": "京都茶会 別口",
+            "slug_candidate": "kyoto-tea-circle-b",
+            "purpose_text": "同じ文脈の別申請です。",
+            "venue_context_json": {
+                "city": "Kyoto",
+                "venue_type": "tea_house"
+            },
+            "expected_member_shape_json": { "size": "small" },
+            "bootstrap_rationale_text": "確認が必要なケースです。",
+            "request_idempotency_key": "realm-duplicate-second"
+        }),
+    )
+    .await;
+    assert_eq!(second.status, StatusCode::OK);
+    assert_eq!(second.body["request_state"], "pending_review");
+    assert_eq!(second.body["review_reason_code"], "review_required");
+    let second_request_id = second.body["realm_request_id"]
+        .as_str()
+        .expect("second request id must exist")
+        .to_owned();
+
+    let rejected = operator_post_json(
+        &app,
+        &format!("/api/internal/operator/realms/requests/{second_request_id}/reject"),
+        &approver_id,
+        json!({
+            "review_reason_code": "duplicate_or_invalid",
+            "review_decision_idempotency_key": "realm-duplicate-reject"
+        }),
+    )
+    .await;
+    assert_eq!(rejected.status, StatusCode::OK);
+    assert_eq!(rejected.body["request_state"], "rejected");
+    assert_eq!(rejected.body["review_reason_code"], "duplicate_or_invalid");
+    assert_eq!(rejected.body["reviewed_by_operator_id"], approver_id);
+    assert!(rejected.body["created_realm_id"].is_null());
+
+    let participant_request = get_json(
+        &app,
+        &format!("/api/realms/requests/{second_request_id}"),
+        Some(requester_b.token.as_str()),
+    )
+    .await;
+    assert_eq!(participant_request.status, StatusCode::OK);
+    assert_eq!(participant_request.body["request_state"], "rejected");
+    assert!(
+        participant_request
+            .body
+            .get("reviewed_by_operator_id")
+            .is_none()
+    );
+    assert!(participant_request.body["created_realm_id"].is_null());
+}
+
+#[tokio::test]
+async fn suspicious_requests_enter_review_even_when_trigger_is_already_open() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let requester_a = sign_in(&app, "pi-user-realm-trigger-a", "realm-trigger-a").await;
+    let requester_b = sign_in(&app, "pi-user-realm-trigger-b", "realm-trigger-b").await;
+    let requester_c = sign_in(&app, "pi-user-realm-trigger-c", "realm-trigger-c").await;
+    let rejected_requester = sign_in(&app, "pi-user-realm-trigger-d", "realm-trigger-d").await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let shared_venue = json!({
+        "city": "Nara",
+        "venue_type": "gallery"
+    });
+    let first_duplicate = post_json(
+        &app,
+        "/api/realms/requests",
+        Some(requester_a.token.as_str()),
+        json!({
+            "display_name": "奈良ギャラリー散歩",
+            "slug_candidate": "nara-gallery-walks-a",
+            "purpose_text": "静かな展示を一緒に見ます。",
+            "venue_context_json": shared_venue,
+            "expected_member_shape_json": { "size": "small" },
+            "bootstrap_rationale_text": "少人数から始めます。",
+            "request_idempotency_key": "realm-trigger-duplicate-a"
+        }),
+    )
+    .await;
+    assert_eq!(first_duplicate.status, StatusCode::OK);
+
+    let second_duplicate = post_json(
+        &app,
+        "/api/realms/requests",
+        Some(requester_b.token.as_str()),
+        json!({
+            "display_name": "奈良ギャラリー散歩 別口",
+            "slug_candidate": "nara-gallery-walks-b",
+            "purpose_text": "同じ文脈の申請です。",
+            "venue_context_json": {
+                "city": "Nara",
+                "venue_type": "gallery"
+            },
+            "expected_member_shape_json": { "size": "small" },
+            "bootstrap_rationale_text": "確認が必要です。",
+            "request_idempotency_key": "realm-trigger-duplicate-b"
+        }),
+    )
+    .await;
+    assert_eq!(second_duplicate.status, StatusCode::OK);
+    assert_eq!(second_duplicate.body["request_state"], "pending_review");
+
+    let third_duplicate = post_json(
+        &app,
+        "/api/realms/requests",
+        Some(requester_c.token.as_str()),
+        json!({
+            "display_name": "奈良ギャラリー散歩 追加",
+            "slug_candidate": "nara-gallery-walks-c",
+            "purpose_text": "同じ venue context の追加申請です。",
+            "venue_context_json": {
+                "city": "Nara",
+                "venue_type": "gallery"
+            },
+            "expected_member_shape_json": { "size": "small" },
+            "bootstrap_rationale_text": "既存 trigger があっても review が必要です。",
+            "request_idempotency_key": "realm-trigger-duplicate-c"
+        }),
+    )
+    .await;
+    assert_eq!(third_duplicate.status, StatusCode::OK);
+    assert_eq!(third_duplicate.body["request_state"], "pending_review");
+
+    for index in 0..2 {
+        let request = post_json(
+            &app,
+            "/api/realms/requests",
+            Some(rejected_requester.token.as_str()),
+            json!({
+                "display_name": format!("Repeated rejected {index}"),
+                "slug_candidate": format!("repeated-rejected-{index}"),
+                "purpose_text": "反復 rejected path の確認です。",
+                "venue_context_json": {
+                    "city": "Nagoya",
+                    "sequence": index
+                },
+                "expected_member_shape_json": { "size": "small" },
+                "bootstrap_rationale_text": "審査の結果 rejected にします。",
+                "request_idempotency_key": format!("realm-trigger-rejected-{index}")
+            }),
+        )
+        .await;
+        assert_eq!(request.status, StatusCode::OK);
+        let request_id = request.body["realm_request_id"]
+            .as_str()
+            .expect("realm request id must exist");
+        let rejected = operator_post_json(
+            &app,
+            &format!("/api/internal/operator/realms/requests/{request_id}/reject"),
+            &approver_id,
+            json!({
+                "review_reason_code": "duplicate_or_invalid",
+                "review_decision_idempotency_key": format!("realm-trigger-reject-{index}")
+            }),
+        )
+        .await;
+        assert_eq!(rejected.status, StatusCode::OK);
+    }
+
+    let repeated_request = post_json(
+        &app,
+        "/api/realms/requests",
+        Some(rejected_requester.token.as_str()),
+        json!({
+            "display_name": "Repeated requester third",
+            "slug_candidate": "repeated-rejected-third",
+            "purpose_text": "既存 repeated trigger があっても review が必要です。",
+            "venue_context_json": {
+                "city": "Nagoya",
+                "sequence": 3
+            },
+            "expected_member_shape_json": { "size": "small" },
+            "bootstrap_rationale_text": "反復 rejected requester の追加申請です。",
+            "request_idempotency_key": "realm-trigger-rejected-third"
+        }),
+    )
+    .await;
+    assert_eq!(repeated_request.status, StatusCode::OK);
+    assert_eq!(repeated_request.body["request_state"], "pending_review");
+}
+
+#[tokio::test]
+async fn realm_request_requires_venue_context_and_expected_member_shape() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let requester = sign_in(&app, "pi-user-realm-required-a", "realm-required-a").await;
+
+    let missing_venue = post_json(
+        &app,
+        "/api/realms/requests",
+        Some(requester.token.as_str()),
+        json!({
+            "display_name": "文脈なし申請",
+            "slug_candidate": "missing-venue-context",
+            "purpose_text": "文脈がない申請です。",
+            "expected_member_shape_json": { "size": "small" },
+            "bootstrap_rationale_text": "確認します。",
+            "request_idempotency_key": "missing-venue-context"
+        }),
+    )
+    .await;
+    assert!(missing_venue.status.is_client_error());
+
+    let empty_shape = post_json(
+        &app,
+        "/api/realms/requests",
+        Some(requester.token.as_str()),
+        json!({
+            "display_name": "形なし申請",
+            "slug_candidate": "empty-member-shape",
+            "purpose_text": "member shape が空の申請です。",
+            "venue_context_json": {
+                "city": "Tokyo"
+            },
+            "expected_member_shape_json": {},
+            "bootstrap_rationale_text": "確認します。",
+            "request_idempotency_key": "empty-member-shape"
+        }),
+    )
+    .await;
+    assert_eq!(empty_shape.status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn active_realm_uses_normal_admission_kind_and_open_posture() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let requester = sign_in(&app, "pi-user-realm-active-a", "realm-active-a").await;
+    let member = sign_in(&app, "pi-user-realm-active-b", "realm-active-b").await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let (realm_id, _) = create_realm(
+        &app,
+        &requester,
+        None,
+        None,
+        &approver_id,
+        "active",
+        "realm-active-001",
+    )
+    .await;
+
+    let summary = get_json(
+        &app,
+        &format!("/api/projection/realms/{realm_id}/bootstrap-summary"),
+        Some(requester.token.as_str()),
+    )
+    .await;
+    assert_eq!(summary.status, StatusCode::OK);
+    assert_eq!(summary.body["bootstrap_view"]["realm_status"], "active");
+    assert_eq!(summary.body["bootstrap_view"]["admission_posture"], "open");
+
+    let admission = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_id}/admissions"),
+        &approver_id,
+        json!({
+            "account_id": member.account_id,
+            "source_fact_kind": "realm_admin_invite",
+            "source_fact_id": "realm-active-admission",
+            "source_snapshot_json": {
+                "private_note": "must stay internal"
+            },
+            "request_idempotency_key": "realm-active-admission"
+        }),
+    )
+    .await;
+    assert_eq!(admission.status, StatusCode::OK);
+    assert_eq!(admission.body["admission_kind"], "normal");
+    assert_eq!(admission.body["admission_status"], "admitted");
+    assert_eq!(admission.body["review_reason_code"], "active_after_review");
+
+    let member_summary = get_json(
+        &app,
+        &format!("/api/projection/realms/{realm_id}/bootstrap-summary"),
+        Some(member.token.as_str()),
+    )
+    .await;
+    assert_eq!(member_summary.status, StatusCode::OK);
+    assert_eq!(
+        member_summary.body["admission_view"]["admission_kind"],
+        "normal"
+    );
+    assert_eq!(
+        member_summary.body["admission_view"]["admission_status"],
+        "admitted"
+    );
+    assert!(
+        member_summary
+            .body
+            .to_string()
+            .contains("active_after_review")
+    );
+    assert!(!member_summary.body.to_string().contains("private_note"));
+}
+
+#[tokio::test]
+async fn approval_rejects_already_expired_corridor() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let requester = sign_in(
+        &app,
+        "pi-user-realm-expired-approval-a",
+        "realm-expired-approval-a",
+    )
+    .await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let request = post_json(
+        &app,
+        "/api/realms/requests",
+        Some(requester.token.as_str()),
+        json!({
+            "display_name": "期限切れ corridor",
+            "slug_candidate": "expired-corridor-approval",
+            "purpose_text": "期限切れ corridor は作れません。",
+            "venue_context_json": {
+                "city": "Tokyo",
+                "venue_type": "community_space"
+            },
+            "expected_member_shape_json": {
+                "size": "small"
+            },
+            "bootstrap_rationale_text": "期限の検証です。",
+            "request_idempotency_key": "expired-corridor-approval-request"
+        }),
+    )
+    .await;
+    assert_eq!(request.status, StatusCode::OK);
+    let realm_request_id = request.body["realm_request_id"]
+        .as_str()
+        .expect("realm request id must exist");
+
+    let approval = operator_post_json(
+        &app,
+        &format!("/api/internal/operator/realms/requests/{realm_request_id}/approve"),
+        &approver_id,
+        json!({
+            "target_realm_status": "limited_bootstrap",
+            "review_reason_code": "limited_bootstrap_active",
+            "corridor_starts_at": (Utc::now() - Duration::days(2)).to_rfc3339(),
+            "corridor_ends_at": (Utc::now() - Duration::hours(1)).to_rfc3339(),
+            "corridor_member_cap": 2,
+            "corridor_sponsor_cap": 1,
+            "review_threshold_json": {},
+            "review_decision_idempotency_key": "expired-corridor-approval"
+        }),
+    )
+    .await;
+    assert_eq!(approval.status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn sponsor_backed_admission_respects_quota_and_review_summary_is_redacted() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let requester = sign_in(&app, "pi-user-realm-quota-a", "realm-quota-a").await;
+    let sponsor = sign_in(&app, "pi-user-realm-quota-b", "realm-quota-b").await;
+    let first_member = sign_in(&app, "pi-user-realm-quota-c", "realm-quota-c").await;
+    let second_member = sign_in(&app, "pi-user-realm-quota-d", "realm-quota-d").await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let (realm_id, _) = create_realm(
+        &app,
+        &requester,
+        Some(&sponsor),
+        None,
+        &approver_id,
+        "limited_bootstrap",
+        "realm-quota-001",
+    )
+    .await;
+    let sponsor_record_id = sponsor_record_id_for_realm(&client, &realm_id).await;
+
+    let review_case = operator_post_json(
+        &app,
+        "/api/internal/operator/review-cases",
+        &approver_id,
+        json!({
+            "case_type": "realm_admission_review",
+            "severity": "sev2",
+            "subject_account_id": requester.account_id,
+            "related_realm_id": realm_id,
+            "opened_reason_code": "policy_review",
+            "source_fact_kind": "realm_request",
+            "source_fact_id": "realm-quota-review",
+            "source_snapshot_json": {
+                "safe_summary": "bootstrap health review"
+            },
+            "request_idempotency_key": "realm-quota-review"
+        }),
+    )
+    .await;
+    assert_eq!(review_case.status, StatusCode::OK);
+
+    let first = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_id}/admissions"),
+        &approver_id,
+        json!({
+            "account_id": first_member.account_id,
+            "sponsor_record_id": sponsor_record_id,
+            "source_fact_kind": "sponsor_invite",
+            "source_fact_id": "realm-quota-first",
+            "source_snapshot_json": {},
+            "request_idempotency_key": "realm-quota-first"
+        }),
+    )
+    .await;
+    assert_eq!(first.status, StatusCode::OK);
+    assert_eq!(first.body["admission_kind"], "sponsor_backed");
+    assert_eq!(first.body["admission_status"], "admitted");
+
+    let second = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_id}/admissions"),
+        &approver_id,
+        json!({
+            "account_id": second_member.account_id,
+            "sponsor_record_id": sponsor_record_id,
+            "source_fact_kind": "sponsor_invite",
+            "source_fact_id": "realm-quota-second",
+            "source_snapshot_json": {
+                "internal_trigger_context": "must not leak"
+            },
+            "request_idempotency_key": "realm-quota-second"
+        }),
+    )
+    .await;
+    assert_eq!(second.status, StatusCode::OK);
+    assert_eq!(second.body["admission_kind"], "review_required");
+    assert_eq!(second.body["admission_status"], "pending");
+    assert_eq!(
+        second.body["review_reason_code"],
+        "bootstrap_capacity_reached"
+    );
+
+    let review_summary = operator_get_json(
+        &app,
+        &format!("/api/internal/operator/realms/{realm_id}/review-summary"),
+        &approver_id,
+    )
+    .await;
+    assert_eq!(review_summary.status, StatusCode::OK);
+    assert_eq!(review_summary.body["open_review_case_count"], 1);
+    assert!(
+        review_summary.body["open_review_trigger_count"]
+            .as_i64()
+            .expect("trigger count must be numeric")
+            >= 1
+    );
+    assert_eq!(
+        review_summary.body["latest_redacted_reason_code"],
+        "bootstrap_capacity_reached"
+    );
+    assert!(
+        review_summary.body["open_review_triggers"][0]
+            .get("context_json")
+            .is_none()
+    );
+    assert!(
+        !review_summary
+            .body
+            .to_string()
+            .contains("internal_trigger_context")
+    );
+}
+
+#[tokio::test]
+async fn sponsor_backed_admission_respects_corridor_member_cap() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let requester = sign_in(&app, "pi-user-realm-member-cap-a", "realm-member-cap-a").await;
+    let sponsor = sign_in(&app, "pi-user-realm-member-cap-b", "realm-member-cap-b").await;
+    let first_member = sign_in(&app, "pi-user-realm-member-cap-c", "realm-member-cap-c").await;
+    let second_member = sign_in(&app, "pi-user-realm-member-cap-d", "realm-member-cap-d").await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let request = post_json(
+        &app,
+        "/api/realms/requests",
+        Some(requester.token.as_str()),
+        json!({
+            "display_name": "Corridor member cap realm",
+            "slug_candidate": "corridor-member-cap-realm",
+            "purpose_text": "member cap を writer path で守ります。",
+            "venue_context_json": {
+                "city": "Tokyo",
+                "venue_type": "library"
+            },
+            "expected_member_shape_json": {
+                "size": "tiny"
+            },
+            "bootstrap_rationale_text": "1人だけ corridor admit します。",
+            "proposed_sponsor_account_id": sponsor.account_id,
+            "request_idempotency_key": "realm-member-cap-request"
+        }),
+    )
+    .await;
+    assert_eq!(request.status, StatusCode::OK);
+    let realm_request_id = request.body["realm_request_id"]
+        .as_str()
+        .expect("realm request id must exist");
+
+    let approval = operator_post_json(
+        &app,
+        &format!("/api/internal/operator/realms/requests/{realm_request_id}/approve"),
+        &approver_id,
+        json!({
+            "target_realm_status": "limited_bootstrap",
+            "review_reason_code": "limited_bootstrap_active",
+            "sponsor_quota_total": 2,
+            "corridor_starts_at": (Utc::now() - Duration::minutes(5)).to_rfc3339(),
+            "corridor_ends_at": (Utc::now() + Duration::days(3)).to_rfc3339(),
+            "corridor_member_cap": 1,
+            "corridor_sponsor_cap": 1,
+            "review_threshold_json": {},
+            "review_decision_idempotency_key": "realm-member-cap-approve"
+        }),
+    )
+    .await;
+    assert_eq!(approval.status, StatusCode::OK);
+    let realm_id = approval.body["realm_id"]
+        .as_str()
+        .expect("realm id must exist")
+        .to_owned();
+    let sponsor_record_id = sponsor_record_id_for_realm(&client, &realm_id).await;
+
+    let first = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_id}/admissions"),
+        &approver_id,
+        json!({
+            "account_id": first_member.account_id,
+            "sponsor_record_id": sponsor_record_id,
+            "source_fact_kind": "sponsor_invite",
+            "source_fact_id": "realm-member-cap-first",
+            "source_snapshot_json": {},
+            "request_idempotency_key": "realm-member-cap-first"
+        }),
+    )
+    .await;
+    assert_eq!(first.status, StatusCode::OK);
+    assert_eq!(first.body["admission_kind"], "sponsor_backed");
+    assert_eq!(first.body["admission_status"], "admitted");
+
+    let second = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_id}/admissions"),
+        &approver_id,
+        json!({
+            "account_id": second_member.account_id,
+            "sponsor_record_id": sponsor_record_id,
+            "source_fact_kind": "sponsor_invite",
+            "source_fact_id": "realm-member-cap-second",
+            "source_snapshot_json": {},
+            "request_idempotency_key": "realm-member-cap-second"
+        }),
+    )
+    .await;
+    assert_eq!(second.status, StatusCode::OK);
+    assert_eq!(second.body["admission_kind"], "review_required");
+    assert_eq!(second.body["admission_status"], "pending");
+    assert_eq!(
+        second.body["review_reason_code"],
+        "bootstrap_capacity_reached"
+    );
+
+    let review_summary = operator_get_json(
+        &app,
+        &format!("/api/internal/operator/realms/{realm_id}/review-summary"),
+        &approver_id,
+    )
+    .await;
+    assert_eq!(review_summary.status, StatusCode::OK);
+    assert_eq!(
+        review_summary.body["latest_redacted_reason_code"],
+        "bootstrap_capacity_reached"
+    );
+    assert_eq!(
+        review_summary.body["open_review_triggers"][0]["trigger_kind"],
+        "corridor_cap_pressure"
+    );
+}
+
+#[tokio::test]
+async fn cross_realm_sponsor_record_cannot_grant_admission() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let requester_a = sign_in(
+        &app,
+        "pi-user-realm-cross-sponsor-a",
+        "realm-cross-sponsor-a",
+    )
+    .await;
+    let requester_b = sign_in(
+        &app,
+        "pi-user-realm-cross-sponsor-b",
+        "realm-cross-sponsor-b",
+    )
+    .await;
+    let sponsor = sign_in(
+        &app,
+        "pi-user-realm-cross-sponsor-c",
+        "realm-cross-sponsor-c",
+    )
+    .await;
+    let member = sign_in(
+        &app,
+        "pi-user-realm-cross-sponsor-d",
+        "realm-cross-sponsor-d",
+    )
+    .await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let (realm_a_id, _) = create_realm(
+        &app,
+        &requester_a,
+        Some(&sponsor),
+        None,
+        &approver_id,
+        "limited_bootstrap",
+        "realm-cross-sponsor-a",
+    )
+    .await;
+    let realm_a_sponsor_record_id = sponsor_record_id_for_realm(&client, &realm_a_id).await;
+    let (realm_b_id, _) = create_realm(
+        &app,
+        &requester_b,
+        None,
+        None,
+        &approver_id,
+        "active",
+        "realm-cross-sponsor-b",
+    )
+    .await;
+
+    let admission = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_b_id}/admissions"),
+        &approver_id,
+        json!({
+            "account_id": member.account_id,
+            "sponsor_record_id": realm_a_sponsor_record_id,
+            "source_fact_kind": "sponsor_invite",
+            "source_fact_id": "realm-cross-sponsor-admission",
+            "source_snapshot_json": {},
+            "request_idempotency_key": "realm-cross-sponsor-admission"
+        }),
+    )
+    .await;
+    assert_eq!(admission.status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        admission_count_for_account(&client, &realm_b_id, &member.account_id).await,
+        0
+    );
+}
+
+#[tokio::test]
+async fn rate_limited_and_revoked_sponsor_do_not_auto_admit() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let requester = sign_in(&app, "pi-user-realm-sponsor-a", "realm-sponsor-a").await;
+    let sponsor = sign_in(&app, "pi-user-realm-sponsor-b", "realm-sponsor-b").await;
+    let first_member = sign_in(&app, "pi-user-realm-sponsor-c", "realm-sponsor-c").await;
+    let second_member = sign_in(&app, "pi-user-realm-sponsor-d", "realm-sponsor-d").await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let (rate_limited_realm_id, _) = create_realm(
+        &app,
+        &requester,
+        Some(&sponsor),
+        None,
+        &approver_id,
+        "limited_bootstrap",
+        "realm-sponsor-rate-limited",
+    )
+    .await;
+    let rate_limited_sponsor_record_id =
+        sponsor_record_id_for_realm(&client, &rate_limited_realm_id).await;
+    set_sponsor_status(
+        &client,
+        &rate_limited_sponsor_record_id,
+        "rate_limited",
+        "sponsor_rate_limited",
+    )
+    .await;
+
+    let rate_limited = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{rate_limited_realm_id}/admissions"),
+        &approver_id,
+        json!({
+            "account_id": first_member.account_id,
+            "sponsor_record_id": rate_limited_sponsor_record_id,
+            "source_fact_kind": "sponsor_invite",
+            "source_fact_id": "realm-rate-limited-admission",
+            "source_snapshot_json": {},
+            "request_idempotency_key": "realm-rate-limited-admission"
+        }),
+    )
+    .await;
+    assert_eq!(rate_limited.status, StatusCode::OK);
+    assert_eq!(rate_limited.body["admission_kind"], "review_required");
+    assert_eq!(rate_limited.body["admission_status"], "pending");
+    assert_eq!(
+        rate_limited.body["review_reason_code"],
+        "sponsor_rate_limited"
+    );
+
+    let (revoked_realm_id, _) = create_realm(
+        &app,
+        &requester,
+        Some(&sponsor),
+        None,
+        &approver_id,
+        "limited_bootstrap",
+        "realm-sponsor-revoked",
+    )
+    .await;
+    let revoked_sponsor_record_id = sponsor_record_id_for_realm(&client, &revoked_realm_id).await;
+    set_sponsor_status(
+        &client,
+        &revoked_sponsor_record_id,
+        "revoked",
+        "sponsor_revoked",
+    )
+    .await;
+
+    let revoked = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{revoked_realm_id}/admissions"),
+        &approver_id,
+        json!({
+            "account_id": second_member.account_id,
+            "sponsor_record_id": revoked_sponsor_record_id,
+            "source_fact_kind": "sponsor_invite",
+            "source_fact_id": "realm-revoked-admission",
+            "source_snapshot_json": {},
+            "request_idempotency_key": "realm-revoked-admission"
+        }),
+    )
+    .await;
+    assert_eq!(revoked.status, StatusCode::OK);
+    assert_eq!(revoked.body["admission_kind"], "review_required");
+    assert_eq!(revoked.body["admission_status"], "pending");
+    assert_eq!(revoked.body["review_reason_code"], "sponsor_revoked");
+}
+
+#[tokio::test]
+async fn expired_and_disabled_corridor_do_not_grant_corridor_benefits_even_if_projection_is_stale()
+{
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let requester = sign_in(&app, "pi-user-realm-corridor-a", "realm-corridor-a").await;
+    let expired_member = sign_in(&app, "pi-user-realm-corridor-b", "realm-corridor-b").await;
+    let disabled_member = sign_in(&app, "pi-user-realm-corridor-c", "realm-corridor-c").await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let (expired_realm_id, _) = create_realm(
+        &app,
+        &requester,
+        None,
+        None,
+        &approver_id,
+        "limited_bootstrap",
+        "realm-corridor-expired",
+    )
+    .await;
+    assert_eq!(
+        current_projection_corridor_status(&client, &expired_realm_id).await,
+        "active"
+    );
+    expire_corridor_without_rebuild(&client, &expired_realm_id).await;
+
+    let expired = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{expired_realm_id}/admissions"),
+        &approver_id,
+        json!({
+            "account_id": expired_member.account_id,
+            "source_fact_kind": "realm_admin_invite",
+            "source_fact_id": "realm-corridor-expired",
+            "source_snapshot_json": {},
+            "request_idempotency_key": "realm-corridor-expired"
+        }),
+    )
+    .await;
+    assert_eq!(expired.status, StatusCode::OK);
+    assert_eq!(expired.body["admission_kind"], "review_required");
+    assert_eq!(expired.body["admission_status"], "pending");
+    assert_eq!(expired.body["review_reason_code"], "bootstrap_expired");
+
+    let expired_summary = get_json(
+        &app,
+        &format!("/api/projection/realms/{expired_realm_id}/bootstrap-summary"),
+        Some(requester.token.as_str()),
+    )
+    .await;
+    assert_eq!(expired_summary.status, StatusCode::OK);
+    assert_eq!(
+        expired_summary.body["bootstrap_view"]["corridor_status"],
+        "expired"
+    );
+    assert_eq!(
+        expired_summary.body["bootstrap_view"]["admission_posture"],
+        "review_required"
+    );
+
+    let (disabled_realm_id, _) = create_realm(
+        &app,
+        &requester,
+        None,
+        None,
+        &approver_id,
+        "limited_bootstrap",
+        "realm-corridor-disabled",
+    )
+    .await;
+    assert_eq!(
+        current_projection_corridor_status(&client, &disabled_realm_id).await,
+        "active"
+    );
+    disable_corridor_without_rebuild(&client, &disabled_realm_id).await;
+
+    let disabled = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{disabled_realm_id}/admissions"),
+        &approver_id,
+        json!({
+            "account_id": disabled_member.account_id,
+            "source_fact_kind": "realm_admin_invite",
+            "source_fact_id": "realm-corridor-disabled",
+            "source_snapshot_json": {},
+            "request_idempotency_key": "realm-corridor-disabled"
+        }),
+    )
+    .await;
+    assert_eq!(disabled.status, StatusCode::OK);
+    assert_eq!(disabled.body["admission_kind"], "review_required");
+    assert_eq!(disabled.body["admission_status"], "pending");
+
+    let disabled_summary = get_json(
+        &app,
+        &format!("/api/projection/realms/{disabled_realm_id}/bootstrap-summary"),
+        Some(requester.token.as_str()),
+    )
+    .await;
+    assert_eq!(disabled_summary.status, StatusCode::OK);
+    assert_eq!(
+        disabled_summary.body["bootstrap_view"]["corridor_status"],
+        "disabled_by_operator"
+    );
+    assert_eq!(
+        disabled_summary.body["bootstrap_view"]["admission_posture"],
+        "review_required"
+    );
+}
+
+#[tokio::test]
+async fn expired_or_disabled_corridor_blocks_sponsor_backed_auto_admission() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let requester = sign_in(
+        &app,
+        "pi-user-realm-corridor-sponsor-a",
+        "realm-corridor-sponsor-a",
+    )
+    .await;
+    let sponsor = sign_in(
+        &app,
+        "pi-user-realm-corridor-sponsor-b",
+        "realm-corridor-sponsor-b",
+    )
+    .await;
+    let expired_member = sign_in(
+        &app,
+        "pi-user-realm-corridor-sponsor-c",
+        "realm-corridor-sponsor-c",
+    )
+    .await;
+    let disabled_member = sign_in(
+        &app,
+        "pi-user-realm-corridor-sponsor-d",
+        "realm-corridor-sponsor-d",
+    )
+    .await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let (expired_realm_id, _) = create_realm(
+        &app,
+        &requester,
+        Some(&sponsor),
+        None,
+        &approver_id,
+        "limited_bootstrap",
+        "realm-corridor-sponsor-expired",
+    )
+    .await;
+    let expired_sponsor_record_id = sponsor_record_id_for_realm(&client, &expired_realm_id).await;
+    expire_corridor_without_rebuild(&client, &expired_realm_id).await;
+    let expired = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{expired_realm_id}/admissions"),
+        &approver_id,
+        json!({
+            "account_id": expired_member.account_id,
+            "sponsor_record_id": expired_sponsor_record_id,
+            "source_fact_kind": "sponsor_invite",
+            "source_fact_id": "realm-corridor-sponsor-expired",
+            "source_snapshot_json": {},
+            "request_idempotency_key": "realm-corridor-sponsor-expired"
+        }),
+    )
+    .await;
+    assert_eq!(expired.status, StatusCode::OK);
+    assert_eq!(expired.body["admission_kind"], "review_required");
+    assert_eq!(expired.body["admission_status"], "pending");
+    assert_eq!(expired.body["review_reason_code"], "bootstrap_expired");
+
+    let (disabled_realm_id, _) = create_realm(
+        &app,
+        &requester,
+        Some(&sponsor),
+        None,
+        &approver_id,
+        "limited_bootstrap",
+        "realm-corridor-sponsor-disabled",
+    )
+    .await;
+    let disabled_sponsor_record_id = sponsor_record_id_for_realm(&client, &disabled_realm_id).await;
+    disable_corridor_without_rebuild(&client, &disabled_realm_id).await;
+    let disabled = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{disabled_realm_id}/admissions"),
+        &approver_id,
+        json!({
+            "account_id": disabled_member.account_id,
+            "sponsor_record_id": disabled_sponsor_record_id,
+            "source_fact_kind": "sponsor_invite",
+            "source_fact_id": "realm-corridor-sponsor-disabled",
+            "source_snapshot_json": {},
+            "request_idempotency_key": "realm-corridor-sponsor-disabled"
+        }),
+    )
+    .await;
+    assert_eq!(disabled.status, StatusCode::OK);
+    assert_eq!(disabled.body["admission_kind"], "review_required");
+    assert_eq!(disabled.body["admission_status"], "pending");
+    assert_eq!(disabled.body["review_reason_code"], "operator_restriction");
+}
+
+#[tokio::test]
+async fn restricted_and_suspended_realms_block_new_admissions() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let requester = sign_in(&app, "pi-user-realm-block-a", "realm-block-a").await;
+    let restricted_member = sign_in(&app, "pi-user-realm-block-b", "realm-block-b").await;
+    let suspended_member = sign_in(&app, "pi-user-realm-block-c", "realm-block-c").await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let (restricted_realm_id, _) = create_realm(
+        &app,
+        &requester,
+        None,
+        None,
+        &approver_id,
+        "active",
+        "realm-restricted",
+    )
+    .await;
+    set_realm_status(
+        &client,
+        &restricted_realm_id,
+        "restricted",
+        "restricted_after_review",
+    )
+    .await;
+    let restricted = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{restricted_realm_id}/admissions"),
+        &approver_id,
+        json!({
+            "account_id": restricted_member.account_id,
+            "source_fact_kind": "realm_admin_invite",
+            "source_fact_id": "realm-restricted-admission",
+            "source_snapshot_json": {},
+            "request_idempotency_key": "realm-restricted-admission"
+        }),
+    )
+    .await;
+    assert_eq!(restricted.status, StatusCode::BAD_REQUEST);
+
+    let (suspended_realm_id, _) = create_realm(
+        &app,
+        &requester,
+        None,
+        None,
+        &approver_id,
+        "active",
+        "realm-suspended",
+    )
+    .await;
+    set_realm_status(
+        &client,
+        &suspended_realm_id,
+        "suspended",
+        "suspended_after_review",
+    )
+    .await;
+    let suspended = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{suspended_realm_id}/admissions"),
+        &approver_id,
+        json!({
+            "account_id": suspended_member.account_id,
+            "source_fact_kind": "realm_admin_invite",
+            "source_fact_id": "realm-suspended-admission",
+            "source_snapshot_json": {},
+            "request_idempotency_key": "realm-suspended-admission"
+        }),
+    )
+    .await;
+    assert_eq!(suspended.status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn request_and_admission_idempotency_replay_mismatch_is_rejected() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let requester = sign_in(&app, "pi-user-realm-idem-a", "realm-idem-a").await;
+    let member = sign_in(&app, "pi-user-realm-idem-b", "realm-idem-b").await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let request_body = json!({
+        "display_name": "神戸読書会",
+        "slug_candidate": "kobe-reading-room",
+        "purpose_text": "静かな読書と対話です。",
+        "venue_context_json": {
+            "city": "Kobe",
+            "venue_type": "bookstore"
+        },
+        "expected_member_shape_json": {
+            "size": "small"
+        },
+        "bootstrap_rationale_text": "まずは小さく始めます。",
+        "request_idempotency_key": "realm-idem-request"
+    });
+    let first_request = post_json(
+        &app,
+        "/api/realms/requests",
+        Some(requester.token.as_str()),
+        request_body.clone(),
+    )
+    .await;
+    assert_eq!(first_request.status, StatusCode::OK);
+    let realm_request_id = first_request.body["realm_request_id"]
+        .as_str()
+        .expect("realm request id must exist")
+        .to_owned();
+
+    let replayed_request = post_json(
+        &app,
+        "/api/realms/requests",
+        Some(requester.token.as_str()),
+        request_body,
+    )
+    .await;
+    assert_eq!(replayed_request.status, StatusCode::OK);
+    assert_eq!(replayed_request.body["realm_request_id"], realm_request_id);
+
+    let mismatched_request = post_json(
+        &app,
+        "/api/realms/requests",
+        Some(requester.token.as_str()),
+        json!({
+            "display_name": "神戸読書会",
+            "slug_candidate": "kobe-reading-room",
+            "purpose_text": "別の目的文です。",
+            "venue_context_json": {
+                "city": "Kobe",
+                "venue_type": "bookstore"
+            },
+            "expected_member_shape_json": {
+                "size": "small"
+            },
+            "bootstrap_rationale_text": "まずは小さく始めます。",
+            "request_idempotency_key": "realm-idem-request"
+        }),
+    )
+    .await;
+    assert_eq!(mismatched_request.status, StatusCode::BAD_REQUEST);
+
+    let approval = operator_post_json(
+        &app,
+        &format!("/api/internal/operator/realms/requests/{realm_request_id}/approve"),
+        &approver_id,
+        json!({
+            "target_realm_status": "active",
+            "review_reason_code": "active_after_review",
+            "review_decision_idempotency_key": "realm-idem-approve"
+        }),
+    )
+    .await;
+    assert_eq!(approval.status, StatusCode::OK);
+    let realm_id = approval.body["realm_id"]
+        .as_str()
+        .expect("realm id must exist")
+        .to_owned();
+
+    let admission_body = json!({
+        "account_id": member.account_id,
+        "source_fact_kind": "realm_admin_invite",
+        "source_fact_id": "realm-idem-admission",
+        "source_snapshot_json": {
+            "safe_summary": "first admission"
+        },
+        "request_idempotency_key": "realm-idem-admission"
+    });
+    let first_admission = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_id}/admissions"),
+        &approver_id,
+        admission_body.clone(),
+    )
+    .await;
+    assert_eq!(first_admission.status, StatusCode::OK);
+    let realm_admission_id = first_admission.body["realm_admission_id"]
+        .as_str()
+        .expect("realm admission id must exist")
+        .to_owned();
+
+    let replayed_admission = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_id}/admissions"),
+        &approver_id,
+        admission_body,
+    )
+    .await;
+    assert_eq!(replayed_admission.status, StatusCode::OK);
+    assert_eq!(
+        replayed_admission.body["realm_admission_id"],
+        realm_admission_id
+    );
+
+    let mismatched_admission = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_id}/admissions"),
+        &approver_id,
+        json!({
+            "account_id": member.account_id,
+            "source_fact_kind": "realm_admin_invite",
+            "source_fact_id": "realm-idem-admission-drift",
+            "source_snapshot_json": {
+                "safe_summary": "first admission"
+            },
+            "request_idempotency_key": "realm-idem-admission"
+        }),
+    )
+    .await;
+    assert_eq!(mismatched_admission.status, StatusCode::BAD_REQUEST);
+}
+
+async fn create_realm(
+    app: &Router,
+    requester: &SignedInUser,
+    sponsor: Option<&SignedInUser>,
+    steward: Option<&SignedInUser>,
+    approver_id: &str,
+    target_realm_status: &str,
+    prefix: &str,
+) -> (String, String) {
+    let request = post_json(
+        app,
+        "/api/realms/requests",
+        Some(requester.token.as_str()),
+        json!({
+            "display_name": format!("Realm {prefix}"),
+            "slug_candidate": format!("slug-{prefix}"),
+            "purpose_text": "Calm bootstrap flow.",
+            "venue_context_json": {
+                "label": prefix,
+                "city": "Tokyo"
+            },
+            "expected_member_shape_json": {
+                "pace": "slow"
+            },
+            "bootstrap_rationale_text": "Bounded early growth only.",
+            "proposed_sponsor_account_id": sponsor.map(|value| value.account_id.clone()),
+            "proposed_steward_account_id": steward.map(|value| value.account_id.clone()),
+            "request_idempotency_key": format!("{prefix}-request")
+        }),
+    )
+    .await;
+    assert_eq!(request.status, StatusCode::OK);
+    let realm_request_id = request.body["realm_request_id"]
+        .as_str()
+        .expect("realm request id must exist")
+        .to_owned();
+
+    let approval = operator_post_json(
+        app,
+        &format!("/api/internal/operator/realms/requests/{realm_request_id}/approve"),
+        approver_id,
+        json!({
+            "target_realm_status": target_realm_status,
+            "review_reason_code": if target_realm_status == "active" {
+                "active_after_review"
+            } else {
+                "limited_bootstrap_active"
+            },
+            "steward_account_id": steward.map(|value| value.account_id.clone()),
+            "sponsor_quota_total": sponsor.map(|_| 1),
+            "corridor_starts_at": if target_realm_status == "limited_bootstrap" {
+                Some((Utc::now() - Duration::minutes(5)).to_rfc3339())
+            } else {
+                None::<String>
+            },
+            "corridor_ends_at": if target_realm_status == "limited_bootstrap" {
+                Some((Utc::now() + Duration::days(3)).to_rfc3339())
+            } else {
+                None::<String>
+            },
+            "corridor_member_cap": if target_realm_status == "limited_bootstrap" { Some(2) } else { None::<i64> },
+            "corridor_sponsor_cap": if target_realm_status == "limited_bootstrap" { Some(1) } else { None::<i64> },
+            "review_threshold_json": {
+                "manual_review_after": 2
+            },
+            "review_decision_idempotency_key": format!("{prefix}-approve")
+        }),
+    )
+    .await;
+    assert_eq!(approval.status, StatusCode::OK);
+    (
+        approval.body["realm_id"]
+            .as_str()
+            .expect("realm id must exist")
+            .to_owned(),
+        realm_request_id,
+    )
+}
+
+async fn sponsor_record_id_for_realm(client: &tokio_postgres::Client, realm_id: &str) -> String {
+    client
+        .query_one(
+            "
+            SELECT realm_sponsor_record_id::text AS realm_sponsor_record_id
+            FROM dao.realm_sponsor_records
+            WHERE realm_id = $1
+            ORDER BY created_at DESC, realm_sponsor_record_id DESC
+            LIMIT 1
+            ",
+            &[&realm_id],
+        )
+        .await
+        .expect("realm sponsor record must exist")
+        .get("realm_sponsor_record_id")
+}
+
+async fn admission_count_for_account(
+    client: &tokio_postgres::Client,
+    realm_id: &str,
+    account_id: &str,
+) -> i64 {
+    let account_id = Uuid::parse_str(account_id).expect("account id must be uuid");
+    client
+        .query_one(
+            "
+            SELECT COUNT(*) AS count
+            FROM dao.realm_admissions
+            WHERE realm_id = $1
+              AND account_id = $2
+            ",
+            &[&realm_id, &account_id],
+        )
+        .await
+        .expect("admission count must query")
+        .get("count")
+}
+
+async fn set_sponsor_status(
+    client: &tokio_postgres::Client,
+    sponsor_record_id: &str,
+    sponsor_status: &str,
+    status_reason_code: &str,
+) {
+    client
+        .execute(
+            "
+            UPDATE dao.realm_sponsor_records
+            SET sponsor_status = $2,
+                status_reason_code = $3,
+                updated_at = CURRENT_TIMESTAMP
+            WHERE realm_sponsor_record_id::text = $1
+            ",
+            &[&sponsor_record_id, &sponsor_status, &status_reason_code],
+        )
+        .await
+        .expect("sponsor status must update");
+}
+
+async fn expire_corridor_without_rebuild(client: &tokio_postgres::Client, realm_id: &str) {
+    client
+        .execute(
+            "
+            UPDATE dao.bootstrap_corridors
+            SET ends_at = CURRENT_TIMESTAMP - interval '1 minute'
+            WHERE realm_id = $1
+            ",
+            &[&realm_id],
+        )
+        .await
+        .expect("corridor must update");
+}
+
+async fn disable_corridor_without_rebuild(client: &tokio_postgres::Client, realm_id: &str) {
+    client
+        .execute(
+            "
+            UPDATE dao.bootstrap_corridors
+            SET corridor_status = 'disabled_by_operator',
+                disabled_reason_code = 'operator_restriction',
+                updated_at = CURRENT_TIMESTAMP
+            WHERE realm_id = $1
+            ",
+            &[&realm_id],
+        )
+        .await
+        .expect("corridor must disable");
+}
+
+async fn current_projection_corridor_status(
+    client: &tokio_postgres::Client,
+    realm_id: &str,
+) -> String {
+    client
+        .query_one(
+            "
+            SELECT corridor_status
+            FROM projection.realm_bootstrap_views
+            WHERE realm_id = $1
+            ",
+            &[&realm_id],
+        )
+        .await
+        .expect("projection row must exist")
+        .get("corridor_status")
+}
+
+async fn set_realm_status(
+    client: &tokio_postgres::Client,
+    realm_id: &str,
+    realm_status: &str,
+    public_reason_code: &str,
+) {
+    client
+        .execute(
+            "
+            UPDATE dao.realms
+            SET realm_status = $2,
+                public_reason_code = $3,
+                updated_at = CURRENT_TIMESTAMP
+            WHERE realm_id = $1
+            ",
+            &[&realm_id, &realm_status, &public_reason_code],
+        )
+        .await
+        .expect("realm status must update");
+}
+
+struct SignedInUser {
+    token: String,
+    account_id: String,
+}
+
+struct JsonResponse {
+    status: StatusCode,
+    body: Value,
+}
+
+async fn sign_in(app: &Router, pi_uid: &str, username: &str) -> SignedInUser {
+    let response = post_json(
+        app,
+        "/api/auth/pi",
+        None,
+        json!({
+            "pi_uid": pi_uid,
+            "username": username,
+            "wallet_address": format!("wallet-{pi_uid}"),
+            "access_token": format!("access-token-{pi_uid}")
+        }),
+    )
+    .await;
+    assert_eq!(response.status, StatusCode::OK);
+
+    SignedInUser {
+        token: response.body["token"]
+            .as_str()
+            .expect("token must exist")
+            .to_owned(),
+        account_id: response.body["user"]["id"]
+            .as_str()
+            .expect("user id must exist")
+            .to_owned(),
+    }
+}
+
+async fn insert_operator_account(client: &tokio_postgres::Client, role: &str) -> String {
+    let account_id = Uuid::new_v4();
+    client
+        .execute(
+            "
+            INSERT INTO core.accounts (account_id, account_class, account_state)
+            VALUES ($1, 'Controlled Exceptional Account', 'active')
+            ",
+            &[&account_id],
+        )
+        .await
+        .expect("operator account must insert");
+    client
+        .execute(
+            "
+            INSERT INTO core.operator_role_assignments (
+                operator_role_assignment_id,
+                operator_account_id,
+                operator_role,
+                grant_reason
+            )
+            VALUES ($1, $2, $3, 'realm bootstrap test role')
+            ",
+            &[&Uuid::new_v4(), &account_id, &role],
+        )
+        .await
+        .expect("operator role assignment must insert");
+    account_id.to_string()
+}
+
+async fn test_db_client() -> tokio_postgres::Client {
+    let database_url = std::env::var("MUSUBI_TEST_DATABASE_URL")
+        .or_else(|_| std::env::var("DATABASE_URL"))
+        .expect("test database url must be present");
+    let (client, connection) = tokio_postgres::connect(&database_url, tokio_postgres::NoTls)
+        .await
+        .expect("test database must be reachable");
+    tokio::spawn(async move {
+        if let Err(error) = connection.await {
+            eprintln!("test database connection error: {error}");
+        }
+    });
+    client
+}
+
+async fn operator_post_json(
+    app: &Router,
+    path: &str,
+    operator_id: &str,
+    body: Value,
+) -> JsonResponse {
+    request_json(app, "POST", path, None, Some(operator_id), Some(body)).await
+}
+
+async fn operator_get_json(app: &Router, path: &str, operator_id: &str) -> JsonResponse {
+    request_json(app, "GET", path, None, Some(operator_id), None).await
+}
+
+async fn post_json(
+    app: &Router,
+    path: &str,
+    bearer_token: Option<&str>,
+    body: Value,
+) -> JsonResponse {
+    request_json(app, "POST", path, bearer_token, None, Some(body)).await
+}
+
+async fn get_json(app: &Router, path: &str, bearer_token: Option<&str>) -> JsonResponse {
+    request_json(app, "GET", path, bearer_token, None, None).await
+}
+
+async fn request_json(
+    app: &Router,
+    method: &str,
+    path: &str,
+    bearer_token: Option<&str>,
+    operator_id: Option<&str>,
+    body: Option<Value>,
+) -> JsonResponse {
+    let mut builder = Request::builder().method(method).uri(path);
+    if let Some(token) = bearer_token {
+        builder = builder.header("authorization", format!("Bearer {token}"));
+    }
+    if let Some(operator_id) = operator_id {
+        builder = builder.header("x-musubi-operator-id", operator_id);
+    }
+
+    let request = builder
+        .header("content-type", "application/json")
+        .body(match body {
+            Some(body) => Body::from(body.to_string()),
+            None => Body::empty(),
+        })
+        .expect("request must build");
+
+    let response = app
+        .clone()
+        .oneshot(request)
+        .await
+        .expect("app should respond");
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body must be readable");
+    let body = if bytes.is_empty() {
+        json!({})
+    } else {
+        serde_json::from_slice(&bytes).unwrap_or_else(|_| {
+            json!({
+                "raw_body": String::from_utf8_lossy(&bytes).to_string()
+            })
+        })
+    };
+
+    JsonResponse { status, body }
+}

--- a/apps/backend/tests/realm_bootstrap.rs
+++ b/apps/backend/tests/realm_bootstrap.rs
@@ -2453,6 +2453,43 @@ async fn participant_summary_read_skips_noop_operator_projection_refresh() {
 }
 
 #[tokio::test]
+async fn operator_review_summary_read_refreshes_lag_metadata() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let requester = sign_in(&app, "pi-user-realm-summary-lag-a", "realm-summary-lag-a").await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let (realm_id, _) = create_realm(
+        &app,
+        &requester,
+        None,
+        None,
+        &approver_id,
+        "limited_bootstrap",
+        "realm-summary-lag",
+    )
+    .await;
+    let projected_at = current_review_summary_last_projected_at(&client, &realm_id).await;
+    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+    let review_summary = operator_get_json(
+        &app,
+        &format!("/api/internal/operator/realms/{realm_id}/review-summary"),
+        &approver_id,
+    )
+    .await;
+    assert_eq!(review_summary.status, StatusCode::OK);
+    assert!(
+        review_summary.body["projection_lag_ms"]
+            .as_i64()
+            .unwrap_or(0)
+            >= 0
+    );
+    assert!(current_review_summary_last_projected_at(&client, &realm_id).await > projected_at);
+}
+
+#[tokio::test]
 async fn unauthorized_summary_read_does_not_expire_corridor_or_refresh_projection() {
     let test_state = new_test_state().await.expect("test database state");
     let app = build_app(test_state.state.clone());

--- a/apps/backend/tests/realm_bootstrap.rs
+++ b/apps/backend/tests/realm_bootstrap.rs
@@ -596,6 +596,17 @@ async fn suspicious_requests_enter_review_even_when_trigger_is_already_open() {
     let third_duplicate_request_id = third_duplicate.body["realm_request_id"]
         .as_str()
         .expect("third duplicate request id must exist");
+    let duplicate_operator_view = operator_get_json(
+        &app,
+        &format!("/api/internal/operator/realms/requests/{third_duplicate_request_id}"),
+        &approver_id,
+    )
+    .await;
+    assert_eq!(duplicate_operator_view.status, StatusCode::OK);
+    assert_eq!(
+        duplicate_operator_view.body["open_review_triggers"][0]["trigger_kind"],
+        "duplicate_venue_context"
+    );
     let duplicate_trigger = client
         .query_one(
             "
@@ -672,6 +683,20 @@ async fn suspicious_requests_enter_review_even_when_trigger_is_already_open() {
     .await;
     assert_eq!(repeated_request.status, StatusCode::OK);
     assert_eq!(repeated_request.body["request_state"], "pending_review");
+    let repeated_request_id = repeated_request.body["realm_request_id"]
+        .as_str()
+        .expect("repeated request id must exist");
+    let repeated_operator_view = operator_get_json(
+        &app,
+        &format!("/api/internal/operator/realms/requests/{repeated_request_id}"),
+        &approver_id,
+    )
+    .await;
+    assert_eq!(repeated_operator_view.status, StatusCode::OK);
+    assert_eq!(
+        repeated_operator_view.body["open_review_triggers"][0]["trigger_kind"],
+        "repeated_rejected_requests"
+    );
 }
 
 #[tokio::test]
@@ -841,7 +866,13 @@ async fn realm_request_rejects_unknown_candidate_account_without_enumeration() {
     .await;
 
     assert_eq!(response.status, StatusCode::BAD_REQUEST);
-    assert!(response.body.to_string().contains("active account"));
+    assert!(
+        response
+            .body
+            .to_string()
+            .contains("provided sponsor/steward account id is invalid")
+    );
+    assert!(!response.body.to_string().contains("active account"));
     assert!(!response.body.to_string().contains("not found"));
 }
 

--- a/apps/backend/tests/realm_bootstrap.rs
+++ b/apps/backend/tests/realm_bootstrap.rs
@@ -4014,6 +4014,232 @@ async fn realm_bootstrap_idempotency_keys_reject_blank_values_at_db_layer() {
 }
 
 #[tokio::test]
+async fn realm_admission_kind_requires_matching_lineage_at_db_layer() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let requester = sign_in(&app, "pi-user-realm-db-lineage-a", "realm-db-lineage-a").await;
+    let sponsor = sign_in(&app, "pi-user-realm-db-lineage-b", "realm-db-lineage-b").await;
+    let member = sign_in(&app, "pi-user-realm-db-lineage-c", "realm-db-lineage-c").await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+    let member_id = Uuid::parse_str(&member.account_id).expect("member id must be uuid");
+    let approver_uuid = Uuid::parse_str(&approver_id).expect("approver id must be uuid");
+
+    let (realm_id, _) = create_realm(
+        &app,
+        &requester,
+        Some(&sponsor),
+        None,
+        &approver_id,
+        "limited_bootstrap",
+        "db-admission-lineage",
+    )
+    .await;
+    let sponsor_record_id = Uuid::parse_str(&sponsor_record_id_for_realm(&client, &realm_id).await)
+        .expect("sponsor record id must be uuid");
+    let corridor_id: Uuid = client
+        .query_one(
+            "
+            SELECT bootstrap_corridor_id
+            FROM dao.bootstrap_corridors
+            WHERE realm_id = $1
+            LIMIT 1
+            ",
+            &[&realm_id],
+        )
+        .await
+        .expect("bootstrap corridor must query")
+        .get("bootstrap_corridor_id");
+
+    assert_check_violation(
+        client
+            .execute(
+                "
+                INSERT INTO dao.realm_admissions (
+                    realm_admission_id,
+                    realm_id,
+                    account_id,
+                    admission_kind,
+                    admission_status,
+                    sponsor_record_id,
+                    bootstrap_corridor_id,
+                    granted_by_actor_kind,
+                    granted_by_actor_id,
+                    review_reason_code,
+                    source_fact_kind,
+                    source_fact_id,
+                    request_idempotency_key,
+                    request_payload_hash
+                )
+                VALUES (
+                    $1,
+                    $2,
+                    $3,
+                    'sponsor_backed',
+                    'pending',
+                    NULL,
+                    $4,
+                    'operator',
+                    $5,
+                    'limited_bootstrap_active',
+                    'db_test',
+                    'sponsor-backed-without-sponsor',
+                    'sponsor-backed-without-sponsor',
+                    repeat('5', 64)
+                )
+                ",
+                &[
+                    &Uuid::new_v4(),
+                    &realm_id,
+                    &member_id,
+                    &corridor_id,
+                    &approver_uuid,
+                ],
+            )
+            .await,
+    );
+
+    assert_check_violation(
+        client
+            .execute(
+                "
+                INSERT INTO dao.realm_admissions (
+                    realm_admission_id,
+                    realm_id,
+                    account_id,
+                    admission_kind,
+                    admission_status,
+                    sponsor_record_id,
+                    bootstrap_corridor_id,
+                    granted_by_actor_kind,
+                    granted_by_actor_id,
+                    review_reason_code,
+                    source_fact_kind,
+                    source_fact_id,
+                    request_idempotency_key,
+                    request_payload_hash
+                )
+                VALUES (
+                    $1,
+                    $2,
+                    $3,
+                    'corridor',
+                    'pending',
+                    NULL,
+                    NULL,
+                    'operator',
+                    $4,
+                    'limited_bootstrap_active',
+                    'db_test',
+                    'corridor-without-corridor',
+                    'corridor-without-corridor',
+                    repeat('6', 64)
+                )
+                ",
+                &[&Uuid::new_v4(), &realm_id, &member_id, &approver_uuid],
+            )
+            .await,
+    );
+
+    assert_check_violation(
+        client
+            .execute(
+                "
+                INSERT INTO dao.realm_admissions (
+                    realm_admission_id,
+                    realm_id,
+                    account_id,
+                    admission_kind,
+                    admission_status,
+                    sponsor_record_id,
+                    bootstrap_corridor_id,
+                    granted_by_actor_kind,
+                    granted_by_actor_id,
+                    review_reason_code,
+                    source_fact_kind,
+                    source_fact_id,
+                    request_idempotency_key,
+                    request_payload_hash
+                )
+                VALUES (
+                    $1,
+                    $2,
+                    $3,
+                    'corridor',
+                    'pending',
+                    $4,
+                    $5,
+                    'operator',
+                    $6,
+                    'limited_bootstrap_active',
+                    'db_test',
+                    'corridor-with-sponsor',
+                    'corridor-with-sponsor',
+                    repeat('7', 64)
+                )
+                ",
+                &[
+                    &Uuid::new_v4(),
+                    &realm_id,
+                    &member_id,
+                    &sponsor_record_id,
+                    &corridor_id,
+                    &approver_uuid,
+                ],
+            )
+            .await,
+    );
+
+    assert_check_violation(
+        client
+            .execute(
+                "
+                INSERT INTO dao.realm_admissions (
+                    realm_admission_id,
+                    realm_id,
+                    account_id,
+                    admission_kind,
+                    admission_status,
+                    sponsor_record_id,
+                    bootstrap_corridor_id,
+                    granted_by_actor_kind,
+                    granted_by_actor_id,
+                    review_reason_code,
+                    source_fact_kind,
+                    source_fact_id,
+                    request_idempotency_key,
+                    request_payload_hash
+                )
+                VALUES (
+                    $1,
+                    $2,
+                    $3,
+                    'normal',
+                    'pending',
+                    $4,
+                    NULL,
+                    'operator',
+                    $5,
+                    'active_after_review',
+                    'db_test',
+                    'normal-with-sponsor',
+                    'normal-with-sponsor',
+                    repeat('8', 64)
+                )
+                ",
+                &[
+                    &Uuid::new_v4(),
+                    &realm_id,
+                    &member_id,
+                    &sponsor_record_id,
+                    &approver_uuid,
+                ],
+            )
+            .await,
+    );
+}
+
+#[tokio::test]
 async fn realm_request_review_states_require_review_audit_fields_at_db_layer() {
     let test_state = new_test_state().await.expect("test database state");
     let app = build_app(test_state.state.clone());
@@ -4151,7 +4377,7 @@ async fn create_realm(
 }
 
 fn assert_check_violation(result: Result<u64, tokio_postgres::Error>) {
-    let error = result.expect_err("blank idempotency key must fail a database check");
+    let error = result.expect_err("database check must reject invalid row");
     assert_eq!(error.code(), Some(&SqlState::CHECK_VIOLATION));
 }
 

--- a/apps/backend/tests/realm_bootstrap.rs
+++ b/apps/backend/tests/realm_bootstrap.rs
@@ -223,6 +223,101 @@ async fn duplicate_venue_request_enters_pending_review_and_rejected_request_crea
 }
 
 #[tokio::test]
+async fn approval_with_changed_slug_releases_original_slug_candidate() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let requester_a = sign_in(
+        &app,
+        "pi-user-realm-approved-slug-a",
+        "realm-approved-slug-a",
+    )
+    .await;
+    let requester_b = sign_in(
+        &app,
+        "pi-user-realm-approved-slug-b",
+        "realm-approved-slug-b",
+    )
+    .await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let first_request = post_json(
+        &app,
+        "/api/realms/requests",
+        Some(requester_a.token.as_str()),
+        json!({
+            "display_name": "Original slug realm",
+            "slug_candidate": "original-slug-candidate",
+            "purpose_text": "The operator will approve a different slug.",
+            "venue_context_json": {
+                "city": "Tokyo",
+                "venue_type": "gallery"
+            },
+            "expected_member_shape_json": {
+                "pace": "slow"
+            },
+            "bootstrap_rationale_text": "Slug release regression coverage.",
+            "request_idempotency_key": "realm-approved-slug-first"
+        }),
+    )
+    .await;
+    assert_eq!(first_request.status, StatusCode::OK);
+    let realm_request_id = first_request.body["realm_request_id"]
+        .as_str()
+        .expect("realm request id must exist")
+        .to_owned();
+
+    let approval = operator_post_json(
+        &app,
+        &format!("/api/internal/operator/realms/requests/{realm_request_id}/approve"),
+        &approver_id,
+        json!({
+            "target_realm_status": "active",
+            "approved_slug": "approved-slug-candidate",
+            "review_reason_code": "active_after_review",
+            "review_decision_idempotency_key": "realm-approved-slug-approve"
+        }),
+    )
+    .await;
+    assert_eq!(approval.status, StatusCode::OK);
+    assert_eq!(approval.body["slug"], "approved-slug-candidate");
+
+    let requester_view = get_json(
+        &app,
+        &format!("/api/realms/requests/{realm_request_id}"),
+        Some(requester_a.token.as_str()),
+    )
+    .await;
+    assert_eq!(requester_view.status, StatusCode::OK);
+    assert_eq!(
+        requester_view.body["slug_candidate"],
+        "approved-slug-candidate"
+    );
+
+    let second_request = post_json(
+        &app,
+        "/api/realms/requests",
+        Some(requester_b.token.as_str()),
+        json!({
+            "display_name": "Reused original slug realm",
+            "slug_candidate": "original-slug-candidate",
+            "purpose_text": "The original candidate should be available again.",
+            "venue_context_json": {
+                "city": "Osaka",
+                "venue_type": "bookstore"
+            },
+            "expected_member_shape_json": {
+                "pace": "quiet"
+            },
+            "bootstrap_rationale_text": "The first request no longer reserves this slug.",
+            "request_idempotency_key": "realm-approved-slug-second"
+        }),
+    )
+    .await;
+    assert_eq!(second_request.status, StatusCode::OK);
+}
+
+#[tokio::test]
 async fn suspicious_requests_enter_review_even_when_trigger_is_already_open() {
     let test_state = new_test_state().await.expect("test database state");
     let app = build_app(test_state.state.clone());
@@ -1131,6 +1226,84 @@ async fn rate_limited_and_revoked_sponsor_do_not_auto_admit() {
     assert_eq!(revoked.body["admission_kind"], "review_required");
     assert_eq!(revoked.body["admission_status"], "pending");
     assert_eq!(revoked.body["review_reason_code"], "sponsor_revoked");
+}
+
+#[tokio::test]
+async fn stale_sponsor_record_id_uses_latest_sponsor_status() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let requester = sign_in(
+        &app,
+        "pi-user-realm-stale-sponsor-a",
+        "realm-stale-sponsor-a",
+    )
+    .await;
+    let sponsor = sign_in(
+        &app,
+        "pi-user-realm-stale-sponsor-b",
+        "realm-stale-sponsor-b",
+    )
+    .await;
+    let member = sign_in(
+        &app,
+        "pi-user-realm-stale-sponsor-c",
+        "realm-stale-sponsor-c",
+    )
+    .await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let (realm_id, _) = create_realm(
+        &app,
+        &requester,
+        Some(&sponsor),
+        None,
+        &approver_id,
+        "active",
+        "realm-stale-sponsor",
+    )
+    .await;
+    let stale_active_sponsor_record_id = sponsor_record_id_for_realm(&client, &realm_id).await;
+    let revoked_sponsor_record = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_id}/sponsor-records"),
+        &approver_id,
+        json!({
+            "sponsor_account_id": sponsor.account_id,
+            "sponsor_status": "revoked",
+            "quota_total": 1,
+            "status_reason_code": "sponsor_revoked",
+            "request_idempotency_key": "realm-stale-sponsor-revoked"
+        }),
+    )
+    .await;
+    assert_eq!(revoked_sponsor_record.status, StatusCode::OK);
+    let revoked_sponsor_record_id = revoked_sponsor_record.body["realm_sponsor_record_id"]
+        .as_str()
+        .expect("revoked sponsor record id must exist");
+
+    let admission = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_id}/admissions"),
+        &approver_id,
+        json!({
+            "account_id": member.account_id,
+            "sponsor_record_id": stale_active_sponsor_record_id,
+            "source_fact_kind": "sponsor_invite",
+            "source_fact_id": "realm-stale-sponsor-admission",
+            "source_snapshot_json": {},
+            "request_idempotency_key": "realm-stale-sponsor-admission"
+        }),
+    )
+    .await;
+    assert_eq!(admission.status, StatusCode::OK);
+    assert_eq!(admission.body["admission_kind"], "review_required");
+    assert_eq!(admission.body["admission_status"], "pending");
+    assert_eq!(admission.body["review_reason_code"], "sponsor_revoked");
+    assert_eq!(
+        admission.body["sponsor_record_id"],
+        revoked_sponsor_record_id
+    );
 }
 
 #[tokio::test]

--- a/apps/backend/tests/realm_bootstrap.rs
+++ b/apps/backend/tests/realm_bootstrap.rs
@@ -2088,6 +2088,22 @@ async fn expired_and_disabled_corridor_do_not_grant_corridor_benefits_even_if_pr
         disabled_summary.body["bootstrap_view"]["admission_posture"],
         "review_required"
     );
+
+    let disabled_review_summary = operator_get_json(
+        &app,
+        &format!("/api/internal/operator/realms/{disabled_realm_id}/review-summary"),
+        &approver_id,
+    )
+    .await;
+    assert_eq!(disabled_review_summary.status, StatusCode::OK);
+    assert_eq!(
+        disabled_review_summary.body["corridor_status"],
+        "disabled_by_operator"
+    );
+    assert_eq!(
+        disabled_review_summary.body["corridor_remaining_seconds"],
+        0
+    );
 }
 
 #[tokio::test]

--- a/apps/backend/tests/realm_bootstrap.rs
+++ b/apps/backend/tests/realm_bootstrap.rs
@@ -393,6 +393,96 @@ async fn concurrent_realm_request_replay_returns_existing_request() {
 }
 
 #[tokio::test]
+async fn operator_realm_request_list_is_bounded_and_cursor_paged() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let client = test_db_client().await;
+    let operator_id = insert_operator_account(&client, "reviewer").await;
+
+    for index in 0..3 {
+        let requester = sign_in(
+            &app,
+            &format!("pi-user-realm-list-{index}"),
+            &format!("realm-list-{index}"),
+        )
+        .await;
+        let request = post_json(
+            &app,
+            "/api/realms/requests",
+            Some(requester.token.as_str()),
+            json!({
+                "display_name": format!("Realm list {index}"),
+                "slug_candidate": format!("realm-list-{index}"),
+                "purpose_text": "Operator list pagination coverage.",
+                "venue_context_json": {
+                    "city": "Tokyo",
+                    "venue": format!("list-{index}")
+                },
+                "expected_member_shape_json": {
+                    "pace": "calm",
+                    "index": index
+                },
+                "bootstrap_rationale_text": "Keep the operator list bounded.",
+                "request_idempotency_key": format!("realm-list-{index}")
+            }),
+        )
+        .await;
+        assert_eq!(request.status, StatusCode::OK);
+    }
+
+    let first_page = operator_get_json(
+        &app,
+        "/api/internal/operator/realms/requests?limit=2",
+        &operator_id,
+    )
+    .await;
+    assert_eq!(first_page.status, StatusCode::OK);
+    let first_items = first_page
+        .body
+        .as_array()
+        .expect("first page must be an array");
+    assert_eq!(first_items.len(), 2);
+    let cursor_item = &first_items[1];
+    let cursor_created_at = cursor_item["created_at"]
+        .as_str()
+        .expect("cursor created_at must exist");
+    let cursor_request_id = cursor_item["realm_request_id"]
+        .as_str()
+        .expect("cursor realm_request_id must exist");
+
+    let second_page = operator_get_json(
+        &app,
+        &format!(
+            "/api/internal/operator/realms/requests?limit=2&before_created_at={cursor_created_at}&before_realm_request_id={cursor_request_id}"
+        ),
+        &operator_id,
+    )
+    .await;
+    assert_eq!(second_page.status, StatusCode::OK);
+    let second_items = second_page
+        .body
+        .as_array()
+        .expect("second page must be an array");
+    assert_eq!(second_items.len(), 1);
+    assert_ne!(
+        second_items[0]["realm_request_id"],
+        first_items[0]["realm_request_id"]
+    );
+    assert_ne!(
+        second_items[0]["realm_request_id"],
+        first_items[1]["realm_request_id"]
+    );
+
+    let invalid_limit = operator_get_json(
+        &app,
+        "/api/internal/operator/realms/requests?limit=0",
+        &operator_id,
+    )
+    .await;
+    assert_eq!(invalid_limit.status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
 async fn suspicious_requests_enter_review_even_when_trigger_is_already_open() {
     let test_state = new_test_state().await.expect("test database state");
     let app = build_app(test_state.state.clone());

--- a/apps/backend/tests/realm_bootstrap.rs
+++ b/apps/backend/tests/realm_bootstrap.rs
@@ -3434,6 +3434,64 @@ async fn realm_bootstrap_idempotency_keys_reject_blank_values_at_db_layer() {
     );
 }
 
+#[tokio::test]
+async fn realm_request_review_states_require_review_audit_fields_at_db_layer() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let requester = sign_in(
+        &app,
+        "pi-user-realm-db-review-audit",
+        "realm-db-review-audit",
+    )
+    .await;
+    let client = test_db_client().await;
+
+    let requester_id = Uuid::parse_str(&requester.account_id).expect("requester id must be uuid");
+    let unaudited_review_request_id = Uuid::new_v4();
+
+    assert_check_violation(
+        client
+            .execute(
+                "
+                INSERT INTO dao.realm_requests (
+                    realm_request_id,
+                    requested_by_account_id,
+                    display_name,
+                    slug_candidate,
+                    purpose_text,
+                    venue_context_json,
+                    expected_member_shape_json,
+                    bootstrap_rationale_text,
+                    request_state,
+                    review_reason_code,
+                    request_idempotency_key,
+                    request_payload_hash,
+                    review_decision_idempotency_key,
+                    review_decision_payload_hash
+                )
+                VALUES (
+                    $1,
+                    $2,
+                    'Unaudited approved realm',
+                    'unaudited-approved-realm',
+                    'Approved and rejected rows require review actor/time.',
+                    '{\"city\":\"Tokyo\"}'::jsonb,
+                    '{\"size\":\"small\"}'::jsonb,
+                    'The database owns review audit completeness.',
+                    'approved',
+                    'active_after_review',
+                    'unaudited-approved-request',
+                    repeat('5', 64),
+                    'unaudited-approved-review',
+                    repeat('6', 64)
+                )
+                ",
+                &[&unaudited_review_request_id, &requester_id],
+            )
+            .await,
+    );
+}
+
 async fn create_realm(
     app: &Router,
     requester: &SignedInUser,

--- a/apps/backend/tests/realm_bootstrap.rs
+++ b/apps/backend/tests/realm_bootstrap.rs
@@ -1757,6 +1757,83 @@ async fn rate_limited_and_revoked_sponsor_do_not_auto_admit() {
 }
 
 #[tokio::test]
+async fn sponsor_lineage_can_progress_from_proposed_or_approved_to_active() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let requester = sign_in(
+        &app,
+        "pi-user-realm-sponsor-progress-a",
+        "realm-sponsor-progress-a",
+    )
+    .await;
+    let sponsor = sign_in(
+        &app,
+        "pi-user-realm-sponsor-progress-b",
+        "realm-sponsor-progress-b",
+    )
+    .await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let (realm_id, _) = create_realm(
+        &app,
+        &requester,
+        None,
+        None,
+        &approver_id,
+        "active",
+        "realm-sponsor-progress",
+    )
+    .await;
+
+    let proposed = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_id}/sponsor-records"),
+        &approver_id,
+        json!({
+            "sponsor_account_id": sponsor.account_id,
+            "sponsor_status": "proposed",
+            "quota_total": 2,
+            "status_reason_code": "request_received",
+            "request_idempotency_key": "realm-sponsor-progress-proposed"
+        }),
+    )
+    .await;
+    assert_eq!(proposed.status, StatusCode::OK);
+
+    let approved = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_id}/sponsor-records"),
+        &approver_id,
+        json!({
+            "sponsor_account_id": sponsor.account_id,
+            "sponsor_status": "approved",
+            "quota_total": 2,
+            "status_reason_code": "limited_bootstrap_active",
+            "request_idempotency_key": "realm-sponsor-progress-approved"
+        }),
+    )
+    .await;
+    assert_eq!(approved.status, StatusCode::OK);
+
+    let active = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_id}/sponsor-records"),
+        &approver_id,
+        json!({
+            "sponsor_account_id": sponsor.account_id,
+            "sponsor_status": "active",
+            "quota_total": 2,
+            "status_reason_code": "active_after_review",
+            "request_idempotency_key": "realm-sponsor-progress-active"
+        }),
+    )
+    .await;
+    assert_eq!(active.status, StatusCode::OK);
+    assert_eq!(active.body["sponsor_status"], "active");
+}
+
+#[tokio::test]
 async fn stale_sponsor_record_id_uses_latest_sponsor_status() {
     let test_state = new_test_state().await.expect("test database state");
     let app = build_app(test_state.state.clone());
@@ -2580,6 +2657,28 @@ async fn request_and_admission_idempotency_replay_mismatch_is_rejected() {
         realm_admission_id
     );
 
+    grant_operator_role(&client, &approver_id, "steward").await;
+    let role_changed_replay = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_id}/admissions"),
+        &approver_id,
+        json!({
+            "account_id": member.account_id,
+            "source_fact_kind": "realm_admin_invite",
+            "source_fact_id": "realm-idem-admission",
+            "source_snapshot_json": {
+                "safe_summary": "first admission"
+            },
+            "request_idempotency_key": "realm-idem-admission"
+        }),
+    )
+    .await;
+    assert_eq!(role_changed_replay.status, StatusCode::OK);
+    assert_eq!(
+        role_changed_replay.body["realm_admission_id"],
+        realm_admission_id
+    );
+
     let mismatched_admission = operator_post_json(
         &app,
         &format!("/api/internal/realms/{realm_id}/admissions"),
@@ -2992,6 +3091,25 @@ async fn insert_operator_account(client: &tokio_postgres::Client, role: &str) ->
         .await
         .expect("operator role assignment must insert");
     account_id.to_string()
+}
+
+async fn grant_operator_role(client: &tokio_postgres::Client, operator_id: &str, role: &str) {
+    let operator_id = Uuid::parse_str(operator_id).expect("operator id must be a uuid");
+    client
+        .execute(
+            "
+            INSERT INTO core.operator_role_assignments (
+                operator_role_assignment_id,
+                operator_account_id,
+                operator_role,
+                grant_reason
+            )
+            VALUES ($1, $2, $3, 'realm bootstrap test role')
+            ",
+            &[&Uuid::new_v4(), &operator_id, &role],
+        )
+        .await
+        .expect("operator role assignment must insert");
 }
 
 async fn test_db_client() -> tokio_postgres::Client {

--- a/apps/backend/tests/realm_bootstrap.rs
+++ b/apps/backend/tests/realm_bootstrap.rs
@@ -1456,11 +1456,7 @@ async fn admitted_member_is_not_downgraded_by_later_admission_request_after_corr
 
     expire_corridor_without_rebuild(&client, &realm_id).await;
 
-    let later = operator_post_json(
-        &app,
-        &format!("/api/internal/realms/{realm_id}/admissions"),
-        &approver_id,
-        json!({
+    let later_body = json!({
             "account_id": member.account_id,
             "source_fact_kind": "operator_review",
             "source_fact_id": "realm-preserve-after-expiry",
@@ -1468,14 +1464,57 @@ async fn admitted_member_is_not_downgraded_by_later_admission_request_after_corr
                 "review_outcome": "still_admitted"
             },
             "request_idempotency_key": "realm-preserve-after-expiry"
-        }),
+    });
+    let later = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_id}/admissions"),
+        &approver_id,
+        later_body.clone(),
     )
     .await;
     assert_eq!(later.status, StatusCode::OK);
     assert_eq!(later.body["admission_kind"], "corridor");
     assert_eq!(later.body["admission_status"], "admitted");
+    let later_admission_id = later.body["realm_admission_id"]
+        .as_str()
+        .expect("admission id must exist")
+        .to_owned();
     assert_eq!(
         admission_count_for_account(&client, &realm_id, &member.account_id).await,
+        1
+    );
+
+    let drifted_replay = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_id}/admissions"),
+        &approver_id,
+        json!({
+            "account_id": member.account_id,
+            "source_fact_kind": "operator_review",
+            "source_fact_id": "realm-preserve-after-expiry-drift",
+            "source_snapshot_json": {
+                "review_outcome": "still_admitted"
+            },
+            "request_idempotency_key": "realm-preserve-after-expiry"
+        }),
+    )
+    .await;
+    assert_eq!(drifted_replay.status, StatusCode::BAD_REQUEST);
+
+    let replayed_later = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_id}/admissions"),
+        &approver_id,
+        later_body,
+    )
+    .await;
+    assert_eq!(replayed_later.status, StatusCode::OK);
+    assert_eq!(
+        replayed_later.body["realm_admission_id"],
+        later_admission_id
+    );
+    assert_eq!(
+        admission_idempotency_key_count(&client, &realm_id, "realm-preserve-after-expiry").await,
         1
     );
 
@@ -2863,6 +2902,25 @@ async fn inactive_sponsor_account_blocks_auto_admission_and_can_be_revoked() {
     let stale_active_sponsor_record_id = sponsor_record_id_for_realm(&client, &realm_id).await;
     set_account_state(&client, &sponsor.account_id, "suspended").await;
 
+    let replayed_existing_sponsor = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_id}/sponsor-records"),
+        &approver_id,
+        json!({
+            "sponsor_account_id": sponsor.account_id,
+            "sponsor_status": "active",
+            "quota_total": 1,
+            "status_reason_code": "active_after_review",
+            "request_idempotency_key": "realm-inactive-sponsor-approve"
+        }),
+    )
+    .await;
+    assert_eq!(replayed_existing_sponsor.status, StatusCode::OK);
+    assert_eq!(
+        replayed_existing_sponsor.body["realm_sponsor_record_id"],
+        stale_active_sponsor_record_id
+    );
+
     let blocked = operator_post_json(
         &app,
         &format!("/api/internal/realms/{realm_id}/admissions"),
@@ -3180,6 +3238,26 @@ async fn summary_reads_derive_expired_corridor_without_unrelated_write() {
     assert_eq!(review_summary.status, StatusCode::OK);
     assert_eq!(review_summary.body["corridor_status"], "expired");
     assert_eq!(review_summary.body["corridor_remaining_seconds"], 0);
+}
+
+#[tokio::test]
+async fn rebuild_realm_bootstrap_views_accepts_empty_json_body() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let rebuild = operator_post_json(
+        &app,
+        "/api/internal/projection/realms/rebuild",
+        &approver_id,
+        json!({}),
+    )
+    .await;
+    assert_eq!(rebuild.status, StatusCode::OK);
+    assert!(rebuild.body["bootstrap_view_count"].as_i64().is_some());
+    assert!(rebuild.body["admission_view_count"].as_i64().is_some());
+    assert!(rebuild.body["review_summary_count"].as_i64().is_some());
 }
 
 #[tokio::test]
@@ -3841,6 +3919,7 @@ async fn realm_bootstrap_idempotency_keys_reject_blank_values_at_db_layer() {
     let blank_review_request_id = Uuid::new_v4();
     let blank_sponsor_record_id = Uuid::new_v4();
     let blank_admission_id = Uuid::new_v4();
+    let valid_admission_id = Uuid::new_v4();
 
     assert_check_violation(
         client
@@ -4008,6 +4087,67 @@ async fn realm_bootstrap_idempotency_keys_reject_blank_values_at_db_layer() {
                 )
                 ",
                 &[&blank_admission_id, &realm_id, &member_id, &approver_uuid],
+            )
+            .await,
+    );
+
+    client
+        .execute(
+            "
+            INSERT INTO dao.realm_admissions (
+                realm_admission_id,
+                realm_id,
+                account_id,
+                admission_kind,
+                admission_status,
+                granted_by_actor_kind,
+                granted_by_actor_id,
+                review_reason_code,
+                source_fact_kind,
+                source_fact_id,
+                request_idempotency_key,
+                request_payload_hash
+            )
+            VALUES (
+                $1,
+                $2,
+                $3,
+                'normal',
+                'admitted',
+                'operator',
+                $4,
+                'active_after_review',
+                'db_test',
+                'valid-admission-key-source',
+                'valid-admission-key',
+                repeat('5', 64)
+            )
+            ",
+            &[&valid_admission_id, &realm_id, &member_id, &approver_uuid],
+        )
+        .await
+        .expect("valid admission fixture");
+
+    assert_check_violation(
+        client
+            .execute(
+                "
+                INSERT INTO dao.realm_admission_idempotency_keys (
+                    realm_id,
+                    granted_by_actor_id,
+                    request_idempotency_key,
+                    realm_admission_id,
+                    request_payload_hash
+                )
+                VALUES (
+                    $1,
+                    $2,
+                    '   ',
+                    $3,
+                    repeat('6', 64)
+                )
+                ",
+                &[&realm_id, &approver_uuid, &valid_admission_id],
             )
             .await,
     );
@@ -4416,6 +4556,26 @@ async fn admission_count_for_account(
         )
         .await
         .expect("admission count must query")
+        .get("count")
+}
+
+async fn admission_idempotency_key_count(
+    client: &tokio_postgres::Client,
+    realm_id: &str,
+    request_idempotency_key: &str,
+) -> i64 {
+    client
+        .query_one(
+            "
+            SELECT COUNT(*) AS count
+            FROM dao.realm_admission_idempotency_keys
+            WHERE realm_id = $1
+              AND request_idempotency_key = $2
+            ",
+            &[&realm_id, &request_idempotency_key],
+        )
+        .await
+        .expect("admission idempotency key count must query")
         .get("count")
 }
 

--- a/apps/backend/tests/realm_bootstrap.rs
+++ b/apps/backend/tests/realm_bootstrap.rs
@@ -1829,6 +1829,15 @@ async fn sponsor_quota_counts_distinct_accounts_when_pending_rows_repeat() {
     assert_eq!(next.status, StatusCode::OK);
     assert_eq!(next.body["admission_kind"], "sponsor_backed");
     assert_eq!(next.body["admission_status"], "admitted");
+
+    let review_summary = operator_get_json(
+        &app,
+        &format!("/api/internal/operator/realms/{realm_id}/review-summary"),
+        &approver_id,
+    )
+    .await;
+    assert_eq!(review_summary.status, StatusCode::OK);
+    assert_eq!(review_summary.body["sponsor_backed_admission_count"], 2);
 }
 
 #[tokio::test]

--- a/apps/backend/tests/realm_bootstrap.rs
+++ b/apps/backend/tests/realm_bootstrap.rs
@@ -2178,6 +2178,67 @@ async fn sponsor_quota_counts_reactivated_sponsor_lineage() {
 }
 
 #[tokio::test]
+async fn restrictive_sponsor_status_requires_existing_lineage() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let requester = sign_in(
+        &app,
+        "pi-user-realm-sponsor-restrictive-a",
+        "realm-sponsor-restrictive-a",
+    )
+    .await;
+    let sponsor = sign_in(
+        &app,
+        "pi-user-realm-sponsor-restrictive-b",
+        "realm-sponsor-restrictive-b",
+    )
+    .await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let (realm_id, _) = create_realm(
+        &app,
+        &requester,
+        None,
+        None,
+        &approver_id,
+        "limited_bootstrap",
+        "realm-sponsor-restrictive",
+    )
+    .await;
+
+    let rate_limited = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_id}/sponsor-records"),
+        &approver_id,
+        json!({
+            "sponsor_account_id": sponsor.account_id,
+            "sponsor_status": "rate_limited",
+            "quota_total": 1,
+            "status_reason_code": "sponsor_rate_limited",
+            "request_idempotency_key": "realm-sponsor-restrictive-rate-limited"
+        }),
+    )
+    .await;
+    assert_eq!(rate_limited.status, StatusCode::BAD_REQUEST);
+
+    let revoked = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_id}/sponsor-records"),
+        &approver_id,
+        json!({
+            "sponsor_account_id": sponsor.account_id,
+            "sponsor_status": "revoked",
+            "quota_total": 1,
+            "status_reason_code": "sponsor_revoked",
+            "request_idempotency_key": "realm-sponsor-restrictive-revoked"
+        }),
+    )
+    .await;
+    assert_eq!(revoked.status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
 async fn concurrent_corridor_admissions_do_not_exceed_member_cap() {
     let test_state = new_test_state().await.expect("test database state");
     let app = build_app(test_state.state.clone());

--- a/apps/backend/tests/realm_bootstrap.rs
+++ b/apps/backend/tests/realm_bootstrap.rs
@@ -1331,6 +1331,124 @@ async fn sponsor_lineage_churn_counts_sponsor_accounts_for_caps_and_summary() {
 }
 
 #[tokio::test]
+async fn sponsor_quota_counts_reactivated_sponsor_lineage() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let requester = sign_in(
+        &app,
+        "pi-user-realm-sponsor-quota-lineage-a",
+        "realm-sponsor-quota-lineage-a",
+    )
+    .await;
+    let sponsor = sign_in(
+        &app,
+        "pi-user-realm-sponsor-quota-lineage-b",
+        "realm-sponsor-quota-lineage-b",
+    )
+    .await;
+    let first_member = sign_in(
+        &app,
+        "pi-user-realm-sponsor-quota-lineage-c",
+        "realm-sponsor-quota-lineage-c",
+    )
+    .await;
+    let second_member = sign_in(
+        &app,
+        "pi-user-realm-sponsor-quota-lineage-d",
+        "realm-sponsor-quota-lineage-d",
+    )
+    .await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let (realm_id, _) = create_realm(
+        &app,
+        &requester,
+        Some(&sponsor),
+        None,
+        &approver_id,
+        "limited_bootstrap",
+        "realm-sponsor-quota-lineage",
+    )
+    .await;
+    let initial_sponsor_record_id = sponsor_record_id_for_realm(&client, &realm_id).await;
+
+    let first = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_id}/admissions"),
+        &approver_id,
+        json!({
+            "account_id": first_member.account_id,
+            "sponsor_record_id": initial_sponsor_record_id,
+            "source_fact_kind": "sponsor_invite",
+            "source_fact_id": "realm-sponsor-quota-lineage-first",
+            "source_snapshot_json": {},
+            "request_idempotency_key": "realm-sponsor-quota-lineage-first"
+        }),
+    )
+    .await;
+    assert_eq!(first.status, StatusCode::OK);
+    assert_eq!(first.body["admission_kind"], "sponsor_backed");
+    assert_eq!(first.body["admission_status"], "admitted");
+
+    let rate_limited = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_id}/sponsor-records"),
+        &approver_id,
+        json!({
+            "sponsor_account_id": sponsor.account_id,
+            "sponsor_status": "rate_limited",
+            "quota_total": 1,
+            "status_reason_code": "sponsor_rate_limited",
+            "request_idempotency_key": "realm-sponsor-quota-lineage-rate-limited"
+        }),
+    )
+    .await;
+    assert_eq!(rate_limited.status, StatusCode::OK);
+
+    let reactivated = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_id}/sponsor-records"),
+        &approver_id,
+        json!({
+            "sponsor_account_id": sponsor.account_id,
+            "sponsor_status": "active",
+            "quota_total": 1,
+            "status_reason_code": "limited_bootstrap_active",
+            "request_idempotency_key": "realm-sponsor-quota-lineage-reactivated"
+        }),
+    )
+    .await;
+    assert_eq!(reactivated.status, StatusCode::OK);
+    let current_sponsor_record_id = reactivated.body["realm_sponsor_record_id"]
+        .as_str()
+        .expect("current sponsor record id must exist");
+
+    let second = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_id}/admissions"),
+        &approver_id,
+        json!({
+            "account_id": second_member.account_id,
+            "sponsor_record_id": initial_sponsor_record_id,
+            "source_fact_kind": "sponsor_invite",
+            "source_fact_id": "realm-sponsor-quota-lineage-second",
+            "source_snapshot_json": {},
+            "request_idempotency_key": "realm-sponsor-quota-lineage-second"
+        }),
+    )
+    .await;
+    assert_eq!(second.status, StatusCode::OK);
+    assert_eq!(second.body["admission_kind"], "review_required");
+    assert_eq!(second.body["admission_status"], "pending");
+    assert_eq!(
+        second.body["review_reason_code"],
+        "bootstrap_capacity_reached"
+    );
+    assert_eq!(second.body["sponsor_record_id"], current_sponsor_record_id);
+}
+
+#[tokio::test]
 async fn concurrent_corridor_admissions_do_not_exceed_member_cap() {
     let test_state = new_test_state().await.expect("test database state");
     let app = build_app(test_state.state.clone());

--- a/apps/backend/tests/realm_bootstrap.rs
+++ b/apps/backend/tests/realm_bootstrap.rs
@@ -3732,6 +3732,8 @@ async fn request_and_admission_idempotency_replay_mismatch_is_rejected() {
     let app = build_app(test_state.state.clone());
     let requester = sign_in(&app, "pi-user-realm-idem-a", "realm-idem-a").await;
     let member = sign_in(&app, "pi-user-realm-idem-b", "realm-idem-b").await;
+    let proposed_sponsor = sign_in(&app, "pi-user-realm-idem-c", "realm-idem-c").await;
+    let proposed_steward = sign_in(&app, "pi-user-realm-idem-d", "realm-idem-d").await;
     let client = test_db_client().await;
     let approver_id = insert_operator_account(&client, "approver").await;
 
@@ -3747,6 +3749,8 @@ async fn request_and_admission_idempotency_replay_mismatch_is_rejected() {
             "size": "small"
         },
         "bootstrap_rationale_text": "まずは小さく始めます。",
+        "proposed_sponsor_account_id": proposed_sponsor.account_id,
+        "proposed_steward_account_id": proposed_steward.account_id,
         "request_idempotency_key": "realm-idem-request"
     });
     let first_request = post_json(
@@ -3766,11 +3770,26 @@ async fn request_and_admission_idempotency_replay_mismatch_is_rejected() {
         &app,
         "/api/realms/requests",
         Some(requester.token.as_str()),
-        request_body,
+        request_body.clone(),
     )
     .await;
     assert_eq!(replayed_request.status, StatusCode::OK);
     assert_eq!(replayed_request.body["realm_request_id"], realm_request_id);
+
+    set_account_state(&client, &proposed_sponsor.account_id, "suspended").await;
+    set_account_state(&client, &proposed_steward.account_id, "suspended").await;
+    let inactive_candidate_replay = post_json(
+        &app,
+        "/api/realms/requests",
+        Some(requester.token.as_str()),
+        request_body.clone(),
+    )
+    .await;
+    assert_eq!(inactive_candidate_replay.status, StatusCode::OK);
+    assert_eq!(
+        inactive_candidate_replay.body["realm_request_id"],
+        realm_request_id
+    );
 
     let mismatched_request = post_json(
         &app,
@@ -3788,12 +3807,16 @@ async fn request_and_admission_idempotency_replay_mismatch_is_rejected() {
                 "size": "small"
             },
             "bootstrap_rationale_text": "まずは小さく始めます。",
+            "proposed_sponsor_account_id": proposed_sponsor.account_id,
+            "proposed_steward_account_id": proposed_steward.account_id,
             "request_idempotency_key": "realm-idem-request"
         }),
     )
     .await;
     assert_eq!(mismatched_request.status, StatusCode::BAD_REQUEST);
 
+    set_account_state(&client, &proposed_sponsor.account_id, "active").await;
+    set_account_state(&client, &proposed_steward.account_id, "active").await;
     let approval = operator_post_json(
         &app,
         &format!("/api/internal/operator/realms/requests/{realm_request_id}/approve"),
@@ -3801,6 +3824,7 @@ async fn request_and_admission_idempotency_replay_mismatch_is_rejected() {
         json!({
             "target_realm_status": "active",
             "review_reason_code": "active_after_review",
+            "sponsor_quota_total": 1,
             "review_decision_idempotency_key": "realm-idem-approve"
         }),
     )

--- a/apps/backend/tests/realm_bootstrap.rs
+++ b/apps/backend/tests/realm_bootstrap.rs
@@ -4,7 +4,8 @@ use axum::{
     http::{Request, StatusCode},
 };
 use chrono::{Duration, Utc};
-use musubi_backend::{build_app, new_test_state};
+use musubi_backend::{build_app, new_state_from_config, new_test_state};
+use musubi_db_runtime::DbConfig;
 use serde_json::{Value, json};
 use tower::ServiceExt;
 use uuid::Uuid;
@@ -759,6 +760,119 @@ async fn sponsor_backed_admission_respects_corridor_member_cap() {
         review_summary.body["open_review_triggers"][0]["trigger_kind"],
         "corridor_cap_pressure"
     );
+}
+
+#[tokio::test]
+async fn concurrent_corridor_admissions_do_not_exceed_member_cap() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let database_url = std::env::var("MUSUBI_TEST_DATABASE_URL")
+        .or_else(|_| std::env::var("DATABASE_URL"))
+        .expect("test database url must be present");
+    let config = DbConfig::from_lookup(|name| match name {
+        "APP_ENV" => Some("local".to_owned()),
+        "DATABASE_URL" => Some(database_url.clone()),
+        _ => std::env::var(name).ok(),
+    })
+    .expect("db config");
+    let second_state = new_state_from_config(&config).await.expect("second state");
+    let second_app = build_app(second_state.clone());
+    let requester = sign_in(
+        &app,
+        "pi-user-realm-corridor-race-requester",
+        "realm-corridor-race-requester",
+    )
+    .await;
+    let first_member = sign_in(
+        &app,
+        "pi-user-realm-corridor-race-first",
+        "realm-corridor-race-first",
+    )
+    .await;
+    let second_member = sign_in(
+        &app,
+        "pi-user-realm-corridor-race-second",
+        "realm-corridor-race-second",
+    )
+    .await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let (realm_id, _) = create_realm(
+        &app,
+        &requester,
+        None,
+        None,
+        &approver_id,
+        "limited_bootstrap",
+        "realm-corridor-race",
+    )
+    .await;
+    client
+        .execute(
+            "
+            UPDATE dao.bootstrap_corridors
+            SET member_cap = 1,
+                updated_at = CURRENT_TIMESTAMP
+            WHERE realm_id = $1
+            ",
+            &[&realm_id],
+        )
+        .await
+        .expect("corridor member cap must update");
+
+    let path = format!("/api/internal/realms/{realm_id}/admissions");
+    let first_body = json!({
+        "account_id": first_member.account_id,
+        "source_fact_kind": "manual_review",
+        "source_fact_id": "realm-corridor-race-first",
+        "source_snapshot_json": {},
+        "request_idempotency_key": "realm-corridor-race-first"
+    });
+    let second_body = json!({
+        "account_id": second_member.account_id,
+        "source_fact_kind": "manual_review",
+        "source_fact_id": "realm-corridor-race-second",
+        "source_snapshot_json": {},
+        "request_idempotency_key": "realm-corridor-race-second"
+    });
+
+    let (first, second) = tokio::join!(
+        operator_post_json(&app, &path, &approver_id, first_body),
+        operator_post_json(&second_app, &path, &approver_id, second_body)
+    );
+    assert_eq!(first.status, StatusCode::OK);
+    assert_eq!(second.status, StatusCode::OK);
+    let responses = [&first, &second];
+    assert_eq!(
+        responses
+            .iter()
+            .filter(|response| response.body["admission_kind"] == "corridor")
+            .count(),
+        1
+    );
+    assert_eq!(
+        responses
+            .iter()
+            .filter(|response| response.body["review_reason_code"] == "bootstrap_capacity_reached")
+            .count(),
+        1
+    );
+    let admitted_count: i64 = client
+        .query_one(
+            "
+            SELECT COUNT(*) AS admitted_count
+            FROM dao.realm_admissions
+            WHERE realm_id = $1
+              AND bootstrap_corridor_id IS NOT NULL
+              AND admission_status = 'admitted'
+            ",
+            &[&realm_id],
+        )
+        .await
+        .expect("admission count must query")
+        .get("admitted_count");
+    assert_eq!(admitted_count, 1);
 }
 
 #[tokio::test]

--- a/apps/backend/tests/realm_bootstrap.rs
+++ b/apps/backend/tests/realm_bootstrap.rs
@@ -318,6 +318,75 @@ async fn approval_with_changed_slug_releases_original_slug_candidate() {
 }
 
 #[tokio::test]
+async fn concurrent_realm_request_replay_returns_existing_request() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let database_url = std::env::var("MUSUBI_TEST_DATABASE_URL")
+        .or_else(|_| std::env::var("DATABASE_URL"))
+        .expect("test database url must be present");
+    let config = DbConfig::from_lookup(|name| match name {
+        "APP_ENV" => Some("local".to_owned()),
+        "DATABASE_URL" => Some(database_url.clone()),
+        _ => std::env::var(name).ok(),
+    })
+    .expect("db config");
+    let second_state = new_state_from_config(&config).await.expect("second state");
+    let second_app = build_app(second_state.clone());
+    let requester = sign_in(&app, "pi-user-realm-request-race", "realm-request-race").await;
+    let client = test_db_client().await;
+
+    let request_body = json!({
+        "display_name": "Concurrent request realm",
+        "slug_candidate": "concurrent-request-realm",
+        "purpose_text": "Concurrent duplicate delivery should replay.",
+        "venue_context_json": {
+            "city": "Tokyo",
+            "venue_type": "library"
+        },
+        "expected_member_shape_json": {
+            "pace": "quiet"
+        },
+        "bootstrap_rationale_text": "Idempotency race regression coverage.",
+        "request_idempotency_key": "realm-request-race"
+    });
+    let (first, second) = tokio::join!(
+        post_json(
+            &app,
+            "/api/realms/requests",
+            Some(requester.token.as_str()),
+            request_body.clone()
+        ),
+        post_json(
+            &second_app,
+            "/api/realms/requests",
+            Some(requester.token.as_str()),
+            request_body
+        )
+    );
+    assert_eq!(first.status, StatusCode::OK);
+    assert_eq!(second.status, StatusCode::OK);
+    assert_eq!(
+        first.body["realm_request_id"],
+        second.body["realm_request_id"]
+    );
+
+    let request_count: i64 = client
+        .query_one(
+            "
+            SELECT COUNT(*) AS request_count
+            FROM dao.realm_requests
+            WHERE requested_by_account_id::text = $1
+              AND request_idempotency_key = 'realm-request-race'
+            ",
+            &[&requester.account_id],
+        )
+        .await
+        .expect("realm request count must query")
+        .get("request_count");
+    assert_eq!(request_count, 1);
+}
+
+#[tokio::test]
 async fn suspicious_requests_enter_review_even_when_trigger_is_already_open() {
     let test_state = new_test_state().await.expect("test database state");
     let app = build_app(test_state.state.clone());
@@ -616,6 +685,66 @@ async fn approval_rejects_already_expired_corridor() {
             "corridor_sponsor_cap": 1,
             "review_threshold_json": {},
             "review_decision_idempotency_key": "expired-corridor-approval"
+        }),
+    )
+    .await;
+    assert_eq!(approval.status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn approval_rejects_non_positive_sponsor_quota_total() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let requester = sign_in(
+        &app,
+        "pi-user-realm-sponsor-quota-approval-a",
+        "realm-sponsor-quota-approval-a",
+    )
+    .await;
+    let sponsor = sign_in(
+        &app,
+        "pi-user-realm-sponsor-quota-approval-b",
+        "realm-sponsor-quota-approval-b",
+    )
+    .await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let request = post_json(
+        &app,
+        "/api/realms/requests",
+        Some(requester.token.as_str()),
+        json!({
+            "display_name": "Sponsor quota approval",
+            "slug_candidate": "sponsor-quota-approval",
+            "purpose_text": "Sponsor quota must be validated before insert.",
+            "venue_context_json": {
+                "city": "Tokyo",
+                "venue_type": "community_space"
+            },
+            "expected_member_shape_json": {
+                "size": "small"
+            },
+            "bootstrap_rationale_text": "Non-positive quota should be rejected.",
+            "proposed_sponsor_account_id": sponsor.account_id,
+            "request_idempotency_key": "realm-sponsor-quota-approval-request"
+        }),
+    )
+    .await;
+    assert_eq!(request.status, StatusCode::OK);
+    let realm_request_id = request.body["realm_request_id"]
+        .as_str()
+        .expect("realm request id must exist");
+
+    let approval = operator_post_json(
+        &app,
+        &format!("/api/internal/operator/realms/requests/{realm_request_id}/approve"),
+        &approver_id,
+        json!({
+            "target_realm_status": "active",
+            "review_reason_code": "active_after_review",
+            "sponsor_quota_total": 0,
+            "review_decision_idempotency_key": "realm-sponsor-quota-approval"
         }),
     )
     .await;

--- a/apps/backend/tests/realm_bootstrap.rs
+++ b/apps/backend/tests/realm_bootstrap.rs
@@ -1000,6 +1000,96 @@ async fn active_realm_uses_normal_admission_kind_and_open_posture() {
 }
 
 #[tokio::test]
+async fn realm_admission_replay_survives_operator_role_revocation() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let requester = sign_in(
+        &app,
+        "pi-user-realm-admission-replay-a",
+        "realm-admission-replay-a",
+    )
+    .await;
+    let member = sign_in(
+        &app,
+        "pi-user-realm-admission-replay-b",
+        "realm-admission-replay-b",
+    )
+    .await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let (realm_id, _) = create_realm(
+        &app,
+        &requester,
+        None,
+        None,
+        &approver_id,
+        "active",
+        "realm-admission-replay",
+    )
+    .await;
+    let body = json!({
+        "account_id": member.account_id,
+        "source_fact_kind": "realm_admin_invite",
+        "source_fact_id": "realm-admission-replay",
+        "source_snapshot_json": {},
+        "request_idempotency_key": "realm-admission-replay"
+    });
+    let first = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_id}/admissions"),
+        &approver_id,
+        body.clone(),
+    )
+    .await;
+    assert_eq!(first.status, StatusCode::OK);
+    let admission_id = first.body["realm_admission_id"]
+        .as_str()
+        .expect("admission id must exist")
+        .to_owned();
+
+    let approver_uuid = Uuid::parse_str(&approver_id).expect("operator id must be uuid");
+    client
+        .execute(
+            "
+            UPDATE core.operator_role_assignments
+            SET revoked_at = CURRENT_TIMESTAMP
+            WHERE operator_account_id = $1
+              AND operator_role = 'approver'
+              AND revoked_at IS NULL
+            ",
+            &[&approver_uuid],
+        )
+        .await
+        .expect("operator role must be revoked");
+
+    let replay = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_id}/admissions"),
+        &approver_id,
+        body,
+    )
+    .await;
+    assert_eq!(replay.status, StatusCode::OK);
+    assert_eq!(replay.body["realm_admission_id"], admission_id);
+
+    let drifted_replay = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_id}/admissions"),
+        &approver_id,
+        json!({
+            "account_id": member.account_id,
+            "source_fact_kind": "realm_admin_invite",
+            "source_fact_id": "realm-admission-replay-drifted",
+            "source_snapshot_json": {},
+            "request_idempotency_key": "realm-admission-replay"
+        }),
+    )
+    .await;
+    assert_eq!(drifted_replay.status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
 async fn bootstrap_summary_authorizes_against_latest_admission_status() {
     let test_state = new_test_state().await.expect("test database state");
     let app = build_app(test_state.state.clone());

--- a/apps/backend/tests/realm_bootstrap.rs
+++ b/apps/backend/tests/realm_bootstrap.rs
@@ -1069,6 +1069,195 @@ async fn sponsor_backed_admission_respects_corridor_member_cap() {
 }
 
 #[tokio::test]
+async fn sponsor_lineage_churn_counts_sponsor_accounts_for_caps_and_summary() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let requester = sign_in(
+        &app,
+        "pi-user-realm-sponsor-lineage-a",
+        "realm-sponsor-lineage-a",
+    )
+    .await;
+    let sponsor = sign_in(
+        &app,
+        "pi-user-realm-sponsor-lineage-b",
+        "realm-sponsor-lineage-b",
+    )
+    .await;
+    let first_member = sign_in(
+        &app,
+        "pi-user-realm-sponsor-lineage-c",
+        "realm-sponsor-lineage-c",
+    )
+    .await;
+    let second_member = sign_in(
+        &app,
+        "pi-user-realm-sponsor-lineage-d",
+        "realm-sponsor-lineage-d",
+    )
+    .await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let request = post_json(
+        &app,
+        "/api/realms/requests",
+        Some(requester.token.as_str()),
+        json!({
+            "display_name": "Sponsor lineage realm",
+            "slug_candidate": "sponsor-lineage-realm",
+            "purpose_text": "Sponsor status churn must not consume extra sponsor slots.",
+            "venue_context_json": {
+                "city": "Tokyo",
+                "venue_type": "gallery"
+            },
+            "expected_member_shape_json": {
+                "size": "small"
+            },
+            "bootstrap_rationale_text": "One sponsor account may have multiple records over time.",
+            "proposed_sponsor_account_id": sponsor.account_id,
+            "request_idempotency_key": "realm-sponsor-lineage-request"
+        }),
+    )
+    .await;
+    assert_eq!(request.status, StatusCode::OK);
+    let realm_request_id = request.body["realm_request_id"]
+        .as_str()
+        .expect("realm request id must exist");
+
+    let approval = operator_post_json(
+        &app,
+        &format!("/api/internal/operator/realms/requests/{realm_request_id}/approve"),
+        &approver_id,
+        json!({
+            "target_realm_status": "limited_bootstrap",
+            "review_reason_code": "limited_bootstrap_active",
+            "sponsor_quota_total": 3,
+            "corridor_starts_at": (Utc::now() - Duration::minutes(5)).to_rfc3339(),
+            "corridor_ends_at": (Utc::now() + Duration::days(3)).to_rfc3339(),
+            "corridor_member_cap": 3,
+            "corridor_sponsor_cap": 1,
+            "review_threshold_json": {},
+            "review_decision_idempotency_key": "realm-sponsor-lineage-approve"
+        }),
+    )
+    .await;
+    assert_eq!(approval.status, StatusCode::OK);
+    let realm_id = approval.body["realm_id"]
+        .as_str()
+        .expect("realm id must exist")
+        .to_owned();
+    let initial_sponsor_record_id = sponsor_record_id_for_realm(&client, &realm_id).await;
+
+    let first = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_id}/admissions"),
+        &approver_id,
+        json!({
+            "account_id": first_member.account_id,
+            "sponsor_record_id": initial_sponsor_record_id,
+            "source_fact_kind": "sponsor_invite",
+            "source_fact_id": "realm-sponsor-lineage-first",
+            "source_snapshot_json": {},
+            "request_idempotency_key": "realm-sponsor-lineage-first"
+        }),
+    )
+    .await;
+    assert_eq!(first.status, StatusCode::OK);
+    assert_eq!(first.body["admission_kind"], "sponsor_backed");
+    assert_eq!(first.body["admission_status"], "admitted");
+
+    set_sponsor_status(
+        &client,
+        &initial_sponsor_record_id,
+        "rate_limited",
+        "sponsor_rate_limited",
+    )
+    .await;
+    let reactivated_once = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_id}/sponsor-records"),
+        &approver_id,
+        json!({
+            "sponsor_account_id": sponsor.account_id,
+            "sponsor_status": "active",
+            "quota_total": 3,
+            "status_reason_code": "limited_bootstrap_active",
+            "request_idempotency_key": "realm-sponsor-lineage-reactivate-once"
+        }),
+    )
+    .await;
+    assert_eq!(reactivated_once.status, StatusCode::OK);
+    let reactivated_once_id = reactivated_once.body["realm_sponsor_record_id"]
+        .as_str()
+        .expect("reactivated sponsor record id must exist");
+
+    set_sponsor_status(
+        &client,
+        reactivated_once_id,
+        "rate_limited",
+        "sponsor_rate_limited",
+    )
+    .await;
+    let reactivated_twice = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_id}/sponsor-records"),
+        &approver_id,
+        json!({
+            "sponsor_account_id": sponsor.account_id,
+            "sponsor_status": "active",
+            "quota_total": 3,
+            "status_reason_code": "limited_bootstrap_active",
+            "request_idempotency_key": "realm-sponsor-lineage-reactivate-twice"
+        }),
+    )
+    .await;
+    assert_eq!(reactivated_twice.status, StatusCode::OK);
+    let current_sponsor_record_id = reactivated_twice.body["realm_sponsor_record_id"]
+        .as_str()
+        .expect("current sponsor record id must exist");
+
+    let review_summary = operator_get_json(
+        &app,
+        &format!("/api/internal/operator/realms/{realm_id}/review-summary"),
+        &approver_id,
+    )
+    .await;
+    assert_eq!(review_summary.status, StatusCode::OK);
+    assert_eq!(review_summary.body["active_sponsor_count"], 1);
+    let trigger_kinds = review_summary.body["open_review_triggers"]
+        .as_array()
+        .expect("open review triggers must be an array")
+        .iter()
+        .map(|value| {
+            value["trigger_kind"]
+                .as_str()
+                .expect("trigger kind must be present")
+        })
+        .collect::<Vec<_>>();
+    assert!(!trigger_kinds.contains(&"sponsor_concentration"));
+
+    let second = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_id}/admissions"),
+        &approver_id,
+        json!({
+            "account_id": second_member.account_id,
+            "sponsor_record_id": initial_sponsor_record_id,
+            "source_fact_kind": "sponsor_invite",
+            "source_fact_id": "realm-sponsor-lineage-second",
+            "source_snapshot_json": {},
+            "request_idempotency_key": "realm-sponsor-lineage-second"
+        }),
+    )
+    .await;
+    assert_eq!(second.status, StatusCode::OK);
+    assert_eq!(second.body["admission_kind"], "sponsor_backed");
+    assert_eq!(second.body["admission_status"], "admitted");
+    assert_eq!(second.body["sponsor_record_id"], current_sponsor_record_id);
+}
+
+#[tokio::test]
 async fn concurrent_corridor_admissions_do_not_exceed_member_cap() {
     let test_state = new_test_state().await.expect("test database state");
     let app = build_app(test_state.state.clone());
@@ -1906,6 +2095,77 @@ async fn duplicate_sponsor_record_conflict_is_bad_request() {
     )
     .await;
     assert_eq!(duplicate.status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn concurrent_sponsor_and_admission_replays_return_existing_rows() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let database_url = std::env::var("MUSUBI_TEST_DATABASE_URL")
+        .or_else(|_| std::env::var("DATABASE_URL"))
+        .expect("test database url must be present");
+    let config = DbConfig::from_lookup(|name| match name {
+        "APP_ENV" => Some("local".to_owned()),
+        "DATABASE_URL" => Some(database_url.clone()),
+        _ => std::env::var(name).ok(),
+    })
+    .expect("db config");
+    let second_state = new_state_from_config(&config).await.expect("second state");
+    let second_app = build_app(second_state.clone());
+    let requester = sign_in(&app, "pi-user-realm-idem-race-a", "realm-idem-race-a").await;
+    let sponsor = sign_in(&app, "pi-user-realm-idem-race-b", "realm-idem-race-b").await;
+    let member = sign_in(&app, "pi-user-realm-idem-race-c", "realm-idem-race-c").await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let (realm_id, _) = create_realm(
+        &app,
+        &requester,
+        None,
+        None,
+        &approver_id,
+        "active",
+        "realm-idem-race",
+    )
+    .await;
+
+    let sponsor_path = format!("/api/internal/realms/{realm_id}/sponsor-records");
+    let sponsor_body = json!({
+        "sponsor_account_id": sponsor.account_id,
+        "sponsor_status": "active",
+        "quota_total": 2,
+        "status_reason_code": "active_after_review",
+        "request_idempotency_key": "realm-idem-race-sponsor"
+    });
+    let (first_sponsor, second_sponsor) = tokio::join!(
+        operator_post_json(&app, &sponsor_path, &approver_id, sponsor_body.clone()),
+        operator_post_json(&second_app, &sponsor_path, &approver_id, sponsor_body)
+    );
+    assert_eq!(first_sponsor.status, StatusCode::OK);
+    assert_eq!(second_sponsor.status, StatusCode::OK);
+    assert_eq!(
+        first_sponsor.body["realm_sponsor_record_id"],
+        second_sponsor.body["realm_sponsor_record_id"]
+    );
+
+    let admission_path = format!("/api/internal/realms/{realm_id}/admissions");
+    let admission_body = json!({
+        "account_id": member.account_id,
+        "source_fact_kind": "realm_admin_invite",
+        "source_fact_id": "realm-idem-race-admission",
+        "source_snapshot_json": {},
+        "request_idempotency_key": "realm-idem-race-admission"
+    });
+    let (first_admission, second_admission) = tokio::join!(
+        operator_post_json(&app, &admission_path, &approver_id, admission_body.clone()),
+        operator_post_json(&second_app, &admission_path, &approver_id, admission_body)
+    );
+    assert_eq!(first_admission.status, StatusCode::OK);
+    assert_eq!(second_admission.status, StatusCode::OK);
+    assert_eq!(
+        first_admission.body["realm_admission_id"],
+        second_admission.body["realm_admission_id"]
+    );
 }
 
 #[tokio::test]

--- a/apps/backend/tests/realm_bootstrap.rs
+++ b/apps/backend/tests/realm_bootstrap.rs
@@ -635,6 +635,39 @@ async fn realm_request_requires_venue_context_and_expected_member_shape() {
 }
 
 #[tokio::test]
+async fn realm_request_rejects_unknown_candidate_account_without_enumeration() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let requester = sign_in(
+        &app,
+        "pi-user-realm-candidate-validation",
+        "realm-candidate-validation",
+    )
+    .await;
+
+    let response = post_json(
+        &app,
+        "/api/realms/requests",
+        Some(requester.token.as_str()),
+        json!({
+            "display_name": "候補検証Realm",
+            "slug_candidate": "candidate-validation-realm",
+            "purpose_text": "候補アカウント検証",
+            "venue_context_json": {"area": "tokyo"},
+            "expected_member_shape_json": {"shape": "small"},
+            "bootstrap_rationale_text": "未知の候補は公開面で列挙させない",
+            "proposed_sponsor_account_id": Uuid::new_v4(),
+            "request_idempotency_key": "candidate-validation-request"
+        }),
+    )
+    .await;
+
+    assert_eq!(response.status, StatusCode::BAD_REQUEST);
+    assert!(response.body.to_string().contains("active account"));
+    assert!(!response.body.to_string().contains("not found"));
+}
+
+#[tokio::test]
 async fn active_realm_uses_normal_admission_kind_and_open_posture() {
     let test_state = new_test_state().await.expect("test database state");
     let app = build_app(test_state.state.clone());
@@ -2225,7 +2258,7 @@ async fn expired_and_disabled_corridor_do_not_grant_corridor_benefits_even_if_pr
 }
 
 #[tokio::test]
-async fn summary_reads_refresh_expired_corridor_without_unrelated_write() {
+async fn summary_reads_derive_expired_corridor_without_unrelated_write() {
     let test_state = new_test_state().await.expect("test database state");
     let app = build_app(test_state.state.clone());
     let requester = sign_in(
@@ -2268,6 +2301,11 @@ async fn summary_reads_refresh_expired_corridor_without_unrelated_write() {
     assert_eq!(
         participant_summary.body["bootstrap_view"]["admission_posture"],
         "review_required"
+    );
+    assert_eq!(current_corridor_status(&client, &realm_id).await, "active");
+    assert_eq!(
+        current_projection_corridor_status(&client, &realm_id).await,
+        "active"
     );
     assert_eq!(
         current_projection_rebuild_generation(&client, &realm_id).await,
@@ -2380,7 +2418,11 @@ async fn unauthorized_summary_read_does_not_expire_corridor_or_refresh_projectio
     )
     .await;
     assert_eq!(requester_summary.status, StatusCode::OK);
-    assert_eq!(current_corridor_status(&client, &realm_id).await, "expired");
+    assert_eq!(current_corridor_status(&client, &realm_id).await, "active");
+    assert_eq!(
+        current_projection_corridor_status(&client, &realm_id).await,
+        "active"
+    );
     assert_eq!(
         requester_summary.body["bootstrap_view"]["corridor_status"],
         "expired"

--- a/apps/backend/tests/realm_bootstrap.rs
+++ b/apps/backend/tests/realm_bootstrap.rs
@@ -575,6 +575,9 @@ async fn suspicious_requests_enter_review_even_when_trigger_is_already_open() {
     .await;
     assert_eq!(second_duplicate.status, StatusCode::OK);
     assert_eq!(second_duplicate.body["request_state"], "pending_review");
+    let second_duplicate_request_id = second_duplicate.body["realm_request_id"]
+        .as_str()
+        .expect("second duplicate request id must exist");
 
     let third_duplicate = post_json(
         &app,
@@ -610,26 +613,35 @@ async fn suspicious_requests_enter_review_even_when_trigger_is_already_open() {
         duplicate_operator_view.body["open_review_triggers"][0]["trigger_kind"],
         "duplicate_venue_context"
     );
-    let duplicate_trigger = client
-        .query_one(
+    let duplicate_triggers = client
+        .query(
             "
             SELECT related_realm_request_id::text AS related_realm_request_id,
                    context_json
             FROM dao.realm_review_triggers
             WHERE trigger_kind = 'duplicate_venue_context'
               AND trigger_state = 'open'
+            ORDER BY created_at ASC, realm_review_trigger_id ASC
             ",
             &[],
         )
         .await
         .expect("duplicate trigger must query");
+    assert_eq!(duplicate_triggers.len(), 2);
     assert_eq!(
-        duplicate_trigger.get::<_, String>("related_realm_request_id"),
+        duplicate_triggers[0].get::<_, String>("related_realm_request_id"),
+        second_duplicate_request_id
+    );
+    let second_duplicate_context: Value = duplicate_triggers[0].get("context_json");
+    assert_eq!(second_duplicate_context["matching_request_count"], 1);
+    assert_eq!(
+        duplicate_triggers[1].get::<_, String>("related_realm_request_id"),
         third_duplicate_request_id
     );
-    let duplicate_context: Value = duplicate_trigger.get("context_json");
-    assert_eq!(duplicate_context["matching_request_count"], 2);
+    let third_duplicate_context: Value = duplicate_triggers[1].get("context_json");
+    assert_eq!(third_duplicate_context["matching_request_count"], 2);
 
+    let mut second_rejected_request_id = None;
     for index in 0..2 {
         let request = post_json(
             &app,
@@ -665,6 +677,7 @@ async fn suspicious_requests_enter_review_even_when_trigger_is_already_open() {
         .await;
         assert_eq!(rejected.status, StatusCode::OK);
         if index == 1 {
+            second_rejected_request_id = Some(request_id.to_owned());
             assert_eq!(
                 rejected.body["open_review_triggers"][0]["trigger_kind"],
                 "repeated_rejected_requests"
@@ -706,6 +719,33 @@ async fn suspicious_requests_enter_review_even_when_trigger_is_already_open() {
         repeated_operator_view.body["open_review_triggers"][0]["trigger_kind"],
         "repeated_rejected_requests"
     );
+    let repeated_triggers = client
+        .query(
+            "
+            SELECT related_realm_request_id::text AS related_realm_request_id,
+                   context_json
+            FROM dao.realm_review_triggers
+            WHERE trigger_kind = 'repeated_rejected_requests'
+              AND trigger_state = 'open'
+            ORDER BY created_at ASC, realm_review_trigger_id ASC
+            ",
+            &[],
+        )
+        .await
+        .expect("repeated rejection triggers must query");
+    assert_eq!(repeated_triggers.len(), 2);
+    assert_eq!(
+        repeated_triggers[0].get::<_, String>("related_realm_request_id"),
+        second_rejected_request_id.expect("second rejected request id must exist")
+    );
+    let second_repeated_context: Value = repeated_triggers[0].get("context_json");
+    assert_eq!(second_repeated_context["rejected_request_count"], 2);
+    assert_eq!(
+        repeated_triggers[1].get::<_, String>("related_realm_request_id"),
+        repeated_request_id
+    );
+    let third_repeated_context: Value = repeated_triggers[1].get("context_json");
+    assert_eq!(third_repeated_context["rejected_request_count"], 2);
 }
 
 #[tokio::test]

--- a/apps/backend/tests/realm_bootstrap.rs
+++ b/apps/backend/tests/realm_bootstrap.rs
@@ -1416,6 +1416,83 @@ async fn pending_admission_can_be_superseded_by_operator_admission_after_review(
 }
 
 #[tokio::test]
+async fn admitted_member_is_not_downgraded_by_later_admission_request_after_corridor_expiry() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let requester = sign_in(&app, "pi-user-realm-preserve-a", "realm-preserve-a").await;
+    let member = sign_in(&app, "pi-user-realm-preserve-b", "realm-preserve-b").await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let (realm_id, _) = create_realm(
+        &app,
+        &requester,
+        None,
+        None,
+        &approver_id,
+        "limited_bootstrap",
+        "realm-preserve-admitted-001",
+    )
+    .await;
+
+    let first = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_id}/admissions"),
+        &approver_id,
+        json!({
+            "account_id": member.account_id,
+            "source_fact_kind": "operator_review",
+            "source_fact_id": "realm-preserve-first",
+            "source_snapshot_json": {
+                "review_outcome": "approved"
+            },
+            "request_idempotency_key": "realm-preserve-first"
+        }),
+    )
+    .await;
+    assert_eq!(first.status, StatusCode::OK);
+    assert_eq!(first.body["admission_kind"], "corridor");
+    assert_eq!(first.body["admission_status"], "admitted");
+
+    expire_corridor_without_rebuild(&client, &realm_id).await;
+
+    let later = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_id}/admissions"),
+        &approver_id,
+        json!({
+            "account_id": member.account_id,
+            "source_fact_kind": "operator_review",
+            "source_fact_id": "realm-preserve-after-expiry",
+            "source_snapshot_json": {
+                "review_outcome": "still_admitted"
+            },
+            "request_idempotency_key": "realm-preserve-after-expiry"
+        }),
+    )
+    .await;
+    assert_eq!(later.status, StatusCode::OK);
+    assert_eq!(later.body["admission_kind"], "corridor");
+    assert_eq!(later.body["admission_status"], "admitted");
+    assert_eq!(
+        admission_count_for_account(&client, &realm_id, &member.account_id).await,
+        1
+    );
+
+    let member_summary = get_json(
+        &app,
+        &format!("/api/projection/realms/{realm_id}/bootstrap-summary"),
+        Some(member.token.as_str()),
+    )
+    .await;
+    assert_eq!(member_summary.status, StatusCode::OK);
+    assert_eq!(
+        member_summary.body["admission_view"]["admission_status"],
+        "admitted"
+    );
+}
+
+#[tokio::test]
 async fn corridor_member_cap_counts_distinct_accounts_when_pending_rows_repeat() {
     let test_state = new_test_state().await.expect("test database state");
     let app = build_app(test_state.state.clone());

--- a/apps/backend/tests/realm_bootstrap.rs
+++ b/apps/backend/tests/realm_bootstrap.rs
@@ -3837,12 +3837,26 @@ async fn request_and_admission_idempotency_replay_mismatch_is_rejected() {
         &app,
         &format!("/api/internal/realms/{realm_id}/admissions"),
         &approver_id,
-        admission_body,
+        admission_body.clone(),
     )
     .await;
     assert_eq!(replayed_admission.status, StatusCode::OK);
     assert_eq!(
         replayed_admission.body["realm_admission_id"],
+        realm_admission_id
+    );
+
+    set_account_state(&client, &member.account_id, "suspended").await;
+    let inactive_account_replay = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_id}/admissions"),
+        &approver_id,
+        admission_body.clone(),
+    )
+    .await;
+    assert_eq!(inactive_account_replay.status, StatusCode::OK);
+    assert_eq!(
+        inactive_account_replay.body["realm_admission_id"],
         realm_admission_id
     );
 

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -22,3 +22,18 @@ account already exists in the backend database; otherwise the UI shows bounded
 unavailable copy instead of inventing Promise truth on the client.
 
 See `docs/promise_ui_baseline.md` for the ISSUE-14 boundary.
+
+## Realm bootstrap UI baseline
+
+Design source: ISSUE-15 realm bootstrap / admission / sponsor-backed early growth.
+
+The `/realms/bootstrap` screen adds the minimal participant-side Realm request
+form and participant-safe bootstrap summary surface. It does not make Realm
+creation self-serve, and it does not expose internal operator notes, source
+facts, review trigger context, or raw evidence.
+
+The operator / Steward panel is a redacted review surface. Internal approval,
+rejection, sponsor-record, admission, and review-summary APIs remain
+backend-gated and are not unlocked by client state.
+
+See `docs/realm_bootstrap_ui.md` for the ISSUE-15 UI boundary.

--- a/apps/mobile/docs/realm_bootstrap_ui.md
+++ b/apps/mobile/docs/realm_bootstrap_ui.md
@@ -1,0 +1,23 @@
+# Realm Bootstrap UI
+
+Design source: ISSUE-15 realm bootstrap / admission / sponsor-backed early growth.
+
+This UI is intentionally narrow:
+- authenticated participants can submit a Realm creation request
+- participants can check a participant-safe bootstrap summary by `realm_id`
+- the operator / Steward panel is a redacted display surface only
+
+The Flutter Web client does not embed internal operator bearer tokens. Internal
+review actions stay on backend/operator-gated routes and are not made available
+from the participant web surface.
+
+The UI must not imply:
+- guaranteed admission
+- public self-serve Realm issuance
+- referral growth
+- ranking or recommendation boost
+- DM unlock
+- paid romantic advantage
+
+Projection rows displayed here are read models. Writer-owned Realm,
+sponsor, corridor, and admission decisions remain backend/PostgreSQL truth.

--- a/apps/mobile/docs/realm_bootstrap_ui.md
+++ b/apps/mobile/docs/realm_bootstrap_ui.md
@@ -7,9 +7,9 @@ This UI is intentionally narrow:
 - participants can check a participant-safe bootstrap summary by `realm_id`
 - the operator / Steward panel is a redacted display surface only
 
-The Flutter Web client does not embed internal operator bearer tokens. Internal
-review actions stay on backend/operator-gated routes and are not made available
-from the participant web surface.
+The Flutter participant client does not embed internal operator bearer tokens.
+Internal review actions stay on backend/operator-gated routes and are not made
+available from the participant-facing client surface.
 
 The UI must not imply:
 - guaranteed admission

--- a/apps/mobile/lib/app/router.dart
+++ b/apps/mobile/lib/app/router.dart
@@ -5,6 +5,7 @@ import '../features/auth/presentation/pi_sign_in_screen.dart';
 import '../features/home/presentation/home_screen.dart';
 import '../features/home/presentation/match_detail_screen.dart';
 import '../features/promise/presentation/promise_status_screen.dart';
+import '../features/realm_bootstrap/presentation/realm_bootstrap_screen.dart';
 import '../repositories/auth/auth_session_controller.dart';
 
 final goRouterProvider = Provider<GoRouter>((ref) {
@@ -17,6 +18,7 @@ final goRouterProvider = Provider<GoRouter>((ref) {
       final path = state.uri.path;
       final isSignInRoute = path == '/sign-in';
       final isHomeFlow = path == '/home' ||
+          path == '/realms/bootstrap' ||
           path.startsWith('/detail/') ||
           path.startsWith('/promises/');
 
@@ -44,6 +46,10 @@ final goRouterProvider = Provider<GoRouter>((ref) {
         builder: (context, state) => const PiSignInScreen(),
       ),
       GoRoute(path: '/home', builder: (context, state) => const HomeScreen()),
+      GoRoute(
+        path: '/realms/bootstrap',
+        builder: (context, state) => const RealmBootstrapScreen(),
+      ),
       GoRoute(
         path: '/detail/:profileId',
         builder: (context, state) => MatchDetailScreen(

--- a/apps/mobile/lib/features/home/presentation/home_screen.dart
+++ b/apps/mobile/lib/features/home/presentation/home_screen.dart
@@ -33,7 +33,30 @@ class HomeScreen extends ConsumerWidget {
         children: [
           _HomeHero(sessionName: session?.displayName ?? '@pi_guest'),
           const SizedBox(height: 24),
-          Text('今すぐ会話を始められる相手', style: Theme.of(context).textTheme.titleLarge),
+          MusubiSurfaceCard(
+            color: const Color(0xFF101821),
+            child: Row(
+              children: [
+                const Icon(Icons.public_rounded, color: Color(0xFFE2B76A)),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Text(
+                    'Realmの立ち上げ申請を見る',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                ),
+                MusubiGhostButton(
+                  label: '開く',
+                  onPressed: () => context.push('/realms/bootstrap'),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 24),
+          Text(
+            '今すぐ会話を始められる相手',
+            style: Theme.of(context).textTheme.titleLarge,
+          ),
           const SizedBox(height: 8),
           Text(
             'Bot と冷やかしを減らすため、アプローチ時に 10 Pi のデポジットを入れる前提です。',
@@ -181,7 +204,9 @@ class _DiscoveryCard extends StatelessWidget {
                         children: [
                           Text(
                             '${profile.name}, ${profile.age}',
-                            style: Theme.of(context).textTheme.titleLarge
+                            style: Theme.of(context)
+                                .textTheme
+                                .titleLarge
                                 ?.copyWith(fontWeight: FontWeight.w700),
                           ),
                           const SizedBox(height: 6),

--- a/apps/mobile/lib/features/realm_bootstrap/models/realm_bootstrap_models.dart
+++ b/apps/mobile/lib/features/realm_bootstrap/models/realm_bootstrap_models.dart
@@ -33,7 +33,7 @@ class CreateRealmRequestDraft {
       'bootstrap_rationale_text': bootstrapRationaleText.trim(),
       'proposed_sponsor_account_id': _trimmedOrNull(proposedSponsorAccountId),
       'proposed_steward_account_id': _trimmedOrNull(proposedStewardAccountId),
-      'request_idempotency_key': requestIdempotencyKey,
+      'request_idempotency_key': requestIdempotencyKey.trim(),
     };
   }
 }

--- a/apps/mobile/lib/features/realm_bootstrap/models/realm_bootstrap_models.dart
+++ b/apps/mobile/lib/features/realm_bootstrap/models/realm_bootstrap_models.dart
@@ -1,0 +1,331 @@
+class CreateRealmRequestDraft {
+  const CreateRealmRequestDraft({
+    required this.displayName,
+    required this.slugCandidate,
+    required this.purposeText,
+    required this.venueContextText,
+    required this.expectedMemberShapeText,
+    required this.bootstrapRationaleText,
+    required this.requestIdempotencyKey,
+    this.proposedSponsorAccountId,
+    this.proposedStewardAccountId,
+  });
+
+  final String displayName;
+  final String slugCandidate;
+  final String purposeText;
+  final String venueContextText;
+  final String expectedMemberShapeText;
+  final String bootstrapRationaleText;
+  final String requestIdempotencyKey;
+  final String? proposedSponsorAccountId;
+  final String? proposedStewardAccountId;
+
+  Map<String, Object?> toJson() {
+    return {
+      'display_name': displayName.trim(),
+      'slug_candidate': slugCandidate.trim(),
+      'purpose_text': purposeText.trim(),
+      'venue_context_json': {'summary': venueContextText.trim()},
+      'expected_member_shape_json': {
+        'summary': expectedMemberShapeText.trim(),
+      },
+      'bootstrap_rationale_text': bootstrapRationaleText.trim(),
+      'proposed_sponsor_account_id': _trimmedOrNull(proposedSponsorAccountId),
+      'proposed_steward_account_id': _trimmedOrNull(proposedStewardAccountId),
+      'request_idempotency_key': requestIdempotencyKey,
+    };
+  }
+}
+
+class RealmRequestView {
+  const RealmRequestView({
+    required this.realmRequestId,
+    required this.displayName,
+    required this.slugCandidate,
+    required this.purposeText,
+    required this.venueContextSummary,
+    required this.expectedMemberShapeSummary,
+    required this.bootstrapRationaleText,
+    required this.requestState,
+    required this.reviewReasonCode,
+    required this.createdRealmId,
+    required this.proposedSponsorAccountId,
+    required this.proposedStewardAccountId,
+  });
+
+  final String realmRequestId;
+  final String displayName;
+  final String slugCandidate;
+  final String purposeText;
+  final String venueContextSummary;
+  final String expectedMemberShapeSummary;
+  final String bootstrapRationaleText;
+  final String requestState;
+  final String reviewReasonCode;
+  final String? createdRealmId;
+  final String? proposedSponsorAccountId;
+  final String? proposedStewardAccountId;
+
+  factory RealmRequestView.fromJson(Map<String, dynamic> json) {
+    return RealmRequestView(
+      realmRequestId: _stringField(json, 'realm_request_id'),
+      displayName: _stringField(json, 'display_name'),
+      slugCandidate: _stringField(json, 'slug_candidate'),
+      purposeText: _stringField(json, 'purpose_text'),
+      venueContextSummary: _summaryFromJson(json['venue_context_json']),
+      expectedMemberShapeSummary: _summaryFromJson(
+        json['expected_member_shape_json'],
+      ),
+      bootstrapRationaleText: _stringField(
+        json,
+        'bootstrap_rationale_text',
+      ),
+      requestState: _stringField(json, 'request_state'),
+      reviewReasonCode: _stringField(json, 'review_reason_code'),
+      createdRealmId: _nullableString(json, 'created_realm_id'),
+      proposedSponsorAccountId: _nullableString(
+        json,
+        'proposed_sponsor_account_id',
+      ),
+      proposedStewardAccountId: _nullableString(
+        json,
+        'proposed_steward_account_id',
+      ),
+    );
+  }
+}
+
+class RealmBootstrapView {
+  const RealmBootstrapView({
+    required this.realmId,
+    required this.slug,
+    required this.displayName,
+    required this.realmStatus,
+    required this.admissionPosture,
+    required this.corridorStatus,
+    required this.publicReasonCode,
+    required this.sponsorDisplayState,
+  });
+
+  final String realmId;
+  final String slug;
+  final String displayName;
+  final String realmStatus;
+  final String admissionPosture;
+  final String corridorStatus;
+  final String publicReasonCode;
+  final String sponsorDisplayState;
+
+  factory RealmBootstrapView.fromJson(Map<String, dynamic> json) {
+    return RealmBootstrapView(
+      realmId: _stringField(json, 'realm_id'),
+      slug: _stringField(json, 'slug'),
+      displayName: _stringField(json, 'display_name'),
+      realmStatus: _stringField(json, 'realm_status'),
+      admissionPosture: _stringField(json, 'admission_posture'),
+      corridorStatus: _stringField(json, 'corridor_status'),
+      publicReasonCode: _stringField(json, 'public_reason_code'),
+      sponsorDisplayState: _stringField(json, 'sponsor_display_state'),
+    );
+  }
+}
+
+class RealmAdmissionView {
+  const RealmAdmissionView({
+    required this.realmId,
+    required this.accountId,
+    required this.admissionStatus,
+    required this.admissionKind,
+    required this.publicReasonCode,
+  });
+
+  final String realmId;
+  final String accountId;
+  final String admissionStatus;
+  final String admissionKind;
+  final String publicReasonCode;
+
+  factory RealmAdmissionView.fromJson(Map<String, dynamic> json) {
+    return RealmAdmissionView(
+      realmId: _stringField(json, 'realm_id'),
+      accountId: _stringField(json, 'account_id'),
+      admissionStatus: _stringField(json, 'admission_status'),
+      admissionKind: _stringField(json, 'admission_kind'),
+      publicReasonCode: _stringField(json, 'public_reason_code'),
+    );
+  }
+}
+
+class RealmBootstrapSummaryBundle {
+  const RealmBootstrapSummaryBundle({
+    required this.realmRequest,
+    required this.bootstrapView,
+    required this.admissionView,
+  });
+
+  final RealmRequestView? realmRequest;
+  final RealmBootstrapView bootstrapView;
+  final RealmAdmissionView? admissionView;
+
+  factory RealmBootstrapSummaryBundle.fromJson(Map<String, dynamic> json) {
+    final requestJson = json['realm_request'];
+    final admissionJson = json['admission_view'];
+    return RealmBootstrapSummaryBundle(
+      realmRequest: requestJson is Map
+          ? RealmRequestView.fromJson(requestJson.cast<String, dynamic>())
+          : null,
+      bootstrapView: RealmBootstrapView.fromJson(
+        (json['bootstrap_view'] as Map).cast<String, dynamic>(),
+      ),
+      admissionView: admissionJson is Map
+          ? RealmAdmissionView.fromJson(admissionJson.cast<String, dynamic>())
+          : null,
+    );
+  }
+}
+
+String realmRequestStateLabel(String state) {
+  return switch (state) {
+    'requested' => '申請済み',
+    'pending_review' => '確認中',
+    'approved' => '承認済み',
+    'rejected' => '見送り',
+    _ => '確認中',
+  };
+}
+
+String realmStatusLabel(String status) {
+  return switch (status) {
+    'limited_bootstrap' => '限定立ち上げ',
+    'active' => '稼働中',
+    'restricted' => '制限中',
+    'suspended' => '停止中',
+    'pending_review' => '確認中',
+    _ => '確認中',
+  };
+}
+
+String admissionPostureLabel(String posture) {
+  return switch (posture) {
+    'open' => '受付中',
+    'limited' => '限定受付',
+    'review_required' => '確認後に受付',
+    'closed' => '受付停止',
+    _ => '確認中',
+  };
+}
+
+String admissionStatusLabel(String status) {
+  return switch (status) {
+    'pending' => '確認中',
+    'admitted' => '参加中',
+    'rejected' => '見送り',
+    'revoked' => '取り消し',
+    _ => '未申請',
+  };
+}
+
+String admissionKindLabel(String kind) {
+  return switch (kind) {
+    'normal' => '通常',
+    'sponsor_backed' => 'スポンサー経由',
+    'corridor' => 'corridor',
+    'review_required' => '確認待ち',
+    _ => '未申請',
+  };
+}
+
+String admissionQueueLabel(String status) {
+  return switch (status) {
+    'pending' => '確認キュー',
+    'admitted' => '確定済み',
+    'rejected' => '見送り済み',
+    'revoked' => '取り消し済み',
+    _ => '未申請',
+  };
+}
+
+String corridorStatusLabel(String status) {
+  return switch (status) {
+    'active' => '有効',
+    'cooling_down' => '冷却中',
+    'expired' => '終了',
+    'disabled_by_operator' => '停止中',
+    'none' => 'なし',
+    _ => '確認中',
+  };
+}
+
+String sponsorDisplayStateLabel(String state) {
+  return switch (state) {
+    'sponsor_and_steward' => 'スポンサーとStewardあり',
+    'sponsor_backed' => 'スポンサーあり',
+    'steward_present' => 'Stewardあり',
+    'none' => '未設定',
+    _ => '確認中',
+  };
+}
+
+String participantBootstrapCopy(RealmBootstrapSummaryBundle bundle) {
+  final posture = bundle.bootstrapView.admissionPosture;
+  final admissionStatus = bundle.admissionView?.admissionStatus;
+  if (admissionStatus == 'admitted') {
+    return '参加状態はwriter-ownedな記録から確認されています。';
+  }
+  if (posture == 'limited') {
+    return '立ち上げ期間中です。受付は上限と確認状態に合わせて進みます。';
+  }
+  if (posture == 'review_required') {
+    return '申請は確認を通して扱われます。参加はこの画面だけでは確定しません。';
+  }
+  if (posture == 'closed') {
+    return '現在このRealmの新しい受付は止まっています。';
+  }
+  return 'Realmの状態を落ち着いて確認できます。';
+}
+
+String operatorBootstrapCopy(RealmBootstrapView view) {
+  final parts = <String>[
+    realmStatusLabel(view.realmStatus),
+    admissionPostureLabel(view.admissionPosture),
+    corridorStatusLabel(view.corridorStatus),
+    sponsorDisplayStateLabel(view.sponsorDisplayState),
+  ];
+  return parts.join(' / ');
+}
+
+String _stringField(Map<String, dynamic> json, String key) {
+  final value = json[key];
+  if (value == null) {
+    return '';
+  }
+  return '$value';
+}
+
+String? _nullableString(Map<String, dynamic> json, String key) {
+  final value = json[key];
+  if (value == null) {
+    return null;
+  }
+  final normalized = '$value'.trim();
+  return normalized.isEmpty ? null : normalized;
+}
+
+String? _trimmedOrNull(String? value) {
+  final normalized = value?.trim();
+  if (normalized == null || normalized.isEmpty) {
+    return null;
+  }
+  return normalized;
+}
+
+String _summaryFromJson(Object? value) {
+  if (value is Map) {
+    final summary = value['summary'];
+    if (summary != null && '$summary'.trim().isNotEmpty) {
+      return '$summary';
+    }
+  }
+  return '';
+}

--- a/apps/mobile/lib/features/realm_bootstrap/models/realm_bootstrap_models.dart
+++ b/apps/mobile/lib/features/realm_bootstrap/models/realm_bootstrap_models.dart
@@ -377,13 +377,15 @@ String _jsonValueToSummary(Object? value) {
   }
   if (value is Map) {
     final parts = <String>[];
-    value.forEach((key, nestedValue) {
-      final nestedSummary = _jsonValueToSummary(nestedValue);
+    final sortedKeys = value.keys.toList()
+      ..sort((a, b) => a.toString().compareTo(b.toString()));
+    for (final key in sortedKeys) {
+      final nestedSummary = _jsonValueToSummary(value[key]);
       if (nestedSummary.isEmpty) {
-        return;
+        continue;
       }
       parts.add('${key.toString()}: $nestedSummary');
-    });
+    }
     return parts.join(', ');
   }
   return value.toString().trim();

--- a/apps/mobile/lib/features/realm_bootstrap/models/realm_bootstrap_models.dart
+++ b/apps/mobile/lib/features/realm_bootstrap/models/realm_bootstrap_models.dart
@@ -73,8 +73,10 @@ class RealmRequestView {
       displayName: _stringField(json, 'display_name'),
       slugCandidate: _stringField(json, 'slug_candidate'),
       purposeText: _stringField(json, 'purpose_text'),
-      venueContextSummary: _summaryFromJson(json['venue_context_json']),
-      expectedMemberShapeSummary: _summaryFromJson(
+      venueContextSummary: _summaryOrFallbackFromJson(
+        json['venue_context_json'],
+      ),
+      expectedMemberShapeSummary: _summaryOrFallbackFromJson(
         json['expected_member_shape_json'],
       ),
       bootstrapRationaleText: _stringField(
@@ -326,12 +328,43 @@ String? _trimmedOrNull(String? value) {
   return normalized;
 }
 
-String _summaryFromJson(Object? value) {
+String _summaryOrFallbackFromJson(Object? value) {
   if (value is Map) {
     final summary = value['summary'];
-    if (summary != null && '$summary'.trim().isNotEmpty) {
-      return '$summary';
+    if (summary is String && summary.trim().isNotEmpty) {
+      return summary.trim();
     }
   }
-  return '';
+  return _jsonValueToSummary(value);
+}
+
+String _jsonValueToSummary(Object? value) {
+  if (value == null) {
+    return '';
+  }
+  if (value is String) {
+    return value.trim();
+  }
+  if (value is num || value is bool) {
+    return value.toString();
+  }
+  if (value is List) {
+    final parts = value
+        .map(_jsonValueToSummary)
+        .where((part) => part.isNotEmpty)
+        .toList();
+    return parts.join(', ');
+  }
+  if (value is Map) {
+    final parts = <String>[];
+    value.forEach((key, nestedValue) {
+      final nestedSummary = _jsonValueToSummary(nestedValue);
+      if (nestedSummary.isEmpty) {
+        return;
+      }
+      parts.add('${key.toString()}: $nestedSummary');
+    });
+    return parts.join(', ');
+  }
+  return value.toString().trim();
 }

--- a/apps/mobile/lib/features/realm_bootstrap/models/realm_bootstrap_models.dart
+++ b/apps/mobile/lib/features/realm_bootstrap/models/realm_bootstrap_models.dart
@@ -170,13 +170,19 @@ class RealmBootstrapSummaryBundle {
 
   factory RealmBootstrapSummaryBundle.fromJson(Map<String, dynamic> json) {
     final requestJson = json['realm_request'];
+    final bootstrapJson = json['bootstrap_view'];
     final admissionJson = json['admission_view'];
+    if (bootstrapJson is! Map) {
+      throw const FormatException(
+        'Expected "bootstrap_view" to be a JSON object.',
+      );
+    }
     return RealmBootstrapSummaryBundle(
       realmRequest: requestJson is Map
           ? RealmRequestView.fromJson(requestJson.cast<String, dynamic>())
           : null,
       bootstrapView: RealmBootstrapView.fromJson(
-        (json['bootstrap_view'] as Map).cast<String, dynamic>(),
+        bootstrapJson.cast<String, dynamic>(),
       ),
       admissionView: admissionJson is Map
           ? RealmAdmissionView.fromJson(admissionJson.cast<String, dynamic>())

--- a/apps/mobile/lib/features/realm_bootstrap/models/realm_bootstrap_models.dart
+++ b/apps/mobile/lib/features/realm_bootstrap/models/realm_bootstrap_models.dart
@@ -297,10 +297,10 @@ String operatorBootstrapCopy(RealmBootstrapView view) {
 
 String _stringField(Map<String, dynamic> json, String key) {
   final value = json[key];
-  if (value == null) {
-    return '';
+  if (value is String && value.isNotEmpty) {
+    return value;
   }
-  return '$value';
+  throw FormatException('Missing string field: $key');
 }
 
 String? _nullableString(Map<String, dynamic> json, String key) {

--- a/apps/mobile/lib/features/realm_bootstrap/models/realm_bootstrap_models.dart
+++ b/apps/mobile/lib/features/realm_bootstrap/models/realm_bootstrap_models.dart
@@ -179,6 +179,11 @@ class RealmBootstrapSummaryBundle {
         'Expected "bootstrap_view" to be a JSON object.',
       );
     }
+    if (admissionJson != null && admissionJson is! Map) {
+      throw const FormatException(
+        'Expected "admission_view" to be null or a JSON object.',
+      );
+    }
     return RealmBootstrapSummaryBundle(
       realmRequest: requestJson is Map
           ? RealmRequestView.fromJson(requestJson.cast<String, dynamic>())

--- a/apps/mobile/lib/features/realm_bootstrap/models/realm_bootstrap_models.dart
+++ b/apps/mobile/lib/features/realm_bootstrap/models/realm_bootstrap_models.dart
@@ -238,9 +238,29 @@ String admissionKindLabel(String kind) {
   return switch (kind) {
     'normal' => '通常',
     'sponsor_backed' => 'スポンサー経由',
-    'corridor' => 'corridor',
+    'corridor' => 'コリドー',
     'review_required' => '確認待ち',
     _ => '未申請',
+  };
+}
+
+String reviewReasonCodeLabel(String reasonCode) {
+  return switch (reasonCode) {
+    'request_received' => '申請を確認中',
+    'review_required' => '確認が必要です',
+    'limited_bootstrap_active' => '限定受付中',
+    'active_after_review' => '受付中',
+    'request_rejected' => '今回は見送り',
+    'duplicate_or_invalid' => '内容を確認中',
+    'sponsor_required' => 'スポンサー確認中',
+    'bootstrap_capacity_reached' => '受付枠を確認中',
+    'bootstrap_expired' => '受付期間を確認中',
+    'sponsor_rate_limited' => 'スポンサー確認中',
+    'sponsor_revoked' => 'スポンサー確認中',
+    'restricted_after_review' => '安全確認中',
+    'suspended_after_review' => '一時停止中',
+    'operator_restriction' => '安全確認中',
+    _ => '確認中',
   };
 }
 

--- a/apps/mobile/lib/features/realm_bootstrap/presentation/realm_bootstrap_screen.dart
+++ b/apps/mobile/lib/features/realm_bootstrap/presentation/realm_bootstrap_screen.dart
@@ -379,7 +379,10 @@ class _RealmRequestPanel extends StatelessWidget {
           ),
           _RealmStatusRow(label: 'Realm', value: request.displayName),
           _RealmStatusRow(label: 'slug', value: request.slugCandidate),
-          _RealmStatusRow(label: '確認理由', value: request.reviewReasonCode),
+          _RealmStatusRow(
+            label: '確認理由',
+            value: reviewReasonCodeLabel(request.reviewReasonCode),
+          ),
           if (request.createdRealmId != null)
             _RealmStatusRow(label: 'realm_id', value: request.createdRealmId!),
           const SizedBox(height: 12),
@@ -469,7 +472,7 @@ class _AdmissionRequestPanel extends StatelessWidget {
             value: admissionKindLabel(admission?.admissionKind ?? ''),
           ),
           _RealmStatusRow(
-            label: 'queue',
+            label: '確認状態',
             value: admissionQueueLabel(admission?.admissionStatus ?? ''),
           ),
         ],

--- a/apps/mobile/lib/features/realm_bootstrap/presentation/realm_bootstrap_screen.dart
+++ b/apps/mobile/lib/features/realm_bootstrap/presentation/realm_bootstrap_screen.dart
@@ -27,7 +27,7 @@ class _RealmBootstrapScreenState extends ConsumerState<RealmBootstrapScreen> {
   final _rationaleController = TextEditingController();
   final _sponsorController = TextEditingController();
   final _stewardController = TextEditingController();
-  final _realmIdController = TextEditingController(text: 'realm-tokyo-day1');
+  final _realmIdController = TextEditingController();
 
   bool _isSubmitting = false;
   bool _isLoadingSummary = false;

--- a/apps/mobile/lib/features/realm_bootstrap/presentation/realm_bootstrap_screen.dart
+++ b/apps/mobile/lib/features/realm_bootstrap/presentation/realm_bootstrap_screen.dart
@@ -214,8 +214,10 @@ class _RealmBootstrapScreenState extends ConsumerState<RealmBootstrapScreen> {
                   venueContextText: _venueController.text,
                   expectedMemberShapeText: _memberShapeController.text,
                   bootstrapRationaleText: _rationaleController.text,
-                  proposedSponsorAccountId: _sponsorController.text,
-                  proposedStewardAccountId: _stewardController.text,
+                  proposedSponsorAccountId:
+                      _trimmedOrNull(_sponsorController.text),
+                  proposedStewardAccountId:
+                      _trimmedOrNull(_stewardController.text),
                   requestIdempotencyKey: _pendingRequestKey!,
                 ),
               );
@@ -336,6 +338,11 @@ class _RealmTextField extends StatelessWidget {
       ),
     );
   }
+}
+
+String? _trimmedOrNull(String value) {
+  final normalized = value.trim();
+  return normalized.isEmpty ? null : normalized;
 }
 
 class _RealmRequestPanel extends StatelessWidget {

--- a/apps/mobile/lib/features/realm_bootstrap/presentation/realm_bootstrap_screen.dart
+++ b/apps/mobile/lib/features/realm_bootstrap/presentation/realm_bootstrap_screen.dart
@@ -199,8 +199,7 @@ class _RealmBootstrapScreenState extends ConsumerState<RealmBootstrapScreen> {
       _isSubmitting = true;
       if (_pendingRequestKey == null ||
           _pendingRequestFingerprint != requestFingerprint) {
-        _pendingRequestKey =
-            'realm-ui-${session.userId}-${randomHex(bytes: 8)}';
+        _pendingRequestKey = 'realm-ui-${randomHex(bytes: 16)}';
         _pendingRequestFingerprint = requestFingerprint;
       }
     });

--- a/apps/mobile/lib/features/realm_bootstrap/presentation/realm_bootstrap_screen.dart
+++ b/apps/mobile/lib/features/realm_bootstrap/presentation/realm_bootstrap_screen.dart
@@ -233,8 +233,6 @@ class _RealmBootstrapScreenState extends ConsumerState<RealmBootstrapScreen> {
       }
       setState(() {
         _request = request;
-        _pendingRequestKey = null;
-        _pendingRequestFingerprint = null;
         if (request.createdRealmId != null) {
           _realmIdController.text = request.createdRealmId!;
         }

--- a/apps/mobile/lib/features/realm_bootstrap/presentation/realm_bootstrap_screen.dart
+++ b/apps/mobile/lib/features/realm_bootstrap/presentation/realm_bootstrap_screen.dart
@@ -1,0 +1,490 @@
+import 'package:flutter/material.dart';
+import 'package:musubi_mobile/core/riverpod_compat.dart';
+
+import '../../../app/widgets/musubi_pressable.dart';
+import '../../../core/errors/app_exception.dart';
+import '../../../core/utils/random_hex.dart';
+import '../../../repositories/auth/auth_session_controller.dart';
+import '../../../repositories/repository_providers.dart';
+import '../models/realm_bootstrap_models.dart';
+
+class RealmBootstrapScreen extends ConsumerStatefulWidget {
+  const RealmBootstrapScreen({super.key});
+
+  @override
+  ConsumerState<RealmBootstrapScreen> createState() =>
+      _RealmBootstrapScreenState();
+}
+
+class _RealmBootstrapScreenState extends ConsumerState<RealmBootstrapScreen> {
+  final _displayNameController = TextEditingController();
+  final _slugController = TextEditingController();
+  final _purposeController = TextEditingController();
+  final _venueController = TextEditingController();
+  final _memberShapeController = TextEditingController();
+  final _rationaleController = TextEditingController();
+  final _sponsorController = TextEditingController();
+  final _stewardController = TextEditingController();
+  final _realmIdController = TextEditingController(text: 'realm-tokyo-day1');
+
+  bool _isSubmitting = false;
+  bool _isLoadingSummary = false;
+  String? _pendingRequestKey;
+  RealmRequestView? _request;
+  RealmBootstrapSummaryBundle? _summary;
+
+  @override
+  void dispose() {
+    _displayNameController.dispose();
+    _slugController.dispose();
+    _purposeController.dispose();
+    _venueController.dispose();
+    _memberShapeController.dispose();
+    _rationaleController.dispose();
+    _sponsorController.dispose();
+    _stewardController.dispose();
+    _realmIdController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final request = _request;
+    final summary = _summary;
+    return Scaffold(
+      appBar: AppBar(title: const Text('Realm bootstrap')),
+      body: ListView(
+        padding: const EdgeInsets.fromLTRB(24, 20, 24, 40),
+        children: [
+          Text(
+            'Realmを静かに立ち上げる',
+            style: Theme.of(context).textTheme.headlineSmall,
+          ),
+          const SizedBox(height: 10),
+          Text(
+            '申請、確認、限定受付の状態だけを扱います。',
+            style: Theme.of(context).textTheme.bodyLarge,
+          ),
+          const SizedBox(height: 22),
+          MusubiSurfaceCard(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Realm request',
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                const SizedBox(height: 16),
+                _RealmTextField(
+                  controller: _displayNameController,
+                  label: 'Realm name',
+                  icon: Icons.public_rounded,
+                ),
+                const SizedBox(height: 12),
+                _RealmTextField(
+                  controller: _slugController,
+                  label: 'slug',
+                  icon: Icons.link_rounded,
+                ),
+                const SizedBox(height: 12),
+                _RealmTextField(
+                  controller: _purposeController,
+                  label: 'purpose',
+                  icon: Icons.flag_outlined,
+                  maxLines: 3,
+                ),
+                const SizedBox(height: 12),
+                _RealmTextField(
+                  controller: _venueController,
+                  label: 'venue / locality / context',
+                  icon: Icons.place_outlined,
+                  maxLines: 3,
+                ),
+                const SizedBox(height: 12),
+                _RealmTextField(
+                  controller: _memberShapeController,
+                  label: 'intended member pattern',
+                  icon: Icons.groups_2_outlined,
+                  maxLines: 3,
+                ),
+                const SizedBox(height: 12),
+                _RealmTextField(
+                  controller: _rationaleController,
+                  label: 'bootstrap rationale',
+                  icon: Icons.auto_awesome_motion_outlined,
+                  maxLines: 3,
+                ),
+                const SizedBox(height: 12),
+                _RealmTextField(
+                  controller: _sponsorController,
+                  label: 'sponsor account id',
+                  icon: Icons.volunteer_activism_outlined,
+                  requiredField: false,
+                ),
+                const SizedBox(height: 12),
+                _RealmTextField(
+                  controller: _stewardController,
+                  label: 'Steward account id',
+                  icon: Icons.verified_user_outlined,
+                  requiredField: false,
+                ),
+                const SizedBox(height: 18),
+                MusubiPrimaryButton(
+                  label: _isSubmitting ? '送信しています...' : 'Realm申請を送る',
+                  icon: Icons.send_rounded,
+                  isBusy: _isSubmitting,
+                  onPressed: _isSubmitting ? null : _submitRequest,
+                ),
+              ],
+            ),
+          ),
+          if (request != null) ...[
+            const SizedBox(height: 18),
+            _RealmRequestPanel(request: request),
+          ],
+          const SizedBox(height: 18),
+          MusubiSurfaceCard(
+            color: const Color(0xFF101821),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Bootstrap summary',
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                const SizedBox(height: 14),
+                _RealmTextField(
+                  controller: _realmIdController,
+                  label: 'realm_id',
+                  icon: Icons.tag_rounded,
+                ),
+                const SizedBox(height: 14),
+                MusubiGhostButton(
+                  label: _isLoadingSummary ? '確認しています...' : '状態を確認',
+                  onPressed: _isLoadingSummary ? null : _loadSummary,
+                ),
+              ],
+            ),
+          ),
+          if (summary != null) ...[
+            const SizedBox(height: 18),
+            _BootstrapSummaryPanel(summary: summary),
+            const SizedBox(height: 18),
+            _AdmissionRequestPanel(summary: summary),
+            const SizedBox(height: 18),
+            _OperatorSummaryPanel(view: summary.bootstrapView),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Future<void> _submitRequest() async {
+    final session = ref.read(authSessionControllerProvider).valueOrNull;
+    if (session == null) {
+      _showSnack('サインイン状態を確認できませんでした。');
+      return;
+    }
+    final missing = _missingRequiredField();
+    if (missing != null) {
+      _showSnack('$missing を入力してください。');
+      return;
+    }
+
+    setState(() => _isSubmitting = true);
+    _pendingRequestKey ??= 'realm-ui-${session.userId}-${randomHex(bytes: 8)}';
+    try {
+      final request =
+          await ref.read(realmBootstrapRepositoryProvider).createRealmRequest(
+                CreateRealmRequestDraft(
+                  displayName: _displayNameController.text,
+                  slugCandidate: _slugController.text,
+                  purposeText: _purposeController.text,
+                  venueContextText: _venueController.text,
+                  expectedMemberShapeText: _memberShapeController.text,
+                  bootstrapRationaleText: _rationaleController.text,
+                  proposedSponsorAccountId: _sponsorController.text,
+                  proposedStewardAccountId: _stewardController.text,
+                  requestIdempotencyKey: _pendingRequestKey!,
+                ),
+              );
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _request = request;
+        if (request.createdRealmId != null) {
+          _realmIdController.text = request.createdRealmId!;
+        }
+      });
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+      _showSnack(AppExceptionMapper.fromObject(error).message);
+    } finally {
+      if (mounted) {
+        setState(() => _isSubmitting = false);
+      }
+    }
+  }
+
+  Future<void> _loadSummary() async {
+    final realmId = _realmIdController.text.trim();
+    if (realmId.isEmpty) {
+      _showSnack('realm_id を入力してください。');
+      return;
+    }
+    setState(() => _isLoadingSummary = true);
+    try {
+      final summary = await ref
+          .read(realmBootstrapRepositoryProvider)
+          .fetchBootstrapSummary(
+            realmId,
+          );
+      if (!mounted) {
+        return;
+      }
+      setState(() => _summary = summary);
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+      _showSnack(AppExceptionMapper.fromObject(error).message);
+    } finally {
+      if (mounted) {
+        setState(() => _isLoadingSummary = false);
+      }
+    }
+  }
+
+  String? _missingRequiredField() {
+    final fields = <String, TextEditingController>{
+      'Realm name': _displayNameController,
+      'slug': _slugController,
+      'purpose': _purposeController,
+      'venue / locality / context': _venueController,
+      'intended member pattern': _memberShapeController,
+      'bootstrap rationale': _rationaleController,
+    };
+    for (final entry in fields.entries) {
+      if (entry.value.text.trim().isEmpty) {
+        return entry.key;
+      }
+    }
+    return null;
+  }
+
+  void _showSnack(String message) {
+    final messenger = ScaffoldMessenger.of(context);
+    messenger.hideCurrentSnackBar();
+    messenger.showSnackBar(SnackBar(content: Text(message)));
+  }
+}
+
+class _RealmTextField extends StatelessWidget {
+  const _RealmTextField({
+    required this.controller,
+    required this.label,
+    required this.icon,
+    this.maxLines = 1,
+    this.requiredField = true,
+  });
+
+  final TextEditingController controller;
+  final String label;
+  final IconData icon;
+  final int maxLines;
+  final bool requiredField;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      controller: controller,
+      maxLines: maxLines,
+      textInputAction:
+          maxLines == 1 ? TextInputAction.next : TextInputAction.newline,
+      decoration: InputDecoration(
+        labelText: requiredField ? label : '$label · optional',
+        prefixIcon: Icon(icon),
+      ),
+    );
+  }
+}
+
+class _RealmRequestPanel extends StatelessWidget {
+  const _RealmRequestPanel({required this.request});
+
+  final RealmRequestView request;
+
+  @override
+  Widget build(BuildContext context) {
+    return MusubiSurfaceCard(
+      color: const Color(0xFF111A16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('申請を受け付けました', style: Theme.of(context).textTheme.titleMedium),
+          const SizedBox(height: 12),
+          _RealmStatusRow(
+            label: '状態',
+            value: realmRequestStateLabel(request.requestState),
+          ),
+          _RealmStatusRow(label: 'Realm', value: request.displayName),
+          _RealmStatusRow(label: 'slug', value: request.slugCandidate),
+          _RealmStatusRow(label: '確認理由', value: request.reviewReasonCode),
+          if (request.createdRealmId != null)
+            _RealmStatusRow(label: 'realm_id', value: request.createdRealmId!),
+          const SizedBox(height: 12),
+          Text(
+            '承認や参加状態はwriter-ownedな記録が反映された後に確定します。',
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _BootstrapSummaryPanel extends StatelessWidget {
+  const _BootstrapSummaryPanel({required this.summary});
+
+  final RealmBootstrapSummaryBundle summary;
+
+  @override
+  Widget build(BuildContext context) {
+    final view = summary.bootstrapView;
+    final admission = summary.admissionView;
+    return MusubiSurfaceCard(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(view.displayName, style: Theme.of(context).textTheme.titleLarge),
+          const SizedBox(height: 12),
+          _RealmStatusRow(
+            label: 'Realm状態',
+            value: realmStatusLabel(view.realmStatus),
+          ),
+          _RealmStatusRow(
+            label: '受付',
+            value: admissionPostureLabel(view.admissionPosture),
+          ),
+          _RealmStatusRow(
+            label: 'corridor',
+            value: corridorStatusLabel(view.corridorStatus),
+          ),
+          _RealmStatusRow(
+            label: '参加',
+            value: admissionStatusLabel(admission?.admissionStatus ?? ''),
+          ),
+          const SizedBox(height: 12),
+          Text(
+            participantBootstrapCopy(summary),
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AdmissionRequestPanel extends StatelessWidget {
+  const _AdmissionRequestPanel({required this.summary});
+
+  final RealmBootstrapSummaryBundle summary;
+
+  @override
+  Widget build(BuildContext context) {
+    final admission = summary.admissionView;
+    return MusubiSurfaceCard(
+      color: const Color(0xFF101821),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Admission request',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: 12),
+          _RealmStatusRow(label: '申請者', value: '現在のアカウント'),
+          _RealmStatusRow(
+            label: 'スポンサー',
+            value: sponsorDisplayStateLabel(
+              summary.bootstrapView.sponsorDisplayState,
+            ),
+          ),
+          _RealmStatusRow(
+            label: '参加状態',
+            value: admissionStatusLabel(admission?.admissionStatus ?? ''),
+          ),
+          _RealmStatusRow(
+            label: '判定',
+            value: admissionKindLabel(admission?.admissionKind ?? ''),
+          ),
+          _RealmStatusRow(
+            label: 'queue',
+            value: admissionQueueLabel(admission?.admissionStatus ?? ''),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _OperatorSummaryPanel extends StatelessWidget {
+  const _OperatorSummaryPanel({required this.view});
+
+  final RealmBootstrapView view;
+
+  @override
+  Widget build(BuildContext context) {
+    return MusubiSurfaceCard(
+      color: const Color(0xFF17120A),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Operator / Steward review',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: 12),
+          Text(
+            operatorBootstrapCopy(view),
+            style: Theme.of(context).textTheme.bodyLarge,
+          ),
+          const SizedBox(height: 12),
+          Text(
+            '内部メモ、内部ID、証跡の所在はこの面には出しません。',
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _RealmStatusRow extends StatelessWidget {
+  const _RealmStatusRow({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 92,
+            child: Text(label, style: Theme.of(context).textTheme.labelMedium),
+          ),
+          Expanded(
+            child: Text(value, style: Theme.of(context).textTheme.bodyMedium),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/features/realm_bootstrap/presentation/realm_bootstrap_screen.dart
+++ b/apps/mobile/lib/features/realm_bootstrap/presentation/realm_bootstrap_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:musubi_mobile/core/riverpod_compat.dart';
 
@@ -30,6 +32,7 @@ class _RealmBootstrapScreenState extends ConsumerState<RealmBootstrapScreen> {
   bool _isSubmitting = false;
   bool _isLoadingSummary = false;
   String? _pendingRequestKey;
+  String? _pendingRequestFingerprint;
   RealmRequestView? _request;
   RealmBootstrapSummaryBundle? _summary;
 
@@ -191,10 +194,15 @@ class _RealmBootstrapScreenState extends ConsumerState<RealmBootstrapScreen> {
       return;
     }
 
+    final requestFingerprint = _currentRequestFingerprint();
     setState(() {
       _isSubmitting = true;
-      _pendingRequestKey ??=
-          'realm-ui-${session.userId}-${randomHex(bytes: 8)}';
+      if (_pendingRequestKey == null ||
+          _pendingRequestFingerprint != requestFingerprint) {
+        _pendingRequestKey =
+            'realm-ui-${session.userId}-${randomHex(bytes: 8)}';
+        _pendingRequestFingerprint = requestFingerprint;
+      }
     });
     try {
       final request =
@@ -217,6 +225,7 @@ class _RealmBootstrapScreenState extends ConsumerState<RealmBootstrapScreen> {
       setState(() {
         _request = request;
         _pendingRequestKey = null;
+        _pendingRequestFingerprint = null;
         if (request.createdRealmId != null) {
           _realmIdController.text = request.createdRealmId!;
         }
@@ -231,6 +240,19 @@ class _RealmBootstrapScreenState extends ConsumerState<RealmBootstrapScreen> {
         setState(() => _isSubmitting = false);
       }
     }
+  }
+
+  String _currentRequestFingerprint() {
+    return jsonEncode({
+      'display_name': _displayNameController.text.trim(),
+      'slug_candidate': _slugController.text.trim(),
+      'purpose_text': _purposeController.text.trim(),
+      'venue_context_text': _venueController.text.trim(),
+      'expected_member_shape_text': _memberShapeController.text.trim(),
+      'bootstrap_rationale_text': _rationaleController.text.trim(),
+      'proposed_sponsor_account_id': _sponsorController.text.trim(),
+      'proposed_steward_account_id': _stewardController.text.trim(),
+    });
   }
 
   Future<void> _loadSummary() async {

--- a/apps/mobile/lib/features/realm_bootstrap/presentation/realm_bootstrap_screen.dart
+++ b/apps/mobile/lib/features/realm_bootstrap/presentation/realm_bootstrap_screen.dart
@@ -256,8 +256,8 @@ class _RealmBootstrapScreenState extends ConsumerState<RealmBootstrapScreen> {
       'venue_context_text': _venueController.text.trim(),
       'expected_member_shape_text': _memberShapeController.text.trim(),
       'bootstrap_rationale_text': _rationaleController.text.trim(),
-      'proposed_sponsor_account_id': _sponsorController.text.trim(),
-      'proposed_steward_account_id': _stewardController.text.trim(),
+      'proposed_sponsor_account_id': _trimmedOrNull(_sponsorController.text),
+      'proposed_steward_account_id': _trimmedOrNull(_stewardController.text),
     });
   }
 

--- a/apps/mobile/lib/features/realm_bootstrap/presentation/realm_bootstrap_screen.dart
+++ b/apps/mobile/lib/features/realm_bootstrap/presentation/realm_bootstrap_screen.dart
@@ -192,8 +192,7 @@ class _RealmBootstrapScreenState extends ConsumerState<RealmBootstrapScreen> {
   }
 
   Future<void> _submitRequest() async {
-    final session = ref.read(authSessionControllerProvider).valueOrNull;
-    if (session == null) {
+    if (ref.read(authSessionControllerProvider).valueOrNull == null) {
       _showSnack('サインイン状態を確認できませんでした。');
       return;
     }

--- a/apps/mobile/lib/features/realm_bootstrap/presentation/realm_bootstrap_screen.dart
+++ b/apps/mobile/lib/features/realm_bootstrap/presentation/realm_bootstrap_screen.dart
@@ -79,18 +79,21 @@ class _RealmBootstrapScreenState extends ConsumerState<RealmBootstrapScreen> {
                 ),
                 const SizedBox(height: 16),
                 _RealmTextField(
+                  fieldKey: const Key('realm_request_display_name'),
                   controller: _displayNameController,
                   label: 'Realm name',
                   icon: Icons.public_rounded,
                 ),
                 const SizedBox(height: 12),
                 _RealmTextField(
+                  fieldKey: const Key('realm_request_slug'),
                   controller: _slugController,
                   label: 'slug',
                   icon: Icons.link_rounded,
                 ),
                 const SizedBox(height: 12),
                 _RealmTextField(
+                  fieldKey: const Key('realm_request_purpose'),
                   controller: _purposeController,
                   label: 'purpose',
                   icon: Icons.flag_outlined,
@@ -98,6 +101,7 @@ class _RealmBootstrapScreenState extends ConsumerState<RealmBootstrapScreen> {
                 ),
                 const SizedBox(height: 12),
                 _RealmTextField(
+                  fieldKey: const Key('realm_request_venue_context'),
                   controller: _venueController,
                   label: 'venue / locality / context',
                   icon: Icons.place_outlined,
@@ -105,6 +109,7 @@ class _RealmBootstrapScreenState extends ConsumerState<RealmBootstrapScreen> {
                 ),
                 const SizedBox(height: 12),
                 _RealmTextField(
+                  fieldKey: const Key('realm_request_member_shape'),
                   controller: _memberShapeController,
                   label: 'intended member pattern',
                   icon: Icons.groups_2_outlined,
@@ -112,6 +117,7 @@ class _RealmBootstrapScreenState extends ConsumerState<RealmBootstrapScreen> {
                 ),
                 const SizedBox(height: 12),
                 _RealmTextField(
+                  fieldKey: const Key('realm_request_bootstrap_rationale'),
                   controller: _rationaleController,
                   label: 'bootstrap rationale',
                   icon: Icons.auto_awesome_motion_outlined,
@@ -119,6 +125,7 @@ class _RealmBootstrapScreenState extends ConsumerState<RealmBootstrapScreen> {
                 ),
                 const SizedBox(height: 12),
                 _RealmTextField(
+                  fieldKey: const Key('realm_request_sponsor_account_id'),
                   controller: _sponsorController,
                   label: 'sponsor account id',
                   icon: Icons.volunteer_activism_outlined,
@@ -126,6 +133,7 @@ class _RealmBootstrapScreenState extends ConsumerState<RealmBootstrapScreen> {
                 ),
                 const SizedBox(height: 12),
                 _RealmTextField(
+                  fieldKey: const Key('realm_request_steward_account_id'),
                   controller: _stewardController,
                   label: 'Steward account id',
                   icon: Icons.verified_user_outlined,
@@ -157,6 +165,7 @@ class _RealmBootstrapScreenState extends ConsumerState<RealmBootstrapScreen> {
                 ),
                 const SizedBox(height: 14),
                 _RealmTextField(
+                  fieldKey: const Key('realm_summary_realm_id'),
                   controller: _realmIdController,
                   label: 'realm_id',
                   icon: Icons.tag_rounded,
@@ -204,22 +213,21 @@ class _RealmBootstrapScreenState extends ConsumerState<RealmBootstrapScreen> {
       }
     });
     try {
-      final request =
-          await ref.read(realmBootstrapRepositoryProvider).createRealmRequest(
-                CreateRealmRequestDraft(
-                  displayName: _displayNameController.text,
-                  slugCandidate: _slugController.text,
-                  purposeText: _purposeController.text,
-                  venueContextText: _venueController.text,
-                  expectedMemberShapeText: _memberShapeController.text,
-                  bootstrapRationaleText: _rationaleController.text,
-                  proposedSponsorAccountId:
-                      _trimmedOrNull(_sponsorController.text),
-                  proposedStewardAccountId:
-                      _trimmedOrNull(_stewardController.text),
-                  requestIdempotencyKey: _pendingRequestKey!,
-                ),
-              );
+      final request = await ref
+          .read(realmBootstrapRepositoryProvider)
+          .createRealmRequest(
+            CreateRealmRequestDraft(
+              displayName: _displayNameController.text,
+              slugCandidate: _slugController.text,
+              purposeText: _purposeController.text,
+              venueContextText: _venueController.text,
+              expectedMemberShapeText: _memberShapeController.text,
+              bootstrapRationaleText: _rationaleController.text,
+              proposedSponsorAccountId: _trimmedOrNull(_sponsorController.text),
+              proposedStewardAccountId: _trimmedOrNull(_stewardController.text),
+              requestIdempotencyKey: _pendingRequestKey!,
+            ),
+          );
       if (!mounted) {
         return;
       }
@@ -311,6 +319,7 @@ class _RealmBootstrapScreenState extends ConsumerState<RealmBootstrapScreen> {
 
 class _RealmTextField extends StatelessWidget {
   const _RealmTextField({
+    required this.fieldKey,
     required this.controller,
     required this.label,
     required this.icon,
@@ -318,6 +327,7 @@ class _RealmTextField extends StatelessWidget {
     this.requiredField = true,
   });
 
+  final Key fieldKey;
   final TextEditingController controller;
   final String label;
   final IconData icon;
@@ -327,6 +337,7 @@ class _RealmTextField extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return TextField(
+      key: fieldKey,
       controller: controller,
       maxLines: maxLines,
       textInputAction:

--- a/apps/mobile/lib/features/realm_bootstrap/presentation/realm_bootstrap_screen.dart
+++ b/apps/mobile/lib/features/realm_bootstrap/presentation/realm_bootstrap_screen.dart
@@ -267,10 +267,14 @@ class _RealmBootstrapScreenState extends ConsumerState<RealmBootstrapScreen> {
   Future<void> _loadSummary() async {
     final realmId = _realmIdController.text.trim();
     if (realmId.isEmpty) {
+      setState(() => _summary = null);
       _showSnack('realm_id を入力してください。');
       return;
     }
-    setState(() => _isLoadingSummary = true);
+    setState(() {
+      _isLoadingSummary = true;
+      _summary = null;
+    });
     try {
       final summary = await ref
           .read(realmBootstrapRepositoryProvider)

--- a/apps/mobile/lib/features/realm_bootstrap/presentation/realm_bootstrap_screen.dart
+++ b/apps/mobile/lib/features/realm_bootstrap/presentation/realm_bootstrap_screen.dart
@@ -191,8 +191,11 @@ class _RealmBootstrapScreenState extends ConsumerState<RealmBootstrapScreen> {
       return;
     }
 
-    setState(() => _isSubmitting = true);
-    _pendingRequestKey ??= 'realm-ui-${session.userId}-${randomHex(bytes: 8)}';
+    setState(() {
+      _isSubmitting = true;
+      _pendingRequestKey ??=
+          'realm-ui-${session.userId}-${randomHex(bytes: 8)}';
+    });
     try {
       final request =
           await ref.read(realmBootstrapRepositoryProvider).createRealmRequest(
@@ -213,6 +216,7 @@ class _RealmBootstrapScreenState extends ConsumerState<RealmBootstrapScreen> {
       }
       setState(() {
         _request = request;
+        _pendingRequestKey = null;
         if (request.createdRealmId != null) {
           _realmIdController.text = request.createdRealmId!;
         }

--- a/apps/mobile/lib/repositories/realm_bootstrap/api_realm_bootstrap_repository.dart
+++ b/apps/mobile/lib/repositories/realm_bootstrap/api_realm_bootstrap_repository.dart
@@ -81,6 +81,11 @@ class ApiRealmBootstrapRepository implements RealmBootstrapRepository {
         );
       }
     }
+    if (error is FormatException || error is TypeError) {
+      return const UnknownAppException(
+        message: 'データの読み込みに失敗しました。しばらくしてからもう一度お試しください。',
+      );
+    }
     return AppExceptionMapper.fromObject(error);
   }
 

--- a/apps/mobile/lib/repositories/realm_bootstrap/api_realm_bootstrap_repository.dart
+++ b/apps/mobile/lib/repositories/realm_bootstrap/api_realm_bootstrap_repository.dart
@@ -83,17 +83,12 @@ class ApiRealmBootstrapRepository implements RealmBootstrapRepository {
   }
 
   String? _errorResponseMessage(Object? data) {
-    if (data is Map<String, dynamic>) {
-      final message = data['error'];
-      if (message is String && message.isNotEmpty) {
-        return message;
-      }
+    if (data is! Map) {
+      return null;
     }
-    if (data is Map) {
-      final message = data['error'];
-      if (message is String && message.isNotEmpty) {
-        return message;
-      }
+    final message = data['error'];
+    if (message is String && message.isNotEmpty) {
+      return message;
     }
     return null;
   }

--- a/apps/mobile/lib/repositories/realm_bootstrap/api_realm_bootstrap_repository.dart
+++ b/apps/mobile/lib/repositories/realm_bootstrap/api_realm_bootstrap_repository.dart
@@ -1,0 +1,44 @@
+import '../../api/api_client.dart';
+import '../../features/realm_bootstrap/models/realm_bootstrap_models.dart';
+import 'realm_bootstrap_repository.dart';
+
+class ApiRealmBootstrapRepository implements RealmBootstrapRepository {
+  ApiRealmBootstrapRepository(this._apiClient);
+
+  final ApiClient _apiClient;
+
+  @override
+  Future<RealmRequestView> createRealmRequest(
+    CreateRealmRequestDraft draft,
+  ) async {
+    final response = await _apiClient.dio.post<Map<String, dynamic>>(
+      '/api/realms/requests',
+      data: draft.toJson(),
+    );
+    return RealmRequestView.fromJson(
+      response.data ?? const <String, dynamic>{},
+    );
+  }
+
+  @override
+  Future<RealmRequestView> fetchRealmRequest(String realmRequestId) async {
+    final response = await _apiClient.dio.get<Map<String, dynamic>>(
+      '/api/realms/requests/${Uri.encodeComponent(realmRequestId)}',
+    );
+    return RealmRequestView.fromJson(
+      response.data ?? const <String, dynamic>{},
+    );
+  }
+
+  @override
+  Future<RealmBootstrapSummaryBundle> fetchBootstrapSummary(
+    String realmId,
+  ) async {
+    final response = await _apiClient.dio.get<Map<String, dynamic>>(
+      '/api/projection/realms/${Uri.encodeComponent(realmId)}/bootstrap-summary',
+    );
+    return RealmBootstrapSummaryBundle.fromJson(
+      response.data ?? const <String, dynamic>{},
+    );
+  }
+}

--- a/apps/mobile/lib/repositories/realm_bootstrap/api_realm_bootstrap_repository.dart
+++ b/apps/mobile/lib/repositories/realm_bootstrap/api_realm_bootstrap_repository.dart
@@ -101,8 +101,6 @@ class ApiRealmBootstrapRepository implements RealmBootstrapRepository {
         'このslugは確認中です。別のslugで申請してください。',
       'approved slug is already in use' =>
         'このslugはすでに使われています。別のslugで申請してください。',
-      'realm bootstrap summary was not found' => 'Realmの状態を確認できませんでした。',
-      'realm request was not found' => 'Realm申請を確認できませんでした。',
       _ => null,
     };
   }

--- a/apps/mobile/lib/repositories/realm_bootstrap/api_realm_bootstrap_repository.dart
+++ b/apps/mobile/lib/repositories/realm_bootstrap/api_realm_bootstrap_repository.dart
@@ -73,9 +73,11 @@ class ApiRealmBootstrapRepository implements RealmBootstrapRepository {
         return BusinessException(message: notFoundMessage);
       }
       if (statusCode == 400 || statusCode == 409) {
+        final safeMessage = _safeRealmBootstrapMessage(
+          _errorResponseMessage(error.response?.data),
+        );
         return BusinessException(
-          message: _errorResponseMessage(error.response?.data) ??
-              'Realm申請の内容を確認してください。',
+          message: safeMessage ?? 'Realm申請の内容を確認してください。',
         );
       }
     }
@@ -91,5 +93,17 @@ class ApiRealmBootstrapRepository implements RealmBootstrapRepository {
       return message;
     }
     return null;
+  }
+
+  String? _safeRealmBootstrapMessage(String? message) {
+    return switch (message) {
+      'slug_candidate already has an open realm request' =>
+        'このslugは確認中です。別のslugで申請してください。',
+      'approved slug is already in use' =>
+        'このslugはすでに使われています。別のslugで申請してください。',
+      'realm bootstrap summary was not found' => 'Realmの状態を確認できませんでした。',
+      'realm request was not found' => 'Realm申請を確認できませんでした。',
+      _ => null,
+    };
   }
 }

--- a/apps/mobile/lib/repositories/realm_bootstrap/api_realm_bootstrap_repository.dart
+++ b/apps/mobile/lib/repositories/realm_bootstrap/api_realm_bootstrap_repository.dart
@@ -1,4 +1,7 @@
+import 'package:dio/dio.dart';
+
 import '../../api/api_client.dart';
+import '../../core/errors/app_exception.dart';
 import '../../features/realm_bootstrap/models/realm_bootstrap_models.dart';
 import 'realm_bootstrap_repository.dart';
 
@@ -11,34 +14,87 @@ class ApiRealmBootstrapRepository implements RealmBootstrapRepository {
   Future<RealmRequestView> createRealmRequest(
     CreateRealmRequestDraft draft,
   ) async {
-    final response = await _apiClient.dio.post<Map<String, dynamic>>(
-      '/api/realms/requests',
-      data: draft.toJson(),
-    );
-    return RealmRequestView.fromJson(
-      response.data ?? const <String, dynamic>{},
-    );
+    try {
+      final response = await _apiClient.dio.post<Map<String, dynamic>>(
+        '/api/realms/requests',
+        data: draft.toJson(),
+      );
+      return RealmRequestView.fromJson(
+        response.data ?? const <String, dynamic>{},
+      );
+    } catch (error) {
+      throw _mapRealmBootstrapError(error);
+    }
   }
 
   @override
   Future<RealmRequestView> fetchRealmRequest(String realmRequestId) async {
-    final response = await _apiClient.dio.get<Map<String, dynamic>>(
-      '/api/realms/requests/${Uri.encodeComponent(realmRequestId)}',
-    );
-    return RealmRequestView.fromJson(
-      response.data ?? const <String, dynamic>{},
-    );
+    try {
+      final response = await _apiClient.dio.get<Map<String, dynamic>>(
+        '/api/realms/requests/${Uri.encodeComponent(realmRequestId)}',
+      );
+      return RealmRequestView.fromJson(
+        response.data ?? const <String, dynamic>{},
+      );
+    } catch (error) {
+      throw _mapRealmBootstrapError(
+        error,
+        notFoundMessage: 'Realm申請を確認できませんでした。',
+      );
+    }
   }
 
   @override
   Future<RealmBootstrapSummaryBundle> fetchBootstrapSummary(
     String realmId,
   ) async {
-    final response = await _apiClient.dio.get<Map<String, dynamic>>(
-      '/api/projection/realms/${Uri.encodeComponent(realmId)}/bootstrap-summary',
-    );
-    return RealmBootstrapSummaryBundle.fromJson(
-      response.data ?? const <String, dynamic>{},
-    );
+    try {
+      final response = await _apiClient.dio.get<Map<String, dynamic>>(
+        '/api/projection/realms/${Uri.encodeComponent(realmId)}/bootstrap-summary',
+      );
+      return RealmBootstrapSummaryBundle.fromJson(
+        response.data ?? const <String, dynamic>{},
+      );
+    } catch (error) {
+      throw _mapRealmBootstrapError(
+        error,
+        notFoundMessage: 'Realmの状態を確認できませんでした。',
+      );
+    }
+  }
+
+  AppException _mapRealmBootstrapError(
+    Object error, {
+    String? notFoundMessage,
+  }) {
+    if (error is DioException) {
+      final statusCode = error.response?.statusCode;
+      if (statusCode == 404 && notFoundMessage != null) {
+        return BusinessException(message: notFoundMessage);
+      }
+      if (statusCode == 400 || statusCode == 409) {
+        return BusinessException(
+          message: _errorResponseMessage(error.response?.data) ??
+              'Realm申請の内容を確認してください。',
+        );
+      }
+    }
+    return AppExceptionMapper.fromObject(error);
+  }
+
+  String? _errorResponseMessage(Object? data) {
+    if (data is Map<String, dynamic>) {
+      final message = data['error'];
+      if (message is String && message.isNotEmpty) {
+        return message;
+      }
+    }
+    if (data is Map) {
+      final message = data['error'];
+      if (message is String && message.isNotEmpty) {
+        return message;
+      }
+    }
+    return null;
   }
 }

--- a/apps/mobile/lib/repositories/realm_bootstrap/dummy_realm_bootstrap_repository.dart
+++ b/apps/mobile/lib/repositories/realm_bootstrap/dummy_realm_bootstrap_repository.dart
@@ -4,12 +4,26 @@ import 'realm_bootstrap_repository.dart';
 
 class DummyRealmBootstrapRepository implements RealmBootstrapRepository {
   final _requests = <String, RealmRequestView>{};
+  final _recordsByKey = <String, _DummyRealmRequestRecord>{};
 
   @override
   Future<RealmRequestView> createRealmRequest(
     CreateRealmRequestDraft draft,
   ) async {
-    final requestId = 'realm-request-${_requests.length + 1}';
+    final requestIdempotencyKey = draft.requestIdempotencyKey.trim();
+    final fingerprint = _fingerprint(draft);
+    final existing = _recordsByKey[requestIdempotencyKey];
+    if (existing != null) {
+      if (existing.fingerprint != fingerprint) {
+        throw const BusinessException(
+          message: '同じ操作キーで別のRealm申請は作れません。'
+              'もう一度画面を開き直してください。',
+        );
+      }
+      return existing.view;
+    }
+
+    final requestId = 'realm-request-${_recordsByKey.length + 1}';
     final view = RealmRequestView(
       realmRequestId: requestId,
       displayName: draft.displayName.trim(),
@@ -24,6 +38,11 @@ class DummyRealmBootstrapRepository implements RealmBootstrapRepository {
       proposedSponsorAccountId: _trimmedOrNull(draft.proposedSponsorAccountId),
       proposedStewardAccountId: _trimmedOrNull(draft.proposedStewardAccountId),
     );
+    final record = _DummyRealmRequestRecord(
+      view: view,
+      fingerprint: fingerprint,
+    );
+    _recordsByKey[requestIdempotencyKey] = record;
     _requests[requestId] = view;
     return view;
   }
@@ -64,10 +83,33 @@ class DummyRealmBootstrapRepository implements RealmBootstrapRepository {
   }
 }
 
+String _fingerprint(CreateRealmRequestDraft draft) {
+  return [
+    draft.displayName.trim(),
+    draft.slugCandidate.trim(),
+    draft.purposeText.trim(),
+    draft.venueContextText.trim(),
+    draft.expectedMemberShapeText.trim(),
+    draft.bootstrapRationaleText.trim(),
+    _trimmedOrNull(draft.proposedSponsorAccountId) ?? '',
+    _trimmedOrNull(draft.proposedStewardAccountId) ?? '',
+  ].join('|');
+}
+
 String? _trimmedOrNull(String? value) {
   final normalized = value?.trim();
   if (normalized == null || normalized.isEmpty) {
     return null;
   }
   return normalized;
+}
+
+class _DummyRealmRequestRecord {
+  const _DummyRealmRequestRecord({
+    required this.view,
+    required this.fingerprint,
+  });
+
+  final RealmRequestView view;
+  final String fingerprint;
 }

--- a/apps/mobile/lib/repositories/realm_bootstrap/dummy_realm_bootstrap_repository.dart
+++ b/apps/mobile/lib/repositories/realm_bootstrap/dummy_realm_bootstrap_repository.dart
@@ -19,7 +19,7 @@ class DummyRealmBootstrapRepository implements RealmBootstrapRepository {
       expectedMemberShapeSummary: draft.expectedMemberShapeText.trim(),
       bootstrapRationaleText: draft.bootstrapRationaleText.trim(),
       requestState: 'requested',
-      reviewReasonCode: 'pending_operator_review',
+      reviewReasonCode: 'request_received',
       createdRealmId: null,
       proposedSponsorAccountId: _trimmedOrNull(draft.proposedSponsorAccountId),
       proposedStewardAccountId: _trimmedOrNull(draft.proposedStewardAccountId),

--- a/apps/mobile/lib/repositories/realm_bootstrap/dummy_realm_bootstrap_repository.dart
+++ b/apps/mobile/lib/repositories/realm_bootstrap/dummy_realm_bootstrap_repository.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import '../../core/errors/app_exception.dart';
 import '../../features/realm_bootstrap/models/realm_bootstrap_models.dart';
 import 'realm_bootstrap_repository.dart';
@@ -84,16 +86,20 @@ class DummyRealmBootstrapRepository implements RealmBootstrapRepository {
 }
 
 String _fingerprint(CreateRealmRequestDraft draft) {
-  return [
-    draft.displayName.trim(),
-    draft.slugCandidate.trim(),
-    draft.purposeText.trim(),
-    draft.venueContextText.trim(),
-    draft.expectedMemberShapeText.trim(),
-    draft.bootstrapRationaleText.trim(),
-    _trimmedOrNull(draft.proposedSponsorAccountId) ?? '',
-    _trimmedOrNull(draft.proposedStewardAccountId) ?? '',
-  ].join('|');
+  return jsonEncode({
+    'display_name': draft.displayName.trim(),
+    'slug_candidate': draft.slugCandidate.trim(),
+    'purpose_text': draft.purposeText.trim(),
+    'venue_context_summary': draft.venueContextText.trim(),
+    'expected_member_shape_summary': draft.expectedMemberShapeText.trim(),
+    'bootstrap_rationale_text': draft.bootstrapRationaleText.trim(),
+    'proposed_sponsor_account_id': _trimmedOrNull(
+      draft.proposedSponsorAccountId,
+    ),
+    'proposed_steward_account_id': _trimmedOrNull(
+      draft.proposedStewardAccountId,
+    ),
+  });
 }
 
 String? _trimmedOrNull(String? value) {

--- a/apps/mobile/lib/repositories/realm_bootstrap/dummy_realm_bootstrap_repository.dart
+++ b/apps/mobile/lib/repositories/realm_bootstrap/dummy_realm_bootstrap_repository.dart
@@ -1,0 +1,73 @@
+import '../../core/errors/app_exception.dart';
+import '../../features/realm_bootstrap/models/realm_bootstrap_models.dart';
+import 'realm_bootstrap_repository.dart';
+
+class DummyRealmBootstrapRepository implements RealmBootstrapRepository {
+  final _requests = <String, RealmRequestView>{};
+
+  @override
+  Future<RealmRequestView> createRealmRequest(
+    CreateRealmRequestDraft draft,
+  ) async {
+    final requestId = 'realm-request-${_requests.length + 1}';
+    final view = RealmRequestView(
+      realmRequestId: requestId,
+      displayName: draft.displayName.trim(),
+      slugCandidate: draft.slugCandidate.trim(),
+      purposeText: draft.purposeText.trim(),
+      venueContextSummary: draft.venueContextText.trim(),
+      expectedMemberShapeSummary: draft.expectedMemberShapeText.trim(),
+      bootstrapRationaleText: draft.bootstrapRationaleText.trim(),
+      requestState: 'requested',
+      reviewReasonCode: 'pending_operator_review',
+      createdRealmId: null,
+      proposedSponsorAccountId: _trimmedOrNull(draft.proposedSponsorAccountId),
+      proposedStewardAccountId: _trimmedOrNull(draft.proposedStewardAccountId),
+    );
+    _requests[requestId] = view;
+    return view;
+  }
+
+  @override
+  Future<RealmRequestView> fetchRealmRequest(String realmRequestId) async {
+    final view = _requests[realmRequestId];
+    if (view == null) {
+      throw const BusinessException(message: 'Realm申請を確認できませんでした。');
+    }
+    return view;
+  }
+
+  @override
+  Future<RealmBootstrapSummaryBundle> fetchBootstrapSummary(
+    String realmId,
+  ) async {
+    return RealmBootstrapSummaryBundle(
+      realmRequest: null,
+      bootstrapView: RealmBootstrapView(
+        realmId: realmId,
+        slug: 'tokyo-calm-bootstrap',
+        displayName: 'Tokyo calm bootstrap',
+        realmStatus: 'limited_bootstrap',
+        admissionPosture: 'limited',
+        corridorStatus: 'active',
+        publicReasonCode: 'limited_bootstrap_active',
+        sponsorDisplayState: 'sponsor_and_steward',
+      ),
+      admissionView: RealmAdmissionView(
+        realmId: realmId,
+        accountId: 'demo-account',
+        admissionStatus: 'pending',
+        admissionKind: 'review_required',
+        publicReasonCode: 'review_required',
+      ),
+    );
+  }
+}
+
+String? _trimmedOrNull(String? value) {
+  final normalized = value?.trim();
+  if (normalized == null || normalized.isEmpty) {
+    return null;
+  }
+  return normalized;
+}

--- a/apps/mobile/lib/repositories/realm_bootstrap/dummy_realm_bootstrap_repository.dart
+++ b/apps/mobile/lib/repositories/realm_bootstrap/dummy_realm_bootstrap_repository.dart
@@ -13,6 +13,11 @@ class DummyRealmBootstrapRepository implements RealmBootstrapRepository {
     CreateRealmRequestDraft draft,
   ) async {
     final requestIdempotencyKey = draft.requestIdempotencyKey.trim();
+    if (requestIdempotencyKey.isEmpty) {
+      throw const BusinessException(
+        message: '操作キーが不正です。もう一度画面を開き直してください。',
+      );
+    }
     final fingerprint = _fingerprint(draft);
     final existing = _recordsByKey[requestIdempotencyKey];
     if (existing != null) {

--- a/apps/mobile/lib/repositories/realm_bootstrap/realm_bootstrap_repository.dart
+++ b/apps/mobile/lib/repositories/realm_bootstrap/realm_bootstrap_repository.dart
@@ -1,6 +1,6 @@
 import '../../features/realm_bootstrap/models/realm_bootstrap_models.dart';
 
-abstract interface class RealmBootstrapRepository {
+abstract class RealmBootstrapRepository {
   Future<RealmRequestView> createRealmRequest(CreateRealmRequestDraft draft);
 
   Future<RealmRequestView> fetchRealmRequest(String realmRequestId);

--- a/apps/mobile/lib/repositories/realm_bootstrap/realm_bootstrap_repository.dart
+++ b/apps/mobile/lib/repositories/realm_bootstrap/realm_bootstrap_repository.dart
@@ -1,0 +1,9 @@
+import '../../features/realm_bootstrap/models/realm_bootstrap_models.dart';
+
+abstract interface class RealmBootstrapRepository {
+  Future<RealmRequestView> createRealmRequest(CreateRealmRequestDraft draft);
+
+  Future<RealmRequestView> fetchRealmRequest(String realmRequestId);
+
+  Future<RealmBootstrapSummaryBundle> fetchBootstrapSummary(String realmId);
+}

--- a/apps/mobile/lib/repositories/repository_providers.dart
+++ b/apps/mobile/lib/repositories/repository_providers.dart
@@ -10,6 +10,9 @@ import 'auth/dummy_auth_repository.dart';
 import 'promise/api_promise_repository.dart';
 import 'promise/dummy_promise_repository.dart';
 import 'promise/promise_repository.dart';
+import 'realm_bootstrap/api_realm_bootstrap_repository.dart';
+import 'realm_bootstrap/dummy_realm_bootstrap_repository.dart';
+import 'realm_bootstrap/realm_bootstrap_repository.dart';
 
 final authRepositoryProvider = Provider<AuthRepository>((ref) {
   if (ref.watch(useApiRepositoriesProvider)) {
@@ -27,4 +30,13 @@ final promiseRepositoryProvider = Provider<PromiseRepository>((ref) {
     return ApiPromiseRepository(ref.watch(apiClientProvider));
   }
   return DummyPromiseRepository();
+});
+
+final realmBootstrapRepositoryProvider = Provider<RealmBootstrapRepository>((
+  ref,
+) {
+  if (ref.watch(useApiRepositoriesProvider)) {
+    return ApiRealmBootstrapRepository(ref.watch(apiClientProvider));
+  }
+  return DummyRealmBootstrapRepository();
 });

--- a/apps/mobile/test/features/realm_bootstrap/realm_bootstrap_models_test.dart
+++ b/apps/mobile/test/features/realm_bootstrap/realm_bootstrap_models_test.dart
@@ -47,6 +47,30 @@ void main() {
     expect(participantBootstrapCopy(summary), isNot(contains('source')));
   });
 
+  test('realm request parsing summarizes arbitrary context JSON', () {
+    final request = RealmRequestView.fromJson({
+      'realm_request_id': 'request-1',
+      'display_name': 'Tokyo slow coffee',
+      'slug_candidate': 'tokyo-slow-coffee',
+      'purpose_text': 'Small calm meetings.',
+      'venue_context_json': {
+        'city': 'Tokyo',
+        'venue_type': 'cafe',
+      },
+      'expected_member_shape_json': {
+        'size': 'small',
+        'locality': 'neighborhood',
+      },
+      'bootstrap_rationale_text': 'Start with a bounded group.',
+      'request_state': 'approved',
+      'review_reason_code': 'limited_bootstrap_active',
+    });
+
+    expect(request.venueContextSummary, contains('city: Tokyo'));
+    expect(request.venueContextSummary, contains('venue_type: cafe'));
+    expect(request.expectedMemberShapeSummary, contains('size: small'));
+  });
+
   test('realm bootstrap copy stays calm and non-gamified', () {
     const summary = RealmBootstrapSummaryBundle(
       realmRequest: null,

--- a/apps/mobile/test/features/realm_bootstrap/realm_bootstrap_models_test.dart
+++ b/apps/mobile/test/features/realm_bootstrap/realm_bootstrap_models_test.dart
@@ -128,4 +128,24 @@ void main() {
       throwsFormatException,
     );
   });
+
+  test('realm bootstrap summary parsing fails fast on malformed admission view', () {
+    expect(
+      () => RealmBootstrapSummaryBundle.fromJson({
+        'realm_request': null,
+        'bootstrap_view': {
+          'realm_id': 'realm-1',
+          'slug': 'realm-one',
+          'display_name': 'Realm one',
+          'realm_status': 'limited_bootstrap',
+          'admission_posture': 'review_required',
+          'corridor_status': 'active',
+          'public_reason_code': 'review_required',
+          'sponsor_display_state': 'steward_present',
+        },
+        'admission_view': 'not-an-object',
+      }),
+      throwsFormatException,
+    );
+  });
 }

--- a/apps/mobile/test/features/realm_bootstrap/realm_bootstrap_models_test.dart
+++ b/apps/mobile/test/features/realm_bootstrap/realm_bootstrap_models_test.dart
@@ -54,8 +54,8 @@ void main() {
       'slug_candidate': 'tokyo-slow-coffee',
       'purpose_text': 'Small calm meetings.',
       'venue_context_json': {
-        'city': 'Tokyo',
         'venue_type': 'cafe',
+        'city': 'Tokyo',
       },
       'expected_member_shape_json': {
         'size': 'small',
@@ -66,9 +66,11 @@ void main() {
       'review_reason_code': 'limited_bootstrap_active',
     });
 
-    expect(request.venueContextSummary, contains('city: Tokyo'));
-    expect(request.venueContextSummary, contains('venue_type: cafe'));
-    expect(request.expectedMemberShapeSummary, contains('size: small'));
+    expect(request.venueContextSummary, 'city: Tokyo, venue_type: cafe');
+    expect(
+      request.expectedMemberShapeSummary,
+      'locality: neighborhood, size: small',
+    );
   });
 
   test('realm bootstrap copy stays calm and non-gamified', () {

--- a/apps/mobile/test/features/realm_bootstrap/realm_bootstrap_models_test.dart
+++ b/apps/mobile/test/features/realm_bootstrap/realm_bootstrap_models_test.dart
@@ -84,4 +84,15 @@ void main() {
       throwsFormatException,
     );
   });
+
+  test('realm bootstrap summary parsing fails fast on malformed view shape', () {
+    expect(
+      () => RealmBootstrapSummaryBundle.fromJson({
+        'realm_request': null,
+        'bootstrap_view': null,
+        'admission_view': null,
+      }),
+      throwsFormatException,
+    );
+  });
 }

--- a/apps/mobile/test/features/realm_bootstrap/realm_bootstrap_models_test.dart
+++ b/apps/mobile/test/features/realm_bootstrap/realm_bootstrap_models_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:musubi_mobile/features/realm_bootstrap/models/realm_bootstrap_models.dart';
+
+void main() {
+  test('realm bootstrap parsing ignores internal fields not modeled by UI', () {
+    final summary = RealmBootstrapSummaryBundle.fromJson({
+      'realm_request': {
+        'realm_request_id': 'request-1',
+        'display_name': 'Tokyo slow coffee',
+        'slug_candidate': 'tokyo-slow-coffee',
+        'purpose_text': 'Small calm meetings.',
+        'venue_context_json': {'summary': 'Tokyo cafe'},
+        'expected_member_shape_json': {'summary': 'quiet and local'},
+        'bootstrap_rationale_text': 'Start with a bounded group.',
+        'request_state': 'approved',
+        'review_reason_code': 'limited_bootstrap_active',
+        'created_realm_id': 'realm-1',
+        'reviewed_by_operator_id': 'operator-secret',
+        'operator_note_internal': 'must not render',
+      },
+      'bootstrap_view': {
+        'realm_id': 'realm-1',
+        'slug': 'tokyo-slow-coffee',
+        'display_name': 'Tokyo slow coffee',
+        'realm_status': 'limited_bootstrap',
+        'admission_posture': 'limited',
+        'corridor_status': 'active',
+        'public_reason_code': 'limited_bootstrap_active',
+        'sponsor_display_state': 'sponsor_and_steward',
+        'source_fact_count': 100,
+        'raw_evidence_locator': 'private://evidence',
+      },
+      'admission_view': {
+        'realm_id': 'realm-1',
+        'account_id': 'account-1',
+        'admission_status': 'pending',
+        'admission_kind': 'review_required',
+        'public_reason_code': 'review_required',
+        'source_fact_id': 'source-secret',
+      },
+    });
+
+    expect(summary.realmRequest?.realmRequestId, 'request-1');
+    expect(summary.bootstrapView.displayName, 'Tokyo slow coffee');
+    expect(summary.admissionView?.admissionStatus, 'pending');
+    expect(participantBootstrapCopy(summary), isNot(contains('operator')));
+    expect(participantBootstrapCopy(summary), isNot(contains('source')));
+  });
+
+  test('realm bootstrap copy stays calm and non-gamified', () {
+    const summary = RealmBootstrapSummaryBundle(
+      realmRequest: null,
+      bootstrapView: RealmBootstrapView(
+        realmId: 'realm-1',
+        slug: 'realm-one',
+        displayName: 'Realm one',
+        realmStatus: 'limited_bootstrap',
+        admissionPosture: 'review_required',
+        corridorStatus: 'active',
+        publicReasonCode: 'review_required',
+        sponsorDisplayState: 'steward_present',
+      ),
+      admissionView: null,
+    );
+
+    final copy = participantBootstrapCopy(summary);
+    expect(copy, contains('確認'));
+    expect(copy, isNot(contains('DM')));
+    expect(copy, isNot(contains('ランキング')));
+    expect(copy, isNot(contains('boost')));
+  });
+}

--- a/apps/mobile/test/features/realm_bootstrap/realm_bootstrap_models_test.dart
+++ b/apps/mobile/test/features/realm_bootstrap/realm_bootstrap_models_test.dart
@@ -69,4 +69,19 @@ void main() {
     expect(copy, isNot(contains('ランキング')));
     expect(copy, isNot(contains('boost')));
   });
+
+  test('realm bootstrap parsing fails fast on missing required fields', () {
+    expect(
+      () => RealmBootstrapView.fromJson({
+        'realm_id': 'realm-1',
+        'slug': 'realm-one',
+        'display_name': 'Realm one',
+        'realm_status': 'limited_bootstrap',
+        'admission_posture': 'review_required',
+        'corridor_status': 'active',
+        'public_reason_code': 'review_required',
+      }),
+      throwsFormatException,
+    );
+  });
 }

--- a/apps/mobile/test/features/realm_bootstrap/realm_bootstrap_models_test.dart
+++ b/apps/mobile/test/features/realm_bootstrap/realm_bootstrap_models_test.dart
@@ -94,6 +94,13 @@ void main() {
     expect(copy, isNot(contains('boost')));
   });
 
+  test('realm bootstrap labels keep participant copy bounded', () {
+    expect(admissionKindLabel('corridor'), 'コリドー');
+    expect(reviewReasonCodeLabel('duplicate_or_invalid'), '内容を確認中');
+    expect(reviewReasonCodeLabel('operator_restriction'), '安全確認中');
+    expect(reviewReasonCodeLabel('raw_internal_reason'), '確認中');
+  });
+
   test('realm bootstrap parsing fails fast on missing required fields', () {
     expect(
       () => RealmBootstrapView.fromJson({

--- a/apps/mobile/test/features/realm_bootstrap/realm_bootstrap_screen_test.dart
+++ b/apps/mobile/test/features/realm_bootstrap/realm_bootstrap_screen_test.dart
@@ -50,6 +50,8 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(repository.createdDraft?.displayName, 'Tokyo slow coffee');
+    expect(repository.createdDraft?.proposedSponsorAccountId, isNull);
+    expect(repository.createdDraft?.proposedStewardAccountId, isNull);
     expect(find.text('申請を受け付けました'), findsOneWidget);
     expect(find.text('申請済み'), findsOneWidget);
     expect(find.textContaining('operator id'), findsNothing);

--- a/apps/mobile/test/features/realm_bootstrap/realm_bootstrap_screen_test.dart
+++ b/apps/mobile/test/features/realm_bootstrap/realm_bootstrap_screen_test.dart
@@ -29,16 +29,28 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    await tester.enterText(find.byType(TextField).at(0), 'Tokyo slow coffee');
-    await tester.enterText(find.byType(TextField).at(1), 'tokyo-slow-coffee');
     await tester.enterText(
-      find.byType(TextField).at(2),
+      find.byKey(const Key('realm_request_display_name')),
+      'Tokyo slow coffee',
+    );
+    await tester.enterText(
+      find.byKey(const Key('realm_request_slug')),
+      'tokyo-slow-coffee',
+    );
+    await tester.enterText(
+      find.byKey(const Key('realm_request_purpose')),
       'Calm local meetings.',
     );
-    await tester.enterText(find.byType(TextField).at(3), 'Tokyo cafe');
-    await tester.enterText(find.byType(TextField).at(4), 'Small and local');
     await tester.enterText(
-      find.byType(TextField).at(5),
+      find.byKey(const Key('realm_request_venue_context')),
+      'Tokyo cafe',
+    );
+    await tester.enterText(
+      find.byKey(const Key('realm_request_member_shape')),
+      'Small and local',
+    );
+    await tester.enterText(
+      find.byKey(const Key('realm_request_bootstrap_rationale')),
       'Start with bounded growth.',
     );
     final submitButton = find.byType(MusubiPrimaryButton);
@@ -90,16 +102,28 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    await tester.enterText(find.byType(TextField).at(0), 'Tokyo slow coffee');
-    await tester.enterText(find.byType(TextField).at(1), 'tokyo-slow-coffee');
     await tester.enterText(
-      find.byType(TextField).at(2),
+      find.byKey(const Key('realm_request_display_name')),
+      'Tokyo slow coffee',
+    );
+    await tester.enterText(
+      find.byKey(const Key('realm_request_slug')),
+      'tokyo-slow-coffee',
+    );
+    await tester.enterText(
+      find.byKey(const Key('realm_request_purpose')),
       'Calm local meetings.',
     );
-    await tester.enterText(find.byType(TextField).at(3), 'Tokyo cafe');
-    await tester.enterText(find.byType(TextField).at(4), 'Small and local');
     await tester.enterText(
-      find.byType(TextField).at(5),
+      find.byKey(const Key('realm_request_venue_context')),
+      'Tokyo cafe',
+    );
+    await tester.enterText(
+      find.byKey(const Key('realm_request_member_shape')),
+      'Small and local',
+    );
+    await tester.enterText(
+      find.byKey(const Key('realm_request_bootstrap_rationale')),
       'Start with bounded growth.',
     );
 
@@ -109,7 +133,7 @@ void main() {
     final failedRequestKey = repository.createdDraft!.requestIdempotencyKey;
 
     await tester.enterText(
-      find.byType(TextField).at(2),
+      find.byKey(const Key('realm_request_purpose')),
       'Calm local meetings with a smaller first circle.',
     );
     await tester.tap(submitButton);
@@ -143,7 +167,7 @@ void main() {
     await tester.pumpAndSettle();
 
     await tester.enterText(
-      find.byType(TextField).last,
+      find.byKey(const Key('realm_summary_realm_id')),
       'realm-00000000-0000-4000-8000-000000000001',
     );
     final summaryButton = find.widgetWithText(MusubiGhostButton, '状態を確認');

--- a/apps/mobile/test/features/realm_bootstrap/realm_bootstrap_screen_test.dart
+++ b/apps/mobile/test/features/realm_bootstrap/realm_bootstrap_screen_test.dart
@@ -50,6 +50,19 @@ void main() {
     expect(find.text('申請済み'), findsOneWidget);
     expect(find.textContaining('operator id'), findsNothing);
     expect(find.textContaining('source fact'), findsNothing);
+
+    final firstRequestKey = repository.createdDraft!.requestIdempotencyKey;
+    tester
+        .widget<MusubiPrimaryButton>(find.byType(MusubiPrimaryButton))
+        .onPressed
+        ?.call();
+    await tester.pumpAndSettle();
+
+    expect(repository.createdDrafts, hasLength(2));
+    expect(
+      repository.createdDrafts.last.requestIdempotencyKey,
+      isNot(firstRequestKey),
+    );
   });
 
   testWidgets('realm summary UI renders redacted bootstrap and operator panels',
@@ -133,12 +146,14 @@ class _FakeAuthRepository implements AuthRepository {
 
 class _FakeRealmBootstrapRepository implements RealmBootstrapRepository {
   CreateRealmRequestDraft? createdDraft;
+  final createdDrafts = <CreateRealmRequestDraft>[];
 
   @override
   Future<RealmRequestView> createRealmRequest(
     CreateRealmRequestDraft draft,
   ) async {
     createdDraft = draft;
+    createdDrafts.add(draft);
     return RealmRequestView(
       realmRequestId: 'request-1',
       displayName: draft.displayName,

--- a/apps/mobile/test/features/realm_bootstrap/realm_bootstrap_screen_test.dart
+++ b/apps/mobile/test/features/realm_bootstrap/realm_bootstrap_screen_test.dart
@@ -227,7 +227,7 @@ class _FakeRealmBootstrapRepository implements RealmBootstrapRepository {
       expectedMemberShapeSummary: draft.expectedMemberShapeText,
       bootstrapRationaleText: draft.bootstrapRationaleText,
       requestState: 'requested',
-      reviewReasonCode: 'pending_operator_review',
+      reviewReasonCode: 'request_received',
       createdRealmId: null,
       proposedSponsorAccountId: null,
       proposedStewardAccountId: null,

--- a/apps/mobile/test/features/realm_bootstrap/realm_bootstrap_screen_test.dart
+++ b/apps/mobile/test/features/realm_bootstrap/realm_bootstrap_screen_test.dart
@@ -80,7 +80,7 @@ void main() {
     expect(repository.createdDrafts, hasLength(2));
     expect(
       repository.createdDrafts.last.requestIdempotencyKey,
-      isNot(firstRequestKey),
+      firstRequestKey,
     );
   });
 

--- a/apps/mobile/test/features/realm_bootstrap/realm_bootstrap_screen_test.dart
+++ b/apps/mobile/test/features/realm_bootstrap/realm_bootstrap_screen_test.dart
@@ -190,6 +190,45 @@ void main() {
     expect(find.textContaining('ランキング'), findsNothing);
     expect(find.textContaining('DM unlock'), findsNothing);
   });
+
+  testWidgets('realm summary UI clears stale summary after failed fetch', (
+    tester,
+  ) async {
+    await _useTallSurface(tester);
+    final repository = _FakeRealmBootstrapRepository();
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authRepositoryProvider.overrideWith((ref) => _FakeAuthRepository()),
+          realmBootstrapRepositoryProvider.overrideWith((ref) => repository),
+        ],
+        child: const _WarmAuthSession(
+          child: MaterialApp(home: RealmBootstrapScreen()),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.byKey(const Key('realm_summary_realm_id')),
+      'realm-00000000-0000-4000-8000-000000000001',
+    );
+    final summaryButton = find.widgetWithText(MusubiGhostButton, '状態を確認');
+    await tester.tap(summaryButton);
+    await tester.pumpAndSettle();
+    expect(find.text('Tokyo slow coffee'), findsOneWidget);
+
+    repository.failNextSummary = true;
+    await tester.enterText(
+      find.byKey(const Key('realm_summary_realm_id')),
+      'realm-00000000-0000-4000-8000-000000000404',
+    );
+    await tester.tap(summaryButton);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Tokyo slow coffee'), findsNothing);
+    expect(find.textContaining('realm summary failed'), findsOneWidget);
+  });
 }
 
 Future<void> _useTallSurface(WidgetTester tester) async {
@@ -233,6 +272,7 @@ class _FakeRealmBootstrapRepository implements RealmBootstrapRepository {
   CreateRealmRequestDraft? createdDraft;
   final createdDrafts = <CreateRealmRequestDraft>[];
   bool failNextCreate = false;
+  bool failNextSummary = false;
 
   @override
   Future<RealmRequestView> createRealmRequest(
@@ -269,6 +309,10 @@ class _FakeRealmBootstrapRepository implements RealmBootstrapRepository {
   Future<RealmBootstrapSummaryBundle> fetchBootstrapSummary(
     String realmId,
   ) async {
+    if (failNextSummary) {
+      failNextSummary = false;
+      throw Exception('realm summary failed');
+    }
     return const RealmBootstrapSummaryBundle(
       realmRequest: null,
       bootstrapView: RealmBootstrapView(

--- a/apps/mobile/test/features/realm_bootstrap/realm_bootstrap_screen_test.dart
+++ b/apps/mobile/test/features/realm_bootstrap/realm_bootstrap_screen_test.dart
@@ -82,6 +82,25 @@ void main() {
       repository.createdDrafts.last.requestIdempotencyKey,
       firstRequestKey,
     );
+
+    await tester.enterText(
+      find.byKey(const Key('realm_request_sponsor_account_id')),
+      '   ',
+    );
+    await tester.enterText(
+      find.byKey(const Key('realm_request_steward_account_id')),
+      '   ',
+    );
+    await tester.tap(submitButton);
+    await tester.pumpAndSettle();
+
+    expect(repository.createdDrafts, hasLength(3));
+    expect(repository.createdDraft?.proposedSponsorAccountId, isNull);
+    expect(repository.createdDraft?.proposedStewardAccountId, isNull);
+    expect(
+      repository.createdDrafts.last.requestIdempotencyKey,
+      firstRequestKey,
+    );
   });
 
   testWidgets('realm request UI regenerates key after edited failed intent', (

--- a/apps/mobile/test/features/realm_bootstrap/realm_bootstrap_screen_test.dart
+++ b/apps/mobile/test/features/realm_bootstrap/realm_bootstrap_screen_test.dart
@@ -140,6 +140,10 @@ void main() {
     );
     await tester.pumpAndSettle();
 
+    await tester.enterText(
+      find.byType(TextField).last,
+      'realm-00000000-0000-4000-8000-000000000001',
+    );
     final summaryButton = find.widgetWithText(MusubiGhostButton, '状態を確認');
     expect(
       tester.widget<MusubiGhostButton>(summaryButton).onPressed,

--- a/apps/mobile/test/features/realm_bootstrap/realm_bootstrap_screen_test.dart
+++ b/apps/mobile/test/features/realm_bootstrap/realm_bootstrap_screen_test.dart
@@ -1,0 +1,188 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:musubi_mobile/app/widgets/musubi_pressable.dart';
+import 'package:musubi_mobile/core/riverpod_compat.dart';
+import 'package:musubi_mobile/features/realm_bootstrap/models/realm_bootstrap_models.dart';
+import 'package:musubi_mobile/features/realm_bootstrap/presentation/realm_bootstrap_screen.dart';
+import 'package:musubi_mobile/repositories/auth/auth_repository.dart';
+import 'package:musubi_mobile/repositories/auth/auth_session_controller.dart';
+import 'package:musubi_mobile/repositories/auth/pi_auth_session.dart';
+import 'package:musubi_mobile/repositories/realm_bootstrap/realm_bootstrap_repository.dart';
+import 'package:musubi_mobile/repositories/repository_providers.dart';
+
+void main() {
+  testWidgets('realm request UI submits required participant fields', (
+    tester,
+  ) async {
+    await _useTallSurface(tester);
+    final repository = _FakeRealmBootstrapRepository();
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authRepositoryProvider.overrideWith((ref) => _FakeAuthRepository()),
+          realmBootstrapRepositoryProvider.overrideWith((ref) => repository),
+        ],
+        child: const _WarmAuthSession(
+          child: MaterialApp(home: RealmBootstrapScreen()),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField).at(0), 'Tokyo slow coffee');
+    await tester.enterText(find.byType(TextField).at(1), 'tokyo-slow-coffee');
+    await tester.enterText(
+        find.byType(TextField).at(2), 'Calm local meetings.');
+    await tester.enterText(find.byType(TextField).at(3), 'Tokyo cafe');
+    await tester.enterText(find.byType(TextField).at(4), 'Small and local');
+    await tester.enterText(
+      find.byType(TextField).at(5),
+      'Start with bounded growth.',
+    );
+    tester
+        .widget<MusubiPrimaryButton>(find.byType(MusubiPrimaryButton))
+        .onPressed
+        ?.call();
+    await tester.pumpAndSettle();
+
+    expect(repository.createdDraft?.displayName, 'Tokyo slow coffee');
+    expect(find.text('申請を受け付けました'), findsOneWidget);
+    expect(find.text('申請済み'), findsOneWidget);
+    expect(find.textContaining('operator id'), findsNothing);
+    expect(find.textContaining('source fact'), findsNothing);
+  });
+
+  testWidgets('realm summary UI renders redacted bootstrap and operator panels',
+      (
+    tester,
+  ) async {
+    await _useTallSurface(tester);
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authRepositoryProvider.overrideWith((ref) => _FakeAuthRepository()),
+          realmBootstrapRepositoryProvider.overrideWith(
+            (ref) => _FakeRealmBootstrapRepository(),
+          ),
+        ],
+        child: const _WarmAuthSession(
+          child: MaterialApp(home: RealmBootstrapScreen()),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    tester
+        .widget<MusubiGhostButton>(
+          find.widgetWithText(MusubiGhostButton, '状態を確認'),
+        )
+        .onPressed
+        ?.call();
+    await tester.pumpAndSettle();
+    await tester.drag(find.byType(ListView), const Offset(0, -700));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Tokyo slow coffee'), findsOneWidget);
+    expect(find.text('限定受付'), findsOneWidget);
+    expect(find.text('Admission request'), findsOneWidget);
+    expect(find.text('確認キュー'), findsOneWidget);
+    expect(find.text('Operator / Steward review'), findsOneWidget);
+    expect(find.textContaining('証跡の所在'), findsOneWidget);
+    expect(find.textContaining('private://'), findsNothing);
+    expect(find.textContaining('ランキング'), findsNothing);
+    expect(find.textContaining('DM unlock'), findsNothing);
+  });
+}
+
+Future<void> _useTallSurface(WidgetTester tester) async {
+  await tester.binding.setSurfaceSize(const Size(1000, 1400));
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+}
+
+class _WarmAuthSession extends ConsumerWidget {
+  const _WarmAuthSession({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.watch(authSessionControllerProvider);
+    return child;
+  }
+}
+
+class _FakeAuthRepository implements AuthRepository {
+  static const _session = PiAuthSession(
+    userId: 'test-user',
+    piUid: 'test-pi-user',
+    displayName: '@test_user',
+  );
+
+  @override
+  Future<PiAuthSession?> getCurrentSession() async => _session;
+
+  @override
+  Future<PiAuthSession> signInWithPi() async => _session;
+
+  @override
+  Future<void> signOut() async {}
+
+  @override
+  Future<PiAuthSession?> trySilentSignIn() async => _session;
+}
+
+class _FakeRealmBootstrapRepository implements RealmBootstrapRepository {
+  CreateRealmRequestDraft? createdDraft;
+
+  @override
+  Future<RealmRequestView> createRealmRequest(
+    CreateRealmRequestDraft draft,
+  ) async {
+    createdDraft = draft;
+    return RealmRequestView(
+      realmRequestId: 'request-1',
+      displayName: draft.displayName,
+      slugCandidate: draft.slugCandidate,
+      purposeText: draft.purposeText,
+      venueContextSummary: draft.venueContextText,
+      expectedMemberShapeSummary: draft.expectedMemberShapeText,
+      bootstrapRationaleText: draft.bootstrapRationaleText,
+      requestState: 'requested',
+      reviewReasonCode: 'pending_operator_review',
+      createdRealmId: null,
+      proposedSponsorAccountId: null,
+      proposedStewardAccountId: null,
+    );
+  }
+
+  @override
+  Future<RealmRequestView> fetchRealmRequest(String realmRequestId) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<RealmBootstrapSummaryBundle> fetchBootstrapSummary(
+    String realmId,
+  ) async {
+    return const RealmBootstrapSummaryBundle(
+      realmRequest: null,
+      bootstrapView: RealmBootstrapView(
+        realmId: 'realm-tokyo-day1',
+        slug: 'tokyo-slow-coffee',
+        displayName: 'Tokyo slow coffee',
+        realmStatus: 'limited_bootstrap',
+        admissionPosture: 'limited',
+        corridorStatus: 'active',
+        publicReasonCode: 'limited_bootstrap_active',
+        sponsorDisplayState: 'sponsor_and_steward',
+      ),
+      admissionView: RealmAdmissionView(
+        realmId: 'realm-tokyo-day1',
+        accountId: 'account-1',
+        admissionStatus: 'pending',
+        admissionKind: 'review_required',
+        publicReasonCode: 'review_required',
+      ),
+    );
+  }
+}

--- a/apps/mobile/test/features/realm_bootstrap/realm_bootstrap_screen_test.dart
+++ b/apps/mobile/test/features/realm_bootstrap/realm_bootstrap_screen_test.dart
@@ -327,10 +327,10 @@ class _FakeRealmBootstrapRepository implements RealmBootstrapRepository {
       ),
       admissionView: RealmAdmissionView(
         realmId: 'realm-tokyo-day1',
-        accountId: 'account-1',
-        admissionStatus: 'pending',
-        admissionKind: 'review_required',
-        publicReasonCode: 'review_required',
+        accountId: 'test-user',
+        admissionStatus: 'admitted',
+        admissionKind: 'normal',
+        publicReasonCode: 'active_after_review',
       ),
     );
   }

--- a/apps/mobile/test/features/realm_bootstrap/realm_bootstrap_screen_test.dart
+++ b/apps/mobile/test/features/realm_bootstrap/realm_bootstrap_screen_test.dart
@@ -32,17 +32,21 @@ void main() {
     await tester.enterText(find.byType(TextField).at(0), 'Tokyo slow coffee');
     await tester.enterText(find.byType(TextField).at(1), 'tokyo-slow-coffee');
     await tester.enterText(
-        find.byType(TextField).at(2), 'Calm local meetings.');
+      find.byType(TextField).at(2),
+      'Calm local meetings.',
+    );
     await tester.enterText(find.byType(TextField).at(3), 'Tokyo cafe');
     await tester.enterText(find.byType(TextField).at(4), 'Small and local');
     await tester.enterText(
       find.byType(TextField).at(5),
       'Start with bounded growth.',
     );
-    tester
-        .widget<MusubiPrimaryButton>(find.byType(MusubiPrimaryButton))
-        .onPressed
-        ?.call();
+    final submitButton = find.byType(MusubiPrimaryButton);
+    expect(
+      tester.widget<MusubiPrimaryButton>(submitButton).onPressed,
+      isNotNull,
+    );
+    await tester.tap(submitButton);
     await tester.pumpAndSettle();
 
     expect(repository.createdDraft?.displayName, 'Tokyo slow coffee');
@@ -52,16 +56,67 @@ void main() {
     expect(find.textContaining('source fact'), findsNothing);
 
     final firstRequestKey = repository.createdDraft!.requestIdempotencyKey;
-    tester
-        .widget<MusubiPrimaryButton>(find.byType(MusubiPrimaryButton))
-        .onPressed
-        ?.call();
+    expect(
+      tester.widget<MusubiPrimaryButton>(submitButton).onPressed,
+      isNotNull,
+    );
+    await tester.tap(submitButton);
     await tester.pumpAndSettle();
 
     expect(repository.createdDrafts, hasLength(2));
     expect(
       repository.createdDrafts.last.requestIdempotencyKey,
       isNot(firstRequestKey),
+    );
+  });
+
+  testWidgets('realm request UI regenerates key after edited failed intent', (
+    tester,
+  ) async {
+    await _useTallSurface(tester);
+    final repository = _FakeRealmBootstrapRepository()..failNextCreate = true;
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authRepositoryProvider.overrideWith((ref) => _FakeAuthRepository()),
+          realmBootstrapRepositoryProvider.overrideWith((ref) => repository),
+        ],
+        child: const _WarmAuthSession(
+          child: MaterialApp(home: RealmBootstrapScreen()),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField).at(0), 'Tokyo slow coffee');
+    await tester.enterText(find.byType(TextField).at(1), 'tokyo-slow-coffee');
+    await tester.enterText(
+      find.byType(TextField).at(2),
+      'Calm local meetings.',
+    );
+    await tester.enterText(find.byType(TextField).at(3), 'Tokyo cafe');
+    await tester.enterText(find.byType(TextField).at(4), 'Small and local');
+    await tester.enterText(
+      find.byType(TextField).at(5),
+      'Start with bounded growth.',
+    );
+
+    final submitButton = find.byType(MusubiPrimaryButton);
+    await tester.tap(submitButton);
+    await tester.pumpAndSettle();
+    final failedRequestKey = repository.createdDraft!.requestIdempotencyKey;
+
+    await tester.enterText(
+      find.byType(TextField).at(2),
+      'Calm local meetings with a smaller first circle.',
+    );
+    await tester.tap(submitButton);
+    await tester.pumpAndSettle();
+
+    expect(repository.createdDrafts, hasLength(2));
+    expect(
+      repository.createdDrafts.last.requestIdempotencyKey,
+      isNot(failedRequestKey),
     );
   });
 
@@ -85,12 +140,12 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    tester
-        .widget<MusubiGhostButton>(
-          find.widgetWithText(MusubiGhostButton, '状態を確認'),
-        )
-        .onPressed
-        ?.call();
+    final summaryButton = find.widgetWithText(MusubiGhostButton, '状態を確認');
+    expect(
+      tester.widget<MusubiGhostButton>(summaryButton).onPressed,
+      isNotNull,
+    );
+    await tester.tap(summaryButton);
     await tester.pumpAndSettle();
     await tester.drag(find.byType(ListView), const Offset(0, -700));
     await tester.pumpAndSettle();
@@ -147,6 +202,7 @@ class _FakeAuthRepository implements AuthRepository {
 class _FakeRealmBootstrapRepository implements RealmBootstrapRepository {
   CreateRealmRequestDraft? createdDraft;
   final createdDrafts = <CreateRealmRequestDraft>[];
+  bool failNextCreate = false;
 
   @override
   Future<RealmRequestView> createRealmRequest(
@@ -154,6 +210,10 @@ class _FakeRealmBootstrapRepository implements RealmBootstrapRepository {
   ) async {
     createdDraft = draft;
     createdDrafts.add(draft);
+    if (failNextCreate) {
+      failNextCreate = false;
+      throw Exception('realm request failed');
+    }
     return RealmRequestView(
       realmRequestId: 'request-1',
       displayName: draft.displayName,

--- a/apps/mobile/test/repositories/realm_bootstrap/api_realm_bootstrap_repository_test.dart
+++ b/apps/mobile/test/repositories/realm_bootstrap/api_realm_bootstrap_repository_test.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 

--- a/apps/mobile/test/repositories/realm_bootstrap/api_realm_bootstrap_repository_test.dart
+++ b/apps/mobile/test/repositories/realm_bootstrap/api_realm_bootstrap_repository_test.dart
@@ -80,6 +80,30 @@ void main() {
     expect(summary.admissionView, isNull);
   });
 
+  test('api realm repository maps missing fetched request to business error',
+      () async {
+    final dio = Dio();
+    dio.httpClientAdapter = _StubHttpClientAdapter((options) async {
+      expect(
+        options.path,
+        '/api/realms/requests/request%2Fwith%20space',
+      );
+      return _jsonResponse(404, {'error': 'realm request was not found'});
+    });
+    final repository = ApiRealmBootstrapRepository(ApiClient(dio));
+
+    await expectLater(
+      repository.fetchRealmRequest('request/with space'),
+      throwsA(
+        isA<BusinessException>().having(
+          (error) => error.message,
+          'message',
+          'Realm申請を確認できませんでした。',
+        ),
+      ),
+    );
+  });
+
   test('api realm repository maps malformed request response to business error',
       () async {
     final dio = Dio();

--- a/apps/mobile/test/repositories/realm_bootstrap/api_realm_bootstrap_repository_test.dart
+++ b/apps/mobile/test/repositories/realm_bootstrap/api_realm_bootstrap_repository_test.dart
@@ -167,6 +167,30 @@ void main() {
       ),
     );
   });
+
+  test('api realm repository maps malformed success payload to safe error',
+      () async {
+    final dio = Dio();
+    dio.httpClientAdapter = _StubHttpClientAdapter((options) async {
+      return _jsonResponse(200, {
+        'realm_request': null,
+        'bootstrap_view': null,
+        'admission_view': null,
+      });
+    });
+    final repository = ApiRealmBootstrapRepository(ApiClient(dio));
+
+    await expectLater(
+      repository.fetchBootstrapSummary('realm-bad-shape'),
+      throwsA(
+        isA<UnknownAppException>().having(
+          (error) => error.message,
+          'message',
+          'データの読み込みに失敗しました。しばらくしてからもう一度お試しください。',
+        ),
+      ),
+    );
+  });
 }
 
 class _StubHttpClientAdapter implements HttpClientAdapter {

--- a/apps/mobile/test/repositories/realm_bootstrap/api_realm_bootstrap_repository_test.dart
+++ b/apps/mobile/test/repositories/realm_bootstrap/api_realm_bootstrap_repository_test.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data';
 import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:musubi_mobile/api/api_client.dart';
+import 'package:musubi_mobile/core/errors/app_exception.dart';
 import 'package:musubi_mobile/features/realm_bootstrap/models/realm_bootstrap_models.dart';
 import 'package:musubi_mobile/repositories/realm_bootstrap/api_realm_bootstrap_repository.dart';
 
@@ -77,6 +78,61 @@ void main() {
 
     expect(summary.bootstrapView.realmStatus, 'limited_bootstrap');
     expect(summary.admissionView, isNull);
+  });
+
+  test('api realm repository maps malformed request response to business error',
+      () async {
+    final dio = Dio();
+    dio.httpClientAdapter = _StubHttpClientAdapter((options) async {
+      return _jsonResponse(400, {
+        'error': 'request_idempotency_key replay payload mismatch',
+      });
+    });
+    final repository = ApiRealmBootstrapRepository(ApiClient(dio));
+
+    expect(
+      () => repository.createRealmRequest(
+        const CreateRealmRequestDraft(
+          displayName: 'Tokyo slow coffee',
+          slugCandidate: 'tokyo-slow-coffee',
+          purposeText: 'Calm local meetings.',
+          venueContextText: 'Tokyo cafe',
+          expectedMemberShapeText: 'small',
+          bootstrapRationaleText: 'Start bounded.',
+          requestIdempotencyKey: 'realm-request-1',
+        ),
+      ),
+      throwsA(
+        isA<BusinessException>().having(
+          (error) => error.message,
+          'message',
+          'request_idempotency_key replay payload mismatch',
+        ),
+      ),
+    );
+  });
+
+  test('api realm repository maps missing bootstrap summary to business error',
+      () async {
+    final dio = Dio();
+    dio.httpClientAdapter = _StubHttpClientAdapter((options) async {
+      return _jsonResponse(
+        404,
+        {'error': 'realm bootstrap view was not found'},
+      );
+    });
+    final repository = ApiRealmBootstrapRepository(ApiClient(dio));
+
+    expect(
+      () => repository.fetchBootstrapSummary('realm-missing'),
+      throwsA(
+        isA<BusinessException>().having(
+          (error) => error.message,
+          'message',
+          'Realmの状態を確認できませんでした。',
+        ),
+      ),
+    );
   });
 }
 

--- a/apps/mobile/test/repositories/realm_bootstrap/api_realm_bootstrap_repository_test.dart
+++ b/apps/mobile/test/repositories/realm_bootstrap/api_realm_bootstrap_repository_test.dart
@@ -85,7 +85,8 @@ void main() {
     final dio = Dio();
     dio.httpClientAdapter = _StubHttpClientAdapter((options) async {
       return _jsonResponse(400, {
-        'error': 'request_idempotency_key replay payload mismatch',
+        'error':
+            'request_idempotency_key was already used with a different realm request payload',
       });
     });
     final repository = ApiRealmBootstrapRepository(ApiClient(dio));
@@ -116,7 +117,7 @@ void main() {
       () async {
     final dio = Dio();
     dio.httpClientAdapter = _StubHttpClientAdapter((options) async {
-      return _jsonResponse(409, {
+      return _jsonResponse(400, {
         'error': 'slug_candidate already has an open realm request',
       });
     });
@@ -150,7 +151,7 @@ void main() {
     dio.httpClientAdapter = _StubHttpClientAdapter((options) async {
       return _jsonResponse(
         404,
-        {'error': 'realm bootstrap view was not found'},
+        {'error': 'realm bootstrap summary was not found'},
       );
     });
     final repository = ApiRealmBootstrapRepository(ApiClient(dio));

--- a/apps/mobile/test/repositories/realm_bootstrap/api_realm_bootstrap_repository_test.dart
+++ b/apps/mobile/test/repositories/realm_bootstrap/api_realm_bootstrap_repository_test.dart
@@ -1,0 +1,109 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:musubi_mobile/api/api_client.dart';
+import 'package:musubi_mobile/features/realm_bootstrap/models/realm_bootstrap_models.dart';
+import 'package:musubi_mobile/repositories/realm_bootstrap/api_realm_bootstrap_repository.dart';
+
+void main() {
+  test('api realm repository posts participant request payload', () async {
+    final dio = Dio();
+    dio.httpClientAdapter = _StubHttpClientAdapter((options) async {
+      expect(options.path, '/api/realms/requests');
+      final body = options.data as Map;
+      expect(body['display_name'], 'Tokyo slow coffee');
+      expect(body['venue_context_json'], {'summary': 'Tokyo cafe'});
+      expect(body['expected_member_shape_json'], {'summary': 'small'});
+      expect(body['proposed_sponsor_account_id'], isNull);
+      return _jsonResponse(200, {
+        'realm_request_id': 'request-1',
+        'display_name': 'Tokyo slow coffee',
+        'slug_candidate': 'tokyo-slow-coffee',
+        'purpose_text': 'Calm local meetings.',
+        'venue_context_json': {'summary': 'Tokyo cafe'},
+        'expected_member_shape_json': {'summary': 'small'},
+        'bootstrap_rationale_text': 'Start bounded.',
+        'request_state': 'requested',
+        'review_reason_code': 'pending_operator_review',
+      });
+    });
+    final repository = ApiRealmBootstrapRepository(ApiClient(dio));
+
+    final request = await repository.createRealmRequest(
+      const CreateRealmRequestDraft(
+        displayName: 'Tokyo slow coffee',
+        slugCandidate: 'tokyo-slow-coffee',
+        purposeText: 'Calm local meetings.',
+        venueContextText: 'Tokyo cafe',
+        expectedMemberShapeText: 'small',
+        bootstrapRationaleText: 'Start bounded.',
+        requestIdempotencyKey: 'realm-request-1',
+      ),
+    );
+
+    expect(request.realmRequestId, 'request-1');
+    expect(request.requestState, 'requested');
+  });
+
+  test('api realm repository fetches participant-safe bootstrap summary',
+      () async {
+    final dio = Dio();
+    dio.httpClientAdapter = _StubHttpClientAdapter((options) async {
+      expect(
+        options.path,
+        '/api/projection/realms/realm-1/bootstrap-summary',
+      );
+      return _jsonResponse(200, {
+        'realm_request': null,
+        'bootstrap_view': {
+          'realm_id': 'realm-1',
+          'slug': 'realm-one',
+          'display_name': 'Realm one',
+          'realm_status': 'limited_bootstrap',
+          'admission_posture': 'limited',
+          'corridor_status': 'active',
+          'public_reason_code': 'limited_bootstrap_active',
+          'sponsor_display_state': 'sponsor_backed',
+        },
+        'admission_view': null,
+      });
+    });
+    final repository = ApiRealmBootstrapRepository(ApiClient(dio));
+
+    final summary = await repository.fetchBootstrapSummary('realm-1');
+
+    expect(summary.bootstrapView.realmStatus, 'limited_bootstrap');
+    expect(summary.admissionView, isNull);
+  });
+}
+
+class _StubHttpClientAdapter implements HttpClientAdapter {
+  _StubHttpClientAdapter(this._handler);
+
+  final Future<ResponseBody> Function(RequestOptions options) _handler;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) {
+    return _handler(options);
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+ResponseBody _jsonResponse(int statusCode, Map<String, Object?> body) {
+  return ResponseBody.fromString(
+    jsonEncode(body),
+    statusCode,
+    headers: {
+      Headers.contentTypeHeader: [Headers.jsonContentType],
+    },
+  );
+}

--- a/apps/mobile/test/repositories/realm_bootstrap/api_realm_bootstrap_repository_test.dart
+++ b/apps/mobile/test/repositories/realm_bootstrap/api_realm_bootstrap_repository_test.dart
@@ -27,7 +27,7 @@ void main() {
         'expected_member_shape_json': {'summary': 'small'},
         'bootstrap_rationale_text': 'Start bounded.',
         'request_state': 'requested',
-        'review_reason_code': 'pending_operator_review',
+        'review_reason_code': 'request_received',
       });
     });
     final repository = ApiRealmBootstrapRepository(ApiClient(dio));

--- a/apps/mobile/test/repositories/realm_bootstrap/api_realm_bootstrap_repository_test.dart
+++ b/apps/mobile/test/repositories/realm_bootstrap/api_realm_bootstrap_repository_test.dart
@@ -90,8 +90,8 @@ void main() {
     });
     final repository = ApiRealmBootstrapRepository(ApiClient(dio));
 
-    expect(
-      () => repository.createRealmRequest(
+    await expectLater(
+      repository.createRealmRequest(
         const CreateRealmRequestDraft(
           displayName: 'Tokyo slow coffee',
           slugCandidate: 'tokyo-slow-coffee',
@@ -122,8 +122,8 @@ void main() {
     });
     final repository = ApiRealmBootstrapRepository(ApiClient(dio));
 
-    expect(
-      () => repository.createRealmRequest(
+    await expectLater(
+      repository.createRealmRequest(
         const CreateRealmRequestDraft(
           displayName: 'Tokyo slow coffee',
           slugCandidate: 'tokyo-slow-coffee',
@@ -155,8 +155,8 @@ void main() {
     });
     final repository = ApiRealmBootstrapRepository(ApiClient(dio));
 
-    expect(
-      () => repository.fetchBootstrapSummary('realm-missing'),
+    await expectLater(
+      repository.fetchBootstrapSummary('realm-missing'),
       throwsA(
         isA<BusinessException>().having(
           (error) => error.message,

--- a/apps/mobile/test/repositories/realm_bootstrap/api_realm_bootstrap_repository_test.dart
+++ b/apps/mobile/test/repositories/realm_bootstrap/api_realm_bootstrap_repository_test.dart
@@ -19,6 +19,7 @@ void main() {
       expect(body['venue_context_json'], {'summary': 'Tokyo cafe'});
       expect(body['expected_member_shape_json'], {'summary': 'small'});
       expect(body['proposed_sponsor_account_id'], isNull);
+      expect(body['request_idempotency_key'], 'realm-request-1');
       return _jsonResponse(200, {
         'realm_request_id': 'request-1',
         'display_name': 'Tokyo slow coffee',
@@ -41,7 +42,7 @@ void main() {
         venueContextText: 'Tokyo cafe',
         expectedMemberShapeText: 'small',
         bootstrapRationaleText: 'Start bounded.',
-        requestIdempotencyKey: 'realm-request-1',
+        requestIdempotencyKey: ' realm-request-1 ',
       ),
     );
 

--- a/apps/mobile/test/repositories/realm_bootstrap/api_realm_bootstrap_repository_test.dart
+++ b/apps/mobile/test/repositories/realm_bootstrap/api_realm_bootstrap_repository_test.dart
@@ -106,7 +106,39 @@ void main() {
         isA<BusinessException>().having(
           (error) => error.message,
           'message',
-          'request_idempotency_key replay payload mismatch',
+          'Realm申請の内容を確認してください。',
+        ),
+      ),
+    );
+  });
+
+  test('api realm repository maps safe backend errors to participant copy',
+      () async {
+    final dio = Dio();
+    dio.httpClientAdapter = _StubHttpClientAdapter((options) async {
+      return _jsonResponse(409, {
+        'error': 'slug_candidate already has an open realm request',
+      });
+    });
+    final repository = ApiRealmBootstrapRepository(ApiClient(dio));
+
+    expect(
+      () => repository.createRealmRequest(
+        const CreateRealmRequestDraft(
+          displayName: 'Tokyo slow coffee',
+          slugCandidate: 'tokyo-slow-coffee',
+          purposeText: 'Calm local meetings.',
+          venueContextText: 'Tokyo cafe',
+          expectedMemberShapeText: 'small',
+          bootstrapRationaleText: 'Start bounded.',
+          requestIdempotencyKey: 'realm-request-1',
+        ),
+      ),
+      throwsA(
+        isA<BusinessException>().having(
+          (error) => error.message,
+          'message',
+          'このslugは確認中です。別のslugで申請してください。',
         ),
       ),
     );

--- a/apps/mobile/test/repositories/realm_bootstrap/dummy_realm_bootstrap_repository_test.dart
+++ b/apps/mobile/test/repositories/realm_bootstrap/dummy_realm_bootstrap_repository_test.dart
@@ -51,8 +51,30 @@ void main() {
 
       await repository.createRealmRequest(draft);
 
-      expect(
+      await expectLater(
         repository.createRealmRequest(drift),
+        throwsA(isA<BusinessException>()),
+      );
+    },
+  );
+
+  test(
+    'dummy realm bootstrap repository rejects blank idempotency key',
+    () async {
+      final repository = DummyRealmBootstrapRepository();
+
+      await expectLater(
+        repository.createRealmRequest(
+          const CreateRealmRequestDraft(
+            displayName: 'Tokyo slow coffee',
+            slugCandidate: 'tokyo-slow-coffee',
+            purposeText: 'Calm local meetings.',
+            venueContextText: 'Tokyo cafe',
+            expectedMemberShapeText: 'Small and local',
+            bootstrapRationaleText: 'Start with bounded growth.',
+            requestIdempotencyKey: '   ',
+          ),
+        ),
         throwsA(isA<BusinessException>()),
       );
     },

--- a/apps/mobile/test/repositories/realm_bootstrap/dummy_realm_bootstrap_repository_test.dart
+++ b/apps/mobile/test/repositories/realm_bootstrap/dummy_realm_bootstrap_repository_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:musubi_mobile/core/errors/app_exception.dart';
+import 'package:musubi_mobile/features/realm_bootstrap/models/realm_bootstrap_models.dart';
+import 'package:musubi_mobile/repositories/realm_bootstrap/dummy_realm_bootstrap_repository.dart';
+
+void main() {
+  test(
+    'dummy realm bootstrap repository replays same idempotency key and payload',
+    () async {
+      final repository = DummyRealmBootstrapRepository();
+      const draft = CreateRealmRequestDraft(
+        displayName: 'Tokyo slow coffee',
+        slugCandidate: 'tokyo-slow-coffee',
+        purposeText: 'Calm local meetings.',
+        venueContextText: 'Tokyo cafe',
+        expectedMemberShapeText: 'Small and local',
+        bootstrapRationaleText: 'Start with bounded growth.',
+        requestIdempotencyKey: 'realm-request-action-1',
+      );
+
+      final created = await repository.createRealmRequest(draft);
+      final replayed = await repository.createRealmRequest(draft);
+
+      expect(created.realmRequestId, replayed.realmRequestId);
+      expect(created.displayName, replayed.displayName);
+    },
+  );
+
+  test(
+    'dummy realm bootstrap repository rejects idempotency payload drift',
+    () async {
+      final repository = DummyRealmBootstrapRepository();
+      const draft = CreateRealmRequestDraft(
+        displayName: 'Tokyo slow coffee',
+        slugCandidate: 'tokyo-slow-coffee',
+        purposeText: 'Calm local meetings.',
+        venueContextText: 'Tokyo cafe',
+        expectedMemberShapeText: 'Small and local',
+        bootstrapRationaleText: 'Start with bounded growth.',
+        requestIdempotencyKey: 'realm-request-action-1',
+      );
+      const drift = CreateRealmRequestDraft(
+        displayName: 'Tokyo loud coffee',
+        slugCandidate: 'tokyo-slow-coffee',
+        purposeText: 'Calm local meetings.',
+        venueContextText: 'Tokyo cafe',
+        expectedMemberShapeText: 'Small and local',
+        bootstrapRationaleText: 'Start with bounded growth.',
+        requestIdempotencyKey: 'realm-request-action-1',
+      );
+
+      await repository.createRealmRequest(draft);
+
+      expect(
+        repository.createRealmRequest(drift),
+        throwsA(isA<BusinessException>()),
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Implements design ISSUE-15 / GitHub issue #31: realm bootstrap, admission, and sponsor-backed early growth baseline.

Design source: `ISSUE-15-realm-bootstrap-and-admission.md`

This adds a bounded backend foundation for realm creation requests, sponsor-backed bootstrap records, bootstrap corridors, admissions, internal review triggers, and safe projections.

Closes #31.

## What changed

- Added forward-only migration:
  - `apps/backend/migrations/0018_realm_bootstrap_admission.sql`
- Added writer-owned realm bootstrap/admission tables under `dao`
- Added participant-safe and operator-safe projection tables under `projection`
- Added backend service/domain layer:
  - `apps/backend/src/services/realm_bootstrap/`
- Added handlers/routes:
  - `POST /api/realms/requests`
  - `GET /api/realms/requests/{realm_request_id}`
  - `GET /api/projection/realms/{realm_id}/bootstrap-summary`
  - `GET /api/internal/operator/realms/requests`
  - `GET /api/internal/operator/realms/requests/{realm_request_id}`
  - `POST /api/internal/operator/realms/requests/{realm_request_id}/approve`
  - `POST /api/internal/operator/realms/requests/{realm_request_id}/reject`
  - `POST /api/internal/realms/{realm_id}/sponsor-records`
  - `POST /api/internal/realms/{realm_id}/admissions`
  - `GET /api/internal/operator/realms/{realm_id}/review-summary`
  - `POST /api/internal/projection/realms/rebuild`
- Added integration coverage:
  - `apps/backend/tests/realm_bootstrap.rs`
- Added/updated docs:
  - `apps/backend/docs/realm_bootstrap_surface.md`
  - `apps/backend/docs/schema_skeleton.md`
  - `apps/backend/README.md`

## Core behavior

- Realm creation starts as a reviewable request, not public self-serve issuance.
- Approved requests can create `limited_bootstrap` or `active` realms.
- Rejected requests do not create active realms.
- Sponsor records are explicit, auditable, quota-bounded, and realm-local.
- Sponsor `rate_limited` / `revoked` states prevent new sponsor-backed auto-admission.
- Bootstrap corridors enforce server-side expiry, member caps, and sponsor caps.
- Sponsor-backed admissions also respect active corridor `member_cap`.
- Expired or operator-disabled corridors fall back to `review_required` rather than auto-admit.
- Restricted or suspended realms block new admissions.
- Admission kind is server-derived from writer-owned facts.
- Projection rows are display-only and are not used for writer-owned admission decisions.

## Privacy / safety boundary

Participant-facing responses expose bounded realm/admission posture only. They do not expose:

- raw operator notes
- internal review notes
- operator IDs
- source fact IDs
- source fact counts
- incident details
- abuse heuristics
- raw evidence
- private trust internals
- moderation internals
- sealed fallback internals
- unnecessary raw PII

## Out of scope

This PR does not implement:

- mobile UI
- Promise proof persistence
- Promise completion writer baseline
- ISSUE-12 operator review reimplementation
- ISSUE-13 room progression reimplementation
- ISSUE-14 Promise UI reimplementation
- fully self-serve public realm creation
- referral loops / ranking / DM unlock / paid romantic advantage
- public trust score / reputation vanity UI

## Validation

Passed from `apps/backend`:

- `make ENV_FILE=.env.example db-bootstrap`
- `make ENV_FILE=.env.example db-migrate`
- `make ENV_FILE=.env.example db-status`
- `cargo check`
- `cargo test --test realm_bootstrap --no-fail-fast`
- `cargo test --no-fail-fast`
- `git diff --check`

`db-status` reported applied 18 / pending 0 / failed 0 / checksum drift 0.

Also reset/migrated the local test DB after editing the uncommitted `0018` migration so tests used the current checksum.