### PR TITLE
Implement Social Trust intake contract

### DIFF
--- a/apps/backend/Cargo.lock
+++ b/apps/backend/Cargo.lock
@@ -723,6 +723,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "musubi_social_trust_domain"
+version = "0.1.0"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/apps/backend/Cargo.toml
+++ b/apps/backend/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/db-runtime",
     "crates/realm-domain",
     "crates/settlement-domain",
+    "crates/social-trust-domain",
     "crates/orchestration",
     "crates/ops",
 ]
@@ -19,6 +20,7 @@ default-members = [
     "crates/db-runtime",
     "crates/realm-domain",
     "crates/settlement-domain",
+    "crates/social-trust-domain",
     "crates/orchestration",
     "crates/ops",
 ]

--- a/apps/backend/crates/social-trust-domain/Cargo.toml
+++ b/apps/backend/crates/social-trust-domain/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "musubi_social_trust_domain"
+version.workspace = true
+edition.workspace = true

--- a/apps/backend/crates/social-trust-domain/src/lib.rs
+++ b/apps/backend/crates/social-trust-domain/src/lib.rs
@@ -1,0 +1,273 @@
+//! MUSUBI social-trust-domain crate.
+//! Owns the pure Social Trust intake / no-authority decision contract.
+//! Must not own DB persistence, projections, HTTP/API wiring, Relationship Depth,
+//! proof, settlement, discovery, recommendation, or runtime orchestration.
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProposedSocialTrustMutationAttempt {
+    pub source_category: SocialTrustSourceCategory,
+    pub writer_source_reference: Option<WriterSourceReference>,
+    pub reason_fact: Option<ReasonFactReference>,
+    pub idempotency_posture: Option<DurableIdempotencyPosture>,
+    pub evidence_posture: Option<EvidencePosture>,
+    pub reviewability_posture: Option<ReviewabilityPosture>,
+    pub retention_posture: Option<RetentionPosture>,
+    pub authority_posture: SocialTrustAuthorityPosture,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SocialTrustSourceCategory {
+    /// A placeholder for a writer-owned source category that a later accepted
+    /// implementation boundary must name before persistence is wired. This is
+    /// not a Social Trust source taxonomy or a runtime allowlist.
+    WriterSourceCandidate,
+    Forbidden(ForbiddenSocialTrustSourceCategory),
+    Unknown,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ForbiddenSocialTrustSourceCategory {
+    ProjectionState,
+    AnalyticsState,
+    ModelOutput,
+    ObservabilityState,
+    ClientState,
+    FrontendState,
+    PaymentAmount,
+    PaymentFrequency,
+    SupportAmountOrStatus,
+    TokenHoldings,
+    Popularity,
+    FollowerCount,
+    ReplySpeed,
+    DwellTime,
+    Tenure,
+    RomanticDesirability,
+    Engagement,
+    EngagementTelemetry,
+    RecommendationState,
+    DiscoveryState,
+    DiscoveryRanking,
+    RelationshipDepth,
+    RoomProjection,
+    OperatorNotes,
+    SupportTickets,
+    IssueComments,
+    AntiAbuseMarkerExistence,
+    AgeAssurancePosture,
+    ProofCallbackAlone,
+    VendorCallbackAlone,
+    ControlledExceptionalAccountActivity,
+    ImplementationConvenience,
+}
+
+impl ForbiddenSocialTrustSourceCategory {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::ProjectionState => "projection_state",
+            Self::AnalyticsState => "analytics_state",
+            Self::ModelOutput => "model_output",
+            Self::ObservabilityState => "observability_state",
+            Self::ClientState => "client_state",
+            Self::FrontendState => "frontend_state",
+            Self::PaymentAmount => "payment_amount",
+            Self::PaymentFrequency => "payment_frequency",
+            Self::SupportAmountOrStatus => "support_amount_or_status",
+            Self::TokenHoldings => "token_holdings",
+            Self::Popularity => "popularity",
+            Self::FollowerCount => "follower_count",
+            Self::ReplySpeed => "reply_speed",
+            Self::DwellTime => "dwell_time",
+            Self::Tenure => "tenure",
+            Self::RomanticDesirability => "romantic_desirability",
+            Self::Engagement => "engagement",
+            Self::EngagementTelemetry => "engagement_telemetry",
+            Self::RecommendationState => "recommendation_state",
+            Self::DiscoveryState => "discovery_state",
+            Self::DiscoveryRanking => "discovery_ranking",
+            Self::RelationshipDepth => "relationship_depth",
+            Self::RoomProjection => "room_projection",
+            Self::OperatorNotes => "operator_notes",
+            Self::SupportTickets => "support_tickets",
+            Self::IssueComments => "issue_comments",
+            Self::AntiAbuseMarkerExistence => "anti_abuse_marker_existence",
+            Self::AgeAssurancePosture => "age_assurance_posture",
+            Self::ProofCallbackAlone => "proof_callback_alone",
+            Self::VendorCallbackAlone => "vendor_callback_alone",
+            Self::ControlledExceptionalAccountActivity => "controlled_exceptional_account_activity",
+            Self::ImplementationConvenience => "implementation_convenience",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DurableIdempotencyPosture {
+    DurableDedupeKey(SocialTrustMutationAttemptIdempotencyKey),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum EvidencePosture {
+    Bounded,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ReviewabilityPosture {
+    Reviewable,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RetentionPosture {
+    Classified(RetentionClassReference),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SocialTrustAuthorityPosture {
+    WriterTruthOnly,
+    ProjectionOnly,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SocialTrustIntakeDecision {
+    Reject(SocialTrustIntakeRejection),
+    /// The attempt satisfied this pure intake contract, but Social Trust has
+    /// not been mutated and no writer fact has been persisted by this crate.
+    CandidateForWriterPersistence,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SocialTrustIntakeRejection {
+    ForbiddenSource {
+        source: ForbiddenSocialTrustSourceCategory,
+    },
+    UnknownSourceCategory,
+    ProjectionOnlyAuthority,
+    MissingWriterSourceReference,
+    MissingReasonFact,
+    MissingIdempotencyPosture,
+    MissingEvidencePosture,
+    MissingReviewabilityPosture,
+    MissingRetentionPosture,
+}
+
+#[must_use]
+pub fn decide_social_trust_intake(
+    attempt: &ProposedSocialTrustMutationAttempt,
+) -> SocialTrustIntakeDecision {
+    match &attempt.source_category {
+        SocialTrustSourceCategory::Forbidden(source) => {
+            return SocialTrustIntakeDecision::Reject(
+                SocialTrustIntakeRejection::ForbiddenSource { source: *source },
+            );
+        }
+        SocialTrustSourceCategory::Unknown => {
+            return SocialTrustIntakeDecision::Reject(
+                SocialTrustIntakeRejection::UnknownSourceCategory,
+            );
+        }
+        SocialTrustSourceCategory::WriterSourceCandidate => {}
+    }
+
+    if attempt.authority_posture == SocialTrustAuthorityPosture::ProjectionOnly {
+        return SocialTrustIntakeDecision::Reject(
+            SocialTrustIntakeRejection::ProjectionOnlyAuthority,
+        );
+    }
+
+    if !attempt
+        .writer_source_reference
+        .as_ref()
+        .is_some_and(WriterSourceReference::is_present)
+    {
+        return SocialTrustIntakeDecision::Reject(
+            SocialTrustIntakeRejection::MissingWriterSourceReference,
+        );
+    }
+
+    if !attempt
+        .reason_fact
+        .as_ref()
+        .is_some_and(ReasonFactReference::is_present)
+    {
+        return SocialTrustIntakeDecision::Reject(SocialTrustIntakeRejection::MissingReasonFact);
+    }
+
+    if !attempt
+        .idempotency_posture
+        .as_ref()
+        .is_some_and(DurableIdempotencyPosture::is_present)
+    {
+        return SocialTrustIntakeDecision::Reject(
+            SocialTrustIntakeRejection::MissingIdempotencyPosture,
+        );
+    }
+
+    if attempt.evidence_posture.is_none() {
+        return SocialTrustIntakeDecision::Reject(
+            SocialTrustIntakeRejection::MissingEvidencePosture,
+        );
+    }
+
+    if attempt.reviewability_posture.is_none() {
+        return SocialTrustIntakeDecision::Reject(
+            SocialTrustIntakeRejection::MissingReviewabilityPosture,
+        );
+    }
+
+    if !attempt
+        .retention_posture
+        .as_ref()
+        .is_some_and(RetentionPosture::is_present)
+    {
+        return SocialTrustIntakeDecision::Reject(
+            SocialTrustIntakeRejection::MissingRetentionPosture,
+        );
+    }
+
+    SocialTrustIntakeDecision::CandidateForWriterPersistence
+}
+
+macro_rules! string_ref {
+    ($name:ident) => {
+        #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+        pub struct $name(String);
+
+        impl $name {
+            pub fn new(value: impl Into<String>) -> Self {
+                Self(value.into())
+            }
+
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+
+            pub fn into_inner(self) -> String {
+                self.0
+            }
+
+            pub fn is_present(&self) -> bool {
+                !self.0.trim().is_empty()
+            }
+        }
+    };
+}
+
+string_ref!(WriterSourceReference);
+string_ref!(ReasonFactReference);
+string_ref!(SocialTrustMutationAttemptIdempotencyKey);
+string_ref!(RetentionClassReference);
+
+impl DurableIdempotencyPosture {
+    pub fn is_present(&self) -> bool {
+        match self {
+            Self::DurableDedupeKey(key) => key.is_present(),
+        }
+    }
+}
+
+impl RetentionPosture {
+    pub fn is_present(&self) -> bool {
+        match self {
+            Self::Classified(reference) => reference.is_present(),
+        }
+    }
+}

--- a/apps/backend/crates/social-trust-domain/tests/intake_contract.rs
+++ b/apps/backend/crates/social-trust-domain/tests/intake_contract.rs
@@ -1,0 +1,248 @@
+use musubi_social_trust_domain::{
+    DurableIdempotencyPosture, EvidencePosture, ForbiddenSocialTrustSourceCategory,
+    ProposedSocialTrustMutationAttempt, ReasonFactReference, RetentionClassReference,
+    RetentionPosture, ReviewabilityPosture, SocialTrustAuthorityPosture, SocialTrustIntakeDecision,
+    SocialTrustIntakeRejection, SocialTrustMutationAttemptIdempotencyKey,
+    SocialTrustSourceCategory, WriterSourceReference, decide_social_trust_intake,
+};
+
+#[test]
+fn forbidden_sources_fail_closed() {
+    for source in forbidden_sources() {
+        let mut attempt = complete_attempt();
+        attempt.source_category = SocialTrustSourceCategory::Forbidden(source);
+
+        let decision = decide_social_trust_intake(&attempt);
+
+        assert_eq!(
+            decision,
+            SocialTrustIntakeDecision::Reject(SocialTrustIntakeRejection::ForbiddenSource {
+                source
+            })
+        );
+    }
+}
+
+#[test]
+fn unknown_source_category_fails_closed() {
+    let mut attempt = complete_attempt();
+    attempt.source_category = SocialTrustSourceCategory::Unknown;
+
+    let decision = decide_social_trust_intake(&attempt);
+
+    assert_eq!(
+        decision,
+        SocialTrustIntakeDecision::Reject(SocialTrustIntakeRejection::UnknownSourceCategory)
+    );
+}
+
+#[test]
+fn missing_writer_source_reference_fails_closed() {
+    let mut attempt = complete_attempt();
+    attempt.writer_source_reference = None;
+
+    let decision = decide_social_trust_intake(&attempt);
+
+    assert_eq!(
+        decision,
+        SocialTrustIntakeDecision::Reject(SocialTrustIntakeRejection::MissingWriterSourceReference)
+    );
+}
+
+#[test]
+fn blank_writer_source_reference_fails_closed() {
+    let mut attempt = complete_attempt();
+    attempt.writer_source_reference = Some(WriterSourceReference::new("  "));
+
+    let decision = decide_social_trust_intake(&attempt);
+
+    assert_eq!(
+        decision,
+        SocialTrustIntakeDecision::Reject(SocialTrustIntakeRejection::MissingWriterSourceReference)
+    );
+}
+
+#[test]
+fn missing_idempotency_posture_fails_closed() {
+    let mut attempt = complete_attempt();
+    attempt.idempotency_posture = None;
+
+    let decision = decide_social_trust_intake(&attempt);
+
+    assert_eq!(
+        decision,
+        SocialTrustIntakeDecision::Reject(SocialTrustIntakeRejection::MissingIdempotencyPosture)
+    );
+}
+
+#[test]
+fn blank_idempotency_key_fails_closed() {
+    let mut attempt = complete_attempt();
+    attempt.idempotency_posture = Some(DurableIdempotencyPosture::DurableDedupeKey(
+        SocialTrustMutationAttemptIdempotencyKey::new(""),
+    ));
+
+    let decision = decide_social_trust_intake(&attempt);
+
+    assert_eq!(
+        decision,
+        SocialTrustIntakeDecision::Reject(SocialTrustIntakeRejection::MissingIdempotencyPosture)
+    );
+}
+
+#[test]
+fn missing_reason_fact_fails_closed() {
+    let mut attempt = complete_attempt();
+    attempt.reason_fact = None;
+
+    let decision = decide_social_trust_intake(&attempt);
+
+    assert_eq!(
+        decision,
+        SocialTrustIntakeDecision::Reject(SocialTrustIntakeRejection::MissingReasonFact)
+    );
+}
+
+#[test]
+fn blank_reason_fact_fails_closed() {
+    let mut attempt = complete_attempt();
+    attempt.reason_fact = Some(ReasonFactReference::new(" "));
+
+    let decision = decide_social_trust_intake(&attempt);
+
+    assert_eq!(
+        decision,
+        SocialTrustIntakeDecision::Reject(SocialTrustIntakeRejection::MissingReasonFact)
+    );
+}
+
+#[test]
+fn missing_evidence_posture_fails_closed() {
+    let mut attempt = complete_attempt();
+    attempt.evidence_posture = None;
+
+    let decision = decide_social_trust_intake(&attempt);
+
+    assert_eq!(
+        decision,
+        SocialTrustIntakeDecision::Reject(SocialTrustIntakeRejection::MissingEvidencePosture)
+    );
+}
+
+#[test]
+fn missing_reviewability_posture_fails_closed() {
+    let mut attempt = complete_attempt();
+    attempt.reviewability_posture = None;
+
+    let decision = decide_social_trust_intake(&attempt);
+
+    assert_eq!(
+        decision,
+        SocialTrustIntakeDecision::Reject(SocialTrustIntakeRejection::MissingReviewabilityPosture)
+    );
+}
+
+#[test]
+fn missing_retention_posture_fails_closed() {
+    let mut attempt = complete_attempt();
+    attempt.retention_posture = None;
+
+    let decision = decide_social_trust_intake(&attempt);
+
+    assert_eq!(
+        decision,
+        SocialTrustIntakeDecision::Reject(SocialTrustIntakeRejection::MissingRetentionPosture)
+    );
+}
+
+#[test]
+fn blank_retention_class_reference_fails_closed() {
+    let mut attempt = complete_attempt();
+    attempt.retention_posture = Some(RetentionPosture::Classified(RetentionClassReference::new(
+        "\t",
+    )));
+
+    let decision = decide_social_trust_intake(&attempt);
+
+    assert_eq!(
+        decision,
+        SocialTrustIntakeDecision::Reject(SocialTrustIntakeRejection::MissingRetentionPosture)
+    );
+}
+
+#[test]
+fn projection_only_posture_fails_closed() {
+    let mut attempt = complete_attempt();
+    attempt.authority_posture = SocialTrustAuthorityPosture::ProjectionOnly;
+
+    let decision = decide_social_trust_intake(&attempt);
+
+    assert_eq!(
+        decision,
+        SocialTrustIntakeDecision::Reject(SocialTrustIntakeRejection::ProjectionOnlyAuthority)
+    );
+}
+
+#[test]
+fn complete_writer_source_candidate_never_mutates_social_trust_directly() {
+    let decision = decide_social_trust_intake(&complete_attempt());
+
+    assert_eq!(
+        decision,
+        SocialTrustIntakeDecision::CandidateForWriterPersistence
+    );
+}
+
+fn complete_attempt() -> ProposedSocialTrustMutationAttempt {
+    ProposedSocialTrustMutationAttempt {
+        source_category: SocialTrustSourceCategory::WriterSourceCandidate,
+        writer_source_reference: Some(WriterSourceReference::new("source-fact-1")),
+        reason_fact: Some(ReasonFactReference::new("reason-fact-1")),
+        idempotency_posture: Some(DurableIdempotencyPosture::DurableDedupeKey(
+            SocialTrustMutationAttemptIdempotencyKey::new("dedupe-1"),
+        )),
+        evidence_posture: Some(EvidencePosture::Bounded),
+        reviewability_posture: Some(ReviewabilityPosture::Reviewable),
+        retention_posture: Some(RetentionPosture::Classified(RetentionClassReference::new(
+            "retention-class-1",
+        ))),
+        authority_posture: SocialTrustAuthorityPosture::WriterTruthOnly,
+    }
+}
+
+fn forbidden_sources() -> Vec<ForbiddenSocialTrustSourceCategory> {
+    vec![
+        ForbiddenSocialTrustSourceCategory::ProjectionState,
+        ForbiddenSocialTrustSourceCategory::AnalyticsState,
+        ForbiddenSocialTrustSourceCategory::ModelOutput,
+        ForbiddenSocialTrustSourceCategory::ObservabilityState,
+        ForbiddenSocialTrustSourceCategory::ClientState,
+        ForbiddenSocialTrustSourceCategory::FrontendState,
+        ForbiddenSocialTrustSourceCategory::PaymentAmount,
+        ForbiddenSocialTrustSourceCategory::PaymentFrequency,
+        ForbiddenSocialTrustSourceCategory::SupportAmountOrStatus,
+        ForbiddenSocialTrustSourceCategory::TokenHoldings,
+        ForbiddenSocialTrustSourceCategory::Popularity,
+        ForbiddenSocialTrustSourceCategory::FollowerCount,
+        ForbiddenSocialTrustSourceCategory::ReplySpeed,
+        ForbiddenSocialTrustSourceCategory::DwellTime,
+        ForbiddenSocialTrustSourceCategory::Tenure,
+        ForbiddenSocialTrustSourceCategory::RomanticDesirability,
+        ForbiddenSocialTrustSourceCategory::Engagement,
+        ForbiddenSocialTrustSourceCategory::EngagementTelemetry,
+        ForbiddenSocialTrustSourceCategory::RecommendationState,
+        ForbiddenSocialTrustSourceCategory::DiscoveryState,
+        ForbiddenSocialTrustSourceCategory::DiscoveryRanking,
+        ForbiddenSocialTrustSourceCategory::RelationshipDepth,
+        ForbiddenSocialTrustSourceCategory::RoomProjection,
+        ForbiddenSocialTrustSourceCategory::OperatorNotes,
+        ForbiddenSocialTrustSourceCategory::SupportTickets,
+        ForbiddenSocialTrustSourceCategory::IssueComments,
+        ForbiddenSocialTrustSourceCategory::AntiAbuseMarkerExistence,
+        ForbiddenSocialTrustSourceCategory::AgeAssurancePosture,
+        ForbiddenSocialTrustSourceCategory::ProofCallbackAlone,
+        ForbiddenSocialTrustSourceCategory::VendorCallbackAlone,
+        ForbiddenSocialTrustSourceCategory::ControlledExceptionalAccountActivity,
+        ForbiddenSocialTrustSourceCategory::ImplementationConvenience,
+    ]
+}

--- a/apps/backend/docs/package_boundaries.md
+++ b/apps/backend/docs/package_boundaries.md
@@ -13,6 +13,7 @@ Later milestone work has since added:
 - DB runtime and migration runner wiring
 - settlement-domain types and backend traits
 - orchestration runtime notes
+- Social Trust intake / no-authority domain contract
 
 The backend still does not implement:
 - provider-specific adapters
@@ -95,6 +96,18 @@ Note:
 the current PoC escrow record and callback input remain in the app crate on purpose.
 They still encode callback-oriented glue and `f64` PoC data that should not be promoted into long-term domain truth by boundary cleanup alone.
 Typed provider payloads in the domain crate must remain provider-agnostic and must not become arbitrary bytes or JSON convenience blobs.
+
+### `musubi_social_trust_domain`
+Owns:
+- pure Social Trust proposed mutation attempt intake decisions
+- forbidden-source and unknown-source fail-closed checks
+- required writer source reference, reason fact, idempotency, evidence, reviewability, retention, and authority posture checks
+
+Must not own:
+- Social Trust scoring, weights, display levels, or recovery ceilings
+- Relationship Depth behavior
+- DB persistence, migrations, HTTP handlers, app-service wiring, or projection refresh behavior
+- proof, settlement, room progression, discovery, recommendation, or operator review behavior
 
 ### `musubi_orchestration`
 Owns:


### PR DESCRIPTION
## Summary
- Add a pure Rust `musubi_social_trust_domain` crate for the Social Trust proposed mutation attempt intake / no-authority decision contract.
- Fail closed for forbidden source categories, unknown source categories, projection-only posture, missing writer source references, missing reason facts, missing durable idempotency posture, missing evidence/reviewability/retention posture, and blank reference/idempotency values.
- Register the crate in the backend workspace and document its package boundary.

## Scope
- Pure Rust domain crate + unit tests only.
- No DB migrations, PostgreSQL writer tables, HTTP routes, Axum handlers, mobile UI, or projection authority wiring.
- The positive decision is only `CandidateForWriterPersistence`; this crate does not mutate Social Trust or persist writer facts.

## Validation
- `cargo test -p musubi_social_trust_domain`
- `cargo clippy -p musubi_social_trust_domain --all-targets -- -D warnings`
- `cargo check --workspace`
- `cargo test --workspace --all-targets`
- `git diff --check`

Refs #58