### PR TITLE
test: enforce ADR-0008 realm admission projection non-authority

### DIFF
--- a/apps/backend/tests/realm_bootstrap.rs
+++ b/apps/backend/tests/realm_bootstrap.rs
@@ -1249,6 +1249,153 @@ async fn bootstrap_summary_authorizes_against_latest_admission_status() {
 }
 
 #[tokio::test]
+async fn forged_realm_admission_projection_does_not_authorize_participant_summary() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let requester = sign_in(
+        &app,
+        "pi-user-realm-projection-authority-a",
+        "realm-projection-authority-a",
+    )
+    .await;
+    let outsider = sign_in(
+        &app,
+        "pi-user-realm-projection-authority-b",
+        "realm-projection-authority-b",
+    )
+    .await;
+    let client = test_db_client().await;
+    let approver_id = insert_operator_account(&client, "approver").await;
+
+    let (realm_id, _) = create_realm(
+        &app,
+        &requester,
+        None,
+        None,
+        &approver_id,
+        "active",
+        "realm-projection-authority",
+    )
+    .await;
+    assert_eq!(
+        admission_count_for_account(&client, &realm_id, &outsider.account_id).await,
+        0
+    );
+    let writer_admission_count_before: i64 = client
+        .query_one(
+            "
+            SELECT COUNT(*) AS count
+            FROM dao.realm_admissions
+            WHERE realm_id = $1
+            ",
+            &[&realm_id],
+        )
+        .await
+        .expect("writer admission count must query")
+        .get("count");
+
+    let outsider_account_id =
+        Uuid::parse_str(&outsider.account_id).expect("outsider account id must be uuid");
+    client
+        .execute(
+            "
+            INSERT INTO projection.realm_admission_views (
+                realm_id,
+                account_id,
+                admission_status,
+                admission_kind,
+                public_reason_code,
+                source_watermark_at,
+                source_fact_count,
+                projection_lag_ms,
+                rebuild_generation,
+                last_projected_at
+            )
+            VALUES (
+                $1,
+                $2,
+                'admitted',
+                'normal',
+                'active_after_review',
+                CURRENT_TIMESTAMP,
+                1,
+                0,
+                99,
+                CURRENT_TIMESTAMP
+            )
+            ",
+            &[&realm_id, &outsider_account_id],
+        )
+        .await
+        .expect("forged admission projection row must insert");
+
+    let forged_projection = client
+        .query_one(
+            "
+            SELECT admission_status, admission_kind, public_reason_code
+            FROM projection.realm_admission_views
+            WHERE realm_id = $1
+              AND account_id = $2
+            ",
+            &[&realm_id, &outsider_account_id],
+        )
+        .await
+        .expect("forged projection row must query");
+    assert_eq!(
+        forged_projection.get::<_, String>("admission_status"),
+        "admitted"
+    );
+    assert_eq!(
+        forged_projection.get::<_, String>("admission_kind"),
+        "normal"
+    );
+    assert_eq!(
+        forged_projection.get::<_, String>("public_reason_code"),
+        "active_after_review"
+    );
+
+    let outsider_summary = get_json(
+        &app,
+        &format!("/api/projection/realms/{realm_id}/bootstrap-summary"),
+        Some(outsider.token.as_str()),
+    )
+    .await;
+    assert_eq!(outsider_summary.status, StatusCode::NOT_FOUND);
+    assert_eq!(
+        admission_count_for_account(&client, &realm_id, &outsider.account_id).await,
+        0
+    );
+    let writer_admission_count_after: i64 = client
+        .query_one(
+            "
+            SELECT COUNT(*) AS count
+            FROM dao.realm_admissions
+            WHERE realm_id = $1
+            ",
+            &[&realm_id],
+        )
+        .await
+        .expect("writer admission count must query")
+        .get("count");
+    assert_eq!(writer_admission_count_after, writer_admission_count_before);
+
+    let forged_projection_status: String = client
+        .query_one(
+            "
+            SELECT admission_status
+            FROM projection.realm_admission_views
+            WHERE realm_id = $1
+              AND account_id = $2
+            ",
+            &[&realm_id, &outsider_account_id],
+        )
+        .await
+        .expect("forged projection row must remain queryable")
+        .get("admission_status");
+    assert_eq!(forged_projection_status, "admitted");
+}
+
+#[tokio::test]
 async fn approval_rejects_already_expired_corridor() {
     let test_state = new_test_state().await.expect("test database state");
     let app = build_app(test_state.state.clone());


### PR DESCRIPTION
## Summary

Adds the ADR-0008 Phase 1 regression test.

This is a test-only patch proving that a forged `projection.realm_admission_views` row cannot authorize participant Realm bootstrap summary access when writer truth does not authorize the participant.

## Foundation

- Accepted foundation ADR: ADR-0008 Server / Realm / Citadel / Pool ownership boundaries
- Supporting accepted ADR: ADR-0006 writer truth / projection authority
- Supporting accepted ADRs: ADR-0007 PII / evidence segregation, ADR-0009 account constraints, ADR-0010 Promise / Social Trust / Relationship Depth semantics
- Foundation revision: musubi-foundation `0c1c636`

## Scope

Changed file:

- `apps/backend/tests/realm_bootstrap.rs`

No runtime code changed.
No schema changed.
No migrations changed.
No projection schema changed.
No Realm admission runtime code changed.
No Realm bootstrap runtime code changed.
No Server alias semantics introduced.
No Server alias tombstone or cooldown semantics introduced.
No Citadel binding semantics introduced.
No authority lease semantics introduced.
No Realm relocation lifecycle semantics introduced.
No Pool attribution or substrate semantics introduced.
No `docs/adr_reconstruction` files were used as implementation authority.

## Added test

- `forged_realm_admission_projection_does_not_authorize_participant_summary`

The test arranges:

- an active Realm
- an outsider account
- no `dao.realm_admissions` writer row authorizing the outsider
- a forged `projection.realm_admission_views` row showing the outsider as `admitted`

Expected result:

- outsider `GET /api/projection/realms/{realm_id}/bootstrap-summary` remains `NOT_FOUND`
- no writer admission row is created
- projection does not become Realm admission authority

## Checks

Passed:

```text
cargo test --test realm_bootstrap forged_realm_admission_projection_does_not_authorize_participant_summary
cargo test --test realm_bootstrap
git diff --check
bidi control character check
```

Known formatting issue:

```text
cargo fmt -- --check
```

This fails due to pre-existing unrelated `operator_review` formatting. The new `realm_bootstrap.rs` hunk was manually kept formatted and is not the source of the formatting failure.

## Prompt 3 boundary

Prompt 3 is not globally unblocked.

This PR implements only the ADR-0008 Phase 1 test-only regression coverage.

This PR does not complete Server alias semantics.
This PR does not introduce Server alias tombstone or cooldown semantics.
This PR does not implement Citadel binding.
This PR does not implement authority lease semantics.
This PR does not implement Realm relocation lifecycle.
This PR does not implement Pool attribution or substrate semantics.
This PR does not redesign topology ownership.