### PR TITLE
feat: persist Social Trust intake attempts

### DIFF
--- a/apps/backend/Cargo.lock
+++ b/apps/backend/Cargo.lock
@@ -675,6 +675,7 @@ dependencies = [
  "hmac",
  "musubi_db_runtime",
  "musubi_settlement_domain",
+ "musubi_social_trust_domain",
  "serde",
  "serde_json",
  "sha2 0.11.0",

--- a/apps/backend/Cargo.toml
+++ b/apps/backend/Cargo.toml
@@ -45,6 +45,7 @@ sha2 = "0.11"
 tokio-postgres = { version = "0.7", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 musubi_db_runtime = { path = "crates/db-runtime" }
 musubi_settlement_domain = { path = "crates/settlement-domain" }
+musubi_social_trust_domain = { path = "crates/social-trust-domain" }
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -175,6 +175,7 @@ Proof challenges are short-lived, proof envelopes are server-verified before acc
 Operator PIN fallback remains an internal/deferred primitive until an authenticated operator surface exists; subject-facing requests for `operator_pin` are rejected before any operator audit or rate-limit state is touched.
 Location hints are sanitized before proof records are built, unsupported fallback modes are rejected before display-code verification, and malformed or cross-subject attempts do not burn another challenge's failed-attempt budget.
 These proof records are input facts only; they are not settlement truth or final anti-spoof guarantees.
+Design source: C1 Social Trust intake handoff adds the first narrow Social Trust intake persistence boundary. Proposed mutation attempts and their intake decisions live in `social_trust`, use PostgreSQL-enforced idempotency and payload-hash replay checks, and remain intake / audit facts only. This does not add Social Trust mutation facts, scores, weights, ranks, display levels, Relationship Depth behavior, projection refresh, public API, or mobile UI.
 
 ## Local design notes
 
@@ -193,4 +194,5 @@ These proof records are input facts only; they are not settlement truth or final
 - `docs/proof_primitives.md`: Day 1 safer venue proof input boundary
 - `docs/c1_runtime_intake_scope.md`: C1 trust/depth runtime intake scope and non-authority boundary for future backend work
 - `docs/c1_social_trust_intake_contract_scope.md`: selected first C1 Social Trust intake / no-authority contract scope
+- `docs/c1_social_trust_writer_fact_scope.md`: C1 Social Trust intake persistence envelope and non-authority stop conditions
 - `docs/happy_route_walkthrough.md`: current Issue #7 end-to-end path

--- a/apps/backend/crates/social-trust-domain/src/lib.rs
+++ b/apps/backend/crates/social-trust-domain/src/lib.rs
@@ -25,6 +25,16 @@ pub enum SocialTrustSourceCategory {
     Unknown,
 }
 
+impl SocialTrustSourceCategory {
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::WriterSourceCandidate => "writer_source_candidate",
+            Self::Forbidden(source) => source.as_str(),
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ForbiddenSocialTrustSourceCategory {
     ProjectionState,
@@ -110,9 +120,25 @@ pub enum EvidencePosture {
     Bounded,
 }
 
+impl EvidencePosture {
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Bounded => "bounded",
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ReviewabilityPosture {
     Reviewable,
+}
+
+impl ReviewabilityPosture {
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Reviewable => "reviewable",
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -126,12 +152,37 @@ pub enum SocialTrustAuthorityPosture {
     ProjectionOnly,
 }
 
+impl SocialTrustAuthorityPosture {
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::WriterTruthOnly => "writer_truth_only",
+            Self::ProjectionOnly => "projection_only",
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SocialTrustIntakeDecision {
     Reject(SocialTrustIntakeRejection),
     /// The attempt satisfied this pure intake contract, but Social Trust has
     /// not been mutated and no writer fact has been persisted by this crate.
     CandidateForWriterPersistence,
+}
+
+impl SocialTrustIntakeDecision {
+    pub const fn kind(&self) -> &'static str {
+        match self {
+            Self::Reject(_) => "rejected",
+            Self::CandidateForWriterPersistence => "candidate_for_writer_persistence",
+        }
+    }
+
+    pub const fn rejection_reason_code(&self) -> Option<&'static str> {
+        match self {
+            Self::Reject(rejection) => Some(rejection.as_str()),
+            Self::CandidateForWriterPersistence => None,
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -147,6 +198,22 @@ pub enum SocialTrustIntakeRejection {
     MissingEvidencePosture,
     MissingReviewabilityPosture,
     MissingRetentionPosture,
+}
+
+impl SocialTrustIntakeRejection {
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::ForbiddenSource { .. } => "forbidden_source",
+            Self::UnknownSourceCategory => "unknown_source_category",
+            Self::ProjectionOnlyAuthority => "projection_only_authority",
+            Self::MissingWriterSourceReference => "missing_writer_source_reference",
+            Self::MissingReasonFact => "missing_reason_fact",
+            Self::MissingIdempotencyPosture => "missing_idempotency_posture",
+            Self::MissingEvidencePosture => "missing_evidence_posture",
+            Self::MissingReviewabilityPosture => "missing_reviewability_posture",
+            Self::MissingRetentionPosture => "missing_retention_posture",
+        }
+    }
 }
 
 #[must_use]
@@ -268,6 +335,12 @@ impl RetentionPosture {
     pub fn is_present(&self) -> bool {
         match self {
             Self::Classified(reference) => reference.is_present(),
+        }
+    }
+
+    pub fn class_reference(&self) -> &RetentionClassReference {
+        match self {
+            Self::Classified(reference) => reference,
         }
     }
 }

--- a/apps/backend/docs/c1_runtime_intake_scope.md
+++ b/apps/backend/docs/c1_runtime_intake_scope.md
@@ -16,22 +16,25 @@ Record what the backend may inspect next, what it must not treat as authority, a
 
 ## Current Gate State
 
-The pinned foundation state is `musubi-foundation` commit `fcb5573b668b6875cf9c983770ad90f9de655e82`.
+The pinned foundation state is `musubi-foundation` commit `f576bcd826b7070f573ef8276c68aff5d0ae864e`.
 
 The accepted foundation C1 handoff records are upstream `mt4110/musubi-foundation` paths at the pinned foundation commit, not local `pi-musubi-core` files:
 
+- `docs/readiness/c1_runtime_gate_invocation_guard.md`
 - `docs/readiness/c1_runtime_behavior_boundary.md`
 - `docs/readiness/c1_runtime_handoff_evidence_package.md`
 - `docs/readiness/c1_runtime_handoff_gate_decision.md`
+- `docs/readiness/c1_social_trust_intake_handoff_gate_decision.md`
 
-The current C1 runtime implementation gate result remains NO-GO.
+The broad C1 runtime implementation gate result remains NO-GO.
+The current C1 Social Trust intake handoff result is `NARROW GO FOR ONE LATER IMPLEMENTATION-REPO PR`.
 
-This note does not authorize runtime implementation.
-This note does not authorize DDL.
-This note does not authorize migrations.
-This note does not authorize runtime tests.
+The authorized implementation-repo slice is Social Trust proposed mutation attempt intake persistence only.
+This authorization is limited to additive backend persistence, deterministic tests, and documentation that keeps the boundary explicit.
+
+This note still does not authorize broad runtime implementation.
 This note does not authorize API changes.
-This note does not authorize app code changes.
+This note does not authorize HTTP handlers, public routes, mobile UI, projection refresh work, or app-state exposure.
 
 ## Local Surfaces Already Present
 
@@ -62,19 +65,16 @@ This note does not select any of those as C1 implementation scope.
 
 The next safe backend step is not to mutate trust/depth.
 
-The next safe backend step is to keep C1 scoped as an intake and non-authority planning problem until a later PR explicitly names:
+The next safe backend step is to persist only the C1 Social Trust intake / non-authority decision boundary authorized by the pinned handoff gate:
 
-- the exact writer-owned fact families C1 may consume;
-- the exact writer-owned fact family C1 may create, if any;
-- the durable idempotency boundary for a proposed mutation attempt;
-- the retention class for `CandidateForWriterPersistence` and rejected attempts;
-- the outbox / inbox behavior for cross-process effects;
-- the broken-path tests that prove forbidden sources fail closed;
-- the projection refresh posture after writer facts exist.
+- proposed mutation attempt intake records;
+- rejected and `CandidateForWriterPersistence` intake decisions;
+- durable database-enforced idempotency / replay posture;
+- minimized reason, evidence, reviewability, retention, and audit metadata;
+- deterministic tests for forbidden sources, missing posture, duplicate replay, payload drift, and projection non-authority.
 
-The next local scope note for that narrowing is:
-
-- `c1_social_trust_writer_fact_scope.md`
+This is intake persistence only.
+It is not Social Trust mutation persistence.
 
 ## Forbidden Shortcut
 
@@ -88,11 +88,11 @@ A future implementation must not:
 - hold an authoritative transaction open across provider, model, analytics, notification, search, or other network I/O;
 - create broad C1 tables, APIs, workers, or migration scope by convenience.
 
-## Candidate Future PR Shape
+## Authorized Narrow PR Shape
 
-The first future C1 implementation PR, if a later gate explicitly permits it, should be narrow enough to review as one behavioral contract.
+The first C1 implementation PR is narrow enough to review as one behavioral contract plus one persistence boundary.
 
-Recommended first contract:
+Selected contract:
 
 - `Social Trust proposed mutation attempt intake / no-authority decision contract`
 
@@ -102,18 +102,15 @@ The follow-up writer-fact planning boundary is:
 
 - `c1_social_trust_writer_fact_scope.md`
 
-Recommended first candidate shape:
+Authorized first candidate shape:
 
 - no public API;
 - no mobile UI;
 - no discovery or recommendation changes;
 - no projection-based authority;
 - no payment or Support influence;
-- one writer-owned C1 intake path or one deterministic no-authority guard, not both;
+- one writer-owned C1 intake persistence path;
 - deterministic tests focused on duplicate delivery, missing source references, forbidden source categories, and projection non-authority.
-
-This candidate shape is not authorization.
-It is the smallest shape that appears compatible with the pinned foundation constraints.
 
 ## Stop Conditions
 
@@ -128,8 +125,6 @@ Stop before implementation if any of the following remain unclear:
 
 ## Bottom Line
 
-The backend is now aligned enough to plan C1 locally.
+The backend is now aligned enough to implement one narrow C1 Social Trust intake persistence PR.
 
-It is not yet authorized to implement C1 runtime behavior.
-
-The next useful PR should either keep narrowing C1 into exact backend implementation scope or, if separately authorized, implement one small writer-owned C1 intake / no-authority contract without touching projection as authority.
+The authorized implementation must remain one small writer-owned C1 intake / no-authority persistence boundary without touching projection as authority.

--- a/apps/backend/docs/c1_social_trust_intake_contract_scope.md
+++ b/apps/backend/docs/c1_social_trust_intake_contract_scope.md
@@ -29,15 +29,12 @@ This does not select room progression / Relationship Depth ambiguity work.
 
 ## Current Authorization State
 
-This document does not authorize runtime implementation.
-This document does not authorize DDL.
-This document does not authorize migrations.
-This document does not authorize runtime tests.
-This document does not authorize API changes.
-This document does not authorize mobile UI changes.
-This document does not authorize app-service wiring.
+This document records the earlier pure intake contract scope.
 
-The C1 runtime implementation gate result remains NO-GO until a later PR explicitly authorizes one narrow implementation step.
+`musubi-foundation` PR #92 later authorized one narrow implementation-repo PR for Social Trust proposed mutation attempt intake persistence only.
+That current persistence envelope is tracked in `c1_social_trust_writer_fact_scope.md`.
+
+This document still does not authorize API changes, mobile UI changes, projection refresh, Social Trust mutation facts, scoring, ranking, display levels, or Relationship Depth behavior.
 
 ## Why Social Trust First
 

--- a/apps/backend/docs/c1_social_trust_writer_fact_scope.md
+++ b/apps/backend/docs/c1_social_trust_writer_fact_scope.md
@@ -16,16 +16,24 @@ Name the writer-owned fact families, idempotency boundary, retention posture, ou
 
 ## Current Authorization State
 
-This document does not authorize runtime implementation.
-This document does not authorize DDL.
-This document does not authorize migrations.
-This document does not authorize PostgreSQL writer tables.
-This document does not authorize HTTP routes or Axum handlers.
-This document does not authorize mobile UI.
-This document does not authorize projection writes.
-This document does not authorize Social Trust scoring, weights, rank, display level, narrowing, freeze, recovery, or public presentation.
+`musubi-foundation` PR #92 authorizes one later implementation-repo PR for Social Trust proposed mutation attempt intake persistence only.
 
-The C1 runtime implementation gate remains NO-GO.
+This document is now the local implementation scope note for that narrow PR.
+
+This document authorizes only:
+
+- additive PostgreSQL persistence for proposed mutation attempt intake;
+- rejected and `CandidateForWriterPersistence` intake decision records;
+- database-enforced idempotency / replay checks;
+- minimal reason, evidence-posture, reviewability, retention-class, and audit metadata;
+- deterministic backend tests for the broken paths named here and in the pinned handoff gate.
+
+This document still does not authorize HTTP routes or Axum handlers.
+This document still does not authorize mobile UI.
+This document still does not authorize projection writes.
+This document still does not authorize Social Trust scoring, weights, rank, display level, narrowing, freeze, recovery, mutation facts, or public presentation.
+
+The broad C1 runtime implementation gate remains NO-GO.
 
 ## Decision
 
@@ -65,7 +73,7 @@ A later C1 persistence PR, if separately authorized, may create only these write
 - Durable idempotency / replay facts for proposed mutation attempts.
 - Minimal reason, retention, reviewability, evidence-posture, and audit facts needed to explain the intake decision.
 
-This is a maximum envelope for a later accepted persistence PR, not authorization from this document.
+This is the maximum envelope for this accepted persistence PR.
 
 That later PR must not create:
 
@@ -189,10 +197,10 @@ A later persistence PR must include deterministic tests for these failure paths:
 
 Stop before implementation if any of these are still unresolved:
 
-- a positive Social Trust source family has not been accepted;
+- the implementation would treat a positive Social Trust source family as accepted mutation authority;
 - the future work would require exact Social Trust weights or mutation magnitude;
 - the future work would require new durable vocabulary outside the pinned foundation docs;
-- an accepted Retention Class Registry entry is not named or cannot be mapped without inventing durations;
+- the intake records cannot be mapped to the ADR-0012 category `Social Trust evidence or future Social Trust writer facts` without inventing durations;
 - idempotency cannot be enforced by durable writer facts or database constraints;
 - projection refresh is being treated as writer truth;
 - outbox / inbox cleanup is being treated as business completion truth;
@@ -200,6 +208,6 @@ Stop before implementation if any of these are still unresolved:
 
 ## Bottom Line
 
-C1 may be narrowed toward Social Trust intake persistence, but the only safe next writer boundary is proposed mutation attempt intake facts.
+C1 is now narrowed toward Social Trust intake persistence, and the only safe writer boundary is proposed mutation attempt intake facts.
 
 Actual Social Trust mutation facts still need a later, separate acceptance boundary.

--- a/apps/backend/docs/package_boundaries.md
+++ b/apps/backend/docs/package_boundaries.md
@@ -109,6 +109,20 @@ Must not own:
 - DB persistence, migrations, HTTP handlers, app-service wiring, or projection refresh behavior
 - proof, settlement, room progression, discovery, recommendation, or operator review behavior
 
+### `musubi_backend::services::social_trust_intake`
+Owns:
+- backend-local persistence for C1 Social Trust proposed mutation attempt intake records
+- backend-local replay of persisted intake decisions
+- database-enforced duplicate delivery and payload-drift checks
+- writer-first account reference checks for Ordinary Account subjects
+- tests proving forbidden source, projection-only, missing posture, and replay paths fail closed
+
+Must not own:
+- HTTP handlers, public API routes, mobile UI, or app-state exposure
+- Social Trust mutation facts, scoring, weights, ranks, display levels, narrowing, freeze, or recovery behavior
+- Relationship Depth, proof, room progression, discovery, recommendation, settlement, Promise, payment, Support, or operator-review behavior
+- projection refresh or projection-derived authority
+
 ### `musubi_orchestration`
 Owns:
 - transactional outbox runtime shape

--- a/apps/backend/docs/schema_skeleton.md
+++ b/apps/backend/docs/schema_skeleton.md
@@ -39,6 +39,20 @@ Must not own:
 - outbox delivery state
 - profile data
 
+### `social_trust`
+Owns:
+- C1 Social Trust proposed mutation attempt intake records
+- C1 Social Trust intake decision records for rejected attempts and `CandidateForWriterPersistence`
+- database-enforced idempotency / replay posture for proposed mutation attempts
+- minimized reason, evidence-posture, reviewability, retention-class, and audit metadata for intake decisions
+
+Must not own:
+- actual Social Trust mutation facts
+- Social Trust scores, weights, ranks, display levels, narrowing, freeze, or recovery facts
+- Relationship Depth facts
+- projection refresh state
+- raw PII, raw evidence payloads, payment behavior, popularity metrics, engagement telemetry, operator notes, support tickets, or issue comments
+
 ### `ledger`
 Owns:
 - append-only journal entries
@@ -182,3 +196,20 @@ The architectural boundary is strict:
 - operator/steward summaries are redacted, rebuildable, and still non-authoritative
 
 ISSUE-12 operator review remains the review/evidence system of record, ISSUE-13 room progression remains the room surface baseline, and ISSUE-14 Promise UI remains out of scope for this schema addition.
+
+## C1 Social Trust intake persistence additions
+
+Design source: `docs/readiness/c1_social_trust_intake_handoff_gate_decision.md` in `musubi-foundation` PR #92.
+
+Migration `0020_social_trust_intake_persistence.sql` adds the narrow C1 Social Trust intake persistence baseline:
+- `social_trust.proposed_mutation_attempts`
+- `social_trust.intake_decisions`
+
+The architectural boundary is strict:
+- proposed mutation attempts and intake decisions are writer-owned intake / replay facts only
+- `CandidateForWriterPersistence` is internal intake classification only
+- durable idempotency is enforced by a PostgreSQL unique index over the minimized dedupe identity
+- duplicate delivery with payload drift fails closed through stored payload hashes
+- retention is mapped to the ADR-0012 category `Social Trust evidence or future Social Trust writer facts` without inventing concrete retention durations
+- rejected attempts and candidates do not emit projection refresh work
+- no Social Trust mutation fact, score, weight, rank, display level, Relationship Depth fact, public API, or mobile UI is introduced

--- a/apps/backend/migrations/0020_social_trust_intake_persistence.sql
+++ b/apps/backend/migrations/0020_social_trust_intake_persistence.sql
@@ -1,0 +1,153 @@
+CREATE SCHEMA IF NOT EXISTS social_trust;
+
+COMMENT ON SCHEMA social_trust IS
+'Writer-owned Social Trust intake facts. This schema does not contain Social Trust mutation facts, scores, ranks, display levels, Relationship Depth facts, or projection truth.';
+
+CREATE TABLE IF NOT EXISTS social_trust.proposed_mutation_attempts (
+    attempt_id UUID PRIMARY KEY,
+    subject_account_id UUID NOT NULL REFERENCES core.accounts(account_id),
+    source_category TEXT NOT NULL CHECK (
+        source_category IN (
+            'writer_source_candidate',
+            'unknown',
+            'projection_state',
+            'analytics_state',
+            'model_output',
+            'observability_state',
+            'client_state',
+            'frontend_state',
+            'payment_amount',
+            'payment_frequency',
+            'support_amount_or_status',
+            'token_holdings',
+            'popularity',
+            'follower_count',
+            'reply_speed',
+            'dwell_time',
+            'tenure',
+            'romantic_desirability',
+            'engagement',
+            'engagement_telemetry',
+            'recommendation_state',
+            'discovery_state',
+            'discovery_ranking',
+            'relationship_depth',
+            'room_projection',
+            'operator_notes',
+            'support_tickets',
+            'issue_comments',
+            'anti_abuse_marker_existence',
+            'age_assurance_posture',
+            'proof_callback_alone',
+            'vendor_callback_alone',
+            'controlled_exceptional_account_activity',
+            'implementation_convenience'
+        )
+    ),
+    writer_source_reference TEXT NOT NULL CHECK (char_length(trim(writer_source_reference)) > 0),
+    reason_fact_reference TEXT NOT NULL CHECK (char_length(trim(reason_fact_reference)) > 0),
+    attempt_idempotency_key TEXT NOT NULL CHECK (
+        char_length(trim(attempt_idempotency_key)) > 0
+    ),
+    policy_version INTEGER NOT NULL CHECK (policy_version > 0),
+    request_payload_hash TEXT NOT NULL CHECK (request_payload_hash ~ '^[0-9a-f]{64}$'),
+    evidence_posture TEXT NOT NULL CHECK (evidence_posture IN ('bounded')),
+    reviewability_posture TEXT NOT NULL CHECK (reviewability_posture IN ('reviewable')),
+    retention_record_family TEXT NOT NULL CHECK (
+        retention_record_family = 'Social Trust evidence or future Social Trust writer facts'
+    ),
+    retention_class_reference TEXT NOT NULL CHECK (
+        char_length(trim(retention_class_reference)) > 0
+    ),
+    authority_posture TEXT NOT NULL CHECK (
+        authority_posture IN ('writer_truth_only', 'projection_only')
+    ),
+    recorded_by_system TEXT NOT NULL DEFAULT 'social_trust_intake_persistence' CHECK (
+        char_length(trim(recorded_by_system)) > 0
+    ),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+COMMENT ON TABLE social_trust.proposed_mutation_attempts IS
+'C1 Social Trust proposed mutation attempt intake records. These are intake/replay facts only, not Social Trust mutation truth.';
+
+COMMENT ON COLUMN social_trust.proposed_mutation_attempts.subject_account_id IS
+'Reference to an accepted account-continuity writer fact. This is not a Social Trust subject fact.';
+
+COMMENT ON COLUMN social_trust.proposed_mutation_attempts.request_payload_hash IS
+'SHA-256 hash of minimized intake meaning used for deterministic duplicate-delivery drift checks. Raw evidence and raw PII do not belong here.';
+
+CREATE UNIQUE INDEX IF NOT EXISTS social_trust_attempt_dedupe_unique
+    ON social_trust.proposed_mutation_attempts (
+        subject_account_id,
+        source_category,
+        writer_source_reference,
+        reason_fact_reference,
+        policy_version,
+        attempt_idempotency_key
+    );
+
+COMMENT ON INDEX social_trust.social_trust_attempt_dedupe_unique IS
+'Durable database-enforced idempotency boundary for C1 Social Trust proposed mutation attempts.';
+
+CREATE INDEX IF NOT EXISTS social_trust_attempt_subject_created_idx
+    ON social_trust.proposed_mutation_attempts (subject_account_id, created_at);
+
+CREATE INDEX IF NOT EXISTS social_trust_attempt_retention_idx
+    ON social_trust.proposed_mutation_attempts (retention_record_family, retention_class_reference);
+
+CREATE TABLE IF NOT EXISTS social_trust.intake_decisions (
+    intake_decision_id UUID PRIMARY KEY,
+    attempt_id UUID NOT NULL UNIQUE REFERENCES social_trust.proposed_mutation_attempts(attempt_id),
+    decision_kind TEXT NOT NULL CHECK (
+        decision_kind IN ('rejected', 'candidate_for_writer_persistence')
+    ),
+    rejection_reason_code TEXT CHECK (
+        rejection_reason_code IS NULL
+        OR rejection_reason_code IN (
+            'forbidden_source',
+            'unknown_source_category',
+            'projection_only_authority',
+            'missing_writer_source_reference',
+            'missing_reason_fact',
+            'missing_idempotency_posture',
+            'missing_evidence_posture',
+            'missing_reviewability_posture',
+            'missing_retention_posture'
+        )
+    ),
+    decision_payload_hash TEXT NOT NULL CHECK (decision_payload_hash ~ '^[0-9a-f]{64}$'),
+    retention_record_family TEXT NOT NULL CHECK (
+        retention_record_family = 'Social Trust evidence or future Social Trust writer facts'
+    ),
+    retention_class_reference TEXT NOT NULL CHECK (
+        char_length(trim(retention_class_reference)) > 0
+    ),
+    recorded_by_system TEXT NOT NULL DEFAULT 'social_trust_intake_persistence' CHECK (
+        char_length(trim(recorded_by_system)) > 0
+    ),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CHECK (
+        (
+            decision_kind = 'rejected'
+            AND rejection_reason_code IS NOT NULL
+        )
+        OR (
+            decision_kind = 'candidate_for_writer_persistence'
+            AND rejection_reason_code IS NULL
+        )
+    )
+);
+
+COMMENT ON TABLE social_trust.intake_decisions IS
+'C1 Social Trust intake decision records. CandidateForWriterPersistence is internal intake classification only and must not be treated as Social Trust mutation truth.';
+
+COMMENT ON COLUMN social_trust.intake_decisions.decision_payload_hash IS
+'SHA-256 hash of the minimized intake decision for deterministic replay checks.';
+
+CREATE INDEX IF NOT EXISTS social_trust_intake_decision_kind_idx
+    ON social_trust.intake_decisions (decision_kind, created_at);
+
+CREATE INDEX IF NOT EXISTS social_trust_intake_decision_retention_idx
+    ON social_trust.intake_decisions (retention_record_family, retention_class_reference);

--- a/apps/backend/src/services/mod.rs
+++ b/apps/backend/src/services/mod.rs
@@ -6,3 +6,4 @@ pub mod ops_observability;
 pub mod proof;
 pub mod realm_bootstrap;
 pub mod room_progression;
+pub mod social_trust_intake;

--- a/apps/backend/src/services/social_trust_intake/mod.rs
+++ b/apps/backend/src/services/social_trust_intake/mod.rs
@@ -1,0 +1,8 @@
+mod repository;
+mod types;
+
+pub use repository::SocialTrustIntakeStore;
+pub use types::{
+    RecordSocialTrustIntakeAttemptInput, SocialTrustIntakePersistenceError,
+    SocialTrustIntakePersistenceOutcome, SocialTrustIntakeReplayStatus, SocialTrustIntakeSnapshot,
+};

--- a/apps/backend/src/services/social_trust_intake/repository.rs
+++ b/apps/backend/src/services/social_trust_intake/repository.rs
@@ -1,0 +1,505 @@
+use std::{fmt::Write as _, sync::Arc};
+
+use musubi_db_runtime::{DbConfig, connect_writer};
+use musubi_social_trust_domain::{
+    DurableIdempotencyPosture, EvidencePosture, ProposedSocialTrustMutationAttempt,
+    RetentionPosture, ReviewabilityPosture, SocialTrustIntakeDecision, decide_social_trust_intake,
+};
+use sha2::{Digest, Sha256};
+use tokio::sync::Mutex;
+use tokio_postgres::{Client, GenericClient, Row, error::SqlState};
+use uuid::Uuid;
+
+use super::types::{
+    RecordSocialTrustIntakeAttemptInput, SocialTrustIntakePersistenceError,
+    SocialTrustIntakePersistenceOutcome, SocialTrustIntakeReplayStatus, SocialTrustIntakeSnapshot,
+};
+
+const POLICY_VERSION: i32 = 1;
+const RETENTION_RECORD_FAMILY: &str = "Social Trust evidence or future Social Trust writer facts";
+
+#[derive(Clone)]
+pub struct SocialTrustIntakeStore {
+    client: Arc<Mutex<Client>>,
+}
+
+struct NormalizedAttempt {
+    subject_account_id: Uuid,
+    source_category: &'static str,
+    writer_source_reference: String,
+    reason_fact_reference: String,
+    attempt_idempotency_key: String,
+    evidence_posture: &'static str,
+    reviewability_posture: &'static str,
+    retention_class_reference: String,
+    authority_posture: &'static str,
+    decision_kind: &'static str,
+    rejection_reason_code: Option<&'static str>,
+    request_payload_hash: String,
+    decision_payload_hash: String,
+}
+
+impl SocialTrustIntakeStore {
+    pub async fn connect(config: &DbConfig) -> musubi_db_runtime::Result<Self> {
+        let client = connect_writer(config, "musubi-backend social-trust-intake").await?;
+        Ok(Self {
+            client: Arc::new(Mutex::new(client)),
+        })
+    }
+
+    pub async fn record_attempt(
+        &self,
+        input: RecordSocialTrustIntakeAttemptInput,
+    ) -> Result<SocialTrustIntakePersistenceOutcome, SocialTrustIntakePersistenceError> {
+        let subject_account_id = parse_uuid(&input.subject_account_id, "subject account id")?;
+        let decision = decide_social_trust_intake(&input.attempt);
+
+        if !has_persistence_minimum(&input.attempt) {
+            return Ok(SocialTrustIntakePersistenceOutcome::RejectedBeforePersistence { decision });
+        }
+
+        let normalized = normalize_attempt(subject_account_id, &input.attempt, &decision)?;
+        let mut client = self.client.lock().await;
+        let tx = client.transaction().await.map_err(db_error)?;
+
+        if let Some(existing) = find_existing_attempt_by_dedupe_tx(&tx, &normalized).await? {
+            let attempt_id = replay_attempt_id(existing, &normalized)?;
+            let snapshot = load_snapshot_by_attempt_id_tx(
+                &tx,
+                &attempt_id,
+                SocialTrustIntakeReplayStatus::ReplayedIdentical,
+            )
+            .await?;
+            tx.commit().await.map_err(db_error)?;
+            return Ok(SocialTrustIntakePersistenceOutcome::Recorded(snapshot));
+        }
+
+        ensure_active_ordinary_account_exists_tx(&tx, &normalized.subject_account_id).await?;
+
+        let inserted_attempt_id = Uuid::new_v4();
+        let inserted = tx
+            .query_opt(
+                "
+                INSERT INTO social_trust.proposed_mutation_attempts (
+                    attempt_id,
+                    subject_account_id,
+                    source_category,
+                    writer_source_reference,
+                    reason_fact_reference,
+                    attempt_idempotency_key,
+                    policy_version,
+                    request_payload_hash,
+                    evidence_posture,
+                    reviewability_posture,
+                    retention_record_family,
+                    retention_class_reference,
+                    authority_posture
+                )
+                VALUES (
+                    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13
+                )
+                ON CONFLICT (
+                    subject_account_id,
+                    source_category,
+                    writer_source_reference,
+                    reason_fact_reference,
+                    policy_version,
+                    attempt_idempotency_key
+                ) DO NOTHING
+                RETURNING attempt_id
+                ",
+                &[
+                    &inserted_attempt_id,
+                    &normalized.subject_account_id,
+                    &normalized.source_category,
+                    &normalized.writer_source_reference,
+                    &normalized.reason_fact_reference,
+                    &normalized.attempt_idempotency_key,
+                    &POLICY_VERSION,
+                    &normalized.request_payload_hash,
+                    &normalized.evidence_posture,
+                    &normalized.reviewability_posture,
+                    &RETENTION_RECORD_FAMILY,
+                    &normalized.retention_class_reference,
+                    &normalized.authority_posture,
+                ],
+            )
+            .await
+            .map_err(attempt_insert_error)?;
+
+        let (attempt_id, replay_status) = match inserted {
+            Some(row) => {
+                let attempt_id: Uuid = row.get("attempt_id");
+                let intake_decision_id = Uuid::new_v4();
+                tx.execute(
+                    "
+                    INSERT INTO social_trust.intake_decisions (
+                        intake_decision_id,
+                        attempt_id,
+                        decision_kind,
+                        rejection_reason_code,
+                        decision_payload_hash,
+                        retention_record_family,
+                        retention_class_reference
+                    )
+                    VALUES ($1, $2, $3, $4, $5, $6, $7)
+                    ",
+                    &[
+                        &intake_decision_id,
+                        &attempt_id,
+                        &normalized.decision_kind,
+                        &normalized.rejection_reason_code,
+                        &normalized.decision_payload_hash,
+                        &RETENTION_RECORD_FAMILY,
+                        &normalized.retention_class_reference,
+                    ],
+                )
+                .await
+                .map_err(db_error)?;
+                (attempt_id, SocialTrustIntakeReplayStatus::Inserted)
+            }
+            None => {
+                let existing = find_existing_attempt_by_dedupe_tx(&tx, &normalized)
+                    .await?
+                    .ok_or_else(|| {
+                        SocialTrustIntakePersistenceError::Internal(
+                            "idempotency conflict did not return existing attempt".to_owned(),
+                        )
+                    })?;
+                let existing_attempt_id = replay_attempt_id(existing, &normalized)?;
+                (
+                    existing_attempt_id,
+                    SocialTrustIntakeReplayStatus::ReplayedIdentical,
+                )
+            }
+        };
+
+        let snapshot = load_snapshot_by_attempt_id_tx(&tx, &attempt_id, replay_status).await?;
+        tx.commit().await.map_err(db_error)?;
+        Ok(SocialTrustIntakePersistenceOutcome::Recorded(snapshot))
+    }
+}
+
+fn normalize_attempt(
+    subject_account_id: Uuid,
+    attempt: &ProposedSocialTrustMutationAttempt,
+    decision: &SocialTrustIntakeDecision,
+) -> Result<NormalizedAttempt, SocialTrustIntakePersistenceError> {
+    let source_category = attempt.source_category.as_str();
+    let writer_source_reference = required_ref(
+        attempt
+            .writer_source_reference
+            .as_ref()
+            .map(|reference| reference.as_str()),
+        "writer source reference",
+    )?;
+    let reason_fact_reference = required_ref(
+        attempt
+            .reason_fact
+            .as_ref()
+            .map(|reference| reference.as_str()),
+        "reason fact reference",
+    )?;
+    let attempt_idempotency_key = required_ref(idempotency_key(attempt), "idempotency key")?;
+    let evidence_posture = evidence_posture(attempt)?;
+    let reviewability_posture = reviewability_posture(attempt)?;
+    let retention_class_reference = retention_class_reference(attempt)?;
+    let authority_posture = attempt.authority_posture.as_str();
+    let decision_kind = decision.kind();
+    let rejection_reason_code = decision.rejection_reason_code();
+    let policy_version = POLICY_VERSION.to_string();
+    let subject = subject_account_id.to_string();
+    let request_payload_hash = hash_parts(&[
+        ("hash_kind", "social_trust_intake_attempt_request"),
+        ("policy_version", &policy_version),
+        ("subject_account_id", &subject),
+        ("source_category", source_category),
+        ("writer_source_reference", &writer_source_reference),
+        ("reason_fact_reference", &reason_fact_reference),
+        ("attempt_idempotency_key", &attempt_idempotency_key),
+        ("evidence_posture", evidence_posture),
+        ("reviewability_posture", reviewability_posture),
+        ("retention_record_family", RETENTION_RECORD_FAMILY),
+        ("retention_class_reference", &retention_class_reference),
+        ("authority_posture", authority_posture),
+    ]);
+    let decision_payload_hash = hash_parts(&[
+        ("hash_kind", "social_trust_intake_attempt_decision"),
+        ("request_payload_hash", &request_payload_hash),
+        ("decision_kind", decision_kind),
+        (
+            "rejection_reason_code",
+            rejection_reason_code.unwrap_or("none"),
+        ),
+    ]);
+
+    Ok(NormalizedAttempt {
+        subject_account_id,
+        source_category,
+        writer_source_reference,
+        reason_fact_reference,
+        attempt_idempotency_key,
+        evidence_posture,
+        reviewability_posture,
+        retention_class_reference,
+        authority_posture,
+        decision_kind,
+        rejection_reason_code,
+        request_payload_hash,
+        decision_payload_hash,
+    })
+}
+
+fn has_persistence_minimum(attempt: &ProposedSocialTrustMutationAttempt) -> bool {
+    attempt
+        .writer_source_reference
+        .as_ref()
+        .is_some_and(|reference| reference.is_present())
+        && attempt
+            .reason_fact
+            .as_ref()
+            .is_some_and(|reference| reference.is_present())
+        && idempotency_key(attempt)
+            .is_some_and(|idempotency_key| !idempotency_key.trim().is_empty())
+        && attempt.evidence_posture.is_some()
+        && attempt.reviewability_posture.is_some()
+        && retention_class_reference(attempt)
+            .is_ok_and(|retention_class_reference| !retention_class_reference.trim().is_empty())
+}
+
+fn idempotency_key(attempt: &ProposedSocialTrustMutationAttempt) -> Option<&str> {
+    match attempt.idempotency_posture.as_ref()? {
+        DurableIdempotencyPosture::DurableDedupeKey(key) => Some(key.as_str()),
+    }
+}
+
+fn evidence_posture(
+    attempt: &ProposedSocialTrustMutationAttempt,
+) -> Result<&'static str, SocialTrustIntakePersistenceError> {
+    match attempt.evidence_posture.as_ref() {
+        Some(EvidencePosture::Bounded) => Ok(EvidencePosture::Bounded.as_str()),
+        None => Err(SocialTrustIntakePersistenceError::BadRequest(
+            "Social Trust intake persistence requires evidence posture".to_owned(),
+        )),
+    }
+}
+
+fn reviewability_posture(
+    attempt: &ProposedSocialTrustMutationAttempt,
+) -> Result<&'static str, SocialTrustIntakePersistenceError> {
+    match attempt.reviewability_posture.as_ref() {
+        Some(ReviewabilityPosture::Reviewable) => Ok(ReviewabilityPosture::Reviewable.as_str()),
+        None => Err(SocialTrustIntakePersistenceError::BadRequest(
+            "Social Trust intake persistence requires reviewability posture".to_owned(),
+        )),
+    }
+}
+
+fn retention_class_reference(
+    attempt: &ProposedSocialTrustMutationAttempt,
+) -> Result<String, SocialTrustIntakePersistenceError> {
+    match attempt.retention_posture.as_ref() {
+        Some(RetentionPosture::Classified(reference)) if reference.is_present() => {
+            Ok(reference.as_str().trim().to_owned())
+        }
+        _ => Err(SocialTrustIntakePersistenceError::BadRequest(
+            "Social Trust intake persistence requires retention classification".to_owned(),
+        )),
+    }
+}
+
+fn required_ref(
+    value: Option<&str>,
+    label: &'static str,
+) -> Result<String, SocialTrustIntakePersistenceError> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| {
+            SocialTrustIntakePersistenceError::BadRequest(format!(
+                "Social Trust intake persistence requires {label}"
+            ))
+        })
+}
+
+async fn find_existing_attempt_by_dedupe_tx(
+    client: &impl GenericClient,
+    normalized: &NormalizedAttempt,
+) -> Result<Option<Row>, SocialTrustIntakePersistenceError> {
+    client
+        .query_opt(
+            "
+            SELECT attempt.attempt_id, attempt.request_payload_hash
+            FROM social_trust.proposed_mutation_attempts attempt
+            WHERE attempt.subject_account_id = $1
+              AND attempt.source_category = $2
+              AND attempt.writer_source_reference = $3
+              AND attempt.reason_fact_reference = $4
+              AND attempt.policy_version = $5
+              AND attempt.attempt_idempotency_key = $6
+            ",
+            &[
+                &normalized.subject_account_id,
+                &normalized.source_category,
+                &normalized.writer_source_reference,
+                &normalized.reason_fact_reference,
+                &POLICY_VERSION,
+                &normalized.attempt_idempotency_key,
+            ],
+        )
+        .await
+        .map_err(db_error)
+}
+
+async fn load_snapshot_by_attempt_id_tx(
+    client: &impl GenericClient,
+    attempt_id: &Uuid,
+    replay_status: SocialTrustIntakeReplayStatus,
+) -> Result<SocialTrustIntakeSnapshot, SocialTrustIntakePersistenceError> {
+    let row = client
+        .query_one(
+            "
+            SELECT
+                attempt.attempt_id,
+                decision.intake_decision_id,
+                attempt.subject_account_id,
+                attempt.source_category,
+                decision.decision_kind,
+                decision.rejection_reason_code,
+                attempt.request_payload_hash,
+                decision.decision_payload_hash,
+                attempt.created_at
+            FROM social_trust.proposed_mutation_attempts attempt
+            JOIN social_trust.intake_decisions decision
+              ON decision.attempt_id = attempt.attempt_id
+            WHERE attempt.attempt_id = $1
+            ",
+            &[attempt_id],
+        )
+        .await
+        .map_err(db_error)?;
+
+    Ok(SocialTrustIntakeSnapshot {
+        attempt_id: row.get::<_, Uuid>("attempt_id").to_string(),
+        intake_decision_id: row.get::<_, Uuid>("intake_decision_id").to_string(),
+        subject_account_id: row.get::<_, Uuid>("subject_account_id").to_string(),
+        source_category: row.get("source_category"),
+        decision_kind: row.get("decision_kind"),
+        rejection_reason_code: row.get("rejection_reason_code"),
+        request_payload_hash: row.get("request_payload_hash"),
+        decision_payload_hash: row.get("decision_payload_hash"),
+        replay_status,
+        created_at: row.get("created_at"),
+    })
+}
+
+fn replay_attempt_id(
+    existing: Row,
+    normalized: &NormalizedAttempt,
+) -> Result<Uuid, SocialTrustIntakePersistenceError> {
+    let existing_hash: String = existing.get("request_payload_hash");
+    let existing_attempt_id: Uuid = existing.get("attempt_id");
+    if existing_hash != normalized.request_payload_hash {
+        return Err(SocialTrustIntakePersistenceError::IdempotencyConflict {
+            message: "duplicate Social Trust intake attempt has payload drift".to_owned(),
+            existing_attempt_id: existing_attempt_id.to_string(),
+        });
+    }
+    Ok(existing_attempt_id)
+}
+
+async fn ensure_active_ordinary_account_exists_tx(
+    client: &impl GenericClient,
+    account_id: &Uuid,
+) -> Result<(), SocialTrustIntakePersistenceError> {
+    let Some(row) = client
+        .query_opt(
+            "
+            SELECT account_class, account_state
+            FROM core.accounts
+            WHERE account_id = $1
+            FOR UPDATE
+            ",
+            &[account_id],
+        )
+        .await
+        .map_err(db_error)?
+    else {
+        return Err(SocialTrustIntakePersistenceError::BadRequest(
+            "Social Trust intake subject must reference an existing account writer fact".to_owned(),
+        ));
+    };
+    let account_class: String = row.get("account_class");
+    let account_state: String = row.get("account_state");
+
+    if account_class != "Ordinary Account" {
+        return Err(SocialTrustIntakePersistenceError::BadRequest(
+            "Social Trust intake subject must be an Ordinary Account".to_owned(),
+        ));
+    }
+
+    if account_state != "active" {
+        return Err(SocialTrustIntakePersistenceError::BadRequest(
+            "Social Trust intake subject account must be active".to_owned(),
+        ));
+    }
+
+    Ok(())
+}
+
+fn attempt_insert_error(error: tokio_postgres::Error) -> SocialTrustIntakePersistenceError {
+    if matches!(error.code(), Some(&SqlState::FOREIGN_KEY_VIOLATION)) {
+        return SocialTrustIntakePersistenceError::BadRequest(
+            "Social Trust intake subject must reference an existing account writer fact".to_owned(),
+        );
+    }
+
+    db_error(error)
+}
+
+fn parse_uuid(value: &str, label: &'static str) -> Result<Uuid, SocialTrustIntakePersistenceError> {
+    Uuid::parse_str(value).map_err(|_| {
+        SocialTrustIntakePersistenceError::BadRequest(format!("{label} must be a valid UUID"))
+    })
+}
+
+fn hash_parts(parts: &[(&str, &str)]) -> String {
+    let mut hasher = Sha256::new();
+    for (name, value) in parts {
+        hasher.update(name.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(value.len().to_string().as_bytes());
+        hasher.update(b":");
+        hasher.update(value.as_bytes());
+        hasher.update(b"\n");
+    }
+    hex_digest(hasher.finalize().as_slice())
+}
+
+fn hex_digest(bytes: &[u8]) -> String {
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        write!(&mut output, "{byte:02x}").expect("writing sha256 hex cannot fail");
+    }
+    output
+}
+
+fn db_error(error: tokio_postgres::Error) -> SocialTrustIntakePersistenceError {
+    let code = error.code().map(SqlState::code).map(ToOwned::to_owned);
+    let constraint = error
+        .as_db_error()
+        .and_then(|db_error| db_error.constraint())
+        .map(ToOwned::to_owned);
+    let retryable = matches!(
+        error.code(),
+        Some(&SqlState::T_R_SERIALIZATION_FAILURE) | Some(&SqlState::T_R_DEADLOCK_DETECTED)
+    );
+
+    SocialTrustIntakePersistenceError::Database {
+        message: error.to_string(),
+        code,
+        constraint,
+        retryable,
+    }
+}

--- a/apps/backend/src/services/social_trust_intake/types.rs
+++ b/apps/backend/src/services/social_trust_intake/types.rs
@@ -1,0 +1,61 @@
+use chrono::{DateTime, Utc};
+use musubi_social_trust_domain::{ProposedSocialTrustMutationAttempt, SocialTrustIntakeDecision};
+
+#[derive(Debug)]
+pub enum SocialTrustIntakePersistenceError {
+    BadRequest(String),
+    IdempotencyConflict {
+        message: String,
+        existing_attempt_id: String,
+    },
+    Database {
+        message: String,
+        code: Option<String>,
+        constraint: Option<String>,
+        retryable: bool,
+    },
+    Internal(String),
+}
+
+impl SocialTrustIntakePersistenceError {
+    pub fn message(&self) -> &str {
+        match self {
+            Self::BadRequest(message)
+            | Self::IdempotencyConflict { message, .. }
+            | Self::Database { message, .. }
+            | Self::Internal(message) => message,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct RecordSocialTrustIntakeAttemptInput {
+    pub subject_account_id: String,
+    pub attempt: ProposedSocialTrustMutationAttempt,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SocialTrustIntakeReplayStatus {
+    Inserted,
+    ReplayedIdentical,
+}
+
+#[derive(Clone, Debug)]
+pub enum SocialTrustIntakePersistenceOutcome {
+    Recorded(SocialTrustIntakeSnapshot),
+    RejectedBeforePersistence { decision: SocialTrustIntakeDecision },
+}
+
+#[derive(Clone, Debug)]
+pub struct SocialTrustIntakeSnapshot {
+    pub attempt_id: String,
+    pub intake_decision_id: String,
+    pub subject_account_id: String,
+    pub source_category: String,
+    pub decision_kind: String,
+    pub rejection_reason_code: Option<String>,
+    pub request_payload_hash: String,
+    pub decision_payload_hash: String,
+    pub replay_status: SocialTrustIntakeReplayStatus,
+    pub created_at: DateTime<Utc>,
+}

--- a/apps/backend/tests/social_trust_intake_persistence.rs
+++ b/apps/backend/tests/social_trust_intake_persistence.rs
@@ -1,0 +1,450 @@
+use std::path::PathBuf;
+
+use musubi_backend::{
+    new_test_state,
+    services::social_trust_intake::{
+        RecordSocialTrustIntakeAttemptInput, SocialTrustIntakePersistenceError,
+        SocialTrustIntakePersistenceOutcome, SocialTrustIntakeReplayStatus, SocialTrustIntakeStore,
+    },
+};
+use musubi_db_runtime::DbConfig;
+use musubi_social_trust_domain::{
+    DurableIdempotencyPosture, EvidencePosture, ForbiddenSocialTrustSourceCategory,
+    ProposedSocialTrustMutationAttempt, ReasonFactReference, RetentionClassReference,
+    RetentionPosture, ReviewabilityPosture, SocialTrustAuthorityPosture, SocialTrustIntakeDecision,
+    SocialTrustIntakeRejection, SocialTrustMutationAttemptIdempotencyKey,
+    SocialTrustSourceCategory, WriterSourceReference,
+};
+use tokio_postgres::NoTls;
+use uuid::Uuid;
+
+fn lookup(database_url: &str, migrations_dir: &str, name: &'static str) -> Option<String> {
+    match name {
+        "APP_ENV" => Some("test".to_owned()),
+        "DATABASE_URL" => Some(database_url.to_owned()),
+        "MIGRATIONS_DIR" => Some(migrations_dir.to_owned()),
+        "REQUIRE_LATEST_SCHEMA" => Some("true".to_owned()),
+        _ => None,
+    }
+}
+
+#[tokio::test]
+async fn candidate_attempt_is_persisted_and_replayed_by_database_identity() {
+    let (_test_state, config, client) = test_context().await;
+    let subject_account_id = insert_account(&client, "Ordinary Account", "active").await;
+    let store = SocialTrustIntakeStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let input = record_input(subject_account_id, complete_attempt("dedupe-candidate"));
+
+    let first = recorded(
+        store
+            .record_attempt(input.clone())
+            .await
+            .expect("first intake should persist"),
+    );
+    let replay = recorded(
+        store
+            .record_attempt(input)
+            .await
+            .expect("identical duplicate should replay"),
+    );
+
+    assert_eq!(first.decision_kind, "candidate_for_writer_persistence");
+    assert_eq!(first.rejection_reason_code, None);
+    assert_eq!(first.replay_status, SocialTrustIntakeReplayStatus::Inserted);
+    assert_eq!(
+        replay.replay_status,
+        SocialTrustIntakeReplayStatus::ReplayedIdentical
+    );
+    assert_eq!(first.attempt_id, replay.attempt_id);
+    assert_eq!(first.intake_decision_id, replay.intake_decision_id);
+    assert_eq!(first.request_payload_hash, replay.request_payload_hash);
+    assert_eq!(
+        attempt_count_for_subject(&client, &subject_account_id).await,
+        1
+    );
+}
+
+#[tokio::test]
+async fn duplicate_delivery_with_payload_drift_fails_closed() {
+    let (_test_state, config, client) = test_context().await;
+    let subject_account_id = insert_account(&client, "Ordinary Account", "active").await;
+    let store = SocialTrustIntakeStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let first = record_input(subject_account_id, complete_attempt("dedupe-drift"));
+    let mut drifted_attempt = complete_attempt("dedupe-drift");
+    drifted_attempt.retention_posture = Some(RetentionPosture::Classified(
+        RetentionClassReference::new("social-trust-intake-review-retention"),
+    ));
+    let drifted = record_input(subject_account_id, drifted_attempt);
+
+    let _ = recorded(
+        store
+            .record_attempt(first)
+            .await
+            .expect("first intake should persist"),
+    );
+    let error = store
+        .record_attempt(drifted)
+        .await
+        .expect_err("payload drift must fail closed");
+
+    match error {
+        SocialTrustIntakePersistenceError::IdempotencyConflict { .. } => {}
+        other => panic!("expected idempotency conflict, got {other:?}"),
+    }
+    assert_eq!(
+        attempt_count_for_subject(&client, &subject_account_id).await,
+        1
+    );
+}
+
+#[tokio::test]
+async fn identical_replay_survives_subject_account_suspension() {
+    let (_test_state, config, client) = test_context().await;
+    let subject_account_id = insert_account(&client, "Ordinary Account", "active").await;
+    let store = SocialTrustIntakeStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let input = record_input(
+        subject_account_id,
+        complete_attempt("dedupe-after-suspension"),
+    );
+
+    let first = recorded(
+        store
+            .record_attempt(input.clone())
+            .await
+            .expect("first intake should persist"),
+    );
+    set_account_state(&client, &subject_account_id, "suspended").await;
+    let replay = recorded(
+        store
+            .record_attempt(input)
+            .await
+            .expect("duplicate intake should replay despite later account suspension"),
+    );
+
+    assert_eq!(first.attempt_id, replay.attempt_id);
+    assert_eq!(
+        replay.replay_status,
+        SocialTrustIntakeReplayStatus::ReplayedIdentical
+    );
+}
+
+#[tokio::test]
+async fn new_attempt_requires_active_ordinary_account() {
+    let (_test_state, config, client) = test_context().await;
+    let subject_account_id = insert_account(&client, "Ordinary Account", "suspended").await;
+    let store = SocialTrustIntakeStore::connect(&config)
+        .await
+        .expect("store should connect");
+
+    let error = store
+        .record_attempt(record_input(
+            subject_account_id,
+            complete_attempt("dedupe-suspended-subject"),
+        ))
+        .await
+        .expect_err("new intake should reject inactive subjects");
+
+    assert!(matches!(
+        error,
+        SocialTrustIntakePersistenceError::BadRequest(_)
+    ));
+    assert_eq!(
+        attempt_count_for_subject(&client, &subject_account_id).await,
+        0
+    );
+}
+
+#[tokio::test]
+async fn forbidden_source_persists_rejected_decision_without_projection_refresh() {
+    let (_test_state, config, client) = test_context().await;
+    let subject_account_id = insert_account(&client, "Ordinary Account", "active").await;
+    let store = SocialTrustIntakeStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let mut attempt = complete_attempt("dedupe-forbidden-payment");
+    attempt.source_category =
+        SocialTrustSourceCategory::Forbidden(ForbiddenSocialTrustSourceCategory::PaymentAmount);
+
+    let snapshot = recorded(
+        store
+            .record_attempt(record_input(subject_account_id, attempt))
+            .await
+            .expect("forbidden source should persist rejected intake decision"),
+    );
+
+    assert_eq!(snapshot.source_category, "payment_amount");
+    assert_eq!(snapshot.decision_kind, "rejected");
+    assert_eq!(
+        snapshot.rejection_reason_code.as_deref(),
+        Some("forbidden_source")
+    );
+    assert_eq!(
+        projection_trust_snapshot_count(&client, &subject_account_id).await,
+        0
+    );
+}
+
+#[tokio::test]
+async fn projection_only_attempt_persists_rejection_without_projection_refresh() {
+    let (_test_state, config, client) = test_context().await;
+    let subject_account_id = insert_account(&client, "Ordinary Account", "active").await;
+    let store = SocialTrustIntakeStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let mut attempt = complete_attempt("dedupe-projection-only");
+    attempt.authority_posture = SocialTrustAuthorityPosture::ProjectionOnly;
+
+    let snapshot = recorded(
+        store
+            .record_attempt(record_input(subject_account_id, attempt))
+            .await
+            .expect("projection-only posture should persist rejected intake decision"),
+    );
+
+    assert_eq!(snapshot.decision_kind, "rejected");
+    assert_eq!(
+        snapshot.rejection_reason_code.as_deref(),
+        Some("projection_only_authority")
+    );
+    assert_eq!(
+        projection_trust_snapshot_count(&client, &subject_account_id).await,
+        0
+    );
+}
+
+#[tokio::test]
+async fn missing_idempotency_fails_before_persistence() {
+    let (_test_state, config, client) = test_context().await;
+    let subject_account_id = insert_account(&client, "Ordinary Account", "active").await;
+    let store = SocialTrustIntakeStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let mut attempt = complete_attempt("ignored-missing-idempotency");
+    attempt.idempotency_posture = None;
+
+    let outcome = store
+        .record_attempt(record_input(subject_account_id, attempt))
+        .await
+        .expect("missing idempotency should fail closed without db write");
+
+    assert_rejected_before_persistence(
+        outcome,
+        SocialTrustIntakeRejection::MissingIdempotencyPosture,
+    );
+    assert_eq!(
+        attempt_count_for_subject(&client, &subject_account_id).await,
+        0
+    );
+}
+
+#[tokio::test]
+async fn missing_retention_fails_before_persistence() {
+    let (_test_state, config, client) = test_context().await;
+    let subject_account_id = insert_account(&client, "Ordinary Account", "active").await;
+    let store = SocialTrustIntakeStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let mut attempt = complete_attempt("ignored-missing-retention");
+    attempt.retention_posture = None;
+
+    let outcome = store
+        .record_attempt(record_input(subject_account_id, attempt))
+        .await
+        .expect("missing retention should fail closed without db write");
+
+    assert_rejected_before_persistence(
+        outcome,
+        SocialTrustIntakeRejection::MissingRetentionPosture,
+    );
+    assert_eq!(
+        attempt_count_for_subject(&client, &subject_account_id).await,
+        0
+    );
+}
+
+#[tokio::test]
+async fn social_trust_intake_schema_does_not_create_scores_or_depth_tables() {
+    let (_test_state, _config, client) = test_context().await;
+
+    let row = client
+        .query_one(
+            "
+            SELECT COUNT(*)::bigint AS count
+            FROM information_schema.columns
+            WHERE table_schema = 'social_trust'
+              AND (
+                  column_name LIKE '%score%'
+                  OR column_name LIKE '%weight%'
+                  OR column_name LIKE '%rank%'
+                  OR column_name LIKE '%display%'
+                  OR column_name LIKE '%relationship_depth%'
+                  OR column_name LIKE '%projection%'
+              )
+            ",
+            &[],
+        )
+        .await
+        .expect("schema guard query should run");
+    let forbidden_column_count: i64 = row.get("count");
+
+    assert_eq!(forbidden_column_count, 0);
+}
+
+async fn test_context() -> (musubi_backend::TestState, DbConfig, tokio_postgres::Client) {
+    let test_state = new_test_state()
+        .await
+        .expect("test database state should initialize");
+    let database_url = std::env::var("MUSUBI_TEST_DATABASE_URL")
+        .or_else(|_| std::env::var("DATABASE_URL"))
+        .expect("integration tests require MUSUBI_TEST_DATABASE_URL or DATABASE_URL to be set");
+    let migrations_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("migrations")
+        .canonicalize()
+        .expect("migrations directory should resolve");
+    let migrations_dir = migrations_dir
+        .to_str()
+        .expect("migrations directory should be utf-8")
+        .to_owned();
+    let config = DbConfig::from_lookup(|name| lookup(&database_url, &migrations_dir, name))
+        .expect("test db config should parse");
+
+    let (client, connection) = tokio_postgres::connect(&database_url, NoTls)
+        .await
+        .expect("failed to connect to test database");
+    tokio::spawn(async move {
+        if let Err(error) = connection.await {
+            eprintln!("test database connection error: {error}");
+        }
+    });
+
+    (test_state, config, client)
+}
+
+fn complete_attempt(idempotency_key: &str) -> ProposedSocialTrustMutationAttempt {
+    ProposedSocialTrustMutationAttempt {
+        source_category: SocialTrustSourceCategory::WriterSourceCandidate,
+        writer_source_reference: Some(WriterSourceReference::new("source-fact-1")),
+        reason_fact: Some(ReasonFactReference::new("reason-fact-1")),
+        idempotency_posture: Some(DurableIdempotencyPosture::DurableDedupeKey(
+            SocialTrustMutationAttemptIdempotencyKey::new(idempotency_key),
+        )),
+        evidence_posture: Some(EvidencePosture::Bounded),
+        reviewability_posture: Some(ReviewabilityPosture::Reviewable),
+        retention_posture: Some(RetentionPosture::Classified(RetentionClassReference::new(
+            "social-trust-intake-retention",
+        ))),
+        authority_posture: SocialTrustAuthorityPosture::WriterTruthOnly,
+    }
+}
+
+fn record_input(
+    subject_account_id: Uuid,
+    attempt: ProposedSocialTrustMutationAttempt,
+) -> RecordSocialTrustIntakeAttemptInput {
+    RecordSocialTrustIntakeAttemptInput {
+        subject_account_id: subject_account_id.to_string(),
+        attempt,
+    }
+}
+
+fn recorded(
+    outcome: SocialTrustIntakePersistenceOutcome,
+) -> musubi_backend::services::social_trust_intake::SocialTrustIntakeSnapshot {
+    match outcome {
+        SocialTrustIntakePersistenceOutcome::Recorded(snapshot) => snapshot,
+        SocialTrustIntakePersistenceOutcome::RejectedBeforePersistence { decision } => {
+            panic!("expected recorded intake, got rejected before persistence: {decision:?}")
+        }
+    }
+}
+
+fn assert_rejected_before_persistence(
+    outcome: SocialTrustIntakePersistenceOutcome,
+    expected: SocialTrustIntakeRejection,
+) {
+    match outcome {
+        SocialTrustIntakePersistenceOutcome::RejectedBeforePersistence {
+            decision: SocialTrustIntakeDecision::Reject(actual),
+        } => assert_eq!(actual, expected),
+        other => panic!("expected rejected before persistence, got {other:?}"),
+    }
+}
+
+async fn insert_account(
+    client: &tokio_postgres::Client,
+    account_class: &str,
+    account_state: &str,
+) -> Uuid {
+    let account_id = Uuid::new_v4();
+    client
+        .execute(
+            "
+            INSERT INTO core.accounts (account_id, account_class, account_state)
+            VALUES ($1, $2, $3)
+            ",
+            &[&account_id, &account_class, &account_state],
+        )
+        .await
+        .expect("account insert should succeed");
+    account_id
+}
+
+async fn set_account_state(
+    client: &tokio_postgres::Client,
+    account_id: &Uuid,
+    account_state: &str,
+) {
+    client
+        .execute(
+            "
+            UPDATE core.accounts
+            SET account_state = $2
+            WHERE account_id = $1
+            ",
+            &[account_id, &account_state],
+        )
+        .await
+        .expect("account state update should succeed");
+}
+
+async fn attempt_count_for_subject(
+    client: &tokio_postgres::Client,
+    subject_account_id: &Uuid,
+) -> i64 {
+    let row = client
+        .query_one(
+            "
+            SELECT COUNT(*)::bigint AS count
+            FROM social_trust.proposed_mutation_attempts
+            WHERE subject_account_id = $1
+            ",
+            &[subject_account_id],
+        )
+        .await
+        .expect("attempt count should load");
+    row.get("count")
+}
+
+async fn projection_trust_snapshot_count(
+    client: &tokio_postgres::Client,
+    subject_account_id: &Uuid,
+) -> i64 {
+    let row = client
+        .query_one(
+            "
+            SELECT COUNT(*)::bigint AS count
+            FROM projection.trust_snapshots
+            WHERE account_id = $1
+            ",
+            &[subject_account_id],
+        )
+        .await
+        .expect("projection trust snapshot count should load");
+    row.get("count")
+}


### PR DESCRIPTION
## Summary
- add the narrow C1 Social Trust intake persistence boundary under `social_trust`
- persist proposed mutation attempts plus intake decisions for rejected and `CandidateForWriterPersistence` outcomes
- enforce duplicate delivery with a PostgreSQL dedupe index and deterministic payload-hash replay checks
- document the PR #92 authorization boundary and package/schema ownership

## Explicitly out of scope
- no actual Social Trust mutation facts
- no score, weight, rank, display level, Relationship Depth, narrowing, freeze, or recovery facts
- no projection refresh, public API, mobile UI, proof, room, discovery, recommendation, settlement, Promise, payment, Support, or operator-review authority

## Validation
- `git diff --check`
- `cargo check`
- `cargo test -p musubi_social_trust_domain`
- `cargo test --test social_trust_intake_persistence`
- `cargo test`

Note: repo-wide `cargo fmt --check` still reports pre-existing formatting drift in operator-review files outside this PR scope. The new/changed Social Trust files pass `rustfmt --edition 2024 --check` when checked directly.
