### PR TITLE
feat(launch): ISSUE-18 launch posture / Day 1 pilot

### DIFF
--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -125,6 +125,7 @@ Day 1 launch posture defaults closed unless configured:
 - `MUSUBI_KILL_SWITCH_PROOF_SUBMISSION`
 - `MUSUBI_KILL_SWITCH_REALM_REQUESTS`
 - `MUSUBI_KILL_SWITCH_REALM_ADMISSIONS`
+- `MUSUBI_KILL_SWITCH_APPEAL_CREATION`
 
 Invalid launch mode, unsupported `open_preview`, or invalid boolean kill switch
 values fail closed. Internal Realm admission is launch-gated by the target

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -8,7 +8,9 @@ Current local HTTP surface:
 - `POST /api/payment/callback`
 - `POST /api/proof/challenges`
 - `POST /api/proof/submissions`
+- `GET /api/launch/posture`; participant-safe launch posture without allowlist members or internal switch detail
 - `POST /api/internal/orchestration/drain` in debug builds, or in release only when `MUSUBI_ENABLE_INTERNAL_ORCHESTRATION_DRAIN=true` and the request includes `Authorization: Bearer $MUSUBI_INTERNAL_API_TOKEN`
+- `GET /api/internal/launch/posture` under the internal/debug auth gate; returns redacted launch mode, kill switch state, and allowlist counts only
 - `GET /api/internal/ops/health` under the internal/debug auth gate, independent of orchestration drain enablement; reports DB connectivity only
 - `GET /api/internal/ops/readiness` under the internal/debug auth gate, independent of orchestration drain enablement; reports migration posture without mutating migration state or probing the migration advisory lock
 - `GET /api/internal/ops/observability/snapshot` under the internal/debug auth gate, independent of orchestration drain enablement; returns a redacted ops snapshot without raw evidence, operator notes, source identifiers, or participant data
@@ -110,6 +112,26 @@ If a valid callback arrives before provider submission mapping is visible, callb
 Callback signature verification is intentionally skipped for Issue #9 until a pinned Pi callback signature / auth contract exists; raw callback records keep `signature_valid = None` as the future slot.
 Those records are durable uniqueness boundaries; they are not a production Pi payment integration yet.
 
+Day 1 launch posture defaults closed unless configured:
+
+- `MUSUBI_LAUNCH_MODE=closed|pilot|paused`
+- `MUSUBI_LAUNCH_ALLOWLIST_PI_UIDS`
+- `MUSUBI_LAUNCH_ALLOWLIST_ACCOUNT_IDS`
+- `MUSUBI_LAUNCH_SUPPORT_CONTACT_URL`
+- `MUSUBI_LAUNCH_SUPPORT_CONTACT_LABEL`
+- `MUSUBI_KILL_SWITCH_AUTH`
+- `MUSUBI_KILL_SWITCH_PROMISE_CREATION`
+- `MUSUBI_KILL_SWITCH_PROOF_CHALLENGE`
+- `MUSUBI_KILL_SWITCH_PROOF_SUBMISSION`
+- `MUSUBI_KILL_SWITCH_REALM_REQUESTS`
+- `MUSUBI_KILL_SWITCH_REALM_ADMISSIONS`
+
+Invalid launch mode, unsupported `open_preview`, or invalid boolean kill switch
+values fail closed. Internal Realm admission is launch-gated by the target
+participant account and cannot bypass closed/pilot/paused posture. Launch
+posture is server policy, not observability truth, projection truth, or UI
+truth. See `docs/launch_posture_day1.md`.
+
 ### Run the orchestration contract tests
 
 ```bash
@@ -142,6 +164,7 @@ Design source: ISSUE-12-operator-review-appeal-evidence.md adds the operator rev
 Design source: ISSUE-13-room-progression.md adds the room progression surface baseline. Room progression facts are append-only writer facts in `dao`, user-facing room state is rebuilt into `projection`, sealed fallback can link to ISSUE-12 review cases without duplicating review/evidence truth, and state-changing progression decisions read writer truth instead of projection rows. See `docs/room_progression_surface.md`.
 Design source: ISSUE-15-realm-bootstrap-and-admission.md adds the first bounded realm bootstrap and admission baseline. Realm creation requests, sponsor records, bootstrap corridors, admissions, and review triggers live in writer-owned `dao` tables, while participant-safe and operator-safe realm summaries stay rebuildable in `projection`. Sponsor quota, revoked/rate-limited sponsor state, corridor expiry/caps, and restricted/suspended realm blocking are enforced on the writer path, not by client/UI state or projection rows. See `docs/realm_bootstrap_surface.md`.
 Design source: ISSUE-17-observability-slo-prompt-pack adds an internal-only, read-only ops observability surface. Health, readiness, projection lag, review queue, Realm review-trigger, and orchestration backlog signals are reported as redacted operational posture only. Unsupported SLIs return `unknown` instead of fake zero values, and projection lag remains display-only rather than writer truth. See `docs/ops_observability_slo.md`.
+Design source: ISSUE-18 launch posture / Day 1 pilot adds server-enforced launch modes, kill switches, and closed cohort posture. Launch posture is server policy, not observability truth, projection truth, or UI truth. See `docs/launch_posture_day1.md`.
 The backend also adds the first sandbox Pi provider adapter boundary for happy-route hold submission and callback intake.
 ISSUE-10 adds Day 1 safer venue proof primitives.
 The public HTTP surface supports the normal venue-code path only.
@@ -162,6 +185,7 @@ These proof records are input facts only; they are not settlement truth or final
 - `docs/room_progression_surface.md`: ISSUE-13 Intent / Coordination / Relationship / Sealed Room progression surface boundary
 - `docs/realm_bootstrap_surface.md`: ISSUE-15 bounded realm bootstrap, admission, sponsor, and corridor boundary
 - `docs/ops_observability_slo.md`: internal-only ISSUE-17 observability SLO skeleton and redaction boundary
+- `docs/launch_posture_day1.md`: ISSUE-18 launch posture, kill switch, and closed cohort boundary
 - `docs/guardrails.md`: executable architectural guardrails
 - `docs/proof_primitives.md`: Day 1 safer venue proof input boundary
 - `docs/happy_route_walkthrough.md`: current Issue #7 end-to-end path

--- a/apps/backend/docs/launch_posture_day1.md
+++ b/apps/backend/docs/launch_posture_day1.md
@@ -66,6 +66,8 @@ For token-authenticated participant writes, pilot allowlist checks accept either
 the account id or the linked Pi UID from the authorized session. Internal
 target-account gates that do not carry a participant session only evaluate the
 target account id after internal operator authorization succeeds.
+Pi auth checks accept a configured Pi UID allowlist entry, or an account id
+allowlist entry when the submitted Pi UID is already linked to that account.
 
 ## HTTP Surface
 
@@ -128,9 +130,10 @@ Server-side launch gates protect:
 - `POST /api/realms/requests`
 - `POST /api/internal/realms/{realm_id}/admissions`
 
-The auth gate uses `pi_uid` before an account exists. Post-auth participant
-gates use the authenticated `account_id`. Client-provided launch mode,
-allowlist state, or UI state is ignored.
+The auth gate uses `pi_uid` before an account exists, and may use an existing
+linked `account_id` for returning pilot members. Post-auth participant gates
+use the authenticated `account_id`. Client-provided launch mode, allowlist
+state, or UI state is ignored.
 Internal Realm admission is a new admission write, so it is launch-gated using
 the target participant account from the request payload. It cannot bypass
 `closed`, `pilot`, `paused`, or the Realm admission kill switch.

--- a/apps/backend/docs/launch_posture_day1.md
+++ b/apps/backend/docs/launch_posture_day1.md
@@ -54,6 +54,7 @@ All keys are optional unless noted.
 | `MUSUBI_KILL_SWITCH_PROOF_SUBMISSION` | `false` | fail closed for proof submission |
 | `MUSUBI_KILL_SWITCH_REALM_REQUESTS` | `false` | fail closed for Realm requests |
 | `MUSUBI_KILL_SWITCH_REALM_ADMISSIONS` | `false` | fail closed for Realm admissions |
+| `MUSUBI_KILL_SWITCH_APPEAL_CREATION` | `false` | fail closed for appeal creation |
 
 Boolean switches parse `1/0`, `true/false`, `yes/no`, and `on/off`
 case-insensitively. Any other value turns that switch on and adds an internal
@@ -127,6 +128,7 @@ Server-side launch gates protect:
 - `POST /api/promise/intents`
 - `POST /api/proof/challenges`
 - `POST /api/proof/submissions`
+- `POST /api/review-cases/{review_case_id}/appeals`
 - `POST /api/realms/requests`
 - `POST /api/internal/realms/{realm_id}/admissions`
 
@@ -155,6 +157,7 @@ Route-level kill switch message codes:
 - `proof_submission_paused`
 - `realm_request_paused`
 - `realm_admission_paused`
+- `appeal_creation_paused`
 
 Mode block message codes:
 

--- a/apps/backend/docs/launch_posture_day1.md
+++ b/apps/backend/docs/launch_posture_day1.md
@@ -65,7 +65,7 @@ return counts only.
 For token-authenticated participant writes, pilot allowlist checks accept either
 the account id or the linked Pi UID from the authorized session. Internal
 target-account gates that do not carry a participant session only evaluate the
-target account id.
+target account id after internal operator authorization succeeds.
 
 ## HTTP Surface
 

--- a/apps/backend/docs/launch_posture_day1.md
+++ b/apps/backend/docs/launch_posture_day1.md
@@ -2,7 +2,7 @@
 
 Design source: ISSUE-18 launch posture / Day 1 pilot.
 
-The GitHub issue number is intentionally not hardcoded.
+The GitHub issue URL is intentionally not hardcoded.
 
 ## Purpose
 
@@ -61,6 +61,11 @@ config warning.
 
 Allowlist members are never returned by API responses. Internal posture may
 return counts only.
+
+For token-authenticated participant writes, pilot allowlist checks accept either
+the account id or the linked Pi UID from the authorized session. Internal
+target-account gates that do not carry a participant session only evaluate the
+target account id.
 
 ## HTTP Surface
 

--- a/apps/backend/docs/launch_posture_day1.md
+++ b/apps/backend/docs/launch_posture_day1.md
@@ -80,6 +80,11 @@ Internal/debug-gated, side-effect-free:
 
 - `GET /api/internal/launch/posture`
 
+In debug builds, this route follows the existing internal route posture:
+requests may omit `Authorization`, but a supplied bearer token is treated as an
+internal credential and must not be a participant session token. In release,
+the internal bearer-token requirement applies.
+
 Public response:
 
 ```json

--- a/apps/backend/docs/launch_posture_day1.md
+++ b/apps/backend/docs/launch_posture_day1.md
@@ -1,0 +1,199 @@
+# Day 1 Launch Posture
+
+Design source: ISSUE-18 launch posture / Day 1 pilot.
+
+The GitHub issue number is intentionally not hardcoded.
+
+## Purpose
+
+ISSUE-18 keeps Day 1 launch bounded by server policy. Launch posture is not
+participant UI state, projection state, or observability state. It is parsed
+from server-owned configuration and enforced on participant write routes.
+
+This baseline exists to prevent accidental public launch while Realm bootstrap,
+operator review, and observability are still pilot-oriented.
+
+## Launch Modes
+
+`MUSUBI_LAUNCH_MODE` accepts:
+
+- `closed`
+- `pilot`
+- `paused`
+
+Missing `MUSUBI_LAUNCH_MODE` defaults to `closed`. Invalid values fail closed
+and are reported only through the internal launch posture endpoint as
+`invalid_launch_mode`.
+`open_preview` is unsupported for Day 1 production launch config and also
+fails closed, with an internal-only warning.
+
+Mode behavior:
+
+- `closed`: participant writes are blocked.
+- `pilot`: allowlisted cohort members may use gated participant flows.
+- `paused`: participant writes are blocked regardless of allowlist.
+
+Day 1 does not include a general public/open launch mode. The global launch
+bound is the configured pilot allowlist plus existing writer-owned Realm
+admission, corridor, and sponsor policy bounds.
+
+## Config Keys
+
+All keys are optional unless noted.
+
+| Key | Default | Invalid value behavior |
+| --- | --- | --- |
+| `MUSUBI_LAUNCH_MODE` | `closed` | fail closed |
+| `MUSUBI_LAUNCH_ALLOWLIST_PI_UIDS` | empty | empty members ignored |
+| `MUSUBI_LAUNCH_ALLOWLIST_ACCOUNT_IDS` | empty | empty members ignored |
+| `MUSUBI_LAUNCH_SUPPORT_CONTACT_URL` | unset | support contact omitted |
+| `MUSUBI_LAUNCH_SUPPORT_CONTACT_LABEL` | unset | support contact omitted |
+| `MUSUBI_KILL_SWITCH_AUTH` | `false` | fail closed for auth |
+| `MUSUBI_KILL_SWITCH_PROMISE_CREATION` | `false` | fail closed for Promise creation |
+| `MUSUBI_KILL_SWITCH_PROOF_CHALLENGE` | `false` | fail closed for proof challenge |
+| `MUSUBI_KILL_SWITCH_PROOF_SUBMISSION` | `false` | fail closed for proof submission |
+| `MUSUBI_KILL_SWITCH_REALM_REQUESTS` | `false` | fail closed for Realm requests |
+| `MUSUBI_KILL_SWITCH_REALM_ADMISSIONS` | `false` | fail closed for Realm admissions |
+
+Boolean switches parse `1/0`, `true/false`, `yes/no`, and `on/off`
+case-insensitively. Any other value turns that switch on and adds an internal
+config warning.
+
+Allowlist members are never returned by API responses. Internal posture may
+return counts only.
+
+## HTTP Surface
+
+Public, side-effect-free:
+
+- `GET /api/launch/posture`
+
+Internal/debug-gated, side-effect-free:
+
+- `GET /api/internal/launch/posture`
+
+Public response:
+
+```json
+{
+  "launch_mode": "closed",
+  "participant_posture": "closed",
+  "message_code": "launch_closed",
+  "support_contact": null,
+  "generated_at": "timestamp"
+}
+```
+
+Internal response:
+
+```json
+{
+  "launch_mode": "closed",
+  "effective_posture": "closed",
+  "config_warnings": [],
+  "kill_switches": {
+    "auth": false,
+    "promise_creation": false,
+    "proof_challenge": false,
+    "proof_submission": false,
+    "realm_requests": false,
+    "realm_admissions": false
+  },
+  "allowlist": {
+    "source": "none",
+    "pi_uid_count": 0,
+    "account_id_count": 0,
+    "members_visible": false
+  },
+  "support_contact_configured": false,
+  "observability_is_launch_truth": false,
+  "projection_is_launch_truth": false,
+  "generated_at": "timestamp"
+}
+```
+
+## Route Gates
+
+Server-side launch gates protect:
+
+- `POST /api/auth/pi`
+- `POST /api/promise/intents`
+- `POST /api/proof/challenges`
+- `POST /api/proof/submissions`
+- `POST /api/realms/requests`
+- `POST /api/internal/realms/{realm_id}/admissions`
+
+The auth gate uses `pi_uid` before an account exists. Post-auth participant
+gates use the authenticated `account_id`. Client-provided launch mode,
+allowlist state, or UI state is ignored.
+Internal Realm admission is a new admission write, so it is launch-gated using
+the target participant account from the request payload. It cannot bypass
+`closed`, `pilot`, `paused`, or the Realm admission kill switch.
+
+Blocked participant responses are bounded:
+
+```json
+{
+  "error": "launch_paused",
+  "message_code": "launch_paused"
+}
+```
+
+Route-level kill switch message codes:
+
+- `auth_paused`
+- `promise_creation_paused`
+- `proof_challenge_paused`
+- `proof_submission_paused`
+- `realm_request_paused`
+- `realm_admission_paused`
+
+Mode block message codes:
+
+- `launch_closed`
+- `launch_pilot_not_allowed`
+- `launch_paused`
+
+## Redaction Boundary
+
+Participant responses must not expose:
+
+- allowlist members
+- raw `pi_uid` lists
+- raw account id lists
+- operator ids
+- operator notes
+- review internals
+- source fact ids
+- source fact counts
+- evidence internals
+- incident internals
+- moderation internals
+- sealed fallback internals
+- raw PII
+
+The internal posture response still exposes counts only, never member lists.
+
+## Relationship To Observability
+
+ISSUE-17 observability can inform humans, but it does not open or close launch
+posture. SLO status, projection lag, readiness, and projection rows are not
+launch truth.
+
+Internal ops/readiness endpoints remain available during participant launch
+pause according to their existing internal/debug gate.
+
+## Deferred Scope
+
+This baseline does not add:
+
+- ISSUE-16 reconciliation / PITR / failover
+- dynamic launch flag admin UI
+- external alert integrations
+- public launch
+- referral or growth programs
+- paid priority access
+- ranking or recommendation boosts
+- DM unlock behavior
+- Promise proof persistence
+- Promise completion writer truth

--- a/apps/backend/docs/launch_posture_day1.md
+++ b/apps/backend/docs/launch_posture_day1.md
@@ -45,7 +45,7 @@ All keys are optional unless noted.
 | --- | --- | --- |
 | `MUSUBI_LAUNCH_MODE` | `closed` | fail closed |
 | `MUSUBI_LAUNCH_ALLOWLIST_PI_UIDS` | empty | empty members ignored |
-| `MUSUBI_LAUNCH_ALLOWLIST_ACCOUNT_IDS` | empty | empty members ignored |
+| `MUSUBI_LAUNCH_ALLOWLIST_ACCOUNT_IDS` | empty | empty members ignored; invalid UUIDs ignored with an internal warning |
 | `MUSUBI_LAUNCH_SUPPORT_CONTACT_URL` | unset | support contact omitted |
 | `MUSUBI_LAUNCH_SUPPORT_CONTACT_LABEL` | unset | support contact omitted |
 | `MUSUBI_KILL_SWITCH_AUTH` | `false` | fail closed for auth |

--- a/apps/backend/docs/launch_posture_day1.md
+++ b/apps/backend/docs/launch_posture_day1.md
@@ -105,7 +105,8 @@ Internal response:
     "proof_challenge": false,
     "proof_submission": false,
     "realm_requests": false,
