### PR TITLE
fix: require Ordinary Account for Promise participants

### DIFF
--- a/apps/backend/src/services/happy_route/repository.rs
+++ b/apps/backend/src/services/happy_route/repository.rs
@@ -339,16 +339,18 @@ impl HappyRouteStore {
         let mut client = self.client.lock().await;
         let tx = client.transaction().await.map_err(db_error)?;
 
-        ensure_account_exists(
+        ensure_ordinary_account_exists(
             &tx,
             &initiator_account_id,
             "initiator account was not found",
+            "initiator account must be an Ordinary Account",
         )
         .await?;
-        ensure_account_exists(
+        ensure_ordinary_account_exists(
             &tx,
             &counterparty_account_id,
             "counterparty account was not found",
+            "counterparty account must be an Ordinary Account",
         )
         .await?;
 
@@ -2790,15 +2792,16 @@ enum CommandBegin {
     Completed,
 }
 
-async fn ensure_account_exists(
+async fn ensure_ordinary_account_exists(
     tx: &tokio_postgres::Transaction<'_>,
     account_id: &Uuid,
     not_found_message: &str,
+    non_ordinary_message: &str,
 ) -> Result<(), HappyRouteError> {
-    let exists = tx
+    let Some(row) = tx
         .query_opt(
             "
-            SELECT account_id
+            SELECT account_class
             FROM core.accounts
             WHERE account_id = $1
               AND account_state = 'active'
@@ -2807,11 +2810,14 @@ async fn ensure_account_exists(
         )
         .await
         .map_err(db_error)?
-        .is_some();
-    if exists {
+    else {
+        return Err(HappyRouteError::NotFound(not_found_message.to_owned()));
+    };
+    let account_class: String = row.get("account_class");
+    if account_class == "Ordinary Account" {
         Ok(())
     } else {
-        Err(HappyRouteError::NotFound(not_found_message.to_owned()))
+        Err(HappyRouteError::BadRequest(non_ordinary_message.to_owned()))
     }
 }
 

--- a/apps/backend/tests/happy_route.rs
+++ b/apps/backend/tests/happy_route.rs
@@ -5021,6 +5021,226 @@ async fn promise_intent_rejects_blank_internal_idempotency_key() {
 }
 
 #[tokio::test]
+async fn controlled_exceptional_account_cannot_create_promise_as_participant() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let controlled = sign_in(&app, "pi-user-controlled-promise-a", "controlled-promise-a").await;
+    let counterparty = sign_in(&app, "pi-user-controlled-promise-b", "controlled-promise-b").await;
+    let controlled_account_id =
+        Uuid::parse_str(&controlled.account_id).expect("controlled account id must be uuid");
+    let client = test_db_client().await;
+
+    client
+        .execute(
+            "
+            UPDATE core.accounts
+            SET account_class = 'Controlled Exceptional Account'
+            WHERE account_id = $1
+            ",
+            &[&controlled_account_id],
+        )
+        .await
+        .expect("account class fixture must update");
+
+    let account_row = client
+        .query_one(
+            "
+            SELECT account_class, account_state
+            FROM core.accounts
+            WHERE account_id = $1
+            ",
+            &[&controlled_account_id],
+        )
+        .await
+        .expect("controlled account fixture must exist");
+    assert_eq!(
+        account_row.get::<_, String>("account_class"),
+        "Controlled Exceptional Account"
+    );
+    assert_eq!(account_row.get::<_, String>("account_state"), "active");
+
+    let create_promise = post_json(
+        &app,
+        "/api/promise/intents",
+        Some(controlled.token.as_str()),
+        json!({
+            "internal_idempotency_key": "controlled-exceptional-promise",
+            "realm_id": "realm-controlled-exceptional-promise",
+            "counterparty_account_id": counterparty.account_id,
+            "deposit_amount_minor_units": 10000,
+            "currency_code": "PI"
+        }),
+    )
+    .await;
+
+    let rebuild = post_json(&app, "/api/internal/projection/rebuild", None, json!({})).await;
+    assert_eq!(rebuild.status, StatusCode::OK);
+
+    let row = client
+        .query_one(
+            "
+            SELECT
+                (SELECT count(*)
+                   FROM dao.promise_intents
+                  WHERE initiator_account_id = $1
+                     OR counterparty_account_id = $1) AS promise_count,
+                (SELECT count(*)
+                   FROM dao.settlement_cases settlement
+                   JOIN dao.promise_intents promise
+                     ON promise.promise_intent_id = settlement.promise_intent_id
+                  WHERE promise.initiator_account_id = $1
+                     OR promise.counterparty_account_id = $1) AS settlement_count,
+                (SELECT count(*)
+                   FROM projection.trust_snapshots
+                  WHERE account_id = $1) AS trust_snapshot_count,
+                (SELECT count(*)
+                   FROM projection.realm_trust_snapshots
+                  WHERE account_id = $1) AS realm_trust_snapshot_count
+            ",
+            &[&controlled_account_id],
+        )
+        .await
+        .expect("controlled account participant effects must be queryable");
+    assert_eq!(
+        row.get::<_, i64>("promise_count"),
+        0,
+        "Controlled Exceptional Account must not create Promise writer facts; response status was {:?}",
+        create_promise.status
+    );
+    assert_eq!(
+        row.get::<_, i64>("settlement_count"),
+        0,
+        "Controlled Exceptional Account must not create settlement writer facts; response status was {:?}",
+        create_promise.status
+    );
+    assert_eq!(row.get::<_, i64>("trust_snapshot_count"), 0);
+    assert_eq!(row.get::<_, i64>("realm_trust_snapshot_count"), 0);
+    assert!(
+        matches!(
+            create_promise.status,
+            StatusCode::BAD_REQUEST | StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN
+        ),
+        "Controlled Exceptional Account participant request must be rejected; got {:?}",
+        create_promise.status
+    );
+}
+
+#[tokio::test]
+async fn controlled_exceptional_account_cannot_be_promise_counterparty() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let initiator = sign_in(
+        &app,
+        "pi-user-controlled-counterparty-a",
+        "controlled-counterparty-a",
+    )
+    .await;
+    let controlled = sign_in(
+        &app,
+        "pi-user-controlled-counterparty-b",
+        "controlled-counterparty-b",
+    )
+    .await;
+    let controlled_account_id =
+        Uuid::parse_str(&controlled.account_id).expect("controlled account id must be uuid");
+    let client = test_db_client().await;
+
+    client
+        .execute(
+            "
+            UPDATE core.accounts
+            SET account_class = 'Controlled Exceptional Account'
+            WHERE account_id = $1
+            ",
+            &[&controlled_account_id],
+        )
+        .await
+        .expect("account class fixture must update");
+
+    let account_row = client
+        .query_one(
+            "
+            SELECT account_class, account_state
+            FROM core.accounts
+            WHERE account_id = $1
+            ",
+            &[&controlled_account_id],
+        )
+        .await
+        .expect("controlled account fixture must exist");
+    assert_eq!(
+        account_row.get::<_, String>("account_class"),
+        "Controlled Exceptional Account"
+    );
+    assert_eq!(account_row.get::<_, String>("account_state"), "active");
+
+    let create_promise = post_json(
+        &app,
+        "/api/promise/intents",
+        Some(initiator.token.as_str()),
+        json!({
+            "internal_idempotency_key": "controlled-exceptional-counterparty",
+            "realm_id": "realm-controlled-exceptional-counterparty",
+            "counterparty_account_id": controlled.account_id,
+            "deposit_amount_minor_units": 10000,
+            "currency_code": "PI"
+        }),
+    )
+    .await;
+
+    let rebuild = post_json(&app, "/api/internal/projection/rebuild", None, json!({})).await;
+    assert_eq!(rebuild.status, StatusCode::OK);
+
+    let row = client
+        .query_one(
+            "
+            SELECT
+                (SELECT count(*)
+                   FROM dao.promise_intents
+                  WHERE initiator_account_id = $1
+                     OR counterparty_account_id = $1) AS promise_count,
+                (SELECT count(*)
+                   FROM dao.settlement_cases settlement
+                   JOIN dao.promise_intents promise
+                     ON promise.promise_intent_id = settlement.promise_intent_id
+                  WHERE promise.initiator_account_id = $1
+                     OR promise.counterparty_account_id = $1) AS settlement_count,
+                (SELECT count(*)
+                   FROM projection.trust_snapshots
+                  WHERE account_id = $1) AS trust_snapshot_count,
+                (SELECT count(*)
+                   FROM projection.realm_trust_snapshots
+                  WHERE account_id = $1) AS realm_trust_snapshot_count
+            ",
+            &[&controlled_account_id],
+        )
+        .await
+        .expect("controlled counterparty participant effects must be queryable");
+    assert_eq!(
+        row.get::<_, i64>("promise_count"),
+        0,
+        "Controlled Exceptional Account must not receive Promise writer facts; response status was {:?}",
+        create_promise.status
+    );
+    assert_eq!(
+        row.get::<_, i64>("settlement_count"),
+        0,
+        "Controlled Exceptional Account must not receive settlement writer facts; response status was {:?}",
+        create_promise.status
+    );
+    assert_eq!(row.get::<_, i64>("trust_snapshot_count"), 0);
+    assert_eq!(row.get::<_, i64>("realm_trust_snapshot_count"), 0);
+    assert!(
+        matches!(
+            create_promise.status,
+            StatusCode::BAD_REQUEST | StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN
+        ),
+        "Controlled Exceptional Account counterparty request must be rejected; got {:?}",
+        create_promise.status
+    );
+}
+
+#[tokio::test]
 async fn promise_intent_idempotency_is_scoped_per_initiator() {
     let test_state = new_test_state().await.expect("test database state");
     let app = build_app(test_state.state.clone());


### PR DESCRIPTION
## Summary

Fixes Issue #50.

A Controlled Exceptional Account could create a Promise as participant. This PR adds a minimal PostgreSQL writer-truth guard to the Promise creation path so Promise participants must be Ordinary Accounts.

## Foundation

- ADR-0009 Account constraints
- ADR-0010 Promise / Social Trust / Relationship Depth semantics
- ADR-0006 writer truth / projection authority
- ADR-0007 PII / evidence segregation
- Foundation revision: musubi-foundation `0c1c636`

## Scope

Changed files:

- `apps/backend/src/services/happy_route/repository.rs`
- `apps/backend/tests/happy_route.rs`

No schema changes.
No migrations.
No projection schema changes.
No broad account lifecycle semantics.
No anti-abuse continuity implementation.
No age-assurance implementation.
No deletion / clean-account-reset semantics.
No memorial / estate workflow.
No discovery / recommendation changes.
No `docs/adr_reconstruction` authority.

## Fix

The Promise creation writer path now checks PostgreSQL writer truth before inserting `dao.promise_intents`.

Promise participants must be Ordinary Accounts.

The guard rejects Controlled Exceptional Accounts before Promise writer facts or downstream settlement facts can be created.

## Regression

Added:

- `controlled_exceptional_account_cannot_create_promise_as_participant`
- `controlled_exceptional_account_cannot_be_promise_counterparty`

Expected:

- Controlled Exceptional Account request is rejected.
- No `dao.promise_intents` row is created.
- No `dao.settlement_cases` row is created.
- No trust projection rows are created for the Controlled Exceptional Account from the rejected attempt.
- Existing Ordinary Account happy path remains valid.

## Checks

Passed:

```text
cargo test --test happy_route controlled_exceptional_account_cannot_create_promise_as_participant
cargo test --test happy_route controlled_exceptional_account_cannot_be_promise_counterparty
cargo test --test happy_route
git diff --check
bidi control character check
```

Known formatting issue:

```text
cargo fmt -- --check
```

This fails due to pre-existing unrelated `operator_review` formatting. The new `happy_route.rs` and `repository.rs` hunks are not the source of the formatting failure.

## Prompt 3 boundary

Prompt 3 is not globally unblocked.

This PR fixes only Issue #50.

This PR does not claim ADR-0009 is fully implemented.
This PR does not complete Natural Person uniqueness.
This PR does not implement anti-abuse continuity.
This PR does not implement age-assurance state.
This PR does not define deletion / clean-account-reset semantics.
This PR does not implement memorial / estate workflow.
This PR does not complete discovery / recommendation constraints.
