### PR TITLE
test: enforce ADR-0010 payment amount trust non-authority

### DIFF
--- a/apps/backend/tests/happy_route.rs
+++ b/apps/backend/tests/happy_route.rs
@@ -265,6 +265,127 @@ async fn projection_read_models_expose_freshness_and_bounded_trust() {
 }
 
 #[tokio::test]
+async fn larger_payment_amount_does_not_improve_trust_projection() {
+    let test_state = new_test_state().await.expect("test database state");
+    let app = build_app(test_state.state.clone());
+    let realm_id = "realm-adr-0010-payment-amount";
+    let smaller_amount_minor_units = 12_345_i64;
+    let larger_amount_minor_units = 9_876_543_i64;
+
+    let smaller = prepare_funded_case_with_amount(
+        &app,
+        "adr-0010-payment-small",
+        realm_id,
+        smaller_amount_minor_units,
+    )
+    .await;
+    let larger = prepare_funded_case_with_amount(
+        &app,
+        "adr-0010-payment-large",
+        realm_id,
+        larger_amount_minor_units,
+    )
+    .await;
+
+    let rebuild = post_json(&app, "/api/internal/projection/rebuild", None, json!({})).await;
+    assert_eq!(rebuild.status, StatusCode::OK);
+
+    let smaller_global = get_json(
+        &app,
+        &format!(
+            "/api/projection/trust-snapshots/{}",
+            smaller.initiator_account_id
+        ),
+        Some(smaller.initiator_token.as_str()),
+    )
+    .await;
+    assert_eq!(smaller_global.status, StatusCode::OK);
+    let larger_global = get_json(
+        &app,
+        &format!(
+            "/api/projection/trust-snapshots/{}",
+            larger.initiator_account_id
+        ),
+        Some(larger.initiator_token.as_str()),
+    )
+    .await;
+    assert_eq!(larger_global.status, StatusCode::OK);
+
+    let smaller_realm = get_json(
+        &app,
+        &format!(
+            "/api/projection/realm-trust-snapshots/{}/{}",
+            realm_id, smaller.initiator_account_id
+        ),
+        Some(smaller.initiator_token.as_str()),
+    )
+    .await;
+    assert_eq!(smaller_realm.status, StatusCode::OK);
+    let larger_realm = get_json(
+        &app,
+        &format!(
+            "/api/projection/realm-trust-snapshots/{}/{}",
+            realm_id, larger.initiator_account_id
+        ),
+        Some(larger.initiator_token.as_str()),
+    )
+    .await;
+    assert_eq!(larger_realm.status, StatusCode::OK);
+
+    let assert_amount_non_authority = |smaller: &Value, larger: &Value| {
+        assert_eq!(
+            smaller["promise_participation_count_90d"],
+            larger["promise_participation_count_90d"]
+        );
+        assert_eq!(
+            smaller["funded_settlement_count_90d"],
+            larger["funded_settlement_count_90d"]
+        );
+        assert_eq!(smaller["promise_participation_count_90d"], 1);
+        assert_eq!(smaller["funded_settlement_count_90d"], 1);
+        assert_eq!(larger["promise_participation_count_90d"], 1);
+        assert_eq!(larger["funded_settlement_count_90d"], 1);
+
+        assert_eq!(smaller["trust_posture"], larger["trust_posture"]);
+        assert_eq!(smaller["reason_codes"], larger["reason_codes"]);
+        assert_eq!(
+            smaller["manual_review_case_bucket"],
+            larger["manual_review_case_bucket"]
+        );
+        assert_eq!(smaller["proof_status"], larger["proof_status"]);
+        assert_eq!(smaller["proof_signal_count"], larger["proof_signal_count"]);
+
+        for projection in [smaller, larger] {
+            assert!(projection.get("trust_score").is_none());
+            assert!(projection.get("rank").is_none());
+            assert!(projection.get("tier").is_none());
+            assert!(projection.get("trust_tier").is_none());
+            assert!(projection.get("amount_minor_units").is_none());
+            assert!(projection.get("deposit_amount_minor_units").is_none());
+            assert!(projection.get("payment_amount").is_none());
+            assert!(projection.get("payment_amount_minor_units").is_none());
+
+            let reason_codes = projection["reason_codes"]
+                .as_array()
+                .expect("reason_codes must be an array");
+            assert!(
+                !reason_codes
+                    .iter()
+                    .any(|code| code.as_str().is_some_and(|code| code.contains("amount"))),
+                "payment amount must not appear as a trust reason"
+            );
+
+            let projection_text = projection.to_string();
+            assert!(!projection_text.contains(&smaller_amount_minor_units.to_string()));
+            assert!(!projection_text.contains(&larger_amount_minor_units.to_string()));
+        }
+    };
+
+    assert_amount_non_authority(&smaller_global.body, &larger_global.body);
+    assert_amount_non_authority(&smaller_realm.body, &larger_realm.body);
+}
+
+#[tokio::test]
 async fn projection_rebuild_restores_read_models_from_writer_truth() {
     let test_state = new_test_state().await.expect("test database state");
     let app = build_app(test_state.state.clone());
@@ -5601,18 +5722,27 @@ async fn create_undrained_open_hold(app: &Router, suffix: &str) -> OpenHoldFixtu
 }
 
 async fn prepare_pending_case(app: &Router) -> PreparedCase {
-    let initiator = sign_in(app, "pi-user-prepare-a", "prepare-a").await;
-    let counterparty = sign_in(app, "pi-user-prepare-b", "prepare-b").await;
+    prepare_pending_case_with_amount(app, "prepare", "realm-prepare", 10000).await
+}
+
+async fn prepare_pending_case_with_amount(
+    app: &Router,
+    suffix: &str,
+    realm_id: &str,
+    amount_minor_units: i64,
+) -> PreparedCase {
+    let initiator = sign_in(app, &format!("pi-user-{suffix}-a"), &format!("{suffix}-a")).await;
+    let counterparty = sign_in(app, &format!("pi-user-{suffix}-b"), &format!("{suffix}-b")).await;
 
     let create_promise = post_json(
         app,
         "/api/promise/intents",
         Some(initiator.token.as_str()),
         json!({
-            "internal_idempotency_key": "promise-intent-prepare",
-            "realm_id": "realm-prepare",
+            "internal_idempotency_key": format!("promise-intent-{suffix}"),
+            "realm_id": realm_id,
             "counterparty_account_id": counterparty.account_id,
-            "deposit_amount_minor_units": 10000,
+            "deposit_amount_minor_units": amount_minor_units,
             "currency_code": "PI"
         }),
     )
@@ -5643,7 +5773,7 @@ async fn prepare_pending_case(app: &Router) -> PreparedCase {
     PreparedCase {
         promise_intent_id,
         settlement_case_id,
-        realm_id: "realm-prepare".to_owned(),
+        realm_id: realm_id.to_owned(),
         payment_id,
         initiator_account_id: initiator.account_id,
         initiator_pi_uid: initiator.pi_uid,
@@ -5949,6 +6079,38 @@ async fn prepare_funded_case(app: &Router) -> PreparedCase {
             "amount_minor_units": 10000,
             "currency_code": "PI",
             "txid": "pi-tx-prepare",
+            "status": "completed"
+        }),
+    )
+    .await;
+    assert_eq!(callback.status, StatusCode::OK);
+
+    let drain_projection =
+        post_json(app, "/api/internal/orchestration/drain", None, json!({})).await;
+    assert_eq!(drain_projection.status, StatusCode::OK);
+
+    prepared
+}
+
+async fn prepare_funded_case_with_amount(
+    app: &Router,
+    suffix: &str,
+    realm_id: &str,
+    amount_minor_units: i64,
+) -> PreparedCase {
+    let prepared =
+        prepare_pending_case_with_amount(app, suffix, realm_id, amount_minor_units).await;
+
+    let callback = post_json(
+        app,
+        "/api/payment/callback",
+        None,
+        json!({
+            "payment_id": prepared.payment_id,
+            "payer_pi_uid": prepared.initiator_pi_uid,
+            "amount_minor_units": amount_minor_units,
+            "currency_code": "PI",
+            "txid": format!("pi-tx-{suffix}"),
             "status": "completed"
         }),
     )


### PR DESCRIPTION
## Summary

Adds the ADR-0010 first regression test.

This is a test-only projection-level patch proving that a larger payment amount does not improve Social Trust projection posture, reason codes, or trust-like display output.

## Foundation

- Accepted foundation ADR: ADR-0010 Promise / Social Trust / Relationship Depth semantics
- Supporting accepted ADR: ADR-0006 writer truth / projection authority
- Supporting accepted ADRs: ADR-0007 PII / evidence segregation, ADR-0009 account constraints
- Foundation revision: musubi-foundation `0c1c636`

## Scope

Changed file:

- `apps/backend/tests/happy_route.rs`

No runtime code changed.
No schema changed.
No migrations changed.
No projection schema changed.
No Social Trust writer facts introduced.
No Social Trust mutation semantics introduced.
No Relationship Depth writer facts or mutation semantics introduced.
No discovery / recommendation semantics introduced.
No `docs/adr_reconstruction` files were used as implementation authority.

The patch also parameterizes existing `happy_route` test helpers so the regression can create comparable funded cases with different payment amounts. This remains test-only and does not change runtime behavior.

## Added test

- `larger_payment_amount_does_not_improve_trust_projection`

The test arranges two comparable Ordinary Account funded Promise paths in the same Realm:

- same number of Promise participations
- same number of funded settlements
- same review / proof posture
- different payment amounts only

It inspects:

- `projection.trust_snapshots` via `/api/projection/trust-snapshots/{account_id}`
- `projection.realm_trust_snapshots` via `/api/projection/realm-trust-snapshots/{realm_id}/{account_id}`

Expected:

- larger payment amount does not improve `trust_posture`
- larger payment amount does not change trust `reason_codes`
- payment amount is not exposed as trust evidence / trust reason
- trust-like score/rank/tier fields remain absent

## Checks

Passed:

```text
cargo test --test happy_route larger_payment_amount_does_not_improve_trust_projection
cargo test --test happy_route
git diff --check
bidi control character check
```

Known formatting issue:

```text
cargo fmt -- --check
```

This fails due to pre-existing unrelated formatting in `apps/backend/tests/operator_review.rs` and `apps/backend/src/services/operator_review/repository.rs`. The new `happy_route.rs` hunk was manually kept formatted and is not the source of the remaining formatting failure.

## Prompt 3 boundary

Prompt 3 is not globally unblocked.

This PR implements only the ADR-0010 first test-only regression coverage.

This PR is projection-level only.
This PR does not introduce Social Trust writer facts.
This PR does not define Social Trust mutation semantics.
This PR does not introduce Relationship Depth writer facts.
This PR does not define Relationship Depth mutation semantics.
This PR does not implement proof-to-trust/depth semantics.
This PR does not implement discovery / recommendation semantics.
This PR does not treat `projection.trust_snapshots` as writer truth.
This PR does not treat `room_progression.relationship` as ADR-0010 Relationship Depth.
This PR does not claim ADR-0010 is fully implemented.