-    "realm_admissions": false
+    "realm_admissions": false,
+    "appeal_creation": false
   },
   "allowlist": {
     "source": "none",

--- a/apps/backend/src/handlers/auth.rs
+++ b/apps/backend/src/handlers/auth.rs
@@ -6,7 +6,8 @@ use crate::{
     SharedState,
     handlers::{ApiResult, bad_request, launch_blocked, map_happy_route_error},
     services::happy_route::{
-        AuthenticationInput, authenticate_pi_account, find_account_id_by_pi_uid,
+        AuthenticationInput, authenticate_pi_account,
+        find_account_id_by_pi_uid_if_access_token_matches,
     },
 };
 
@@ -76,9 +77,10 @@ pub async fn authenticate_pi(
         if block.message_code != "launch_pilot_not_allowed" {
             return Err(launch_blocked(block.status_code, block.message_code));
         }
-        let existing_account_id = find_account_id_by_pi_uid(&state, &pi_uid)
-            .await
-            .map_err(map_happy_route_error)?;
+        let existing_account_id =
+            find_account_id_by_pi_uid_if_access_token_matches(&state, &pi_uid, &access_token)
+                .await
+                .map_err(map_happy_route_error)?;
         state
             .launch_posture
             .check_pi_auth(&pi_uid, existing_account_id.as_deref())

--- a/apps/backend/src/handlers/auth.rs
+++ b/apps/backend/src/handlers/auth.rs
@@ -5,7 +5,9 @@ use serde_json::Value;
 use crate::{
     SharedState,
     handlers::{ApiResult, bad_request, launch_blocked, map_happy_route_error},
-    services::happy_route::{AuthenticationInput, authenticate_pi_account},
+    services::happy_route::{
+        AuthenticationInput, authenticate_pi_account, find_account_id_by_pi_uid,
+    },
 };
 
 #[derive(Debug, Deserialize)]
@@ -70,11 +72,19 @@ pub async fn authenticate_pi(
         );
     }
 
-    state
-        .launch_posture
-        .check_pi_auth(&pi_uid)
-        .await
-        .map_err(|block| launch_blocked(block.status_code, block.message_code))?;
+    if let Err(block) = state.launch_posture.check_pi_auth(&pi_uid, None).await {
+        if block.message_code != "launch_pilot_not_allowed" {
+            return Err(launch_blocked(block.status_code, block.message_code));
+        }
+        let existing_account_id = find_account_id_by_pi_uid(&state, &pi_uid)
+            .await
+            .map_err(map_happy_route_error)?;
+        state
+            .launch_posture
+            .check_pi_auth(&pi_uid, existing_account_id.as_deref())
+            .await
+            .map_err(|block| launch_blocked(block.status_code, block.message_code))?;
+    }
 
     let authenticated = authenticate_pi_account(
         &state,

--- a/apps/backend/src/handlers/auth.rs
+++ b/apps/backend/src/handlers/auth.rs
@@ -4,7 +4,7 @@ use serde_json::Value;
 
 use crate::{
     SharedState,
-    handlers::{ApiResult, bad_request, launch_blocked, map_happy_route_error},
+    handlers::{ApiResult, bad_request, launch_blocked_from_service, map_happy_route_error},
     services::happy_route::{
         AuthenticationInput, authenticate_pi_account,
         find_account_id_by_pi_uid_if_access_token_matches,
@@ -75,7 +75,7 @@ pub async fn authenticate_pi(
 
     if let Err(block) = state.launch_posture.check_pi_auth(&pi_uid, None).await {
         if block.message_code != "launch_pilot_not_allowed" {
-            return Err(launch_blocked(block.status_code, block.message_code));
+            return Err(launch_blocked_from_service(block));
         }
         let existing_account_id =
             find_account_id_by_pi_uid_if_access_token_matches(&state, &pi_uid, &access_token)
@@ -85,7 +85,7 @@ pub async fn authenticate_pi(
             .launch_posture
             .check_pi_auth(&pi_uid, existing_account_id.as_deref())
             .await
-            .map_err(|block| launch_blocked(block.status_code, block.message_code))?;
+            .map_err(launch_blocked_from_service)?;
     }
 
     let authenticated = authenticate_pi_account(

--- a/apps/backend/src/handlers/auth.rs
+++ b/apps/backend/src/handlers/auth.rs
@@ -4,7 +4,7 @@ use serde_json::Value;
 
 use crate::{
     SharedState,
-    handlers::{ApiResult, bad_request, map_happy_route_error},
+    handlers::{ApiResult, bad_request, launch_blocked, map_happy_route_error},
     services::happy_route::{AuthenticationInput, authenticate_pi_account},
 };
 
@@ -69,6 +69,12 @@ pub async fn authenticate_pi(
             payload.profile.is_some(),
         );
     }
+
+    state
+        .launch_posture
+        .check_pi_auth(&pi_uid)
+        .await
+        .map_err(|block| launch_blocked(block.status_code, block.message_code))?;
 
     let authenticated = authenticate_pi_account(
         &state,

--- a/apps/backend/src/handlers/launch_posture.rs
+++ b/apps/backend/src/handlers/launch_posture.rs
@@ -1,0 +1,45 @@
+use axum::{Json, extract::State, http::HeaderMap};
+
+use crate::{
+    SharedState,
+    handlers::{
+        ApiError, ApiResult, require_bearer_token, require_internal_bearer_token, unauthorized,
+    },
+    services::launch_posture::{InternalLaunchPostureSnapshot, LaunchPostureSnapshot},
+};
+
+pub async fn get_public_launch_posture(
+    State(state): State<SharedState>,
+) -> ApiResult<LaunchPostureSnapshot> {
+    Ok(Json(state.launch_posture.public_snapshot().await))
+}
+
+pub async fn get_internal_launch_posture(
+    State(state): State<SharedState>,
+    headers: HeaderMap,
+) -> ApiResult<InternalLaunchPostureSnapshot> {
+    require_launch_internal_access(&headers)?;
+    Ok(Json(state.launch_posture.internal_snapshot().await))
+}
+
+fn require_launch_internal_access(headers: &HeaderMap) -> Result<(), ApiError> {
+    let has_authorization = headers.contains_key(axum::http::header::AUTHORIZATION);
+    if has_authorization {
+        let token = require_bearer_token(headers)
+            .map_err(|_| unauthorized("internal authorization bearer token is required"))?;
+        if let Some(configured_token) = std::env::var("MUSUBI_INTERNAL_API_TOKEN")
+            .ok()
+            .map(|value| value.trim().to_owned())
+            .filter(|value| !value.is_empty())
+        {
+            if token == configured_token {
+                return Ok(());
+            }
+        }
+        return Err(unauthorized(
+            "participant bearer tokens cannot access internal launch posture",
+        ));
+    }
+
+    require_internal_bearer_token(headers)
+}

--- a/apps/backend/src/handlers/launch_posture.rs
+++ b/apps/backend/src/handlers/launch_posture.rs
@@ -37,7 +37,7 @@ fn require_launch_internal_access(headers: &HeaderMap) -> Result<(), ApiError> {
             }
         }
         return Err(unauthorized(
-            "participant bearer tokens cannot access internal launch posture",
+            "internal authorization bearer token is required",
         ));
     }
 

--- a/apps/backend/src/handlers/mod.rs
+++ b/apps/backend/src/handlers/mod.rs
@@ -7,6 +7,7 @@ use serde::Serialize;
 use crate::services::happy_route::{HappyRouteError, ProviderErrorClass};
 
 pub mod auth;
+pub mod launch_posture;
 pub mod operator_review;
 pub mod ops_observability;
 pub mod orchestration;
@@ -20,6 +21,8 @@ pub mod room_progression;
 #[derive(Debug, Serialize)]
 pub struct ErrorResponse {
     pub error: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message_code: Option<String>,
 }
 
 pub type ApiError = (StatusCode, Json<ErrorResponse>);
@@ -30,6 +33,7 @@ pub fn bad_request(message: impl Into<String>) -> ApiError {
         StatusCode::BAD_REQUEST,
         Json(ErrorResponse {
             error: message.into(),
+            message_code: None,
         }),
     )
 }
@@ -39,6 +43,7 @@ pub fn unauthorized(message: impl Into<String>) -> ApiError {
         StatusCode::UNAUTHORIZED,
         Json(ErrorResponse {
             error: message.into(),
+            message_code: None,
         }),
     )
 }
@@ -48,6 +53,7 @@ pub fn not_found(message: impl Into<String>) -> ApiError {
         StatusCode::NOT_FOUND,
         Json(ErrorResponse {
             error: message.into(),
+            message_code: None,
         }),
     )
 }
@@ -57,6 +63,7 @@ pub fn internal_server_error(message: impl Into<String>) -> ApiError {
         StatusCode::INTERNAL_SERVER_ERROR,
         Json(ErrorResponse {
             error: message.into(),
+            message_code: None,
         }),
     )
 }
@@ -66,6 +73,18 @@ pub fn service_unavailable(message: impl Into<String>) -> ApiError {
         StatusCode::SERVICE_UNAVAILABLE,
         Json(ErrorResponse {
             error: message.into(),
+            message_code: None,
+        }),
+    )
+}
+
+pub fn launch_blocked(status: StatusCode, message_code: impl Into<String>) -> ApiError {
+    let message_code = message_code.into();
+    (
+        status,
+        Json(ErrorResponse {
+            error: message_code.clone(),
+            message_code: Some(message_code),
         }),
     )
 }

--- a/apps/backend/src/handlers/mod.rs
+++ b/apps/backend/src/handlers/mod.rs
@@ -4,7 +4,10 @@ use axum::{
 };
 use serde::Serialize;
 
-use crate::services::happy_route::{HappyRouteError, ProviderErrorClass};
+use crate::services::{
+    happy_route::{HappyRouteError, ProviderErrorClass},
+    launch_posture::{LaunchBlock, LaunchBlockKind},
+};
 
 pub mod auth;
 pub mod launch_posture;
@@ -87,6 +90,14 @@ pub fn launch_blocked(status: StatusCode, message_code: impl Into<String>) -> Ap
             message_code: Some(message_code),
         }),
     )
+}
+
+pub fn launch_blocked_from_service(block: LaunchBlock) -> ApiError {
+    let status = match block.kind {
+        LaunchBlockKind::Forbidden => StatusCode::FORBIDDEN,
+        LaunchBlockKind::ServiceUnavailable => StatusCode::SERVICE_UNAVAILABLE,
+    };
+    launch_blocked(status, block.message_code)
 }
 
 pub fn require_bearer_token(headers: &HeaderMap) -> Result<String, ApiError> {

--- a/apps/backend/src/handlers/operator_review.rs
+++ b/apps/backend/src/handlers/operator_review.rs
@@ -10,12 +10,13 @@ use serde_json::Value;
 use crate::{
     SharedState,
     handlers::{
-        ApiError, ApiResult, bad_request, internal_server_error, map_happy_route_error, not_found,
-        require_bearer_token, require_internal_bearer_token, require_operator_id,
-        service_unavailable, unauthorized,
+        ApiError, ApiResult, bad_request, internal_server_error, launch_blocked,
+        map_happy_route_error, not_found, require_bearer_token, require_internal_bearer_token,
+        require_operator_id, service_unavailable, unauthorized,
     },
     services::{
         happy_route::authorize_account,
+        launch_posture::LaunchAction,
         operator_review::{
             AppealCaseSnapshot, AttachEvidenceBundleInput, CreateAppealCaseInput,
             CreateReviewCaseInput, EvidenceAccessGrantSnapshot, EvidenceBundleSnapshot,
@@ -335,6 +336,15 @@ pub async fn create_appeal_case(
     let authenticated_account = authorize_account(&state, &bearer_token)
         .await
         .map_err(map_happy_route_error)?;
+    state
+        .launch_posture
+        .check_participant_action(
+            LaunchAction::AppealCreation,
+            &authenticated_account.account_id,
+            Some(&authenticated_account.pi_uid),
+        )
+        .await
+        .map_err(|block| launch_blocked(block.status_code, block.message_code))?;
     let snapshot = state
         .operator_review
         .create_appeal_case(

--- a/apps/backend/src/handlers/operator_review.rs
+++ b/apps/backend/src/handlers/operator_review.rs
@@ -10,7 +10,7 @@ use serde_json::Value;
 use crate::{
     SharedState,
     handlers::{
-        ApiError, ApiResult, bad_request, internal_server_error, launch_blocked,
+        ApiError, ApiResult, bad_request, internal_server_error, launch_blocked_from_service,
         map_happy_route_error, not_found, require_bearer_token, require_internal_bearer_token,
         require_operator_id, service_unavailable, unauthorized,
     },
@@ -344,7 +344,7 @@ pub async fn create_appeal_case(
             Some(&authenticated_account.pi_uid),
         )
         .await
-        .map_err(|block| launch_blocked(block.status_code, block.message_code))?;
+        .map_err(launch_blocked_from_service)?;
     let snapshot = state
         .operator_review
         .create_appeal_case(

--- a/apps/backend/src/handlers/promise_intents.rs
+++ b/apps/backend/src/handlers/promise_intents.rs
@@ -3,10 +3,15 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     SharedState,
-    handlers::{ApiResult, bad_request, map_happy_route_error, require_bearer_token},
-    services::happy_route::{
-        PromiseIntentInput, authorize_account,
-        create_promise_intent as create_promise_intent_service,
+    handlers::{
+        ApiResult, bad_request, launch_blocked, map_happy_route_error, require_bearer_token,
+    },
+    services::{
+        happy_route::{
+            PromiseIntentInput, authorize_account,
+            create_promise_intent as create_promise_intent_service,
+        },
+        launch_posture::LaunchAction,
     },
 };
 
@@ -37,6 +42,14 @@ pub async fn create_promise_intent(
     let authenticated_account = authorize_account(&state, &bearer_token)
         .await
         .map_err(map_happy_route_error)?;
+    state
+        .launch_posture
+        .check_participant_action(
+            LaunchAction::PromiseCreation,
+            &authenticated_account.account_id,
+        )
+        .await
+        .map_err(|block| launch_blocked(block.status_code, block.message_code))?;
     let internal_idempotency_key = payload.internal_idempotency_key.trim().to_owned();
     if internal_idempotency_key.is_empty() {
         return Err(bad_request("internal_idempotency_key is required"));

--- a/apps/backend/src/handlers/promise_intents.rs
+++ b/apps/backend/src/handlers/promise_intents.rs
@@ -47,6 +47,7 @@ pub async fn create_promise_intent(
         .check_participant_action(
             LaunchAction::PromiseCreation,
             &authenticated_account.account_id,
+            Some(&authenticated_account.pi_uid),
         )
         .await
         .map_err(|block| launch_blocked(block.status_code, block.message_code))?;

--- a/apps/backend/src/handlers/promise_intents.rs
+++ b/apps/backend/src/handlers/promise_intents.rs
@@ -4,7 +4,8 @@ use serde::{Deserialize, Serialize};
 use crate::{
     SharedState,
     handlers::{
-        ApiResult, bad_request, launch_blocked, map_happy_route_error, require_bearer_token,
+        ApiResult, bad_request, launch_blocked_from_service, map_happy_route_error,
+        require_bearer_token,
     },
     services::{
         happy_route::{
@@ -50,7 +51,7 @@ pub async fn create_promise_intent(
             Some(&authenticated_account.pi_uid),
         )
         .await
-        .map_err(|block| launch_blocked(block.status_code, block.message_code))?;
+        .map_err(launch_blocked_from_service)?;
     let internal_idempotency_key = payload.internal_idempotency_key.trim().to_owned();
     if internal_idempotency_key.is_empty() {
         return Err(bad_request("internal_idempotency_key is required"));

--- a/apps/backend/src/handlers/proof.rs
+++ b/apps/backend/src/handlers/proof.rs
@@ -68,6 +68,7 @@ pub async fn start_proof_challenge(
         .check_participant_action(
             LaunchAction::ProofChallenge,
             &authenticated_account.account_id,
+            Some(&authenticated_account.pi_uid),
         )
         .await
         .map_err(|block| launch_blocked(block.status_code, block.message_code))?;
@@ -117,6 +118,7 @@ pub async fn submit_proof_envelope(
         .check_participant_action(
             LaunchAction::ProofSubmission,
             &authenticated_account.account_id,
+            Some(&authenticated_account.pi_uid),
         )
         .await
         .map_err(|block| launch_blocked(block.status_code, block.message_code))?;

--- a/apps/backend/src/handlers/proof.rs
+++ b/apps/backend/src/handlers/proof.rs
@@ -5,7 +5,8 @@ use serde::{Deserialize, Serialize};
 use crate::{
     SharedState,
     handlers::{
-        ApiResult, bad_request, launch_blocked, map_happy_route_error, require_bearer_token,
+        ApiResult, bad_request, launch_blocked_from_service, map_happy_route_error,
+        require_bearer_token,
     },
     services::{
         happy_route::authorize_account,
@@ -71,7 +72,7 @@ pub async fn start_proof_challenge(
             Some(&authenticated_account.pi_uid),
         )
         .await
-        .map_err(|block| launch_blocked(block.status_code, block.message_code))?;
+        .map_err(launch_blocked_from_service)?;
     if public_fallback_mode(&payload.fallback_mode)? != "none" {
         return Err(bad_request(
             "operator_pin fallback is not available from the public proof challenge endpoint",
@@ -121,7 +122,7 @@ pub async fn submit_proof_envelope(
             Some(&authenticated_account.pi_uid),
         )
         .await
-        .map_err(|block| launch_blocked(block.status_code, block.message_code))?;
+        .map_err(launch_blocked_from_service)?;
 
     let outcome = submit_proof_envelope_service(
         &state,

--- a/apps/backend/src/handlers/proof.rs
+++ b/apps/backend/src/handlers/proof.rs
@@ -4,9 +4,12 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     SharedState,
-    handlers::{ApiResult, bad_request, map_happy_route_error, require_bearer_token},
+    handlers::{
+        ApiResult, bad_request, launch_blocked, map_happy_route_error, require_bearer_token,
+    },
     services::{
         happy_route::authorize_account,
+        launch_posture::LaunchAction,
         proof::{
             ProofEnvelopeInput, ProofSubmissionOutcome, StartProofChallengeInput,
             start_proof_challenge as start_proof_challenge_service,
@@ -60,6 +63,14 @@ pub async fn start_proof_challenge(
     let authenticated_account = authorize_account(&state, &bearer_token)
         .await
         .map_err(map_happy_route_error)?;
+    state
+        .launch_posture
+        .check_participant_action(
+            LaunchAction::ProofChallenge,
+            &authenticated_account.account_id,
+        )
+        .await
+        .map_err(|block| launch_blocked(block.status_code, block.message_code))?;
     if public_fallback_mode(&payload.fallback_mode)? != "none" {
         return Err(bad_request(
             "operator_pin fallback is not available from the public proof challenge endpoint",
@@ -101,6 +112,14 @@ pub async fn submit_proof_envelope(
     let authenticated_account = authorize_account(&state, &bearer_token)
         .await
         .map_err(map_happy_route_error)?;
+    state
+        .launch_posture
+        .check_participant_action(
+            LaunchAction::ProofSubmission,
+            &authenticated_account.account_id,
+        )
+        .await
+        .map_err(|block| launch_blocked(block.status_code, block.message_code))?;
 
     let outcome = submit_proof_envelope_service(
         &state,

--- a/apps/backend/src/handlers/realm_bootstrap.rs
+++ b/apps/backend/src/handlers/realm_bootstrap.rs
@@ -436,6 +436,11 @@ pub async fn create_realm_admission(
     require_internal_bearer_token(&headers)?;
     let operator_id = require_operator_id(&headers)?;
     state
+        .realm_bootstrap
+        .ensure_operator_write_role(&operator_id)
+        .await
+        .map_err(map_realm_bootstrap_error)?;
+    state
         .launch_posture
         .check_participant_action(
             LaunchAction::RealmAdmission,

--- a/apps/backend/src/handlers/realm_bootstrap.rs
+++ b/apps/backend/src/handlers/realm_bootstrap.rs
@@ -12,12 +12,12 @@ use crate::{
     SharedState,
     handlers::{
         ApiError, ApiResult, bad_request, internal_server_error, launch_blocked,
-        map_happy_route_error, not_found, require_bearer_token, require_internal_bearer_token,
-        require_operator_id, service_unavailable, unauthorized,
+        launch_blocked_from_service, map_happy_route_error, not_found, require_bearer_token,
+        require_internal_bearer_token, require_operator_id, service_unavailable, unauthorized,
     },
     services::{
         happy_route::authorize_account,
-        launch_posture::LaunchAction,
+        launch_posture::{LaunchAction, LaunchBlockKind},
         realm_bootstrap::{
             CreateRealmAdmissionInput, CreateRealmRequestInput, CreateRealmSponsorRecordInput,
             ListRealmRequestsInput, RealmAdmissionSnapshot, RealmAdmissionViewSnapshot,
@@ -262,7 +262,7 @@ pub async fn create_realm_request(
             Some(&account.pi_uid),
         )
         .await
-        .map_err(|block| launch_blocked(block.status_code, block.message_code))?;
+        .map_err(launch_blocked_from_service)?;
     let snapshot = state
         .realm_bootstrap
         .create_realm_request(
@@ -452,7 +452,7 @@ pub async fn create_realm_admission(
             launch_config
                 .check_participant_action(LaunchAction::RealmAdmission, account_id, None)
                 .map_err(|block| RealmBootstrapError::LaunchBlocked {
-                    status_code: block.status_code,
+                    kind: block.kind,
                     message_code: block.message_code,
                 })
         })
@@ -718,10 +718,13 @@ fn map_realm_bootstrap_error(error: RealmBootstrapError) -> ApiError {
                 internal_server_error("internal server error")
             }
         }
-        RealmBootstrapError::LaunchBlocked {
-            status_code,
+        RealmBootstrapError::LaunchBlocked { kind, message_code } => launch_blocked(
+            match kind {
+                LaunchBlockKind::Forbidden => axum::http::StatusCode::FORBIDDEN,
+                LaunchBlockKind::ServiceUnavailable => axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            },
             message_code,
-        } => launch_blocked(status_code, message_code),
+        ),
         RealmBootstrapError::Internal(message) => {
             eprintln!("internal realm bootstrap error: {message}");
             internal_server_error("internal server error")

--- a/apps/backend/src/handlers/realm_bootstrap.rs
+++ b/apps/backend/src/handlers/realm_bootstrap.rs
@@ -435,36 +435,36 @@ pub async fn create_realm_admission(
 ) -> ApiResult<RealmAdmissionResponse> {
     require_internal_bearer_token(&headers)?;
     let operator_id = require_operator_id(&headers)?;
-    state
+    let input = CreateRealmAdmissionInput {
+        account_id: payload.account_id,
+        sponsor_record_id: payload.sponsor_record_id,
+        source_fact_kind: payload.source_fact_kind,
+        source_fact_id: payload.source_fact_id,
+        source_snapshot_json: payload
+            .source_snapshot_json
+            .unwrap_or_else(|| Value::Object(Default::default())),
+        request_idempotency_key: payload.request_idempotency_key,
+    };
+    let admission_replay = state
         .realm_bootstrap
-        .ensure_operator_write_role(&operator_id)
+        .is_realm_admission_replay(&operator_id, realm_id.trim(), &input)
         .await
         .map_err(map_realm_bootstrap_error)?;
-    state
-        .launch_posture
-        .check_participant_action(
-            LaunchAction::RealmAdmission,
-            payload.account_id.trim(),
-            None,
-        )
-        .await
-        .map_err(|block| launch_blocked(block.status_code, block.message_code))?;
+    if !admission_replay {
+        state
+            .realm_bootstrap
+            .ensure_operator_write_role(&operator_id)
+            .await
+            .map_err(map_realm_bootstrap_error)?;
+        state
+            .launch_posture
+            .check_participant_action(LaunchAction::RealmAdmission, input.account_id.trim(), None)
+            .await
+            .map_err(|block| launch_blocked(block.status_code, block.message_code))?;
+    }
     let snapshot = state
         .realm_bootstrap
-        .create_realm_admission(
-            &operator_id,
-            realm_id.trim(),
-            CreateRealmAdmissionInput {
-                account_id: payload.account_id,
-                sponsor_record_id: payload.sponsor_record_id,
-                source_fact_kind: payload.source_fact_kind,
-                source_fact_id: payload.source_fact_id,
-                source_snapshot_json: payload
-                    .source_snapshot_json
-                    .unwrap_or_else(|| Value::Object(Default::default())),
-                request_idempotency_key: payload.request_idempotency_key,
-            },
-        )
+        .create_realm_admission(&operator_id, realm_id.trim(), input)
         .await
         .map_err(map_realm_bootstrap_error)?;
     Ok(Json(realm_admission_response(snapshot)))

--- a/apps/backend/src/handlers/realm_bootstrap.rs
+++ b/apps/backend/src/handlers/realm_bootstrap.rs
@@ -256,7 +256,11 @@ pub async fn create_realm_request(
         .map_err(map_happy_route_error)?;
     state
         .launch_posture
-        .check_participant_action(LaunchAction::RealmRequest, &account.account_id)
+        .check_participant_action(
+            LaunchAction::RealmRequest,
+            &account.account_id,
+            Some(&account.pi_uid),
+        )
         .await
         .map_err(|block| launch_blocked(block.status_code, block.message_code))?;
     let snapshot = state
@@ -433,7 +437,11 @@ pub async fn create_realm_admission(
     let operator_id = require_operator_id(&headers)?;
     state
         .launch_posture
-        .check_participant_action(LaunchAction::RealmAdmission, payload.account_id.trim())
+        .check_participant_action(
+            LaunchAction::RealmAdmission,
+            payload.account_id.trim(),
+            None,
+        )
         .await
         .map_err(|block| launch_blocked(block.status_code, block.message_code))?;
     let snapshot = state

--- a/apps/backend/src/handlers/realm_bootstrap.rs
+++ b/apps/backend/src/handlers/realm_bootstrap.rs
@@ -11,12 +11,13 @@ use serde_json::Value;
 use crate::{
     SharedState,
     handlers::{
-        ApiError, ApiResult, bad_request, internal_server_error, map_happy_route_error, not_found,
-        require_bearer_token, require_internal_bearer_token, require_operator_id,
-        service_unavailable, unauthorized,
+        ApiError, ApiResult, bad_request, internal_server_error, launch_blocked,
+        map_happy_route_error, not_found, require_bearer_token, require_internal_bearer_token,
+        require_operator_id, service_unavailable, unauthorized,
     },
     services::{
         happy_route::authorize_account,
+        launch_posture::LaunchAction,
         realm_bootstrap::{
             CreateRealmAdmissionInput, CreateRealmRequestInput, CreateRealmSponsorRecordInput,
             ListRealmRequestsInput, RealmAdmissionSnapshot, RealmAdmissionViewSnapshot,
@@ -253,6 +254,11 @@ pub async fn create_realm_request(
     let account = authorize_account(&state, &token)
         .await
         .map_err(map_happy_route_error)?;
+    state
+        .launch_posture
+        .check_participant_action(LaunchAction::RealmRequest, &account.account_id)
+        .await
+        .map_err(|block| launch_blocked(block.status_code, block.message_code))?;
     let snapshot = state
         .realm_bootstrap
         .create_realm_request(
@@ -425,6 +431,11 @@ pub async fn create_realm_admission(
 ) -> ApiResult<RealmAdmissionResponse> {
     require_internal_bearer_token(&headers)?;
     let operator_id = require_operator_id(&headers)?;
+    state
+        .launch_posture
+        .check_participant_action(LaunchAction::RealmAdmission, payload.account_id.trim())
+        .await
+        .map_err(|block| launch_blocked(block.status_code, block.message_code))?;
     let snapshot = state
         .realm_bootstrap
         .create_realm_admission(

--- a/apps/backend/src/handlers/realm_bootstrap.rs
+++ b/apps/backend/src/handlers/realm_bootstrap.rs
@@ -445,26 +445,17 @@ pub async fn create_realm_admission(
             .unwrap_or_else(|| Value::Object(Default::default())),
         request_idempotency_key: payload.request_idempotency_key,
     };
-    let admission_replay = state
-        .realm_bootstrap
-        .is_realm_admission_replay(&operator_id, realm_id.trim(), &input)
-        .await
-        .map_err(map_realm_bootstrap_error)?;
-    if !admission_replay {
-        state
-            .realm_bootstrap
-            .ensure_operator_write_role(&operator_id)
-            .await
-            .map_err(map_realm_bootstrap_error)?;
-        state
-            .launch_posture
-            .check_participant_action(LaunchAction::RealmAdmission, input.account_id.trim(), None)
-            .await
-            .map_err(|block| launch_blocked(block.status_code, block.message_code))?;
-    }
+    let launch_config = state.launch_posture.config_snapshot_for_check().await;
     let snapshot = state
         .realm_bootstrap
-        .create_realm_admission(&operator_id, realm_id.trim(), input)
+        .create_realm_admission(&operator_id, realm_id.trim(), input, |account_id| {
+            launch_config
+                .check_participant_action(LaunchAction::RealmAdmission, account_id, None)
+                .map_err(|block| RealmBootstrapError::LaunchBlocked {
+                    status_code: block.status_code,
+                    message_code: block.message_code,
+                })
+        })
         .await
         .map_err(map_realm_bootstrap_error)?;
     Ok(Json(realm_admission_response(snapshot)))
@@ -727,6 +718,10 @@ fn map_realm_bootstrap_error(error: RealmBootstrapError) -> ApiError {
                 internal_server_error("internal server error")
             }
         }
+        RealmBootstrapError::LaunchBlocked {
+            status_code,
+            message_code,
+        } => launch_blocked(status_code, message_code),
         RealmBootstrapError::Internal(message) => {
             eprintln!("internal realm bootstrap error: {message}");
             internal_server_error("internal server error")

--- a/apps/backend/src/lib.rs
+++ b/apps/backend/src/lib.rs
@@ -23,6 +23,7 @@ pub type SharedState = Arc<AppState>;
 
 pub struct AppState {
     pub happy_route: services::happy_route::HappyRouteStore,
+    pub launch_posture: services::launch_posture::LaunchPostureService,
     pub ops_observability: services::ops_observability::OpsObservabilityStore,
     pub operator_review: services::operator_review::OperatorReviewStore,
     pub realm_bootstrap: services::realm_bootstrap::RealmBootstrapStore,
@@ -45,6 +46,7 @@ pub async fn new_state() -> musubi_db_runtime::Result<SharedState> {
 pub async fn new_state_from_config(config: &DbConfig) -> musubi_db_runtime::Result<SharedState> {
     Ok(Arc::new(AppState {
         happy_route: services::happy_route::HappyRouteStore::connect(config).await?,
+        launch_posture: services::launch_posture::LaunchPostureService::from_env(),
         ops_observability: services::ops_observability::OpsObservabilityStore::connect(config)
             .await?,
         operator_review: services::operator_review::OperatorReviewStore::connect(config).await?,
@@ -92,6 +94,12 @@ pub async fn new_test_state() -> Result<TestState, String> {
         .await
         .map_err(|error| error.to_string())?;
     state
+        .launch_posture
+        .replace_config_for_test(
+            services::launch_posture::LaunchPostureConfig::open_preview_for_test(),
+        )
+        .await;
+    state
         .ops_observability
         .reset_for_test()
         .await
@@ -130,6 +138,10 @@ pub fn build_app(state: SharedState) -> Router {
 
     let app = Router::new()
         .route("/health", get(health))
+        .route(
+            "/api/launch/posture",
+            get(handlers::launch_posture::get_public_launch_posture),
+        )
         .route("/api/auth/pi", post(handlers::auth::authenticate_pi))
         .route(
             "/api/promise/intents",
@@ -204,6 +216,10 @@ pub fn build_app(state: SharedState) -> Router {
         .route(
             "/api/internal/ops/observability/slo",
             get(handlers::ops_observability::get_ops_slo),
+        )
+        .route(
+            "/api/internal/launch/posture",
+            get(handlers::launch_posture::get_internal_launch_posture),
         );
     let app = if unauthenticated_pi_callback_enabled() {
         app.route(

--- a/apps/backend/src/lib.rs
+++ b/apps/backend/src/lib.rs
@@ -61,6 +61,24 @@ pub struct TestState {
     _guard: OwnedMutexGuard<()>,
 }
 
+impl TestState {
+    pub async fn replace_launch_config_for_test(
+        &self,
+        config: services::launch_posture::LaunchPostureConfig,
+    ) {
+        self.replace_launch_config_for_state_for_test(&self.state, config)
+            .await;
+    }
+
+    pub async fn replace_launch_config_for_state_for_test(
+        &self,
+        state: &SharedState,
+        config: services::launch_posture::LaunchPostureConfig,
+    ) {
+        state.launch_posture.replace_config_for_test(config).await;
+    }
+}
+
 static TEST_DB_LOCK: OnceLock<Arc<AsyncMutex<()>>> = OnceLock::new();
 static TEST_DB_MIGRATED: OnceLock<Arc<AsyncMutex<bool>>> = OnceLock::new();
 

--- a/apps/backend/src/services/happy_route/auth.rs
+++ b/apps/backend/src/services/happy_route/auth.rs
@@ -16,6 +16,17 @@ pub async fn find_account_id_by_pi_uid(
     state.happy_route.find_account_id_by_pi_uid(pi_uid).await
 }
 
+pub async fn find_account_id_by_pi_uid_if_access_token_matches(
+    state: &SharedState,
+    pi_uid: &str,
+    access_token: &str,
+) -> Result<Option<String>, HappyRouteError> {
+    state
+        .happy_route
+        .find_account_id_by_pi_uid_if_access_token_matches(pi_uid, access_token)
+        .await
+}
+
 pub async fn authorize_account(
     state: &SharedState,
     token: &str,

--- a/apps/backend/src/services/happy_route/auth.rs
+++ b/apps/backend/src/services/happy_route/auth.rs
@@ -9,6 +9,13 @@ pub async fn authenticate_pi_account(
     state.happy_route.authenticate_pi_account(input).await
 }
 
+pub async fn find_account_id_by_pi_uid(
+    state: &SharedState,
+    pi_uid: &str,
+) -> Result<Option<String>, HappyRouteError> {
+    state.happy_route.find_account_id_by_pi_uid(pi_uid).await
+}
+
 pub async fn authorize_account(
     state: &SharedState,
     token: &str,

--- a/apps/backend/src/services/happy_route/mod.rs
+++ b/apps/backend/src/services/happy_route/mod.rs
@@ -11,7 +11,10 @@ mod repository;
 mod state;
 mod types;
 
-pub use auth::{authenticate_pi_account, authorize_account, find_account_id_by_pi_uid};
+pub use auth::{
+    authenticate_pi_account, authorize_account, find_account_id_by_pi_uid,
+    find_account_id_by_pi_uid_if_access_token_matches,
+};
 pub use callback::{accept_payment_callback, get_settlement_view};
 pub use orchestration::drain_outbox;
 pub use projection_read::{

--- a/apps/backend/src/services/happy_route/mod.rs
+++ b/apps/backend/src/services/happy_route/mod.rs
@@ -11,7 +11,7 @@ mod repository;
 mod state;
 mod types;
 
-pub use auth::{authenticate_pi_account, authorize_account};
+pub use auth::{authenticate_pi_account, authorize_account, find_account_id_by_pi_uid};
 pub use callback::{accept_payment_callback, get_settlement_view};
 pub use orchestration::drain_outbox;
 pub use projection_read::{

--- a/apps/backend/src/services/happy_route/repository.rs
+++ b/apps/backend/src/services/happy_route/repository.rs
@@ -226,6 +226,28 @@ impl HappyRouteStore {
         })
     }
 
+    pub(super) async fn find_account_id_by_pi_uid(
+        &self,
+        pi_uid: &str,
+    ) -> Result<Option<String>, HappyRouteError> {
+        let client = self.client.lock().await;
+        let row = client
+            .query_opt(
+                "
+                SELECT account_id
+                FROM core.pi_account_links
+                WHERE pi_uid = $1
+                ",
+                &[&pi_uid],
+            )
+            .await
+            .map_err(db_error)?;
+        Ok(row.map(|row| {
+            let account_id: Uuid = row.get("account_id");
+            account_id.to_string()
+        }))
+    }
+
     pub(super) async fn authorize_account(
         &self,
         token: &str,

--- a/apps/backend/src/services/happy_route/repository.rs
+++ b/apps/backend/src/services/happy_route/repository.rs
@@ -248,6 +248,31 @@ impl HappyRouteStore {
         }))
     }
 
+    pub(super) async fn find_account_id_by_pi_uid_if_access_token_matches(
+        &self,
+        pi_uid: &str,
+        access_token: &str,
+    ) -> Result<Option<String>, HappyRouteError> {
+        let access_token_digest = digest_access_token(access_token);
+        let client = self.client.lock().await;
+        let row = client
+            .query_opt(
+                "
+                SELECT account_id
+                FROM core.pi_account_links
+                WHERE pi_uid = $1
+                  AND access_token_digest = $2
+                ",
+                &[&pi_uid, &access_token_digest],
+            )
+            .await
+            .map_err(db_error)?;
+        Ok(row.map(|row| {
+            let account_id: Uuid = row.get("account_id");
+            account_id.to_string()
+        }))
+    }
+
     pub(super) async fn authorize_account(
         &self,
         token: &str,

--- a/apps/backend/src/services/launch_posture/mod.rs
+++ b/apps/backend/src/services/launch_posture/mod.rs
@@ -2,6 +2,6 @@ mod service;
 
 pub use service::{
     InternalLaunchPostureSnapshot, KillSwitchSnapshot, LaunchAction, LaunchAllowlistSnapshot,
-    LaunchBlock, LaunchMode, LaunchPostureConfig, LaunchPostureService, LaunchPostureSnapshot,
-    LaunchSupportContact,
+    LaunchBlock, LaunchBlockKind, LaunchMode, LaunchPostureConfig, LaunchPostureService,
+    LaunchPostureSnapshot, LaunchSupportContact,
 };

--- a/apps/backend/src/services/launch_posture/mod.rs
+++ b/apps/backend/src/services/launch_posture/mod.rs
@@ -1,0 +1,7 @@
+mod service;
+
+pub use service::{
+    InternalLaunchPostureSnapshot, KillSwitchSnapshot, LaunchAction, LaunchAllowlistSnapshot,
+    LaunchBlock, LaunchMode, LaunchPostureConfig, LaunchPostureService, LaunchPostureSnapshot,
+    LaunchSupportContact,
+};

--- a/apps/backend/src/services/launch_posture/service.rs
+++ b/apps/backend/src/services/launch_posture/service.rs
@@ -3,6 +3,7 @@ use std::{collections::BTreeSet, sync::Arc};
 use chrono::{DateTime, Utc};
 use serde::Serialize;
 use tokio::sync::RwLock;
+use uuid::Uuid;
 
 const MODE_KEY: &str = "MUSUBI_LAUNCH_MODE";
 const ALLOWLIST_PI_UIDS_KEY: &str = "MUSUBI_LAUNCH_ALLOWLIST_PI_UIDS";
@@ -204,7 +205,10 @@ impl LaunchPostureConfig {
         Self {
             mode,
             allowlist_pi_uids: parse_allowlist(lookup(ALLOWLIST_PI_UIDS_KEY)),
-            allowlist_account_ids: parse_allowlist(lookup(ALLOWLIST_ACCOUNT_IDS_KEY)),
+            allowlist_account_ids: parse_account_id_allowlist(
+                lookup(ALLOWLIST_ACCOUNT_IDS_KEY),
+                &mut config_warnings,
+            ),
             support_contact,
             kill_switches,
             config_warnings,
@@ -461,6 +465,25 @@ fn parse_allowlist(value: Option<String>) -> BTreeSet<String> {
         .collect()
 }
 
+fn parse_account_id_allowlist(
+    value: Option<String>,
+    warnings: &mut Vec<String>,
+) -> BTreeSet<String> {
+    let mut account_ids = BTreeSet::new();
+    for entry in value.unwrap_or_default().split(',').map(str::trim) {
+        if entry.is_empty() {
+            continue;
+        }
+        match Uuid::parse_str(entry) {
+            Ok(account_id) => {
+                account_ids.insert(account_id.to_string());
+            }
+            Err(_) => warnings.push("invalid_account_id_allowlist_entry".to_owned()),
+        }
+    }
+    account_ids
+}
+
 fn parse_support_contact(
     label: Option<String>,
     url: Option<String>,
@@ -489,7 +512,9 @@ fn block_service_unavailable(message_code: &'static str) -> LaunchBlock {
 
 #[cfg(test)]
 mod tests {
-    use super::{LaunchMode, LaunchPostureConfig};
+    use uuid::Uuid;
+
+    use super::{LaunchAction, LaunchMode, LaunchPostureConfig};
 
     #[test]
     fn missing_launch_mode_defaults_closed() {
@@ -504,5 +529,39 @@ mod tests {
         });
         assert_eq!(config.mode, LaunchMode::Closed);
         assert_eq!(config.config_warnings, vec!["invalid_launch_mode"]);
+    }
+
+    #[test]
+    fn account_id_allowlist_normalizes_uuid_entries_and_warns_invalid() {
+        let account_id = Uuid::new_v4();
+        let config = LaunchPostureConfig::from_lookup(|name| match name {
+            "MUSUBI_LAUNCH_MODE" => Some("pilot".to_owned()),
+            "MUSUBI_LAUNCH_ALLOWLIST_ACCOUNT_IDS" => Some(format!(
+                "{},not-a-uuid",
+                account_id.to_string().to_uppercase()
+            )),
+            _ => None,
+        });
+
+        assert_eq!(config.allowlist_account_ids.len(), 1);
+        assert!(
+            config
+                .allowlist_account_ids
+                .contains(&account_id.to_string())
+        );
+        assert!(
+            config
+                .config_warnings
+                .contains(&"invalid_account_id_allowlist_entry".to_owned())
+        );
+        assert!(
+            config
+                .check_participant_action(
+                    LaunchAction::RealmRequest,
+                    &account_id.to_string(),
+                    None,
+                )
+                .is_ok()
+        );
     }
 }

--- a/apps/backend/src/services/launch_posture/service.rs
+++ b/apps/backend/src/services/launch_posture/service.rs
@@ -112,7 +112,7 @@ impl LaunchPostureService {
         }
     }
 
-    pub async fn replace_config_for_test(&self, config: LaunchPostureConfig) {
+    pub(crate) async fn replace_config_for_test(&self, config: LaunchPostureConfig) {
         *self.config.write().await = config;
     }
 
@@ -135,11 +135,12 @@ impl LaunchPostureService {
         &self,
         action: LaunchAction,
         account_id: &str,
+        pi_uid: Option<&str>,
     ) -> Result<(), LaunchBlock> {
         self.config
             .read()
             .await
-            .check_account_action(action, account_id)
+            .check_participant_action(action, account_id, pi_uid)
     }
 }
 
@@ -307,10 +308,11 @@ impl LaunchPostureConfig {
         }
     }
 
-    fn check_account_action(
+    fn check_participant_action(
         &self,
         action: LaunchAction,
         account_id: &str,
+        pi_uid: Option<&str>,
     ) -> Result<(), LaunchBlock> {
         if let Some(block) = self.kill_switch_block(action) {
             return Err(block);
@@ -320,7 +322,9 @@ impl LaunchPostureConfig {
             LaunchMode::Paused => Err(block_service_unavailable("launch_paused")),
             LaunchMode::Closed => Err(block_forbidden("launch_closed")),
             LaunchMode::Pilot => {
-                if self.allowlist_account_ids.contains(account_id) {
+                if self.allowlist_account_ids.contains(account_id)
+                    || pi_uid.is_some_and(|pi_uid| self.allowlist_pi_uids.contains(pi_uid))
+                {
                     Ok(())
                 } else {
                     Err(block_forbidden("launch_pilot_not_allowed"))

--- a/apps/backend/src/services/launch_posture/service.rs
+++ b/apps/backend/src/services/launch_posture/service.rs
@@ -101,8 +101,14 @@ pub struct LaunchAllowlistSnapshot {
 
 #[derive(Clone, Debug)]
 pub struct LaunchBlock {
-    pub status_code: axum::http::StatusCode,
+    pub kind: LaunchBlockKind,
     pub message_code: &'static str,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LaunchBlockKind {
+    Forbidden,
+    ServiceUnavailable,
 }
 
 impl LaunchPostureService {
@@ -502,14 +508,14 @@ fn parse_support_contact(
 
 fn block_forbidden(message_code: &'static str) -> LaunchBlock {
     LaunchBlock {
-        status_code: axum::http::StatusCode::FORBIDDEN,
+        kind: LaunchBlockKind::Forbidden,
         message_code,
     }
 }
 
 fn block_service_unavailable(message_code: &'static str) -> LaunchBlock {
     LaunchBlock {
-        status_code: axum::http::StatusCode::SERVICE_UNAVAILABLE,
+        kind: LaunchBlockKind::ServiceUnavailable,
         message_code,
     }
 }

--- a/apps/backend/src/services/launch_posture/service.rs
+++ b/apps/backend/src/services/launch_posture/service.rs
@@ -15,6 +15,7 @@ const KILL_SWITCH_PROOF_CHALLENGE_KEY: &str = "MUSUBI_KILL_SWITCH_PROOF_CHALLENG
 const KILL_SWITCH_PROOF_SUBMISSION_KEY: &str = "MUSUBI_KILL_SWITCH_PROOF_SUBMISSION";
 const KILL_SWITCH_REALM_REQUESTS_KEY: &str = "MUSUBI_KILL_SWITCH_REALM_REQUESTS";
 const KILL_SWITCH_REALM_ADMISSIONS_KEY: &str = "MUSUBI_KILL_SWITCH_REALM_ADMISSIONS";
+const KILL_SWITCH_APPEAL_CREATION_KEY: &str = "MUSUBI_KILL_SWITCH_APPEAL_CREATION";
 
 #[derive(Clone)]
 pub struct LaunchPostureService {
@@ -37,6 +38,7 @@ pub enum LaunchAction {
     ProofSubmission,
     RealmRequest,
     RealmAdmission,
+    AppealCreation,
 }
 
 #[derive(Clone, Debug)]
@@ -63,6 +65,7 @@ pub struct KillSwitchSnapshot {
     pub proof_submission: bool,
     pub realm_requests: bool,
     pub realm_admissions: bool,
+    pub appeal_creation: bool,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -187,6 +190,11 @@ impl LaunchPostureConfig {
                 lookup(KILL_SWITCH_REALM_ADMISSIONS_KEY).as_deref(),
                 &mut config_warnings,
             ),
+            appeal_creation: parse_bool_switch(
+                KILL_SWITCH_APPEAL_CREATION_KEY,
+                lookup(KILL_SWITCH_APPEAL_CREATION_KEY).as_deref(),
+                &mut config_warnings,
+            ),
         };
         let support_contact = parse_support_contact(
             lookup(SUPPORT_CONTACT_LABEL_KEY),
@@ -261,6 +269,7 @@ impl LaunchPostureConfig {
             LaunchAction::ProofSubmission => config.kill_switches.proof_submission = true,
             LaunchAction::RealmRequest => config.kill_switches.realm_requests = true,
             LaunchAction::RealmAdmission => config.kill_switches.realm_admissions = true,
+            LaunchAction::AppealCreation => config.kill_switches.appeal_creation = true,
         }
         config
     }
@@ -362,6 +371,9 @@ impl LaunchPostureConfig {
             }
             LaunchAction::RealmAdmission if self.kill_switches.realm_admissions => {
                 "realm_admission_paused"
+            }
+            LaunchAction::AppealCreation if self.kill_switches.appeal_creation => {
+                "appeal_creation_paused"
             }
             _ => return None,
         };

--- a/apps/backend/src/services/launch_posture/service.rs
+++ b/apps/backend/src/services/launch_posture/service.rs
@@ -128,6 +128,10 @@ impl LaunchPostureService {
         self.config.read().await.internal_snapshot()
     }
 
+    pub(crate) async fn config_snapshot_for_check(&self) -> LaunchPostureConfig {
+        self.config.read().await.clone()
+    }
+
     pub async fn check_pi_auth(
         &self,
         pi_uid: &str,
@@ -333,7 +337,7 @@ impl LaunchPostureConfig {
         }
     }
 
-    fn check_participant_action(
+    pub(crate) fn check_participant_action(
         &self,
         action: LaunchAction,
         account_id: &str,

--- a/apps/backend/src/services/launch_posture/service.rs
+++ b/apps/backend/src/services/launch_posture/service.rs
@@ -1,0 +1,480 @@
+use std::{collections::BTreeSet, sync::Arc};
+
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use tokio::sync::RwLock;
+
+const MODE_KEY: &str = "MUSUBI_LAUNCH_MODE";
+const ALLOWLIST_PI_UIDS_KEY: &str = "MUSUBI_LAUNCH_ALLOWLIST_PI_UIDS";
+const ALLOWLIST_ACCOUNT_IDS_KEY: &str = "MUSUBI_LAUNCH_ALLOWLIST_ACCOUNT_IDS";
+const SUPPORT_CONTACT_URL_KEY: &str = "MUSUBI_LAUNCH_SUPPORT_CONTACT_URL";
+const SUPPORT_CONTACT_LABEL_KEY: &str = "MUSUBI_LAUNCH_SUPPORT_CONTACT_LABEL";
+const KILL_SWITCH_AUTH_KEY: &str = "MUSUBI_KILL_SWITCH_AUTH";
+const KILL_SWITCH_PROMISE_CREATION_KEY: &str = "MUSUBI_KILL_SWITCH_PROMISE_CREATION";
+const KILL_SWITCH_PROOF_CHALLENGE_KEY: &str = "MUSUBI_KILL_SWITCH_PROOF_CHALLENGE";
+const KILL_SWITCH_PROOF_SUBMISSION_KEY: &str = "MUSUBI_KILL_SWITCH_PROOF_SUBMISSION";
+const KILL_SWITCH_REALM_REQUESTS_KEY: &str = "MUSUBI_KILL_SWITCH_REALM_REQUESTS";
+const KILL_SWITCH_REALM_ADMISSIONS_KEY: &str = "MUSUBI_KILL_SWITCH_REALM_ADMISSIONS";
+
+#[derive(Clone)]
+pub struct LaunchPostureService {
+    config: Arc<RwLock<LaunchPostureConfig>>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LaunchMode {
+    Closed,
+    Pilot,
+    Paused,
+    OpenPreview,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LaunchAction {
+    Auth,
+    PromiseCreation,
+    ProofChallenge,
+    ProofSubmission,
+    RealmRequest,
+    RealmAdmission,
+}
+
+#[derive(Clone, Debug)]
+pub struct LaunchPostureConfig {
+    mode: LaunchMode,
+    allowlist_pi_uids: BTreeSet<String>,
+    allowlist_account_ids: BTreeSet<String>,
+    support_contact: Option<LaunchSupportContact>,
+    kill_switches: KillSwitchSnapshot,
+    config_warnings: Vec<String>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct LaunchSupportContact {
+    pub label: String,
+    pub url: String,
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct KillSwitchSnapshot {
+    pub auth: bool,
+    pub promise_creation: bool,
+    pub proof_challenge: bool,
+    pub proof_submission: bool,
+    pub realm_requests: bool,
+    pub realm_admissions: bool,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct LaunchPostureSnapshot {
+    pub launch_mode: String,
+    pub participant_posture: String,
+    pub message_code: String,
+    pub support_contact: Option<LaunchSupportContact>,
+    pub generated_at: DateTime<Utc>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct InternalLaunchPostureSnapshot {
+    pub launch_mode: String,
+    pub effective_posture: String,
+    pub config_warnings: Vec<String>,
+    pub kill_switches: KillSwitchSnapshot,
+    pub allowlist: LaunchAllowlistSnapshot,
+    pub support_contact_configured: bool,
+    pub observability_is_launch_truth: bool,
+    pub projection_is_launch_truth: bool,
+    pub generated_at: DateTime<Utc>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct LaunchAllowlistSnapshot {
+    pub source: String,
+    pub pi_uid_count: usize,
+    pub account_id_count: usize,
+    pub members_visible: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct LaunchBlock {
+    pub status_code: axum::http::StatusCode,
+    pub message_code: &'static str,
+}
+
+impl LaunchPostureService {
+    pub fn from_env() -> Self {
+        Self::new(LaunchPostureConfig::from_env())
+    }
+
+    pub fn new(config: LaunchPostureConfig) -> Self {
+        Self {
+            config: Arc::new(RwLock::new(config)),
+        }
+    }
+
+    pub async fn replace_config_for_test(&self, config: LaunchPostureConfig) {
+        *self.config.write().await = config;
+    }
+
+    pub async fn public_snapshot(&self) -> LaunchPostureSnapshot {
+        self.config.read().await.public_snapshot()
+    }
+
+    pub async fn internal_snapshot(&self) -> InternalLaunchPostureSnapshot {
+        self.config.read().await.internal_snapshot()
+    }
+
+    pub async fn check_pi_auth(&self, pi_uid: &str) -> Result<(), LaunchBlock> {
+        self.config
+            .read()
+            .await
+            .check_pi_uid_action(LaunchAction::Auth, pi_uid)
+    }
+
+    pub async fn check_participant_action(
+        &self,
+        action: LaunchAction,
+        account_id: &str,
+    ) -> Result<(), LaunchBlock> {
+        self.config
+            .read()
+            .await
+            .check_account_action(action, account_id)
+    }
+}
+
+impl LaunchPostureConfig {
+    pub fn from_env() -> Self {
+        Self::from_lookup(|name| std::env::var(name).ok())
+    }
+
+    pub fn from_lookup(mut lookup: impl FnMut(&str) -> Option<String>) -> Self {
+        let mut config_warnings = Vec::new();
+        let mode = parse_mode(lookup(MODE_KEY).as_deref(), &mut config_warnings);
+        let kill_switches = KillSwitchSnapshot {
+            auth: parse_bool_switch(
+                KILL_SWITCH_AUTH_KEY,
+                lookup(KILL_SWITCH_AUTH_KEY).as_deref(),
+                &mut config_warnings,
+            ),
+            promise_creation: parse_bool_switch(
+                KILL_SWITCH_PROMISE_CREATION_KEY,
+                lookup(KILL_SWITCH_PROMISE_CREATION_KEY).as_deref(),
+                &mut config_warnings,
+            ),
+            proof_challenge: parse_bool_switch(
+                KILL_SWITCH_PROOF_CHALLENGE_KEY,
+                lookup(KILL_SWITCH_PROOF_CHALLENGE_KEY).as_deref(),
+                &mut config_warnings,
+            ),
+            proof_submission: parse_bool_switch(
+                KILL_SWITCH_PROOF_SUBMISSION_KEY,
+                lookup(KILL_SWITCH_PROOF_SUBMISSION_KEY).as_deref(),
+                &mut config_warnings,
+            ),
+            realm_requests: parse_bool_switch(
+                KILL_SWITCH_REALM_REQUESTS_KEY,
+                lookup(KILL_SWITCH_REALM_REQUESTS_KEY).as_deref(),
+                &mut config_warnings,
+            ),
+            realm_admissions: parse_bool_switch(
+                KILL_SWITCH_REALM_ADMISSIONS_KEY,
+                lookup(KILL_SWITCH_REALM_ADMISSIONS_KEY).as_deref(),
+                &mut config_warnings,
+            ),
+        };
+        let support_contact = parse_support_contact(
+            lookup(SUPPORT_CONTACT_LABEL_KEY),
+            lookup(SUPPORT_CONTACT_URL_KEY),
+        );
+
+        Self {
+            mode,
+            allowlist_pi_uids: parse_allowlist(lookup(ALLOWLIST_PI_UIDS_KEY)),
+            allowlist_account_ids: parse_allowlist(lookup(ALLOWLIST_ACCOUNT_IDS_KEY)),
+            support_contact,
+            kill_switches,
+            config_warnings,
+        }
+    }
+
+    pub fn open_preview_for_test() -> Self {
+        // Test-only bypass posture used by integration tests. Production env
+        // parsing intentionally rejects `open_preview` for the Day 1 launch.
+        Self {
+            mode: LaunchMode::OpenPreview,
+            allowlist_pi_uids: BTreeSet::new(),
+            allowlist_account_ids: BTreeSet::new(),
+            support_contact: None,
+            kill_switches: KillSwitchSnapshot::default(),
+            config_warnings: Vec::new(),
+        }
+    }
+
+    pub fn closed_for_test() -> Self {
+        Self {
+            mode: LaunchMode::Closed,
+            allowlist_pi_uids: BTreeSet::new(),
+            allowlist_account_ids: BTreeSet::new(),
+            support_contact: None,
+            kill_switches: KillSwitchSnapshot::default(),
+            config_warnings: Vec::new(),
+        }
+    }
+
+    pub fn pilot_for_test(pi_uids: &[&str], account_ids: &[&str]) -> Self {
+        Self {
+            mode: LaunchMode::Pilot,
+            allowlist_pi_uids: pi_uids.iter().map(|value| (*value).to_owned()).collect(),
+            allowlist_account_ids: account_ids
+                .iter()
+                .map(|value| (*value).to_owned())
+                .collect(),
+            support_contact: None,
+            kill_switches: KillSwitchSnapshot::default(),
+            config_warnings: Vec::new(),
+        }
+    }
+
+    pub fn paused_for_test() -> Self {
+        Self {
+            mode: LaunchMode::Paused,
+            allowlist_pi_uids: BTreeSet::new(),
+            allowlist_account_ids: BTreeSet::new(),
+            support_contact: None,
+            kill_switches: KillSwitchSnapshot::default(),
+            config_warnings: Vec::new(),
+        }
+    }
+
+    pub fn with_kill_switch_for_test(action: LaunchAction) -> Self {
+        let mut config = Self::open_preview_for_test();
+        match action {
+            LaunchAction::Auth => config.kill_switches.auth = true,
+            LaunchAction::PromiseCreation => config.kill_switches.promise_creation = true,
+            LaunchAction::ProofChallenge => config.kill_switches.proof_challenge = true,
+            LaunchAction::ProofSubmission => config.kill_switches.proof_submission = true,
+            LaunchAction::RealmRequest => config.kill_switches.realm_requests = true,
+            LaunchAction::RealmAdmission => config.kill_switches.realm_admissions = true,
+        }
+        config
+    }
+
+    pub fn public_snapshot(&self) -> LaunchPostureSnapshot {
+        LaunchPostureSnapshot {
+            launch_mode: self.mode.as_str().to_owned(),
+            participant_posture: self.participant_posture().to_owned(),
+            message_code: self.public_message_code().to_owned(),
+            support_contact: self.support_contact.clone(),
+            generated_at: Utc::now(),
+        }
+    }
+
+    pub fn internal_snapshot(&self) -> InternalLaunchPostureSnapshot {
+        InternalLaunchPostureSnapshot {
+            launch_mode: self.mode.as_str().to_owned(),
+            effective_posture: self.participant_posture().to_owned(),
+            config_warnings: self.config_warnings.clone(),
+            kill_switches: self.kill_switches.clone(),
+            allowlist: LaunchAllowlistSnapshot {
+                source: self.allowlist_source().to_owned(),
+                pi_uid_count: self.allowlist_pi_uids.len(),
+                account_id_count: self.allowlist_account_ids.len(),
+                members_visible: false,
+            },
+            support_contact_configured: self.support_contact.is_some(),
+            observability_is_launch_truth: false,
+            projection_is_launch_truth: false,
+            generated_at: Utc::now(),
+        }
+    }
+
+    fn check_pi_uid_action(&self, action: LaunchAction, pi_uid: &str) -> Result<(), LaunchBlock> {
+        if let Some(block) = self.kill_switch_block(action) {
+            return Err(block);
+        }
+        match self.mode {
+            LaunchMode::OpenPreview => Ok(()),
+            LaunchMode::Paused => Err(block_service_unavailable("launch_paused")),
+            LaunchMode::Closed => Err(block_forbidden("launch_closed")),
+            LaunchMode::Pilot => {
+                if self.allowlist_pi_uids.contains(pi_uid) {
+                    Ok(())
+                } else {
+                    Err(block_forbidden("launch_pilot_not_allowed"))
+                }
+            }
+        }
+    }
+
+    fn check_account_action(
+        &self,
+        action: LaunchAction,
+        account_id: &str,
+    ) -> Result<(), LaunchBlock> {
+        if let Some(block) = self.kill_switch_block(action) {
+            return Err(block);
+        }
+        match self.mode {
+            LaunchMode::OpenPreview => Ok(()),
+            LaunchMode::Paused => Err(block_service_unavailable("launch_paused")),
+            LaunchMode::Closed => Err(block_forbidden("launch_closed")),
+            LaunchMode::Pilot => {
+                if self.allowlist_account_ids.contains(account_id) {
+                    Ok(())
+                } else {
+                    Err(block_forbidden("launch_pilot_not_allowed"))
+                }
+            }
+        }
+    }
+
+    fn kill_switch_block(&self, action: LaunchAction) -> Option<LaunchBlock> {
+        let message_code = match action {
+            LaunchAction::Auth if self.kill_switches.auth => "auth_paused",
+            LaunchAction::PromiseCreation if self.kill_switches.promise_creation => {
+                "promise_creation_paused"
+            }
+            LaunchAction::ProofChallenge if self.kill_switches.proof_challenge => {
+                "proof_challenge_paused"
+            }
+            LaunchAction::ProofSubmission if self.kill_switches.proof_submission => {
+                "proof_submission_paused"
+            }
+            LaunchAction::RealmRequest if self.kill_switches.realm_requests => {
+                "realm_request_paused"
+            }
+            LaunchAction::RealmAdmission if self.kill_switches.realm_admissions => {
+                "realm_admission_paused"
+            }
+            _ => return None,
+        };
+        Some(block_service_unavailable(message_code))
+    }
+
+    fn participant_posture(&self) -> &'static str {
+        match self.mode {
+            LaunchMode::Closed => "closed",
+            LaunchMode::Pilot => "pilot_only",
+            LaunchMode::Paused => "paused",
+            LaunchMode::OpenPreview => "available",
+        }
+    }
+
+    fn public_message_code(&self) -> &'static str {
+        match self.mode {
+            LaunchMode::Closed => "launch_closed",
+            LaunchMode::Pilot => "launch_pilot_not_allowed",
+            LaunchMode::Paused => "launch_paused",
+            LaunchMode::OpenPreview => "launch_available",
+        }
+    }
+
+    fn allowlist_source(&self) -> &'static str {
+        if self.allowlist_pi_uids.is_empty() && self.allowlist_account_ids.is_empty() {
+            "none"
+        } else {
+            "env"
+        }
+    }
+}
+
+impl LaunchMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Closed => "closed",
+            Self::Pilot => "pilot",
+            Self::Paused => "paused",
+            Self::OpenPreview => "open_preview",
+        }
+    }
+}
+
+fn parse_mode(value: Option<&str>, warnings: &mut Vec<String>) -> LaunchMode {
+    let Some(value) = value.map(str::trim).filter(|value| !value.is_empty()) else {
+        return LaunchMode::Closed;
+    };
+    match value {
+        "closed" => LaunchMode::Closed,
+        "pilot" => LaunchMode::Pilot,
+        "paused" => LaunchMode::Paused,
+        "open_preview" => {
+            warnings.push("unsupported_launch_mode:open_preview".to_owned());
+            LaunchMode::Closed
+        }
+        _ => {
+            warnings.push("invalid_launch_mode".to_owned());
+            LaunchMode::Closed
+        }
+    }
+}
+
+fn parse_bool_switch(key: &str, value: Option<&str>, warnings: &mut Vec<String>) -> bool {
+    let Some(value) = value.map(str::trim).filter(|value| !value.is_empty()) else {
+        return false;
+    };
+    match value.to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => true,
+        "0" | "false" | "no" | "off" => false,
+        _ => {
+            warnings.push(format!("invalid_boolean_switch:{key}"));
+            true
+        }
+    }
+}
+
+fn parse_allowlist(value: Option<String>) -> BTreeSet<String> {
+    value
+        .unwrap_or_default()
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+        .collect()
+}
+
+fn parse_support_contact(
+    label: Option<String>,
+    url: Option<String>,
+) -> Option<LaunchSupportContact> {
+    let label = label.unwrap_or_default().trim().to_owned();
+    let url = url.unwrap_or_default().trim().to_owned();
+    if label.is_empty() || url.is_empty() {
+        return None;
+    }
+    Some(LaunchSupportContact { label, url })
+}
+
+fn block_forbidden(message_code: &'static str) -> LaunchBlock {
+    LaunchBlock {
+        status_code: axum::http::StatusCode::FORBIDDEN,
+        message_code,
+    }
+}
+
+fn block_service_unavailable(message_code: &'static str) -> LaunchBlock {
+    LaunchBlock {
+        status_code: axum::http::StatusCode::SERVICE_UNAVAILABLE,
+        message_code,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{LaunchMode, LaunchPostureConfig};
+
+    #[test]
+    fn missing_launch_mode_defaults_closed() {
+        let config = LaunchPostureConfig::from_lookup(|_| None);
+        assert_eq!(config.mode, LaunchMode::Closed);
+    }
+
+    #[test]
+    fn invalid_launch_mode_fails_closed_with_warning() {
+        let config = LaunchPostureConfig::from_lookup(|name| {
+            (name == "MUSUBI_LAUNCH_MODE").then(|| "public".to_owned())
+        });
+        assert_eq!(config.mode, LaunchMode::Closed);
+        assert_eq!(config.config_warnings, vec!["invalid_launch_mode"]);
+    }
+}

--- a/apps/backend/src/services/launch_posture/service.rs
+++ b/apps/backend/src/services/launch_posture/service.rs
@@ -124,11 +124,15 @@ impl LaunchPostureService {
         self.config.read().await.internal_snapshot()
     }
 
-    pub async fn check_pi_auth(&self, pi_uid: &str) -> Result<(), LaunchBlock> {
+    pub async fn check_pi_auth(
+        &self,
+        pi_uid: &str,
+        account_id: Option<&str>,
+    ) -> Result<(), LaunchBlock> {
         self.config
             .read()
             .await
-            .check_pi_uid_action(LaunchAction::Auth, pi_uid)
+            .check_pi_identity_action(LaunchAction::Auth, pi_uid, account_id)
     }
 
     pub async fn check_participant_action(
@@ -290,7 +294,12 @@ impl LaunchPostureConfig {
         }
     }
 
-    fn check_pi_uid_action(&self, action: LaunchAction, pi_uid: &str) -> Result<(), LaunchBlock> {
+    fn check_pi_identity_action(
+        &self,
+        action: LaunchAction,
+        pi_uid: &str,
+        account_id: Option<&str>,
+    ) -> Result<(), LaunchBlock> {
         if let Some(block) = self.kill_switch_block(action) {
             return Err(block);
         }
@@ -299,7 +308,10 @@ impl LaunchPostureConfig {
             LaunchMode::Paused => Err(block_service_unavailable("launch_paused")),
             LaunchMode::Closed => Err(block_forbidden("launch_closed")),
             LaunchMode::Pilot => {
-                if self.allowlist_pi_uids.contains(pi_uid) {
+                if self.allowlist_pi_uids.contains(pi_uid)
+                    || account_id
+                        .is_some_and(|account_id| self.allowlist_account_ids.contains(account_id))
+                {
                     Ok(())
                 } else {
                     Err(block_forbidden("launch_pilot_not_allowed"))

--- a/apps/backend/src/services/mod.rs
+++ b/apps/backend/src/services/mod.rs
@@ -1,5 +1,6 @@
 #[path = "happy_route/mod.rs"]
 pub mod happy_route;
+pub mod launch_posture;
 pub mod operator_review;
 pub mod ops_observability;
 pub mod proof;

--- a/apps/backend/src/services/realm_bootstrap/repository.rs
+++ b/apps/backend/src/services/realm_bootstrap/repository.rs
@@ -89,6 +89,15 @@ impl RealmBootstrapStore {
         Ok(())
     }
 
+    pub async fn ensure_operator_write_role(
+        &self,
+        operator_id: &str,
+    ) -> Result<(), RealmBootstrapError> {
+        let operator_id = parse_uuid(operator_id, "operator id")?;
+        let client = self.client.lock().await;
+        ensure_operator_role_tx(&*client, &operator_id, OPERATOR_WRITE_ROLES).await
+    }
+
     pub async fn create_realm_request(
         &self,
         requester_account_id: &str,

--- a/apps/backend/src/services/realm_bootstrap/repository.rs
+++ b/apps/backend/src/services/realm_bootstrap/repository.rs
@@ -832,7 +832,8 @@ impl RealmBootstrapStore {
         }
 
         ensure_operator_role_tx(&tx, &operator_id, OPERATOR_WRITE_ROLES).await?;
-        check_new_admission(&account_id.to_string())?;
+        let account_id_text = account_id.to_string();
+        check_new_admission(&account_id_text)?;
 
         let row = {
             ensure_active_account_exists_tx(&tx, &account_id).await?;

--- a/apps/backend/src/services/realm_bootstrap/repository.rs
+++ b/apps/backend/src/services/realm_bootstrap/repository.rs
@@ -89,48 +89,6 @@ impl RealmBootstrapStore {
         Ok(())
     }
 
-    pub async fn ensure_operator_write_role(
-        &self,
-        operator_id: &str,
-    ) -> Result<(), RealmBootstrapError> {
-        let operator_id = parse_uuid(operator_id, "operator id")?;
-        let client = self.client.lock().await;
-        ensure_operator_role_tx(&*client, &operator_id, OPERATOR_WRITE_ROLES).await
-    }
-
-    pub async fn is_realm_admission_replay(
-        &self,
-        operator_id: &str,
-        realm_id: &str,
-        input: &CreateRealmAdmissionInput,
-    ) -> Result<bool, RealmBootstrapError> {
-        let operator_id = parse_uuid(operator_id, "operator id")?;
-        let realm_id = normalize_required(realm_id, "realm id")?;
-        let account_id = parse_uuid(&input.account_id, "account id")?;
-        let sponsor_record_id = parse_optional_uuid(&input.sponsor_record_id, "sponsor record id")?;
-        let request_idempotency_key =
-            normalize_optional(Some(input.request_idempotency_key.as_str())).ok_or_else(|| {
-                RealmBootstrapError::BadRequest(
-                    "admission creation requires request_idempotency_key".to_owned(),
-                )
-            })?;
-        let payload_hash = create_admission_payload_hash(input, &account_id, &sponsor_record_id);
-        let client = self.client.lock().await;
-        if let Some(existing) = find_admission_by_idempotency_tx(
-            &*client,
-            &realm_id,
-            &operator_id,
-            &request_idempotency_key,
-        )
-        .await?
-        {
-            ensure_admission_payload_hash_matches(&existing, &payload_hash)?;
-            Ok(true)
-        } else {
-            Ok(false)
-        }
-    }
-
     pub async fn create_realm_request(
         &self,
         requester_account_id: &str,
@@ -845,6 +803,7 @@ impl RealmBootstrapStore {
         operator_id: &str,
         realm_id: &str,
         input: CreateRealmAdmissionInput,
+        check_new_admission: impl FnOnce(&str) -> Result<(), RealmBootstrapError>,
     ) -> Result<RealmAdmissionSnapshot, RealmBootstrapError> {
         let operator_id = parse_uuid(operator_id, "operator id")?;
         let realm_id = normalize_required(realm_id, "realm id")?;
@@ -873,6 +832,7 @@ impl RealmBootstrapStore {
         }
 
         ensure_operator_role_tx(&tx, &operator_id, OPERATOR_WRITE_ROLES).await?;
+        check_new_admission(&account_id.to_string())?;
 
         let row = {
             ensure_active_account_exists_tx(&tx, &account_id).await?;

--- a/apps/backend/src/services/realm_bootstrap/repository.rs
+++ b/apps/backend/src/services/realm_bootstrap/repository.rs
@@ -98,6 +98,39 @@ impl RealmBootstrapStore {
         ensure_operator_role_tx(&*client, &operator_id, OPERATOR_WRITE_ROLES).await
     }
 
+    pub async fn is_realm_admission_replay(
+        &self,
+        operator_id: &str,
+        realm_id: &str,
+        input: &CreateRealmAdmissionInput,
+    ) -> Result<bool, RealmBootstrapError> {
+        let operator_id = parse_uuid(operator_id, "operator id")?;
+        let realm_id = normalize_required(realm_id, "realm id")?;
+        let account_id = parse_uuid(&input.account_id, "account id")?;
+        let sponsor_record_id = parse_optional_uuid(&input.sponsor_record_id, "sponsor record id")?;
+        let request_idempotency_key =
+            normalize_optional(Some(input.request_idempotency_key.as_str())).ok_or_else(|| {
+                RealmBootstrapError::BadRequest(
+                    "admission creation requires request_idempotency_key".to_owned(),
+                )
+            })?;
+        let payload_hash = create_admission_payload_hash(input, &account_id, &sponsor_record_id);
+        let client = self.client.lock().await;
+        if let Some(existing) = find_admission_by_idempotency_tx(
+            &*client,
+            &realm_id,
+            &operator_id,
+            &request_idempotency_key,
+        )
+        .await?
+        {
+            ensure_admission_payload_hash_matches(&existing, &payload_hash)?;
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
     pub async fn create_realm_request(
         &self,
         requester_account_id: &str,

--- a/apps/backend/src/services/realm_bootstrap/types.rs
+++ b/apps/backend/src/services/realm_bootstrap/types.rs
@@ -12,6 +12,10 @@ pub enum RealmBootstrapError {
         constraint: Option<String>,
         retryable: bool,
     },
+    LaunchBlocked {
+        status_code: axum::http::StatusCode,
+        message_code: &'static str,
+    },
     Internal(String),
 }
 
@@ -23,6 +27,7 @@ impl RealmBootstrapError {
             | Self::NotFound(message)
             | Self::Database { message, .. }
             | Self::Internal(message) => message,
+            Self::LaunchBlocked { message_code, .. } => message_code,
         }
     }
 }

--- a/apps/backend/src/services/realm_bootstrap/types.rs
+++ b/apps/backend/src/services/realm_bootstrap/types.rs
@@ -1,6 +1,8 @@
 use chrono::{DateTime, Utc};
 use serde_json::Value;
 
+use crate::services::launch_posture::LaunchBlockKind;
+
 #[derive(Debug)]
 pub enum RealmBootstrapError {
     BadRequest(String),
@@ -13,7 +15,7 @@ pub enum RealmBootstrapError {
         retryable: bool,
     },
     LaunchBlocked {
-        status_code: axum::http::StatusCode,
+        kind: LaunchBlockKind,
         message_code: &'static str,
     },
     Internal(String),

--- a/apps/backend/tests/launch_posture.rs
+++ b/apps/backend/tests/launch_posture.rs
@@ -65,11 +65,7 @@ async fn open_preview_env_mode_fails_closed_and_blocks_participant_writes() {
     );
 
     let test_state = new_test_state().await.expect("test database state");
-    test_state
-        .state
-        .launch_posture
-        .replace_config_for_test(config)
-        .await;
+    test_state.replace_launch_config_for_test(config).await;
     let app = build_app(test_state.state.clone());
 
     let response = post_json(
@@ -93,9 +89,7 @@ async fn open_preview_env_mode_fails_closed_and_blocks_participant_writes() {
 async fn launch_public_posture_redacts_internal_allowlist() {
     let test_state = new_test_state().await.expect("test database state");
     test_state
-        .state
-        .launch_posture
-        .replace_config_for_test(LaunchPostureConfig::from_lookup(|name| match name {
+        .replace_launch_config_for_test(LaunchPostureConfig::from_lookup(|name| match name {
             "MUSUBI_LAUNCH_MODE" => Some("pilot".to_owned()),
             "MUSUBI_LAUNCH_ALLOWLIST_PI_UIDS" => Some("pi-private-a,pi-private-b".to_owned()),
             "MUSUBI_LAUNCH_ALLOWLIST_ACCOUNT_IDS" => Some(Uuid::new_v4().to_string()),
@@ -135,6 +129,10 @@ async fn launch_internal_posture_requires_internal_gate() {
     .await;
 
     assert_eq!(response.status, StatusCode::UNAUTHORIZED);
+    assert_eq!(
+        response.body["error"],
+        "internal authorization bearer token is required"
+    );
 }
 
 #[tokio::test]
@@ -142,9 +140,7 @@ async fn launch_internal_posture_reports_allowlist_counts_not_members() {
     let test_state = new_test_state().await.expect("test database state");
     let account_id = Uuid::new_v4().to_string();
     test_state
-        .state
-        .launch_posture
-        .replace_config_for_test(LaunchPostureConfig::from_lookup(|name| match name {
+        .replace_launch_config_for_test(LaunchPostureConfig::from_lookup(|name| match name {
             "MUSUBI_LAUNCH_MODE" => Some("pilot".to_owned()),
             "MUSUBI_LAUNCH_ALLOWLIST_PI_UIDS" => Some("pi-count-a, pi-count-b".to_owned()),
             "MUSUBI_LAUNCH_ALLOWLIST_ACCOUNT_IDS" => Some(account_id.clone()),
@@ -169,9 +165,7 @@ async fn launch_internal_posture_reports_allowlist_counts_not_members() {
 async fn closed_launch_blocks_non_allowlisted_pi_auth() {
     let test_state = new_test_state().await.expect("test database state");
     test_state
-        .state
-        .launch_posture
-        .replace_config_for_test(LaunchPostureConfig::closed_for_test())
+        .replace_launch_config_for_test(LaunchPostureConfig::closed_for_test())
         .await;
     let app = build_app(test_state.state.clone());
 
@@ -197,9 +191,7 @@ async fn closed_launch_blocks_non_allowlisted_pi_auth() {
 async fn pilot_launch_allows_allowlisted_pi_auth() {
     let test_state = new_test_state().await.expect("test database state");
     test_state
-        .state
-        .launch_posture
-        .replace_config_for_test(LaunchPostureConfig::pilot_for_test(
+        .replace_launch_config_for_test(LaunchPostureConfig::pilot_for_test(
             &["pi-launch-pilot-allowed"],
             &[],
         ))
@@ -224,15 +216,39 @@ async fn pilot_launch_allows_allowlisted_pi_auth() {
 }
 
 #[tokio::test]
+async fn pilot_launch_pi_allowlisted_account_can_use_participant_write_after_auth() {
+    let test_state = new_test_state().await.expect("test database state");
+    test_state
+        .replace_launch_config_for_test(LaunchPostureConfig::pilot_for_test(
+            &["pi-launch-pilot-write"],
+            &[],
+        ))
+        .await;
+    let app = build_app(test_state.state.clone());
+    let participant = sign_in(&app, "pi-launch-pilot-write", "launch-pilot-write").await;
+
+    let response = post_json(
+        &app,
+        "/api/realms/requests",
+        Some(participant.token.as_str()),
+        realm_request_body("pilot-pi-allowlisted-write"),
+    )
+    .await;
+
+    assert_eq!(response.status, StatusCode::OK, "{}", response.body);
+    assert_eq!(response.body["request_state"], "requested");
+    assert!(response.body["realm_request_id"].as_str().is_some());
+    assert!(response.body.get("requested_by_account_id").is_none());
+}
+
+#[tokio::test]
 async fn paused_launch_blocks_promise_creation() {
     let test_state = new_test_state().await.expect("test database state");
     let app = build_app(test_state.state.clone());
     let initiator = sign_in(&app, "pi-launch-promise-a", "launch-promise-a").await;
     let counterparty = sign_in(&app, "pi-launch-promise-b", "launch-promise-b").await;
     test_state
-        .state
-        .launch_posture
-        .replace_config_for_test(LaunchPostureConfig::paused_for_test())
+        .replace_launch_config_for_test(LaunchPostureConfig::paused_for_test())
         .await;
 
     let response = post_json(
@@ -264,9 +280,7 @@ async fn paused_launch_blocks_proof_submission() {
     let app = build_app(test_state.state.clone());
     let subject = sign_in(&app, "pi-launch-proof", "launch-proof").await;
     test_state
-        .state
-        .launch_posture
-        .replace_config_for_test(LaunchPostureConfig::paused_for_test())
+        .replace_launch_config_for_test(LaunchPostureConfig::paused_for_test())
         .await;
 
     let response = post_json(
@@ -296,9 +310,7 @@ async fn paused_launch_blocks_realm_request() {
     let app = build_app(test_state.state.clone());
     let requester = sign_in(&app, "pi-launch-realm", "launch-realm").await;
     test_state
-        .state
-        .launch_posture
-        .replace_config_for_test(LaunchPostureConfig::paused_for_test())
+        .replace_launch_config_for_test(LaunchPostureConfig::paused_for_test())
         .await;
 
     let response = post_json(
@@ -322,9 +334,7 @@ async fn paused_launch_blocks_realm_request() {
 async fn realm_admission_kill_switch_blocks_new_admissions() {
     let test_state = new_test_state().await.expect("test database state");
     test_state
-        .state
-        .launch_posture
-        .replace_config_for_test(LaunchPostureConfig::with_kill_switch_for_test(
+        .replace_launch_config_for_test(LaunchPostureConfig::with_kill_switch_for_test(
             LaunchAction::RealmAdmission,
         ))
         .await;
@@ -357,9 +367,7 @@ async fn realm_admission_kill_switch_blocks_new_admissions() {
 async fn paused_launch_blocks_internal_realm_admission() {
     let test_state = new_test_state().await.expect("test database state");
     test_state
-        .state
-        .launch_posture
-        .replace_config_for_test(LaunchPostureConfig::paused_for_test())
+        .replace_launch_config_for_test(LaunchPostureConfig::paused_for_test())
         .await;
     let app = build_app(test_state.state.clone());
 
@@ -381,9 +389,7 @@ async fn paused_launch_blocks_internal_realm_admission() {
 async fn closed_launch_blocks_internal_realm_admission_for_non_allowlisted_account() {
     let test_state = new_test_state().await.expect("test database state");
     test_state
-        .state
-        .launch_posture
-        .replace_config_for_test(LaunchPostureConfig::closed_for_test())
+        .replace_launch_config_for_test(LaunchPostureConfig::closed_for_test())
         .await;
     let app = build_app(test_state.state.clone());
 
@@ -405,9 +411,7 @@ async fn closed_launch_blocks_internal_realm_admission_for_non_allowlisted_accou
 async fn pilot_launch_blocks_internal_realm_admission_for_non_allowlisted_account() {
     let test_state = new_test_state().await.expect("test database state");
     test_state
-        .state
-        .launch_posture
-        .replace_config_for_test(LaunchPostureConfig::pilot_for_test(&[], &[]))
+        .replace_launch_config_for_test(LaunchPostureConfig::pilot_for_test(&[], &[]))
         .await;
     let app = build_app(test_state.state.clone());
 
@@ -439,9 +443,7 @@ async fn pilot_launch_allows_allowlisted_internal_realm_admission_to_reach_realm
     )
     .await;
     test_state
-        .state
-        .launch_posture
-        .replace_config_for_test(LaunchPostureConfig::pilot_for_test(
+        .replace_launch_config_for_test(LaunchPostureConfig::pilot_for_test(
             &[],
             &[member.account_id.as_str()],
         ))
@@ -472,9 +474,7 @@ async fn pilot_launch_allows_allowlisted_internal_realm_admission_to_reach_realm
 async fn internal_ops_health_still_available_when_launch_paused() {
     let test_state = new_test_state().await.expect("test database state");
     test_state
-        .state
-        .launch_posture
-        .replace_config_for_test(LaunchPostureConfig::paused_for_test())
+        .replace_launch_config_for_test(LaunchPostureConfig::paused_for_test())
         .await;
     let app = build_app(test_state.state.clone());
 
@@ -488,9 +488,7 @@ async fn internal_ops_health_still_available_when_launch_paused() {
 async fn observability_status_does_not_override_launch_mode() {
     let test_state = new_test_state().await.expect("test database state");
     test_state
-        .state
-        .launch_posture
-        .replace_config_for_test(LaunchPostureConfig::paused_for_test())
+        .replace_launch_config_for_test(LaunchPostureConfig::paused_for_test())
         .await;
     let app = build_app(test_state.state.clone());
 

--- a/apps/backend/tests/launch_posture.rs
+++ b/apps/backend/tests/launch_posture.rs
@@ -358,6 +358,60 @@ async fn paused_launch_blocks_realm_request() {
 }
 
 #[tokio::test]
+async fn paused_launch_blocks_appeal_creation() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let appellant = sign_in(&app, "pi-launch-appeal", "launch-appeal").await;
+    test_state
+        .replace_launch_config_for_test(LaunchPostureConfig::paused_for_test())
+        .await;
+
+    let response = post_json(
+        &app,
+        &format!("/api/review-cases/{}/appeals", Uuid::new_v4()),
+        Some(appellant.token.as_str()),
+        appeal_body("paused"),
+    )
+    .await;
+
+    assert_eq!(
+        response.status,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "{}",
+        response.body
+    );
+    assert_eq!(response.body["message_code"], "launch_paused");
+}
+
+#[tokio::test]
+async fn appeal_creation_kill_switch_blocks_new_appeals() {
+    let test_state = new_test_state().await.expect("test database state");
+    test_state
+        .replace_launch_config_for_test(LaunchPostureConfig::with_kill_switch_for_test(
+            LaunchAction::AppealCreation,
+        ))
+        .await;
+    let app = build_app(test_state.state.clone());
+    let appellant = sign_in(&app, "pi-launch-appeal-switch", "launch-appeal-switch").await;
+
+    let response = post_json(
+        &app,
+        &format!("/api/review-cases/{}/appeals", Uuid::new_v4()),
+        Some(appellant.token.as_str()),
+        appeal_body("kill-switch"),
+    )
+    .await;
+
+    assert_eq!(
+        response.status,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "{}",
+        response.body
+    );
+    assert_eq!(response.body["message_code"], "appeal_creation_paused");
+}
+
+#[tokio::test]
 async fn realm_admission_kill_switch_blocks_new_admissions() {
     let test_state = new_test_state().await.expect("test database state");
     test_state
@@ -615,6 +669,18 @@ fn realm_admission_body(account_id: &str, suffix: &str) -> Value {
         "source_fact_id": format!("launch-admission-{suffix}"),
         "source_snapshot_json": {},
         "request_idempotency_key": format!("launch-admission-{suffix}")
+    })
+}
+
+fn appeal_body(suffix: &str) -> Value {
+    json!({
+        "source_decision_fact_id": null,
+        "submitted_reason_code": "appeal_received",
+        "appellant_statement": format!("Launch posture appeal {suffix}"),
+        "new_evidence_summary_json": {
+            "safe_summary": format!("appeal {suffix}")
+        },
+        "appeal_idempotency_key": format!("launch-appeal-{suffix}")
     })
 }
 

--- a/apps/backend/tests/launch_posture.rs
+++ b/apps/backend/tests/launch_posture.rs
@@ -339,7 +339,8 @@ async fn realm_admission_kill_switch_blocks_new_admissions() {
         ))
         .await;
     let app = build_app(test_state.state.clone());
-    let operator_id = Uuid::new_v4().to_string();
+    let client = test_db_client().await;
+    let operator_id = insert_operator_account(&client, "approver").await;
 
     let response = request_json(
         &app,
@@ -370,13 +371,15 @@ async fn paused_launch_blocks_internal_realm_admission() {
         .replace_launch_config_for_test(LaunchPostureConfig::paused_for_test())
         .await;
     let app = build_app(test_state.state.clone());
+    let client = test_db_client().await;
+    let operator_id = insert_operator_account(&client, "approver").await;
 
     let response = request_json(
         &app,
         "POST",
         &format!("/api/internal/realms/{}/admissions", Uuid::new_v4()),
         Some("local_dev_internal_api_token"),
-        Some(Uuid::new_v4().to_string().as_str()),
+        Some(operator_id.as_str()),
         Some(realm_admission_body(&Uuid::new_v4().to_string(), "paused")),
     )
     .await;
@@ -392,13 +395,15 @@ async fn closed_launch_blocks_internal_realm_admission_for_non_allowlisted_accou
         .replace_launch_config_for_test(LaunchPostureConfig::closed_for_test())
         .await;
     let app = build_app(test_state.state.clone());
+    let client = test_db_client().await;
+    let operator_id = insert_operator_account(&client, "approver").await;
 
     let response = request_json(
         &app,
         "POST",
         &format!("/api/internal/realms/{}/admissions", Uuid::new_v4()),
         Some("local_dev_internal_api_token"),
-        Some(Uuid::new_v4().to_string().as_str()),
+        Some(operator_id.as_str()),
         Some(realm_admission_body(&Uuid::new_v4().to_string(), "closed")),
     )
     .await;
@@ -414,13 +419,15 @@ async fn pilot_launch_blocks_internal_realm_admission_for_non_allowlisted_accoun
         .replace_launch_config_for_test(LaunchPostureConfig::pilot_for_test(&[], &[]))
         .await;
     let app = build_app(test_state.state.clone());
+    let client = test_db_client().await;
+    let operator_id = insert_operator_account(&client, "approver").await;
 
     let response = request_json(
         &app,
         "POST",
         &format!("/api/internal/realms/{}/admissions", Uuid::new_v4()),
         Some("local_dev_internal_api_token"),
-        Some(Uuid::new_v4().to_string().as_str()),
+        Some(operator_id.as_str()),
         Some(realm_admission_body(
             &Uuid::new_v4().to_string(),
             "pilot-blocked",
@@ -448,13 +455,15 @@ async fn pilot_launch_allows_allowlisted_internal_realm_admission_to_reach_realm
             &[member.account_id.as_str()],
         ))
         .await;
+    let client = test_db_client().await;
+    let operator_id = insert_operator_account(&client, "approver").await;
 
     let response = request_json(
         &app,
         "POST",
         &format!("/api/internal/realms/{}/admissions", Uuid::new_v4()),
         Some("local_dev_internal_api_token"),
-        Some(Uuid::new_v4().to_string().as_str()),
+        Some(operator_id.as_str()),
         Some(realm_admission_body(
             &member.account_id,
             "pilot-allowed-next-layer",
@@ -462,12 +471,62 @@ async fn pilot_launch_allows_allowlisted_internal_realm_admission_to_reach_realm
     )
     .await;
 
-    assert_eq!(response.status, StatusCode::UNAUTHORIZED);
+    assert_eq!(response.status, StatusCode::NOT_FOUND);
+    assert_eq!(response.body["error"], "realm was not found");
+    assert!(response.body.get("message_code").is_none());
+}
+
+#[tokio::test]
+async fn internal_realm_admission_authorizes_operator_before_pilot_allowlist_check() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let member = sign_in(
+        &app,
+        "pi-launch-realm-admission-oracle",
+        "launch-realm-admission-oracle",
+    )
+    .await;
+    test_state
+        .replace_launch_config_for_test(LaunchPostureConfig::pilot_for_test(
+            &[],
+            &[member.account_id.as_str()],
+        ))
+        .await;
+    let non_operator_id = Uuid::new_v4().to_string();
+
+    let allowlisted_response = request_json(
+        &app,
+        "POST",
+        &format!("/api/internal/realms/{}/admissions", Uuid::new_v4()),
+        Some("local_dev_internal_api_token"),
+        Some(non_operator_id.as_str()),
+        Some(realm_admission_body(
+            &member.account_id,
+            "operator-before-launch-allowlisted",
+        )),
+    )
+    .await;
+    let non_allowlisted_response = request_json(
+        &app,
+        "POST",
+        &format!("/api/internal/realms/{}/admissions", Uuid::new_v4()),
+        Some("local_dev_internal_api_token"),
+        Some(non_operator_id.as_str()),
+        Some(realm_admission_body(
+            &Uuid::new_v4().to_string(),
+            "operator-before-launch-blocked",
+        )),
+    )
+    .await;
+
+    assert_eq!(allowlisted_response.status, StatusCode::UNAUTHORIZED);
+    assert_eq!(non_allowlisted_response.status, StatusCode::UNAUTHORIZED);
     assert_eq!(
-        response.body["error"],
+        allowlisted_response.body["error"],
         "operator role is not allowed for realm bootstrap actions"
     );
-    assert!(response.body.get("message_code").is_none());
+    assert_eq!(allowlisted_response.body, non_allowlisted_response.body);
+    assert!(allowlisted_response.body.get("message_code").is_none());
 }
 
 #[tokio::test]
@@ -580,6 +639,51 @@ async fn post_json(
 
 async fn get_json(app: &Router, path: &str, bearer_token: Option<&str>) -> JsonResponse {
     request_json(app, "GET", path, bearer_token, None, None).await
+}
+
+async fn insert_operator_account(client: &tokio_postgres::Client, role: &str) -> String {
+    let account_id = Uuid::new_v4();
+    client
+        .execute(
+            "
+            INSERT INTO core.accounts (account_id, account_class, account_state)
+            VALUES ($1, 'Controlled Exceptional Account', 'active')
+            ",
+            &[&account_id],
+        )
+        .await
+        .expect("operator account must insert");
+    client
+        .execute(
+            "
+            INSERT INTO core.operator_role_assignments (
+                operator_role_assignment_id,
+                operator_account_id,
+                operator_role,
+                grant_reason
+            )
+            VALUES ($1, $2, $3, 'launch posture test role')
+            ",
+            &[&Uuid::new_v4(), &account_id, &role],
+        )
+        .await
+        .expect("operator role assignment must insert");
+    account_id.to_string()
+}
+
+async fn test_db_client() -> tokio_postgres::Client {
+    let database_url = std::env::var("MUSUBI_TEST_DATABASE_URL")
+        .or_else(|_| std::env::var("DATABASE_URL"))
+        .expect("test database url must be present");
+    let (client, connection) = tokio_postgres::connect(&database_url, tokio_postgres::NoTls)
+        .await
+        .expect("test database must be reachable");
+    tokio::spawn(async move {
+        if let Err(error) = connection.await {
+            eprintln!("test database connection error: {error}");
+        }
+    });
+    client
 }
 
 async fn request_json(

--- a/apps/backend/tests/launch_posture.rs
+++ b/apps/backend/tests/launch_posture.rs
@@ -216,6 +216,33 @@ async fn pilot_launch_allows_allowlisted_pi_auth() {
 }
 
 #[tokio::test]
+async fn pilot_launch_allows_account_allowlisted_pi_auth_for_existing_account() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let existing = sign_in(
+        &app,
+        "pi-launch-pilot-account-allowed",
+        "launch-pilot-account-allowed",
+    )
+    .await;
+    test_state
+        .replace_launch_config_for_test(LaunchPostureConfig::pilot_for_test(
+            &[],
+            &[existing.account_id.as_str()],
+        ))
+        .await;
+
+    let reauthenticated = sign_in(
+        &app,
+        "pi-launch-pilot-account-allowed",
+        "launch-pilot-account-allowed-returning",
+    )
+    .await;
+
+    assert_eq!(reauthenticated.account_id, existing.account_id);
+}
+
+#[tokio::test]
 async fn pilot_launch_pi_allowlisted_account_can_use_participant_write_after_auth() {
     let test_state = new_test_state().await.expect("test database state");
     test_state

--- a/apps/backend/tests/launch_posture.rs
+++ b/apps/backend/tests/launch_posture.rs
@@ -136,6 +136,25 @@ async fn launch_internal_posture_requires_internal_gate() {
 }
 
 #[tokio::test]
+async fn launch_internal_posture_rejects_arbitrary_bearer_tokens_in_debug_builds() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+
+    let response = get_json(
+        &app,
+        "/api/internal/launch/posture",
+        Some("not-an-internal-token"),
+    )
+    .await;
+
+    assert_eq!(response.status, StatusCode::UNAUTHORIZED);
+    assert_eq!(
+        response.body["error"],
+        "internal authorization bearer token is required"
+    );
+}
+
+#[tokio::test]
 async fn launch_internal_posture_reports_allowlist_counts_not_members() {
     let test_state = new_test_state().await.expect("test database state");
     let account_id = Uuid::new_v4().to_string();
@@ -240,6 +259,63 @@ async fn pilot_launch_allows_account_allowlisted_pi_auth_for_existing_account() 
     .await;
 
     assert_eq!(reauthenticated.account_id, existing.account_id);
+}
+
+#[tokio::test]
+async fn pilot_launch_account_allowlist_does_not_oracle_invalid_credentials() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let allowlisted = sign_in(
+        &app,
+        "pi-launch-pilot-account-oracle-allowed",
+        "launch-pilot-account-oracle-allowed",
+    )
+    .await;
+    sign_in(
+        &app,
+        "pi-launch-pilot-account-oracle-blocked",
+        "launch-pilot-account-oracle-blocked",
+    )
+    .await;
+    test_state
+        .replace_launch_config_for_test(LaunchPostureConfig::pilot_for_test(
+            &[],
+            &[allowlisted.account_id.as_str()],
+        ))
+        .await;
+
+    let allowlisted_response = post_json(
+        &app,
+        "/api/auth/pi",
+        None,
+        json!({
+            "pi_uid": "pi-launch-pilot-account-oracle-allowed",
+            "username": "launch-pilot-account-oracle-allowed-retry",
+            "wallet_address": "wallet-pi-launch-pilot-account-oracle-allowed",
+            "access_token": "wrong-access-token-pi-launch-pilot-account-oracle-allowed"
+        }),
+    )
+    .await;
+    let blocked_response = post_json(
+        &app,
+        "/api/auth/pi",
+        None,
+        json!({
+            "pi_uid": "pi-launch-pilot-account-oracle-blocked",
+            "username": "launch-pilot-account-oracle-blocked-retry",
+            "wallet_address": "wallet-pi-launch-pilot-account-oracle-blocked",
+            "access_token": "wrong-access-token-pi-launch-pilot-account-oracle-blocked"
+        }),
+    )
+    .await;
+
+    assert_eq!(allowlisted_response.status, StatusCode::FORBIDDEN);
+    assert_eq!(allowlisted_response.status, blocked_response.status);
+    assert_eq!(allowlisted_response.body, blocked_response.body);
+    assert_eq!(
+        allowlisted_response.body["message_code"],
+        "launch_pilot_not_allowed"
+    );
 }
 
 #[tokio::test]

--- a/apps/backend/tests/launch_posture.rs
+++ b/apps/backend/tests/launch_posture.rs
@@ -1,0 +1,631 @@
+use axum::{
+    Router,
+    body::{Body, to_bytes},
+    http::{Request, StatusCode},
+};
+use musubi_backend::{
+    build_app, new_test_state,
+    services::launch_posture::{LaunchAction, LaunchPostureConfig},
+};
+use serde_json::{Value, json};
+use tower::ServiceExt;
+use uuid::Uuid;
+
+#[tokio::test]
+async fn launch_posture_defaults_to_closed_or_pilot_safe_mode() {
+    let config = LaunchPostureConfig::from_lookup(|_| None);
+    let snapshot = config.public_snapshot();
+
+    assert_eq!(snapshot.launch_mode, "closed");
+    assert_eq!(snapshot.participant_posture, "closed");
+    assert_eq!(snapshot.message_code, "launch_closed");
+}
+
+#[tokio::test]
+async fn invalid_launch_mode_fails_closed() {
+    let config = LaunchPostureConfig::from_lookup(|name| match name {
+        "MUSUBI_LAUNCH_MODE" => Some("public".to_owned()),
+        "MUSUBI_KILL_SWITCH_PROMISE_CREATION" => Some("maybe".to_owned()),
+        _ => None,
+    });
+    let public = config.public_snapshot();
+    let internal = config.internal_snapshot();
+
+    assert_eq!(public.launch_mode, "closed");
+    assert_eq!(public.message_code, "launch_closed");
+    assert!(
+        internal
+            .config_warnings
+            .contains(&"invalid_launch_mode".to_owned())
+    );
+    assert!(
+        internal
+            .config_warnings
+            .contains(&"invalid_boolean_switch:MUSUBI_KILL_SWITCH_PROMISE_CREATION".to_owned())
+    );
+    assert!(internal.kill_switches.promise_creation);
+}
+
+#[tokio::test]
+async fn open_preview_env_mode_fails_closed_and_blocks_participant_writes() {
+    let config = LaunchPostureConfig::from_lookup(|name| match name {
+        "MUSUBI_LAUNCH_MODE" => Some("open_preview".to_owned()),
+        _ => None,
+    });
+    let public = config.public_snapshot();
+    let internal = config.internal_snapshot();
+
+    assert_eq!(public.launch_mode, "closed");
+    assert_eq!(public.participant_posture, "closed");
+    assert_eq!(public.message_code, "launch_closed");
+    assert!(
+        internal
+            .config_warnings
+            .contains(&"unsupported_launch_mode:open_preview".to_owned())
+    );
+
+    let test_state = new_test_state().await.expect("test database state");
+    test_state
+        .state
+        .launch_posture
+        .replace_config_for_test(config)
+        .await;
+    let app = build_app(test_state.state.clone());
+
+    let response = post_json(
+        &app,
+        "/api/auth/pi",
+        None,
+        json!({
+            "pi_uid": "pi-launch-open-preview-env",
+            "username": "launch-open-preview-env",
+            "wallet_address": "wallet-pi-launch-open-preview-env",
+            "access_token": "access-token-pi-launch-open-preview-env"
+        }),
+    )
+    .await;
+
+    assert_eq!(response.status, StatusCode::FORBIDDEN);
+    assert_eq!(response.body["message_code"], "launch_closed");
+}
+
+#[tokio::test]
+async fn launch_public_posture_redacts_internal_allowlist() {
+    let test_state = new_test_state().await.expect("test database state");
+    test_state
+        .state
+        .launch_posture
+        .replace_config_for_test(LaunchPostureConfig::from_lookup(|name| match name {
+            "MUSUBI_LAUNCH_MODE" => Some("pilot".to_owned()),
+            "MUSUBI_LAUNCH_ALLOWLIST_PI_UIDS" => Some("pi-private-a,pi-private-b".to_owned()),
+            "MUSUBI_LAUNCH_ALLOWLIST_ACCOUNT_IDS" => Some(Uuid::new_v4().to_string()),
+            "MUSUBI_LAUNCH_SUPPORT_CONTACT_LABEL" => Some("お問い合わせ".to_owned()),
+            "MUSUBI_LAUNCH_SUPPORT_CONTACT_URL" => {
+                Some("https://example.invalid/support".to_owned())
+            }
+            _ => None,
+        }))
+        .await;
+    let app = build_app(test_state.state.clone());
+
+    let response = get_json(&app, "/api/launch/posture", None).await;
+
+    assert_eq!(response.status, StatusCode::OK);
+    assert_eq!(response.body["launch_mode"], "pilot");
+    assert_eq!(response.body["participant_posture"], "pilot_only");
+    assert_eq!(response.body["message_code"], "launch_pilot_not_allowed");
+    assert_eq!(response.body["support_contact"]["label"], "お問い合わせ");
+    let body = response.body.to_string();
+    assert!(!body.contains("pi-private-a"));
+    assert!(!body.contains("pi-private-b"));
+    assert!(!body.contains("allowlist"));
+}
+
+#[tokio::test]
+async fn launch_internal_posture_requires_internal_gate() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let participant = sign_in(&app, "pi-launch-internal-gate", "launch-internal-gate").await;
+
+    let response = get_json(
+        &app,
+        "/api/internal/launch/posture",
+        Some(participant.token.as_str()),
+    )
+    .await;
+
+    assert_eq!(response.status, StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn launch_internal_posture_reports_allowlist_counts_not_members() {
+    let test_state = new_test_state().await.expect("test database state");
+    let account_id = Uuid::new_v4().to_string();
+    test_state
+        .state
+        .launch_posture
+        .replace_config_for_test(LaunchPostureConfig::from_lookup(|name| match name {
+            "MUSUBI_LAUNCH_MODE" => Some("pilot".to_owned()),
+            "MUSUBI_LAUNCH_ALLOWLIST_PI_UIDS" => Some("pi-count-a, pi-count-b".to_owned()),
+            "MUSUBI_LAUNCH_ALLOWLIST_ACCOUNT_IDS" => Some(account_id.clone()),
+            _ => None,
+        }))
+        .await;
+    let app = build_app(test_state.state.clone());
+
+    let response = get_json(&app, "/api/internal/launch/posture", None).await;
+
+    assert_eq!(response.status, StatusCode::OK);
+    assert_eq!(response.body["allowlist"]["source"], "env");
+    assert_eq!(response.body["allowlist"]["pi_uid_count"], 2);
+    assert_eq!(response.body["allowlist"]["account_id_count"], 1);
+    assert_eq!(response.body["allowlist"]["members_visible"], false);
+    let body = response.body.to_string();
+    assert!(!body.contains("pi-count-a"));
+    assert!(!body.contains(&account_id));
+}
+
+#[tokio::test]
+async fn closed_launch_blocks_non_allowlisted_pi_auth() {
+    let test_state = new_test_state().await.expect("test database state");
+    test_state
+        .state
+        .launch_posture
+        .replace_config_for_test(LaunchPostureConfig::closed_for_test())
+        .await;
+    let app = build_app(test_state.state.clone());
+
+    let response = post_json(
+        &app,
+        "/api/auth/pi",
+        None,
+        json!({
+            "pi_uid": "pi-launch-closed",
+            "username": "launch-closed",
+            "wallet_address": "wallet-pi-launch-closed",
+            "access_token": "access-token-pi-launch-closed"
+        }),
+    )
+    .await;
+
+    assert_eq!(response.status, StatusCode::FORBIDDEN);
+    assert_eq!(response.body["error"], "launch_closed");
+    assert_eq!(response.body["message_code"], "launch_closed");
+}
+
+#[tokio::test]
+async fn pilot_launch_allows_allowlisted_pi_auth() {
+    let test_state = new_test_state().await.expect("test database state");
+    test_state
+        .state
+        .launch_posture
+        .replace_config_for_test(LaunchPostureConfig::pilot_for_test(
+            &["pi-launch-pilot-allowed"],
+            &[],
+        ))
+        .await;
+    let app = build_app(test_state.state.clone());
+
+    let response = post_json(
+        &app,
+        "/api/auth/pi",
+        None,
+        json!({
+            "pi_uid": "pi-launch-pilot-allowed",
+            "username": "launch-pilot-allowed",
+            "wallet_address": "wallet-pi-launch-pilot-allowed",
+            "access_token": "access-token-pi-launch-pilot-allowed"
+        }),
+    )
+    .await;
+
+    assert_eq!(response.status, StatusCode::OK);
+    assert!(response.body["token"].as_str().is_some());
+}
+
+#[tokio::test]
+async fn paused_launch_blocks_promise_creation() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let initiator = sign_in(&app, "pi-launch-promise-a", "launch-promise-a").await;
+    let counterparty = sign_in(&app, "pi-launch-promise-b", "launch-promise-b").await;
+    test_state
+        .state
+        .launch_posture
+        .replace_config_for_test(LaunchPostureConfig::paused_for_test())
+        .await;
+
+    let response = post_json(
+        &app,
+        "/api/promise/intents",
+        Some(initiator.token.as_str()),
+        json!({
+            "internal_idempotency_key": "launch-promise-paused",
+            "realm_id": "realm-launch-promise",
+            "counterparty_account_id": counterparty.account_id,
+            "deposit_amount_minor_units": 1000,
+            "currency_code": "JPY"
+        }),
+    )
+    .await;
+
+    assert_eq!(
+        response.status,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "{}",
+        response.body
+    );
+    assert_eq!(response.body["message_code"], "launch_paused");
+}
+
+#[tokio::test]
+async fn paused_launch_blocks_proof_submission() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let subject = sign_in(&app, "pi-launch-proof", "launch-proof").await;
+    test_state
+        .state
+        .launch_posture
+        .replace_config_for_test(LaunchPostureConfig::paused_for_test())
+        .await;
+
+    let response = post_json(
+        &app,
+        "/api/proof/submissions",
+        Some(subject.token.as_str()),
+        json!({
+            "challenge_id": null,
+            "venue_id": "venue-launch-proof",
+            "display_code": "123456"
+        }),
+    )
+    .await;
+
+    assert_eq!(
+        response.status,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "{}",
+        response.body
+    );
+    assert_eq!(response.body["message_code"], "launch_paused");
+}
+
+#[tokio::test]
+async fn paused_launch_blocks_realm_request() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let requester = sign_in(&app, "pi-launch-realm", "launch-realm").await;
+    test_state
+        .state
+        .launch_posture
+        .replace_config_for_test(LaunchPostureConfig::paused_for_test())
+        .await;
+
+    let response = post_json(
+        &app,
+        "/api/realms/requests",
+        Some(requester.token.as_str()),
+        realm_request_body("launch-realm-paused"),
+    )
+    .await;
+
+    assert_eq!(
+        response.status,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "{}",
+        response.body
+    );
+    assert_eq!(response.body["message_code"], "launch_paused");
+}
+
+#[tokio::test]
+async fn realm_admission_kill_switch_blocks_new_admissions() {
+    let test_state = new_test_state().await.expect("test database state");
+    test_state
+        .state
+        .launch_posture
+        .replace_config_for_test(LaunchPostureConfig::with_kill_switch_for_test(
+            LaunchAction::RealmAdmission,
+        ))
+        .await;
+    let app = build_app(test_state.state.clone());
+    let operator_id = Uuid::new_v4().to_string();
+
+    let response = request_json(
+        &app,
+        "POST",
+        &format!("/api/internal/realms/{}/admissions", Uuid::new_v4()),
+        Some("local_dev_internal_api_token"),
+        Some(operator_id.as_str()),
+        Some(realm_admission_body(
+            &Uuid::new_v4().to_string(),
+            "kill-switch",
+        )),
+    )
+    .await;
+
+    assert_eq!(
+        response.status,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "{}",
+        response.body
+    );
+    assert_eq!(response.body["message_code"], "realm_admission_paused");
+}
+
+#[tokio::test]
+async fn paused_launch_blocks_internal_realm_admission() {
+    let test_state = new_test_state().await.expect("test database state");
+    test_state
+        .state
+        .launch_posture
+        .replace_config_for_test(LaunchPostureConfig::paused_for_test())
+        .await;
+    let app = build_app(test_state.state.clone());
+
+    let response = request_json(
+        &app,
+        "POST",
+        &format!("/api/internal/realms/{}/admissions", Uuid::new_v4()),
+        Some("local_dev_internal_api_token"),
+        Some(Uuid::new_v4().to_string().as_str()),
+        Some(realm_admission_body(&Uuid::new_v4().to_string(), "paused")),
+    )
+    .await;
+
+    assert_eq!(response.status, StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(response.body["message_code"], "launch_paused");
+}
+
+#[tokio::test]
+async fn closed_launch_blocks_internal_realm_admission_for_non_allowlisted_account() {
+    let test_state = new_test_state().await.expect("test database state");
+    test_state
+        .state
+        .launch_posture
+        .replace_config_for_test(LaunchPostureConfig::closed_for_test())
+        .await;
+    let app = build_app(test_state.state.clone());
+
+    let response = request_json(
+        &app,
+        "POST",
+        &format!("/api/internal/realms/{}/admissions", Uuid::new_v4()),
+        Some("local_dev_internal_api_token"),
+        Some(Uuid::new_v4().to_string().as_str()),
+        Some(realm_admission_body(&Uuid::new_v4().to_string(), "closed")),
+    )
+    .await;
+
+    assert_eq!(response.status, StatusCode::FORBIDDEN);
+    assert_eq!(response.body["message_code"], "launch_closed");
+}
+
+#[tokio::test]
+async fn pilot_launch_blocks_internal_realm_admission_for_non_allowlisted_account() {
+    let test_state = new_test_state().await.expect("test database state");
+    test_state
+        .state
+        .launch_posture
+        .replace_config_for_test(LaunchPostureConfig::pilot_for_test(&[], &[]))
+        .await;
+    let app = build_app(test_state.state.clone());
+
+    let response = request_json(
+        &app,
+        "POST",
+        &format!("/api/internal/realms/{}/admissions", Uuid::new_v4()),
+        Some("local_dev_internal_api_token"),
+        Some(Uuid::new_v4().to_string().as_str()),
+        Some(realm_admission_body(
+            &Uuid::new_v4().to_string(),
+            "pilot-blocked",
+        )),
+    )
+    .await;
+
+    assert_eq!(response.status, StatusCode::FORBIDDEN);
+    assert_eq!(response.body["message_code"], "launch_pilot_not_allowed");
+}
+
+#[tokio::test]
+async fn pilot_launch_allows_allowlisted_internal_realm_admission_to_reach_realm_checks() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let member = sign_in(
+        &app,
+        "pi-launch-realm-admission-allowed",
+        "launch-realm-admission-allowed",
+    )
+    .await;
+    test_state
+        .state
+        .launch_posture
+        .replace_config_for_test(LaunchPostureConfig::pilot_for_test(
+            &[],
+            &[member.account_id.as_str()],
+        ))
+        .await;
+
+    let response = request_json(
+        &app,
+        "POST",
+        &format!("/api/internal/realms/{}/admissions", Uuid::new_v4()),
+        Some("local_dev_internal_api_token"),
+        Some(Uuid::new_v4().to_string().as_str()),
+        Some(realm_admission_body(
+            &member.account_id,
+            "pilot-allowed-next-layer",
+        )),
+    )
+    .await;
+
+    assert_eq!(response.status, StatusCode::UNAUTHORIZED);
+    assert_eq!(
+        response.body["error"],
+        "operator role is not allowed for realm bootstrap actions"
+    );
+    assert!(response.body.get("message_code").is_none());
+}
+
+#[tokio::test]
+async fn internal_ops_health_still_available_when_launch_paused() {
+    let test_state = new_test_state().await.expect("test database state");
+    test_state
+        .state
+        .launch_posture
+        .replace_config_for_test(LaunchPostureConfig::paused_for_test())
+        .await;
+    let app = build_app(test_state.state.clone());
+
+    let response = get_json(&app, "/api/internal/ops/health", None).await;
+
+    assert_eq!(response.status, StatusCode::OK);
+    assert_eq!(response.body["status"], "ok");
+}
+
+#[tokio::test]
+async fn observability_status_does_not_override_launch_mode() {
+    let test_state = new_test_state().await.expect("test database state");
+    test_state
+        .state
+        .launch_posture
+        .replace_config_for_test(LaunchPostureConfig::paused_for_test())
+        .await;
+    let app = build_app(test_state.state.clone());
+
+    let ops = get_json(&app, "/api/internal/ops/observability/snapshot", None).await;
+    let launch = get_json(&app, "/api/launch/posture", None).await;
+
+    assert_eq!(ops.status, StatusCode::OK);
+    assert_eq!(launch.status, StatusCode::OK);
+    assert_eq!(launch.body["launch_mode"], "paused");
+    assert_eq!(launch.body["participant_posture"], "paused");
+    assert_eq!(launch.body["message_code"], "launch_paused");
+}
+
+fn realm_request_body(suffix: &str) -> Value {
+    json!({
+        "display_name": format!("Launch Realm {suffix}"),
+        "slug_candidate": format!("launch-realm-{suffix}"),
+        "purpose_text": "Day 1 launch posture test realm",
+        "venue_context_json": {
+            "kind": "test_venue",
+            "locality": "Tokyo"
+        },
+        "expected_member_shape_json": {
+            "kind": "bounded_test_group"
+        },
+        "bootstrap_rationale_text": "Validate launch posture gating",
+        "proposed_sponsor_account_id": null,
+        "proposed_steward_account_id": null,
+        "request_idempotency_key": format!("launch-realm-request-{suffix}")
+    })
+}
+
+fn realm_admission_body(account_id: &str, suffix: &str) -> Value {
+    json!({
+        "account_id": account_id,
+        "sponsor_record_id": null,
+        "source_fact_kind": "launch_posture_test",
+        "source_fact_id": format!("launch-admission-{suffix}"),
+        "source_snapshot_json": {},
+        "request_idempotency_key": format!("launch-admission-{suffix}")
+    })
+}
+
+struct SignedInUser {
+    token: String,
+    account_id: String,
+}
+
+struct JsonResponse {
+    status: StatusCode,
+    body: Value,
+}
+
+async fn sign_in(app: &Router, pi_uid: &str, username: &str) -> SignedInUser {
+    let response = post_json(
+        app,
+        "/api/auth/pi",
+        None,
+        json!({
+            "pi_uid": pi_uid,
+            "username": username,
+            "wallet_address": format!("wallet-{pi_uid}"),
+            "access_token": format!("access-token-{pi_uid}")
+        }),
+    )
+    .await;
+    assert_eq!(response.status, StatusCode::OK);
+
+    SignedInUser {
+        token: response.body["token"]
+            .as_str()
+            .expect("token must exist")
+            .to_owned(),
+        account_id: response.body["user"]["id"]
+            .as_str()
+            .expect("user id must exist")
+            .to_owned(),
+    }
+}
+
+async fn post_json(
+    app: &Router,
+    path: &str,
+    bearer_token: Option<&str>,
+    body: Value,
+) -> JsonResponse {
+    request_json(app, "POST", path, bearer_token, None, Some(body)).await
+}
+
+async fn get_json(app: &Router, path: &str, bearer_token: Option<&str>) -> JsonResponse {
+    request_json(app, "GET", path, bearer_token, None, None).await
+}
+
+async fn request_json(
+    app: &Router,
+    method: &str,
+    path: &str,
+    bearer_token: Option<&str>,
+    operator_id: Option<&str>,
+    body: Option<Value>,
+) -> JsonResponse {
+    let mut builder = Request::builder().method(method).uri(path);
+    if let Some(token) = bearer_token {
+        builder = builder.header("authorization", format!("Bearer {token}"));
+    }
+    if let Some(operator_id) = operator_id {
+        builder = builder.header("x-musubi-operator-id", operator_id);
+    }
+
+    let request = builder
+        .header("content-type", "application/json")
+        .body(match body {
+            Some(body) => Body::from(body.to_string()),
+            None => Body::empty(),
+        })
+        .expect("request must build");
+
+    let response = app
+        .clone()
+        .oneshot(request)
+        .await
+        .expect("app should respond");
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body must be readable");
+    let body = if bytes.is_empty() {
+        json!({})
+    } else {
+        serde_json::from_slice(&bytes).unwrap_or_else(|_| {
+            json!({
+                "raw_body": String::from_utf8_lossy(&bytes).to_string()
+            })
+        })
+    };
+
+    JsonResponse { status, body }
+}

--- a/apps/backend/tests/realm_bootstrap.rs
+++ b/apps/backend/tests/realm_bootstrap.rs
@@ -6,7 +6,7 @@ use axum::{
 use chrono::{DateTime, Duration, Utc};
 use musubi_backend::{
     build_app, new_state_from_config, new_test_state,
-    services::realm_bootstrap::CreateRealmRequestInput,
+    services::{launch_posture::LaunchPostureConfig, realm_bootstrap::CreateRealmRequestInput},
 };
 use musubi_db_runtime::DbConfig;
 use serde_json::{Value, json};
@@ -378,6 +378,10 @@ async fn concurrent_realm_request_replay_returns_existing_request() {
     })
     .expect("db config");
     let second_state = new_state_from_config(&config).await.expect("second state");
+    second_state
+        .launch_posture
+        .replace_config_for_test(LaunchPostureConfig::open_preview_for_test())
+        .await;
     let second_app = build_app(second_state.clone());
     let requester = sign_in(&app, "pi-user-realm-request-race", "realm-request-race").await;
     let client = test_db_client().await;
@@ -2470,6 +2474,10 @@ async fn concurrent_corridor_admissions_do_not_exceed_member_cap() {
     })
     .expect("db config");
     let second_state = new_state_from_config(&config).await.expect("second state");
+    second_state
+        .launch_posture
+        .replace_config_for_test(LaunchPostureConfig::open_preview_for_test())
+        .await;
     let second_app = build_app(second_state.clone());
     let requester = sign_in(
         &app,
@@ -3859,6 +3867,10 @@ async fn concurrent_sponsor_and_admission_replays_return_existing_rows() {
     })
     .expect("db config");
     let second_state = new_state_from_config(&config).await.expect("second state");
+    second_state
+        .launch_posture
+        .replace_config_for_test(LaunchPostureConfig::open_preview_for_test())
+        .await;
     let second_app = build_app(second_state.clone());
     let requester = sign_in(&app, "pi-user-realm-idem-race-a", "realm-idem-race-a").await;
     let sponsor = sign_in(&app, "pi-user-realm-idem-race-b", "realm-idem-race-b").await;

--- a/apps/backend/tests/realm_bootstrap.rs
+++ b/apps/backend/tests/realm_bootstrap.rs
@@ -1096,6 +1096,86 @@ async fn realm_admission_replay_survives_operator_role_revocation() {
 }
 
 #[tokio::test]
+async fn realm_admission_replay_survives_launch_pause() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let requester = sign_in(
+        &app,
+        "pi-user-realm-admission-launch-replay-a",
+        "realm-admission-launch-replay-a",
+    )
+    .await;
+    let member = sign_in(
+        &app,
+        "pi-user-realm-admission-launch-replay-b",
+        "realm-admission-launch-replay-b",
+    )
+    .await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let (realm_id, _) = create_realm(
+        &app,
+        &requester,
+        None,
+        None,
+        &approver_id,
+        "active",
+        "realm-admission-launch-replay",
+    )
+    .await;
+    let body = json!({
+        "account_id": member.account_id,
+        "source_fact_kind": "realm_admin_invite",
+        "source_fact_id": "realm-admission-launch-replay",
+        "source_snapshot_json": {},
+        "request_idempotency_key": "realm-admission-launch-replay"
+    });
+    let first = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_id}/admissions"),
+        &approver_id,
+        body.clone(),
+    )
+    .await;
+    assert_eq!(first.status, StatusCode::OK);
+    let admission_id = first.body["realm_admission_id"]
+        .as_str()
+        .expect("admission id must exist")
+        .to_owned();
+
+    test_state
+        .replace_launch_config_for_test(LaunchPostureConfig::paused_for_test())
+        .await;
+
+    let replay = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_id}/admissions"),
+        &approver_id,
+        body,
+    )
+    .await;
+    assert_eq!(replay.status, StatusCode::OK);
+    assert_eq!(replay.body["realm_admission_id"], admission_id);
+
+    let new_admission = operator_post_json(
+        &app,
+        &format!("/api/internal/realms/{realm_id}/admissions"),
+        &approver_id,
+        json!({
+            "account_id": member.account_id,
+            "source_fact_kind": "realm_admin_invite",
+            "source_fact_id": "realm-admission-launch-paused-new",
+            "source_snapshot_json": {},
+            "request_idempotency_key": "realm-admission-launch-paused-new"
+        }),
+    )
+    .await;
+    assert_eq!(new_admission.status, StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(new_admission.body["message_code"], "launch_paused");
+}
+
+#[tokio::test]
 async fn bootstrap_summary_authorizes_against_latest_admission_status() {
     let test_state = new_test_state().await.expect("test database state");
     let app = build_app(test_state.state.clone());

--- a/apps/backend/tests/realm_bootstrap.rs
+++ b/apps/backend/tests/realm_bootstrap.rs
@@ -378,9 +378,11 @@ async fn concurrent_realm_request_replay_returns_existing_request() {
     })
     .expect("db config");
     let second_state = new_state_from_config(&config).await.expect("second state");
-    second_state
-        .launch_posture
-        .replace_config_for_test(LaunchPostureConfig::open_preview_for_test())
+    test_state
+        .replace_launch_config_for_state_for_test(
+            &second_state,
+            LaunchPostureConfig::open_preview_for_test(),
+        )
         .await;
     let second_app = build_app(second_state.clone());
     let requester = sign_in(&app, "pi-user-realm-request-race", "realm-request-race").await;
@@ -2474,9 +2476,11 @@ async fn concurrent_corridor_admissions_do_not_exceed_member_cap() {
     })
     .expect("db config");
     let second_state = new_state_from_config(&config).await.expect("second state");
-    second_state
-        .launch_posture
-        .replace_config_for_test(LaunchPostureConfig::open_preview_for_test())
+    test_state
+        .replace_launch_config_for_state_for_test(
+            &second_state,
+            LaunchPostureConfig::open_preview_for_test(),
+        )
         .await;
     let second_app = build_app(second_state.clone());
     let requester = sign_in(
@@ -3867,9 +3871,11 @@ async fn concurrent_sponsor_and_admission_replays_return_existing_rows() {
     })
     .expect("db config");
     let second_state = new_state_from_config(&config).await.expect("second state");
-    second_state
-        .launch_posture
-        .replace_config_for_test(LaunchPostureConfig::open_preview_for_test())
+    test_state
+        .replace_launch_config_for_state_for_test(
+            &second_state,
+            LaunchPostureConfig::open_preview_for_test(),
+        )
         .await;
     let second_app = build_app(second_state.clone());
     let requester = sign_in(&app, "pi-user-realm-idem-race-a", "realm-idem-race-a").await;


### PR DESCRIPTION
## Summary

Implements design ISSUE-18: launch posture / Day 1 pilot.

This PR adds server-enforced launch posture so Day 1 remains bounded by default. It introduces launch modes, kill switch handling, closed cohort gating, participant-safe launch posture copy, and internal redacted launch posture visibility.

## What changed

- Added launch posture config/parser/service.
- Added production launch modes:
  - `closed`
  - `pilot`
  - `paused`
- Added route-level kill switches for:
  - auth
  - Promise creation
  - proof challenge
  - proof submission
  - Realm requests
  - Realm admissions
- Added participant-safe launch posture endpoint:
  - `GET /api/launch/posture`
- Added internal launch posture endpoint:
  - `GET /api/internal/launch/posture`
- Added docs:
  - `apps/backend/docs/launch_posture_day1.md`

`open_preview` remains available only as a test helper; production env parsing treats it as unsupported and fails closed.

## Config keys

- `MUSUBI_LAUNCH_MODE`
- `MUSUBI_LAUNCH_ALLOWLIST_PI_UIDS`
- `MUSUBI_LAUNCH_ALLOWLIST_ACCOUNT_IDS`
- `MUSUBI_LAUNCH_SUPPORT_CONTACT_URL`
- `MUSUBI_LAUNCH_SUPPORT_CONTACT_LABEL`
- `MUSUBI_KILL_SWITCH_AUTH`
- `MUSUBI_KILL_SWITCH_PROMISE_CREATION`
- `MUSUBI_KILL_SWITCH_PROOF_CHALLENGE`
- `MUSUBI_KILL_SWITCH_PROOF_SUBMISSION`
- `MUSUBI_KILL_SWITCH_REALM_REQUESTS`
- `MUSUBI_KILL_SWITCH_REALM_ADMISSIONS`

## Boundary preserved

- Launch posture is server-enforced.
- Public open launch is not implemented.
- Invalid config fails closed.
- Internal Realm admission is launch-gated by the target participant account.
- Observability is not launch truth.
- Projection rows are not launch truth.
- UI/mobile state is not launch truth.
- Participant responses do not expose allowlist members or internal config details.
- Internal ops/readiness remain available during participant launch pause.

## Migration status

No migration added.

## Out of scope

This PR does not implement:

- ISSUE-16 reconciliation / PITR / failover
- public launch
- dynamic admin UI for launch flags
- external alert integrations
- referral loops
- ranking / recommendation boosts
- DM unlock behavior
- paid romantic advantage
- Promise proof persistence
- Promise completion writer baseline
- ISSUE-12/13/14/15/17 reimplementation

## Validation

Run from `apps/backend`:

- `cargo check`
- `cargo test --test launch_posture --no-fail-fast`
- `cargo test --no-fail-fast`
- `make ENV_FILE=.env.example db-status`
- `git diff --check`

`db-status` reported: applied 18 / pending 0 / failed 0 / checksum drift 0.

## Tests added/updated

- `launch_posture_defaults_to_closed_or_pilot_safe_mode`
- `invalid_launch_mode_fails_closed`
- `open_preview_env_mode_fails_closed_and_blocks_participant_writes`
- `launch_public_posture_redacts_internal_allowlist`
- `launch_internal_posture_requires_internal_gate`
- `launch_internal_posture_reports_allowlist_counts_not_members`
- `closed_launch_blocks_non_allowlisted_pi_auth`
- `pilot_launch_allows_allowlisted_pi_auth`
- `paused_launch_blocks_promise_creation`
- `paused_launch_blocks_proof_submission`
- `paused_launch_blocks_realm_request`
- `realm_admission_kill_switch_blocks_new_admissions`
- `paused_launch_blocks_internal_realm_admission`
- `closed_launch_blocks_internal_realm_admission_for_non_allowlisted_account`
- `pilot_launch_blocks_internal_realm_admission_for_non_allowlisted_account`
- `pilot_launch_allows_allowlisted_internal_realm_admission_to_reach_realm_checks`
- `internal_ops_health_still_available_when_launch_paused`
- `observability_status_does_not_override_launch_mode`

## Known limitations / deferred

- Dynamic launch flag admin UI is deferred.
- ISSUE-16 reconciliation/PITR/failover is deferred.
- Public launch is deferred.
- External alert integrations are deferred.

## AI review prevention checklist

- [x] ISSUE-18 only.
- [x] Public open launch is not implemented.
- [x] Invalid config fails closed.
- [x] Participant write routes are server-gated.
- [x] Kill switches are enforced server-side.
- [x] Internal Realm admission cannot bypass closed/pilot/paused posture.
- [x] Internal ops/readiness remain available during pause.
- [x] Allowlist members are not exposed.
- [x] Observability/projection/UI are not launch truth.
- [x] Tests prove closed/pilot/paused behavior.