### PR TITLE
feat: implement C2 bounded Promise reliability mutation fact persistence

### DIFF
--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -176,6 +176,7 @@ Operator PIN fallback remains an internal/deferred primitive until an authentica
 Location hints are sanitized before proof records are built, unsupported fallback modes are rejected before display-code verification, and malformed or cross-subject attempts do not burn another challenge's failed-attempt budget.
 These proof records are input facts only; they are not settlement truth or final anti-spoof guarantees.
 Design source: C1 Social Trust intake handoff adds the first narrow Social Trust intake persistence boundary. Proposed mutation attempts and their intake decisions live in `social_trust`, use PostgreSQL-enforced idempotency and payload-hash replay checks, and remain intake / audit facts only. This does not add Social Trust mutation facts, scores, weights, ranks, display levels, Relationship Depth behavior, projection refresh, public API, or mobile UI.
+Design source: C2 bounded Promise reliability implementation handoff adds one narrow categorical Social Trust mutation fact persistence boundary. Accepted source references and categorical mutation facts live in `social_trust`, use PostgreSQL-enforced idempotency and payload-hash replay checks, and remain backend-local writer facts only. The exact review-required boundary source may persist only a categorical freeze fact. This does not add Social Trust scores, weights, ranks, public display, projection refresh, Relationship Depth behavior, discovery / recommendation use, room progression, settlement behavior, Promise runtime behavior, public API, or mobile UI.
 
 ## Local design notes
 
@@ -195,4 +196,5 @@ Design source: C1 Social Trust intake handoff adds the first narrow Social Trust
 - `docs/c1_runtime_intake_scope.md`: C1 trust/depth runtime intake scope and non-authority boundary for future backend work
 - `docs/c1_social_trust_intake_contract_scope.md`: selected first C1 Social Trust intake / no-authority contract scope
 - `docs/c1_social_trust_writer_fact_scope.md`: C1 Social Trust intake persistence envelope and non-authority stop conditions
+- `docs/c2_bounded_promise_reliability_mutation_fact_persistence.md`: C2 categorical Social Trust mutation fact persistence envelope and non-authority stop conditions
 - `docs/happy_route_walkthrough.md`: current Issue #7 end-to-end path

--- a/apps/backend/crates/social-trust-domain/src/lib.rs
+++ b/apps/backend/crates/social-trust-domain/src/lib.rs
@@ -1,5 +1,5 @@
 //! MUSUBI social-trust-domain crate.
-//! Owns the pure Social Trust intake / no-authority decision contract.
+//! Owns pure Social Trust intake and categorical writer-fact decision contracts.
 //! Must not own DB persistence, projections, HTTP/API wiring, Relationship Depth,
 //! proof, settlement, discovery, recommendation, or runtime orchestration.
 
@@ -144,6 +144,524 @@ impl ReviewabilityPosture {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum RetentionPosture {
     Classified(RetentionClassReference),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProposedC2BoundedPromiseReliabilityMutationFact {
+    pub source_fact: C2BoundedPromiseReliabilitySourceFactCandidate,
+    pub requested_mutation_fact: C2BoundedPromiseReliabilityMutationFactCandidate,
+    pub writer_source_reference: Option<WriterSourceReference>,
+    pub promise_reference: Option<PromiseReference>,
+    pub promise_terms_reference: Option<PromiseTermsReference>,
+    pub consent_at_formation_reference: Option<ConsentStateReference>,
+    pub consent_at_resolution_reference: Option<ConsentStateReference>,
+    pub block_withdrawal_state_reference: Option<BlockWithdrawalStateReference>,
+    pub age_assurance_state_reference: Option<AgeAssuranceStateReference>,
+    pub legal_hold_intersection_reference: Option<LegalHoldIntersectionReference>,
+    pub critical_harm_case_reference: Option<CriticalHarmCaseReference>,
+    pub account_lifecycle_reference: Option<AccountLifecycleReference>,
+    pub anti_abuse_continuity_reference: Option<AntiAbuseContinuityReference>,
+    pub safety_case_reference: Option<SafetyCaseReference>,
+    pub evidence_level_reference: Option<EvidenceLevelReference>,
+    pub audit_reference: Option<AuditReference>,
+    pub reason_fact: Option<ReasonFactReference>,
+    pub fact_idempotency_key: Option<C2BoundedPromiseReliabilityFactIdempotencyKey>,
+    pub evidence_posture: Option<EvidencePosture>,
+    pub reviewability_posture: Option<ReviewabilityPosture>,
+    pub retention_posture: Option<RetentionPosture>,
+    pub authority_posture: SocialTrustAuthorityPosture,
+    pub boundary_posture: C2BoundedPromiseReliabilityBoundaryPosture,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum C2BoundedPromiseReliabilitySourceFactCandidate {
+    Accepted(C2BoundedPromiseReliabilitySourceFact),
+    Rejected(RejectedC2BoundedPromiseReliabilitySourceFact),
+    Unknown,
+}
+
+impl C2BoundedPromiseReliabilitySourceFactCandidate {
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Accepted(source) => source.as_str(),
+            Self::Rejected(source) => source.as_str(),
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum C2BoundedPromiseReliabilitySourceFact {
+    CompletedAsAgreed,
+    CompletedAfterGovernedReview,
+    ValidExcusedExit,
+    SourceFactCorrected,
+    ReviewRequiredBoundaryIntersection,
+    SourceScopeLimitedAfterReview,
+    FreezeOrNarrowingReversedAfterReview,
+}
+
+impl C2BoundedPromiseReliabilitySourceFact {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::CompletedAsAgreed => "promise_reliability_outcome.completed_as_agreed",
+            Self::CompletedAfterGovernedReview => {
+                "promise_reliability_outcome.completed_after_governed_review"
+            }
+            Self::ValidExcusedExit => "promise_reliability_outcome.valid_excused_exit",
+            Self::SourceFactCorrected => "promise_reliability_outcome.source_fact_corrected",
+            Self::ReviewRequiredBoundaryIntersection => {
+                "promise_reliability_outcome.review_required_boundary_intersection"
+            }
+            Self::SourceScopeLimitedAfterReview => {
+                "promise_reliability_outcome.source_scope_limited_after_review"
+            }
+            Self::FreezeOrNarrowingReversedAfterReview => {
+                "promise_reliability_outcome.freeze_or_narrowing_reversed_after_review"
+            }
+        }
+    }
+
+    pub const fn expected_mutation(self) -> C2BoundedPromiseReliabilityMutationFact {
+        match self {
+            Self::CompletedAsAgreed | Self::CompletedAfterGovernedReview => {
+                C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityPositive
+            }
+            Self::ValidExcusedExit => {
+                C2BoundedPromiseReliabilityMutationFact::NoEffectValidExcusedExit
+            }
+            Self::SourceFactCorrected => {
+                C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityCorrection
+            }
+            Self::ReviewRequiredBoundaryIntersection => {
+                C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityFreeze
+            }
+            Self::SourceScopeLimitedAfterReview => {
+                C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityNarrowing
+            }
+            Self::FreezeOrNarrowingReversedAfterReview => {
+                C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityRecovery
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum C2BoundedPromiseReliabilityMutationFactCandidate {
+    Accepted(C2BoundedPromiseReliabilityMutationFact),
+    Unknown,
+}
+
+impl C2BoundedPromiseReliabilityMutationFactCandidate {
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Accepted(mutation) => mutation.as_str(),
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum C2BoundedPromiseReliabilityMutationFact {
+    BoundedPromiseReliabilityPositive,
+    NoEffectValidExcusedExit,
+    BoundedPromiseReliabilityCorrection,
+    BoundedPromiseReliabilityFreeze,
+    BoundedPromiseReliabilityNarrowing,
+    BoundedPromiseReliabilityRecovery,
+}
+
+impl C2BoundedPromiseReliabilityMutationFact {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::BoundedPromiseReliabilityPositive => {
+                "social_trust_mutation.bounded_promise_reliability_positive"
+            }
+            Self::NoEffectValidExcusedExit => "social_trust_mutation.no_effect_valid_excused_exit",
+            Self::BoundedPromiseReliabilityCorrection => {
+                "social_trust_mutation.bounded_promise_reliability_correction"
+            }
+            Self::BoundedPromiseReliabilityFreeze => {
+                "social_trust_mutation.bounded_promise_reliability_freeze"
+            }
+            Self::BoundedPromiseReliabilityNarrowing => {
+                "social_trust_mutation.bounded_promise_reliability_narrowing"
+            }
+            Self::BoundedPromiseReliabilityRecovery => {
+                "social_trust_mutation.bounded_promise_reliability_recovery"
+            }
+        }
+    }
+
+    pub const fn direction(self) -> C2BoundedPromiseReliabilityMutationDirection {
+        match self {
+            Self::BoundedPromiseReliabilityPositive => {
+                C2BoundedPromiseReliabilityMutationDirection::Positive
+            }
+            Self::NoEffectValidExcusedExit => {
+                C2BoundedPromiseReliabilityMutationDirection::NoEffect
+            }
+            Self::BoundedPromiseReliabilityCorrection => {
+                C2BoundedPromiseReliabilityMutationDirection::Correction
+            }
+            Self::BoundedPromiseReliabilityFreeze => {
+                C2BoundedPromiseReliabilityMutationDirection::Freeze
+            }
+            Self::BoundedPromiseReliabilityNarrowing => {
+                C2BoundedPromiseReliabilityMutationDirection::Narrowing
+            }
+            Self::BoundedPromiseReliabilityRecovery => {
+                C2BoundedPromiseReliabilityMutationDirection::Recovery
+            }
+        }
+    }
+
+    pub const fn magnitude(self) -> C2BoundedPromiseReliabilityMutationMagnitude {
+        match self {
+            Self::BoundedPromiseReliabilityPositive => {
+                C2BoundedPromiseReliabilityMutationMagnitude::Categorical
+            }
+            Self::NoEffectValidExcusedExit => {
+                C2BoundedPromiseReliabilityMutationMagnitude::NoEffect
+            }
+            Self::BoundedPromiseReliabilityCorrection => {
+                C2BoundedPromiseReliabilityMutationMagnitude::ForwardCorrection
+            }
+            Self::BoundedPromiseReliabilityFreeze => {
+                C2BoundedPromiseReliabilityMutationMagnitude::TemporarySuppression
+            }
+            Self::BoundedPromiseReliabilityNarrowing => {
+                C2BoundedPromiseReliabilityMutationMagnitude::ScopeLimitedRestriction
+            }
+            Self::BoundedPromiseReliabilityRecovery => {
+                C2BoundedPromiseReliabilityMutationMagnitude::EligibilityRestoration
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum C2BoundedPromiseReliabilityMutationDirection {
+    Positive,
+    NoEffect,
+    Correction,
+    Freeze,
+    Narrowing,
+    Recovery,
+}
+
+impl C2BoundedPromiseReliabilityMutationDirection {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Positive => "positive",
+            Self::NoEffect => "no_effect",
+            Self::Correction => "correction",
+            Self::Freeze => "freeze",
+            Self::Narrowing => "narrowing",
+            Self::Recovery => "recovery",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum C2BoundedPromiseReliabilityMutationMagnitude {
+    Categorical,
+    NoEffect,
+    ForwardCorrection,
+    TemporarySuppression,
+    ScopeLimitedRestriction,
+    EligibilityRestoration,
+}
+
+impl C2BoundedPromiseReliabilityMutationMagnitude {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Categorical => "categorical",
+            Self::NoEffect => "no_effect",
+            Self::ForwardCorrection => "forward_correction",
+            Self::TemporarySuppression => "temporary_suppression",
+            Self::ScopeLimitedRestriction => "scope_limited_restriction",
+            Self::EligibilityRestoration => "eligibility_restoration",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum C2BoundedPromiseReliabilityBoundaryPosture {
+    Clear,
+    Unresolved(C2BoundedPromiseReliabilityBoundaryIntersection),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum C2BoundedPromiseReliabilityBoundaryIntersection {
+    Consent,
+    BlockMuteRefusalOrWithdrawal,
+    AgeAssurance,
+    LegalHold,
+    CriticalHarm,
+    AccountLifecycle,
+    AppealCorrectionOrSafetyReview,
+    AntiAbuseSuppression,
+    CollusionScamOrCoercion,
+    SensitiveExposure,
+}
+
+impl C2BoundedPromiseReliabilityBoundaryIntersection {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Consent => "consent",
+            Self::BlockMuteRefusalOrWithdrawal => "block_mute_refusal_or_withdrawal",
+            Self::AgeAssurance => "age_assurance",
+            Self::LegalHold => "legal_hold",
+            Self::CriticalHarm => "critical_harm",
+            Self::AccountLifecycle => "account_lifecycle",
+            Self::AppealCorrectionOrSafetyReview => "appeal_correction_or_safety_review",
+            Self::AntiAbuseSuppression => "anti_abuse_suppression",
+            Self::CollusionScamOrCoercion => "collusion_scam_or_coercion",
+            Self::SensitiveExposure => "sensitive_exposure",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RejectedC2BoundedPromiseReliabilitySourceFact {
+    PromiseCreation,
+    PromiseAcceptance,
+    PromiseTerms,
+    PromiseEscrowCreation,
+    EscrowAmount,
+    EscrowRelease,
+    Forfeiture,
+    PaymentAmount,
+    PaymentFrequency,
+    SupportAmount,
+    SupportStatus,
+    TokenHoldings,
+    MeetingAttendanceClaimByOneParty,
+    RawVenuePresence,
+    RawGps,
+    StaticQrScan,
+    NfcTapAlone,
+    BleObservationAlone,
+    BleMacAddress,
+    DeviceAttestationAlone,
+    MissingDeviceAttestationAlone,
+    ProximityProofAlone,
+    ProofEligibilityAlone,
+    ProofCallbackAlone,
+    VendorCallbackAlone,
+    ProviderDashboardState,
+    ProjectionReadiness,
+    ReflectionPraise,
+    ApologyText,
+    SubjectiveGratitude,
+    SinglePartyNarrative,
+    ReportCount,
+    MassReportCount,
+    OperatorNote,
+    StewardEndorsementByItself,
+    SupportTicket,
+    IssueComment,
+    Popularity,
+    FollowerCount,
+    ReplySpeed,
+    DwellTime,
+    MessageVolume,
+    AccountTenure,
+    RomanticDesirability,
+    EngagementTelemetry,
+    RelationshipDepth,
+    RoomStateByItself,
+    RoomProjection,
+    DiscoveryRanking,
+    RecommendationState,
+    ObservabilityState,
+    ModelOutput,
+    FrontendState,
+    ClientState,
+    ControlledExceptionalAccountActivity,
+    AgeAssurancePosture,
+    VerifiedAdultPosture,
+    LegalHoldExistence,
+    AntiAbuseContinuityMarkerExistence,
+    AccountLifecycleStateByItself,
+    DeletionClosureTombstoneAnonymizationKeyShreddingOrReEntry,
+    ImplementationConvenience,
+}
+
+impl RejectedC2BoundedPromiseReliabilitySourceFact {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::PromiseCreation => "promise_creation",
+            Self::PromiseAcceptance => "promise_acceptance",
+            Self::PromiseTerms => "promise_terms",
+            Self::PromiseEscrowCreation => "promise_escrow_creation",
+            Self::EscrowAmount => "escrow_amount",
+            Self::EscrowRelease => "escrow_release",
+            Self::Forfeiture => "forfeiture",
+            Self::PaymentAmount => "payment_amount",
+            Self::PaymentFrequency => "payment_frequency",
+            Self::SupportAmount => "support_amount",
+            Self::SupportStatus => "support_status",
+            Self::TokenHoldings => "token_holdings",
+            Self::MeetingAttendanceClaimByOneParty => "meeting_attendance_claim_by_one_party",
+            Self::RawVenuePresence => "raw_venue_presence",
+            Self::RawGps => "raw_gps",
+            Self::StaticQrScan => "static_qr_scan",
+            Self::NfcTapAlone => "nfc_tap_alone",
+            Self::BleObservationAlone => "ble_observation_alone",
+            Self::BleMacAddress => "ble_mac_address",
+            Self::DeviceAttestationAlone => "device_attestation_alone",
+            Self::MissingDeviceAttestationAlone => "missing_device_attestation_alone",
+            Self::ProximityProofAlone => "proximity_proof_alone",
+            Self::ProofEligibilityAlone => "proof_eligibility_alone",
+            Self::ProofCallbackAlone => "proof_callback_alone",
+            Self::VendorCallbackAlone => "vendor_callback_alone",
+            Self::ProviderDashboardState => "provider_dashboard_state",
+            Self::ProjectionReadiness => "projection_readiness",
+            Self::ReflectionPraise => "reflection_praise",
+            Self::ApologyText => "apology_text",
+            Self::SubjectiveGratitude => "subjective_gratitude",
+            Self::SinglePartyNarrative => "single_party_narrative",
+            Self::ReportCount => "report_count",
+            Self::MassReportCount => "mass_report_count",
+            Self::OperatorNote => "operator_note",
+            Self::StewardEndorsementByItself => "steward_endorsement_by_itself",
+            Self::SupportTicket => "support_ticket",
+            Self::IssueComment => "issue_comment",
+            Self::Popularity => "popularity",
+            Self::FollowerCount => "follower_count",
+            Self::ReplySpeed => "reply_speed",
+            Self::DwellTime => "dwell_time",
+            Self::MessageVolume => "message_volume",
+            Self::AccountTenure => "account_tenure",
+            Self::RomanticDesirability => "romantic_desirability",
+            Self::EngagementTelemetry => "engagement_telemetry",
+            Self::RelationshipDepth => "relationship_depth",
+            Self::RoomStateByItself => "room_state_by_itself",
+            Self::RoomProjection => "room_projection",
+            Self::DiscoveryRanking => "discovery_ranking",
+            Self::RecommendationState => "recommendation_state",
+            Self::ObservabilityState => "observability_state",
+            Self::ModelOutput => "model_output",
+            Self::FrontendState => "frontend_state",
+            Self::ClientState => "client_state",
+            Self::ControlledExceptionalAccountActivity => "controlled_exceptional_account_activity",
+            Self::AgeAssurancePosture => "age_assurance_posture",
+            Self::VerifiedAdultPosture => "verified_adult_posture",
+            Self::LegalHoldExistence => "legal_hold_existence",
+            Self::AntiAbuseContinuityMarkerExistence => "anti_abuse_continuity_marker_existence",
+            Self::AccountLifecycleStateByItself => "account_lifecycle_state_by_itself",
+            Self::DeletionClosureTombstoneAnonymizationKeyShreddingOrReEntry => {
+                "deletion_closure_tombstone_anonymization_key_shredding_or_re_entry"
+            }
+            Self::ImplementationConvenience => "implementation_convenience",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum C2BoundedPromiseReliabilityMutationDecision {
+    Persist {
+        source_fact: C2BoundedPromiseReliabilitySourceFact,
+        mutation_fact: C2BoundedPromiseReliabilityMutationFact,
+        direction: C2BoundedPromiseReliabilityMutationDirection,
+        magnitude: C2BoundedPromiseReliabilityMutationMagnitude,
+    },
+    Reject(C2BoundedPromiseReliabilityRejection),
+}
+
+impl C2BoundedPromiseReliabilityMutationDecision {
+    pub const fn kind(&self) -> &'static str {
+        match self {
+            Self::Persist { .. } => "persist",
+            Self::Reject(_) => "rejected",
+        }
+    }
+
+    pub const fn rejection_reason_code(&self) -> Option<&'static str> {
+        match self {
+            Self::Persist { .. } => None,
+            Self::Reject(rejection) => Some(rejection.as_str()),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum C2BoundedPromiseReliabilityRejection {
+    RejectedSourceFact {
+        source: RejectedC2BoundedPromiseReliabilitySourceFact,
+    },
+    UnknownSourceFact,
+    UnknownMutationFact,
+    SourceMutationMismatch {
+        source: C2BoundedPromiseReliabilitySourceFact,
+        requested: C2BoundedPromiseReliabilityMutationFact,
+        expected: C2BoundedPromiseReliabilityMutationFact,
+    },
+    ProjectionOnlyAuthority,
+    MissingReviewRequiredBoundaryIntersection,
+    BoundaryUnresolved {
+        boundary: C2BoundedPromiseReliabilityBoundaryIntersection,
+    },
+    MissingWriterSourceReference,
+    MissingPromiseReference,
+    MissingPromiseTermsReference,
+    MissingConsentAtFormationReference,
+    MissingConsentAtResolutionReference,
+    MissingBlockWithdrawalStateReference,
+    MissingAgeAssuranceStateReference,
+    MissingLegalHoldIntersectionReference,
+    MissingCriticalHarmCaseReference,
+    MissingAccountLifecycleReference,
+    MissingAntiAbuseContinuityReference,
+    MissingSafetyCaseReference,
+    MissingEvidenceLevelReference,
+    MissingAuditReference,
+    MissingReasonFact,
+    MissingFactIdempotencyKey,
+    MissingEvidencePosture,
+    MissingReviewabilityPosture,
+    MissingRetentionPosture,
+}
+
+impl C2BoundedPromiseReliabilityRejection {
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::RejectedSourceFact { .. } => "rejected_source_fact",
+            Self::UnknownSourceFact => "unknown_source_fact",
+            Self::UnknownMutationFact => "unknown_mutation_fact",
+            Self::SourceMutationMismatch { .. } => "source_mutation_mismatch",
+            Self::ProjectionOnlyAuthority => "projection_only_authority",
+            Self::MissingReviewRequiredBoundaryIntersection => {
+                "missing_review_required_boundary_intersection"
+            }
+            Self::BoundaryUnresolved { .. } => "boundary_unresolved",
+            Self::MissingWriterSourceReference => "missing_writer_source_reference",
+            Self::MissingPromiseReference => "missing_promise_reference",
+            Self::MissingPromiseTermsReference => "missing_promise_terms_reference",
+            Self::MissingConsentAtFormationReference => "missing_consent_at_formation_reference",
+            Self::MissingConsentAtResolutionReference => "missing_consent_at_resolution_reference",
+            Self::MissingBlockWithdrawalStateReference => {
+                "missing_block_withdrawal_state_reference"
+            }
+            Self::MissingAgeAssuranceStateReference => "missing_age_assurance_state_reference",
+            Self::MissingLegalHoldIntersectionReference => {
+                "missing_legal_hold_intersection_reference"
+            }
+            Self::MissingCriticalHarmCaseReference => "missing_critical_harm_case_reference",
+            Self::MissingAccountLifecycleReference => "missing_account_lifecycle_reference",
+            Self::MissingAntiAbuseContinuityReference => "missing_anti_abuse_continuity_reference",
+            Self::MissingSafetyCaseReference => "missing_safety_case_reference",
+            Self::MissingEvidenceLevelReference => "missing_evidence_level_reference",
+            Self::MissingAuditReference => "missing_audit_reference",
+            Self::MissingReasonFact => "missing_reason_fact",
+            Self::MissingFactIdempotencyKey => "missing_fact_idempotency_key",
+            Self::MissingEvidencePosture => "missing_evidence_posture",
+            Self::MissingReviewabilityPosture => "missing_reviewability_posture",
+            Self::MissingRetentionPosture => "missing_retention_posture",
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -293,6 +811,242 @@ pub fn decide_social_trust_intake(
     SocialTrustIntakeDecision::CandidateForWriterPersistence
 }
 
+#[must_use]
+pub fn decide_c2_bounded_promise_reliability_mutation(
+    proposal: &ProposedC2BoundedPromiseReliabilityMutationFact,
+) -> C2BoundedPromiseReliabilityMutationDecision {
+    let source_fact = match proposal.source_fact {
+        C2BoundedPromiseReliabilitySourceFactCandidate::Accepted(source) => source,
+        C2BoundedPromiseReliabilitySourceFactCandidate::Rejected(source) => {
+            return C2BoundedPromiseReliabilityMutationDecision::Reject(
+                C2BoundedPromiseReliabilityRejection::RejectedSourceFact { source },
+            );
+        }
+        C2BoundedPromiseReliabilitySourceFactCandidate::Unknown => {
+            return C2BoundedPromiseReliabilityMutationDecision::Reject(
+                C2BoundedPromiseReliabilityRejection::UnknownSourceFact,
+            );
+        }
+    };
+
+    let requested_mutation = match proposal.requested_mutation_fact {
+        C2BoundedPromiseReliabilityMutationFactCandidate::Accepted(mutation) => mutation,
+        C2BoundedPromiseReliabilityMutationFactCandidate::Unknown => {
+            return C2BoundedPromiseReliabilityMutationDecision::Reject(
+                C2BoundedPromiseReliabilityRejection::UnknownMutationFact,
+            );
+        }
+    };
+    let expected_mutation = source_fact.expected_mutation();
+    if requested_mutation != expected_mutation {
+        return C2BoundedPromiseReliabilityMutationDecision::Reject(
+            C2BoundedPromiseReliabilityRejection::SourceMutationMismatch {
+                source: source_fact,
+                requested: requested_mutation,
+                expected: expected_mutation,
+            },
+        );
+    }
+
+    if proposal.authority_posture == SocialTrustAuthorityPosture::ProjectionOnly {
+        return C2BoundedPromiseReliabilityMutationDecision::Reject(
+            C2BoundedPromiseReliabilityRejection::ProjectionOnlyAuthority,
+        );
+    }
+
+    match proposal.boundary_posture {
+        C2BoundedPromiseReliabilityBoundaryPosture::Unresolved(boundary) => {
+            if source_fact
+                != C2BoundedPromiseReliabilitySourceFact::ReviewRequiredBoundaryIntersection
+            {
+                return C2BoundedPromiseReliabilityMutationDecision::Reject(
+                    C2BoundedPromiseReliabilityRejection::BoundaryUnresolved { boundary },
+                );
+            }
+        }
+        C2BoundedPromiseReliabilityBoundaryPosture::Clear
+            if source_fact
+                == C2BoundedPromiseReliabilitySourceFact::ReviewRequiredBoundaryIntersection =>
+        {
+            return C2BoundedPromiseReliabilityMutationDecision::Reject(
+                C2BoundedPromiseReliabilityRejection::MissingReviewRequiredBoundaryIntersection,
+            );
+        }
+        C2BoundedPromiseReliabilityBoundaryPosture::Clear => {}
+    }
+
+    if !proposal
+        .writer_source_reference
+        .as_ref()
+        .is_some_and(WriterSourceReference::is_present)
+    {
+        return C2BoundedPromiseReliabilityMutationDecision::Reject(
+            C2BoundedPromiseReliabilityRejection::MissingWriterSourceReference,
+        );
+    }
+    if !proposal
+        .promise_reference
+        .as_ref()
+        .is_some_and(PromiseReference::is_present)
+    {
+        return C2BoundedPromiseReliabilityMutationDecision::Reject(
+            C2BoundedPromiseReliabilityRejection::MissingPromiseReference,
+        );
+    }
+    if !proposal
+        .promise_terms_reference
+        .as_ref()
+        .is_some_and(PromiseTermsReference::is_present)
+    {
+        return C2BoundedPromiseReliabilityMutationDecision::Reject(
+            C2BoundedPromiseReliabilityRejection::MissingPromiseTermsReference,
+        );
+    }
+    if !proposal
+        .consent_at_formation_reference
+        .as_ref()
+        .is_some_and(ConsentStateReference::is_present)
+    {
+        return C2BoundedPromiseReliabilityMutationDecision::Reject(
+            C2BoundedPromiseReliabilityRejection::MissingConsentAtFormationReference,
+        );
+    }
+    if !proposal
+        .consent_at_resolution_reference
+        .as_ref()
+        .is_some_and(ConsentStateReference::is_present)
+    {
+        return C2BoundedPromiseReliabilityMutationDecision::Reject(
+            C2BoundedPromiseReliabilityRejection::MissingConsentAtResolutionReference,
+        );
+    }
+    if !proposal
+        .block_withdrawal_state_reference
+        .as_ref()
+        .is_some_and(BlockWithdrawalStateReference::is_present)
+    {
+        return C2BoundedPromiseReliabilityMutationDecision::Reject(
+            C2BoundedPromiseReliabilityRejection::MissingBlockWithdrawalStateReference,
+        );
+    }
+    if !proposal
+        .age_assurance_state_reference
+        .as_ref()
+        .is_some_and(AgeAssuranceStateReference::is_present)
+    {
+        return C2BoundedPromiseReliabilityMutationDecision::Reject(
+            C2BoundedPromiseReliabilityRejection::MissingAgeAssuranceStateReference,
+        );
+    }
+    if !proposal
+        .legal_hold_intersection_reference
+        .as_ref()
+        .is_some_and(LegalHoldIntersectionReference::is_present)
+    {
+        return C2BoundedPromiseReliabilityMutationDecision::Reject(
+            C2BoundedPromiseReliabilityRejection::MissingLegalHoldIntersectionReference,
+        );
+    }
+    if !proposal
+        .critical_harm_case_reference
+        .as_ref()
+        .is_some_and(CriticalHarmCaseReference::is_present)
+    {
+        return C2BoundedPromiseReliabilityMutationDecision::Reject(
+            C2BoundedPromiseReliabilityRejection::MissingCriticalHarmCaseReference,
+        );
+    }
+    if !proposal
+        .account_lifecycle_reference
+        .as_ref()
+        .is_some_and(AccountLifecycleReference::is_present)
+    {
+        return C2BoundedPromiseReliabilityMutationDecision::Reject(
+            C2BoundedPromiseReliabilityRejection::MissingAccountLifecycleReference,
+        );
+    }
+    if !proposal
+        .anti_abuse_continuity_reference
+        .as_ref()
+        .is_some_and(AntiAbuseContinuityReference::is_present)
+    {
+        return C2BoundedPromiseReliabilityMutationDecision::Reject(
+            C2BoundedPromiseReliabilityRejection::MissingAntiAbuseContinuityReference,
+        );
+    }
+    if !proposal
+        .safety_case_reference
+        .as_ref()
+        .is_some_and(SafetyCaseReference::is_present)
+    {
+        return C2BoundedPromiseReliabilityMutationDecision::Reject(
+            C2BoundedPromiseReliabilityRejection::MissingSafetyCaseReference,
+        );
+    }
+    if !proposal
+        .evidence_level_reference
+        .as_ref()
+        .is_some_and(EvidenceLevelReference::is_present)
+    {
+        return C2BoundedPromiseReliabilityMutationDecision::Reject(
+            C2BoundedPromiseReliabilityRejection::MissingEvidenceLevelReference,
+        );
+    }
+    if !proposal
+        .audit_reference
+        .as_ref()
+        .is_some_and(AuditReference::is_present)
+    {
+        return C2BoundedPromiseReliabilityMutationDecision::Reject(
+            C2BoundedPromiseReliabilityRejection::MissingAuditReference,
+        );
+    }
+    if !proposal
+        .reason_fact
+        .as_ref()
+        .is_some_and(ReasonFactReference::is_present)
+    {
+        return C2BoundedPromiseReliabilityMutationDecision::Reject(
+            C2BoundedPromiseReliabilityRejection::MissingReasonFact,
+        );
+    }
+    if !proposal
+        .fact_idempotency_key
+        .as_ref()
+        .is_some_and(C2BoundedPromiseReliabilityFactIdempotencyKey::is_present)
+    {
+        return C2BoundedPromiseReliabilityMutationDecision::Reject(
+            C2BoundedPromiseReliabilityRejection::MissingFactIdempotencyKey,
+        );
+    }
+    if proposal.evidence_posture.is_none() {
+        return C2BoundedPromiseReliabilityMutationDecision::Reject(
+            C2BoundedPromiseReliabilityRejection::MissingEvidencePosture,
+        );
+    }
+    if proposal.reviewability_posture.is_none() {
+        return C2BoundedPromiseReliabilityMutationDecision::Reject(
+            C2BoundedPromiseReliabilityRejection::MissingReviewabilityPosture,
+        );
+    }
+    if !proposal
+        .retention_posture
+        .as_ref()
+        .is_some_and(RetentionPosture::is_present)
+    {
+        return C2BoundedPromiseReliabilityMutationDecision::Reject(
+            C2BoundedPromiseReliabilityRejection::MissingRetentionPosture,
+        );
+    }
+
+    C2BoundedPromiseReliabilityMutationDecision::Persist {
+        source_fact,
+        mutation_fact: requested_mutation,
+        direction: requested_mutation.direction(),
+        magnitude: requested_mutation.magnitude(),
+    }
+}
+
 macro_rules! string_ref {
     ($name:ident) => {
         #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -322,6 +1076,19 @@ string_ref!(WriterSourceReference);
 string_ref!(ReasonFactReference);
 string_ref!(SocialTrustMutationAttemptIdempotencyKey);
 string_ref!(RetentionClassReference);
+string_ref!(C2BoundedPromiseReliabilityFactIdempotencyKey);
+string_ref!(PromiseReference);
+string_ref!(PromiseTermsReference);
+string_ref!(ConsentStateReference);
+string_ref!(BlockWithdrawalStateReference);
+string_ref!(AgeAssuranceStateReference);
+string_ref!(LegalHoldIntersectionReference);
+string_ref!(CriticalHarmCaseReference);
+string_ref!(AccountLifecycleReference);
+string_ref!(AntiAbuseContinuityReference);
+string_ref!(SafetyCaseReference);
+string_ref!(EvidenceLevelReference);
+string_ref!(AuditReference);
 
 impl DurableIdempotencyPosture {
     pub fn is_present(&self) -> bool {

--- a/apps/backend/crates/social-trust-domain/tests/c2_bounded_promise_reliability_contract.rs
+++ b/apps/backend/crates/social-trust-domain/tests/c2_bounded_promise_reliability_contract.rs
@@ -1,0 +1,414 @@
+use musubi_social_trust_domain::{
+    AccountLifecycleReference, AgeAssuranceStateReference, AntiAbuseContinuityReference,
+    AuditReference, BlockWithdrawalStateReference, C2BoundedPromiseReliabilityBoundaryIntersection,
+    C2BoundedPromiseReliabilityBoundaryPosture, C2BoundedPromiseReliabilityFactIdempotencyKey,
+    C2BoundedPromiseReliabilityMutationDecision, C2BoundedPromiseReliabilityMutationFact,
+    C2BoundedPromiseReliabilityMutationFactCandidate, C2BoundedPromiseReliabilityMutationMagnitude,
+    C2BoundedPromiseReliabilityRejection, C2BoundedPromiseReliabilitySourceFact,
+    C2BoundedPromiseReliabilitySourceFactCandidate, ConsentStateReference,
+    CriticalHarmCaseReference, EvidenceLevelReference, EvidencePosture,
+    LegalHoldIntersectionReference, PromiseReference, PromiseTermsReference,
+    ProposedC2BoundedPromiseReliabilityMutationFact, ReasonFactReference,
+    RejectedC2BoundedPromiseReliabilitySourceFact, RetentionClassReference, RetentionPosture,
+    ReviewabilityPosture, SafetyCaseReference, SocialTrustAuthorityPosture, WriterSourceReference,
+    decide_c2_bounded_promise_reliability_mutation,
+};
+
+#[test]
+fn accepted_source_facts_map_only_to_exact_categorical_mutation_facts() {
+    for (source, mutation, magnitude) in accepted_mappings() {
+        let mut proposal = complete_proposal();
+        proposal.source_fact = C2BoundedPromiseReliabilitySourceFactCandidate::Accepted(source);
+        proposal.requested_mutation_fact =
+            C2BoundedPromiseReliabilityMutationFactCandidate::Accepted(mutation);
+        if source == C2BoundedPromiseReliabilitySourceFact::ReviewRequiredBoundaryIntersection {
+            proposal.boundary_posture = C2BoundedPromiseReliabilityBoundaryPosture::Unresolved(
+                C2BoundedPromiseReliabilityBoundaryIntersection::AppealCorrectionOrSafetyReview,
+            );
+        }
+
+        let decision = decide_c2_bounded_promise_reliability_mutation(&proposal);
+
+        assert_eq!(
+            decision,
+            C2BoundedPromiseReliabilityMutationDecision::Persist {
+                source_fact: source,
+                mutation_fact: mutation,
+                direction: mutation.direction(),
+                magnitude
+            }
+        );
+    }
+}
+
+#[test]
+fn accepted_source_fact_with_wrong_mutation_fact_fails_closed() {
+    for (source, expected, _) in accepted_mappings() {
+        for requested in accepted_mutation_facts() {
+            if requested == expected {
+                continue;
+            }
+            let mut proposal = complete_proposal();
+            proposal.source_fact = C2BoundedPromiseReliabilitySourceFactCandidate::Accepted(source);
+            proposal.requested_mutation_fact =
+                C2BoundedPromiseReliabilityMutationFactCandidate::Accepted(requested);
+
+            let decision = decide_c2_bounded_promise_reliability_mutation(&proposal);
+
+            assert_eq!(
+                decision,
+                C2BoundedPromiseReliabilityMutationDecision::Reject(
+                    C2BoundedPromiseReliabilityRejection::SourceMutationMismatch {
+                        source,
+                        requested,
+                        expected
+                    }
+                )
+            );
+        }
+    }
+}
+
+#[test]
+fn rejected_source_facts_fail_closed() {
+    for source in rejected_source_facts() {
+        let mut proposal = complete_proposal();
+        proposal.source_fact = C2BoundedPromiseReliabilitySourceFactCandidate::Rejected(source);
+
+        let decision = decide_c2_bounded_promise_reliability_mutation(&proposal);
+
+        assert_eq!(
+            decision,
+            C2BoundedPromiseReliabilityMutationDecision::Reject(
+                C2BoundedPromiseReliabilityRejection::RejectedSourceFact { source }
+            )
+        );
+    }
+}
+
+#[test]
+fn unknown_source_or_mutation_fact_fails_closed() {
+    let mut unknown_source = complete_proposal();
+    unknown_source.source_fact = C2BoundedPromiseReliabilitySourceFactCandidate::Unknown;
+
+    assert_eq!(
+        decide_c2_bounded_promise_reliability_mutation(&unknown_source),
+        C2BoundedPromiseReliabilityMutationDecision::Reject(
+            C2BoundedPromiseReliabilityRejection::UnknownSourceFact
+        )
+    );
+
+    let mut unknown_mutation = complete_proposal();
+    unknown_mutation.requested_mutation_fact =
+        C2BoundedPromiseReliabilityMutationFactCandidate::Unknown;
+
+    assert_eq!(
+        decide_c2_bounded_promise_reliability_mutation(&unknown_mutation),
+        C2BoundedPromiseReliabilityMutationDecision::Reject(
+            C2BoundedPromiseReliabilityRejection::UnknownMutationFact
+        )
+    );
+}
+
+#[test]
+fn projection_authority_and_unresolved_boundaries_fail_closed() {
+    let mut projection_only = complete_proposal();
+    projection_only.authority_posture = SocialTrustAuthorityPosture::ProjectionOnly;
+
+    assert_eq!(
+        decide_c2_bounded_promise_reliability_mutation(&projection_only),
+        C2BoundedPromiseReliabilityMutationDecision::Reject(
+            C2BoundedPromiseReliabilityRejection::ProjectionOnlyAuthority
+        )
+    );
+
+    let mut unresolved = complete_proposal();
+    unresolved.boundary_posture = C2BoundedPromiseReliabilityBoundaryPosture::Unresolved(
+        C2BoundedPromiseReliabilityBoundaryIntersection::Consent,
+    );
+
+    assert_eq!(
+        decide_c2_bounded_promise_reliability_mutation(&unresolved),
+        C2BoundedPromiseReliabilityMutationDecision::Reject(
+            C2BoundedPromiseReliabilityRejection::BoundaryUnresolved {
+                boundary: C2BoundedPromiseReliabilityBoundaryIntersection::Consent
+            }
+        )
+    );
+}
+
+#[test]
+fn review_required_boundary_intersection_can_persist_categorical_freeze() {
+    let mut proposal = complete_proposal();
+    proposal.source_fact = C2BoundedPromiseReliabilitySourceFactCandidate::Accepted(
+        C2BoundedPromiseReliabilitySourceFact::ReviewRequiredBoundaryIntersection,
+    );
+    proposal.requested_mutation_fact = C2BoundedPromiseReliabilityMutationFactCandidate::Accepted(
+        C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityFreeze,
+    );
+    proposal.boundary_posture = C2BoundedPromiseReliabilityBoundaryPosture::Unresolved(
+        C2BoundedPromiseReliabilityBoundaryIntersection::LegalHold,
+    );
+
+    let decision = decide_c2_bounded_promise_reliability_mutation(&proposal);
+
+    assert_eq!(
+        decision,
+        C2BoundedPromiseReliabilityMutationDecision::Persist {
+            source_fact: C2BoundedPromiseReliabilitySourceFact::ReviewRequiredBoundaryIntersection,
+            mutation_fact: C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityFreeze,
+            direction: C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityFreeze
+                .direction(),
+            magnitude: C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityFreeze
+                .magnitude(),
+        }
+    );
+}
+
+#[test]
+fn review_required_boundary_intersection_requires_unresolved_boundary() {
+    let mut proposal = complete_proposal();
+    proposal.source_fact = C2BoundedPromiseReliabilitySourceFactCandidate::Accepted(
+        C2BoundedPromiseReliabilitySourceFact::ReviewRequiredBoundaryIntersection,
+    );
+    proposal.requested_mutation_fact = C2BoundedPromiseReliabilityMutationFactCandidate::Accepted(
+        C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityFreeze,
+    );
+    proposal.boundary_posture = C2BoundedPromiseReliabilityBoundaryPosture::Clear;
+
+    let decision = decide_c2_bounded_promise_reliability_mutation(&proposal);
+
+    assert_eq!(
+        decision,
+        C2BoundedPromiseReliabilityMutationDecision::Reject(
+            C2BoundedPromiseReliabilityRejection::MissingReviewRequiredBoundaryIntersection
+        )
+    );
+}
+
+#[test]
+fn missing_required_references_and_postures_fail_closed() {
+    let mut missing_idempotency = complete_proposal();
+    missing_idempotency.fact_idempotency_key = None;
+    assert_eq!(
+        decide_c2_bounded_promise_reliability_mutation(&missing_idempotency),
+        C2BoundedPromiseReliabilityMutationDecision::Reject(
+            C2BoundedPromiseReliabilityRejection::MissingFactIdempotencyKey
+        )
+    );
+
+    let mut missing_block_withdrawal = complete_proposal();
+    missing_block_withdrawal.block_withdrawal_state_reference = None;
+    assert_eq!(
+        decide_c2_bounded_promise_reliability_mutation(&missing_block_withdrawal),
+        C2BoundedPromiseReliabilityMutationDecision::Reject(
+            C2BoundedPromiseReliabilityRejection::MissingBlockWithdrawalStateReference
+        )
+    );
+
+    let mut missing_age_assurance = complete_proposal();
+    missing_age_assurance.age_assurance_state_reference = None;
+    assert_eq!(
+        decide_c2_bounded_promise_reliability_mutation(&missing_age_assurance),
+        C2BoundedPromiseReliabilityMutationDecision::Reject(
+            C2BoundedPromiseReliabilityRejection::MissingAgeAssuranceStateReference
+        )
+    );
+
+    let mut missing_legal_hold = complete_proposal();
+    missing_legal_hold.legal_hold_intersection_reference = None;
+    assert_eq!(
+        decide_c2_bounded_promise_reliability_mutation(&missing_legal_hold),
+        C2BoundedPromiseReliabilityMutationDecision::Reject(
+            C2BoundedPromiseReliabilityRejection::MissingLegalHoldIntersectionReference
+        )
+    );
+
+    let mut missing_critical_harm = complete_proposal();
+    missing_critical_harm.critical_harm_case_reference = None;
+    assert_eq!(
+        decide_c2_bounded_promise_reliability_mutation(&missing_critical_harm),
+        C2BoundedPromiseReliabilityMutationDecision::Reject(
+            C2BoundedPromiseReliabilityRejection::MissingCriticalHarmCaseReference
+        )
+    );
+
+    let mut missing_retention = complete_proposal();
+    missing_retention.retention_posture = None;
+    assert_eq!(
+        decide_c2_bounded_promise_reliability_mutation(&missing_retention),
+        C2BoundedPromiseReliabilityMutationDecision::Reject(
+            C2BoundedPromiseReliabilityRejection::MissingRetentionPosture
+        )
+    );
+}
+
+fn complete_proposal() -> ProposedC2BoundedPromiseReliabilityMutationFact {
+    ProposedC2BoundedPromiseReliabilityMutationFact {
+        source_fact: C2BoundedPromiseReliabilitySourceFactCandidate::Accepted(
+            C2BoundedPromiseReliabilitySourceFact::CompletedAsAgreed,
+        ),
+        requested_mutation_fact: C2BoundedPromiseReliabilityMutationFactCandidate::Accepted(
+            C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityPositive,
+        ),
+        writer_source_reference: Some(WriterSourceReference::new("writer-source-fact-1")),
+        promise_reference: Some(PromiseReference::new("promise-1")),
+        promise_terms_reference: Some(PromiseTermsReference::new("promise-terms-1")),
+        consent_at_formation_reference: Some(ConsentStateReference::new("consent-at-formation-1")),
+        consent_at_resolution_reference: Some(ConsentStateReference::new(
+            "consent-at-resolution-1",
+        )),
+        block_withdrawal_state_reference: Some(BlockWithdrawalStateReference::new(
+            "block-withdrawal-clear-1",
+        )),
+        age_assurance_state_reference: Some(AgeAssuranceStateReference::new(
+            "age-assurance-adult-eligible-1",
+        )),
+        legal_hold_intersection_reference: Some(LegalHoldIntersectionReference::new(
+            "legal-hold-clear-1",
+        )),
+        critical_harm_case_reference: Some(CriticalHarmCaseReference::new("critical-harm-clear-1")),
+        account_lifecycle_reference: Some(AccountLifecycleReference::new(
+            "account-lifecycle-active-1",
+        )),
+        anti_abuse_continuity_reference: Some(AntiAbuseContinuityReference::new(
+            "anti-abuse-clear-1",
+        )),
+        safety_case_reference: Some(SafetyCaseReference::new("safety-case-clear-1")),
+        evidence_level_reference: Some(EvidenceLevelReference::new("evidence-level-bounded-1")),
+        audit_reference: Some(AuditReference::new("audit-1")),
+        reason_fact: Some(ReasonFactReference::new("reason-fact-1")),
+        fact_idempotency_key: Some(C2BoundedPromiseReliabilityFactIdempotencyKey::new(
+            "dedupe-1",
+        )),
+        evidence_posture: Some(EvidencePosture::Bounded),
+        reviewability_posture: Some(ReviewabilityPosture::Reviewable),
+        retention_posture: Some(RetentionPosture::Classified(RetentionClassReference::new(
+            "R4 Trust / moderation / case",
+        ))),
+        authority_posture: SocialTrustAuthorityPosture::WriterTruthOnly,
+        boundary_posture: C2BoundedPromiseReliabilityBoundaryPosture::Clear,
+    }
+}
+
+fn accepted_mappings() -> Vec<(
+    C2BoundedPromiseReliabilitySourceFact,
+    C2BoundedPromiseReliabilityMutationFact,
+    C2BoundedPromiseReliabilityMutationMagnitude,
+)> {
+    vec![
+        (
+            C2BoundedPromiseReliabilitySourceFact::CompletedAsAgreed,
+            C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityPositive,
+            C2BoundedPromiseReliabilityMutationMagnitude::Categorical,
+        ),
+        (
+            C2BoundedPromiseReliabilitySourceFact::CompletedAfterGovernedReview,
+            C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityPositive,
+            C2BoundedPromiseReliabilityMutationMagnitude::Categorical,
+        ),
+        (
+            C2BoundedPromiseReliabilitySourceFact::ValidExcusedExit,
+            C2BoundedPromiseReliabilityMutationFact::NoEffectValidExcusedExit,
+            C2BoundedPromiseReliabilityMutationMagnitude::NoEffect,
+        ),
+        (
+            C2BoundedPromiseReliabilitySourceFact::SourceFactCorrected,
+            C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityCorrection,
+            C2BoundedPromiseReliabilityMutationMagnitude::ForwardCorrection,
+        ),
+        (
+            C2BoundedPromiseReliabilitySourceFact::ReviewRequiredBoundaryIntersection,
+            C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityFreeze,
+            C2BoundedPromiseReliabilityMutationMagnitude::TemporarySuppression,
+        ),
+        (
+            C2BoundedPromiseReliabilitySourceFact::SourceScopeLimitedAfterReview,
+            C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityNarrowing,
+            C2BoundedPromiseReliabilityMutationMagnitude::ScopeLimitedRestriction,
+        ),
+        (
+            C2BoundedPromiseReliabilitySourceFact::FreezeOrNarrowingReversedAfterReview,
+            C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityRecovery,
+            C2BoundedPromiseReliabilityMutationMagnitude::EligibilityRestoration,
+        ),
+    ]
+}
+
+fn accepted_mutation_facts() -> Vec<C2BoundedPromiseReliabilityMutationFact> {
+    vec![
+        C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityPositive,
+        C2BoundedPromiseReliabilityMutationFact::NoEffectValidExcusedExit,
+        C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityCorrection,
+        C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityFreeze,
+        C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityNarrowing,
+        C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityRecovery,
+    ]
+}
+
+fn rejected_source_facts() -> Vec<RejectedC2BoundedPromiseReliabilitySourceFact> {
+    vec![
+        RejectedC2BoundedPromiseReliabilitySourceFact::PromiseCreation,
+        RejectedC2BoundedPromiseReliabilitySourceFact::PromiseAcceptance,
+        RejectedC2BoundedPromiseReliabilitySourceFact::PromiseTerms,
+        RejectedC2BoundedPromiseReliabilitySourceFact::PromiseEscrowCreation,
+        RejectedC2BoundedPromiseReliabilitySourceFact::EscrowAmount,
+        RejectedC2BoundedPromiseReliabilitySourceFact::EscrowRelease,
+        RejectedC2BoundedPromiseReliabilitySourceFact::Forfeiture,
+        RejectedC2BoundedPromiseReliabilitySourceFact::PaymentAmount,
+        RejectedC2BoundedPromiseReliabilitySourceFact::PaymentFrequency,
+        RejectedC2BoundedPromiseReliabilitySourceFact::SupportAmount,
+        RejectedC2BoundedPromiseReliabilitySourceFact::SupportStatus,
+        RejectedC2BoundedPromiseReliabilitySourceFact::TokenHoldings,
+        RejectedC2BoundedPromiseReliabilitySourceFact::MeetingAttendanceClaimByOneParty,
+        RejectedC2BoundedPromiseReliabilitySourceFact::RawVenuePresence,
+        RejectedC2BoundedPromiseReliabilitySourceFact::RawGps,
+        RejectedC2BoundedPromiseReliabilitySourceFact::StaticQrScan,
+        RejectedC2BoundedPromiseReliabilitySourceFact::NfcTapAlone,
+        RejectedC2BoundedPromiseReliabilitySourceFact::BleObservationAlone,
+        RejectedC2BoundedPromiseReliabilitySourceFact::BleMacAddress,
+        RejectedC2BoundedPromiseReliabilitySourceFact::DeviceAttestationAlone,
+        RejectedC2BoundedPromiseReliabilitySourceFact::MissingDeviceAttestationAlone,
+        RejectedC2BoundedPromiseReliabilitySourceFact::ProximityProofAlone,
+        RejectedC2BoundedPromiseReliabilitySourceFact::ProofEligibilityAlone,
+        RejectedC2BoundedPromiseReliabilitySourceFact::ProofCallbackAlone,
+        RejectedC2BoundedPromiseReliabilitySourceFact::VendorCallbackAlone,
+        RejectedC2BoundedPromiseReliabilitySourceFact::ProviderDashboardState,
+        RejectedC2BoundedPromiseReliabilitySourceFact::ProjectionReadiness,
+        RejectedC2BoundedPromiseReliabilitySourceFact::ReflectionPraise,
+        RejectedC2BoundedPromiseReliabilitySourceFact::ApologyText,
+        RejectedC2BoundedPromiseReliabilitySourceFact::SubjectiveGratitude,
+        RejectedC2BoundedPromiseReliabilitySourceFact::SinglePartyNarrative,
+        RejectedC2BoundedPromiseReliabilitySourceFact::ReportCount,
+        RejectedC2BoundedPromiseReliabilitySourceFact::MassReportCount,
+        RejectedC2BoundedPromiseReliabilitySourceFact::OperatorNote,
+        RejectedC2BoundedPromiseReliabilitySourceFact::StewardEndorsementByItself,
+        RejectedC2BoundedPromiseReliabilitySourceFact::SupportTicket,
+        RejectedC2BoundedPromiseReliabilitySourceFact::IssueComment,
+        RejectedC2BoundedPromiseReliabilitySourceFact::Popularity,
+        RejectedC2BoundedPromiseReliabilitySourceFact::FollowerCount,
+        RejectedC2BoundedPromiseReliabilitySourceFact::ReplySpeed,
+        RejectedC2BoundedPromiseReliabilitySourceFact::DwellTime,
+        RejectedC2BoundedPromiseReliabilitySourceFact::MessageVolume,
+        RejectedC2BoundedPromiseReliabilitySourceFact::AccountTenure,
+        RejectedC2BoundedPromiseReliabilitySourceFact::RomanticDesirability,
+        RejectedC2BoundedPromiseReliabilitySourceFact::EngagementTelemetry,
+        RejectedC2BoundedPromiseReliabilitySourceFact::RelationshipDepth,
+        RejectedC2BoundedPromiseReliabilitySourceFact::RoomStateByItself,
+        RejectedC2BoundedPromiseReliabilitySourceFact::RoomProjection,
+        RejectedC2BoundedPromiseReliabilitySourceFact::DiscoveryRanking,
+        RejectedC2BoundedPromiseReliabilitySourceFact::RecommendationState,
+        RejectedC2BoundedPromiseReliabilitySourceFact::ObservabilityState,
+        RejectedC2BoundedPromiseReliabilitySourceFact::ModelOutput,
+        RejectedC2BoundedPromiseReliabilitySourceFact::FrontendState,
+        RejectedC2BoundedPromiseReliabilitySourceFact::ClientState,
+        RejectedC2BoundedPromiseReliabilitySourceFact::ControlledExceptionalAccountActivity,
+        RejectedC2BoundedPromiseReliabilitySourceFact::AgeAssurancePosture,
+        RejectedC2BoundedPromiseReliabilitySourceFact::VerifiedAdultPosture,
+        RejectedC2BoundedPromiseReliabilitySourceFact::LegalHoldExistence,
+        RejectedC2BoundedPromiseReliabilitySourceFact::AntiAbuseContinuityMarkerExistence,
+        RejectedC2BoundedPromiseReliabilitySourceFact::AccountLifecycleStateByItself,
+        RejectedC2BoundedPromiseReliabilitySourceFact::DeletionClosureTombstoneAnonymizationKeyShreddingOrReEntry,
+        RejectedC2BoundedPromiseReliabilitySourceFact::ImplementationConvenience,
+    ]
+}

--- a/apps/backend/docs/c2_bounded_promise_reliability_mutation_fact_persistence.md
+++ b/apps/backend/docs/c2_bounded_promise_reliability_mutation_fact_persistence.md
@@ -1,0 +1,86 @@
+# C2 Bounded Promise Reliability Mutation Fact Persistence
+
+Status: implementation note for the narrow C2 persistence slice.
+
+Design source:
+- `docs/foundation_lock.md`
+- upstream `docs/readiness/c2_bounded_promise_reliability_mutation_fact_gate.md`
+- upstream `docs/readiness/c2_bounded_promise_reliability_implementation_handoff_gate.md`
+
+This note describes only backend-local categorical persistence.
+It is not a Promise runtime design, proof runtime design, public API design, projection refresh design, display design, scoring design, or implementation handoff for another slice.
+
+## Scope
+
+This slice persists only:
+- accepted C2 bounded Promise reliability source fact references
+- accepted C2 categorical Social Trust mutation facts
+- no-effect valid excused exits
+- forward correction, freeze, narrowing, and recovery categorical facts
+- durable idempotency and deterministic replay checks
+- minimized references needed to explain why persistence was allowed
+
+The implementation lives in:
+- `musubi_social_trust_domain` for pure source / mutation decision contracts
+- `musubi_backend::services::social_trust_mutation` for backend-local persistence
+- `social_trust.categorical_source_references`
+- `social_trust.categorical_mutation_facts`
+
+## Accepted Facts
+
+Accepted source facts:
+- `promise_reliability_outcome.completed_as_agreed`
+- `promise_reliability_outcome.completed_after_governed_review`
+- `promise_reliability_outcome.valid_excused_exit`
+- `promise_reliability_outcome.source_fact_corrected`
+- `promise_reliability_outcome.review_required_boundary_intersection`
+- `promise_reliability_outcome.source_scope_limited_after_review`
+- `promise_reliability_outcome.freeze_or_narrowing_reversed_after_review`
+
+Accepted mutation facts:
+- `social_trust_mutation.bounded_promise_reliability_positive`
+- `social_trust_mutation.no_effect_valid_excused_exit`
+- `social_trust_mutation.bounded_promise_reliability_correction`
+- `social_trust_mutation.bounded_promise_reliability_freeze`
+- `social_trust_mutation.bounded_promise_reliability_narrowing`
+- `social_trust_mutation.bounded_promise_reliability_recovery`
+
+All accepted facts remain categorical internal writer facts.
+They do not carry numeric amount, score delta, point value, rank effect, display tier, discovery priority, recommendation boost, room transition, settlement progression, contact unlock, or public API effect.
+
+## Persistence Rules
+
+The service rejects before persistence when:
+- the source fact is rejected or unknown
+- the requested mutation fact is unknown
+- the source-to-mutation mapping does not match the accepted gate
+- authority posture is projection-only
+- Consent, block / Withdrawal, Age Assurance, Legal Hold, Critical Harm, account lifecycle, anti-abuse, appeal, correction, fraud, collusion, scam, or safety posture remains unresolved for a positive contribution
+- required writer source, Promise, Promise terms, Consent, block / Withdrawal, Age Assurance, Legal Hold, Critical Harm, account lifecycle, anti-abuse, safety, evidence-level, reason, retention, audit, or idempotency references are missing
+- the subject is not an active Ordinary Account for a new fact
+
+The exact `promise_reliability_outcome.review_required_boundary_intersection` source may persist only the categorical freeze fact.
+That freeze is not a negative score, public badge, punishment, projection refresh, or display surface.
+The persisted source reference stores the exact boundary intersection label so replay and review can distinguish Consent, block / Withdrawal, Age Assurance, Legal Hold, Critical Harm, lifecycle, appeal / correction / safety, anti-abuse, collusion / scam / coercion, and sensitive-exposure cases.
+
+Identical duplicate delivery replays the existing stored fact.
+Duplicate delivery with changed meaning fails closed as an idempotency conflict.
+Replay is checked before the active-account check so an already recorded fact can replay after a later suspension without creating a new fact.
+
+## Non-Authority
+
+This slice does not authorize:
+- Social Trust score, weight, rank, public display, display level, recovery ceiling, public status, or romantic advantage
+- projection refresh from Social Trust writer facts
+- discovery or recommendation use
+- Relationship Depth mutation
+- room progression
+- settlement progression
+- Promise runtime behavior
+- proof runtime behavior outside accepted source references
+- public API routes
+- mobile UI
+- raw PII or raw evidence storage inside Social Trust writer truth
+- operator notes, support tickets, issue comments, popularity, payment behavior, Support status, engagement telemetry, frontend state, client state, observability, projection, provider callback alone, or implementation convenience as Social Trust authority
+
+Everything outside this categorical persistence envelope remains blocked until a later accepted foundation decision narrows it.

--- a/apps/backend/docs/package_boundaries.md
+++ b/apps/backend/docs/package_boundaries.md
@@ -14,6 +14,7 @@ Later milestone work has since added:
 - settlement-domain types and backend traits
 - orchestration runtime notes
 - Social Trust intake / no-authority domain contract
+- C2 bounded Promise reliability categorical Social Trust mutation fact persistence
 
 The backend still does not implement:
 - provider-specific adapters
@@ -102,6 +103,10 @@ Owns:
 - pure Social Trust proposed mutation attempt intake decisions
 - forbidden-source and unknown-source fail-closed checks
 - required writer source reference, reason fact, idempotency, evidence, reviewability, retention, and authority posture checks
+- pure C2 bounded Promise reliability source-to-mutation mapping decisions
+- exact accepted / rejected C2 bounded Promise reliability source fact categories
+- exact accepted C2 categorical Social Trust mutation fact categories
+- fail-closed C2 checks for projection-only authority, unresolved boundaries outside the exact freeze source path, missing idempotency, missing Consent / block / Withdrawal / Age Assurance / Legal Hold / Critical Harm / lifecycle / safety / evidence / retention / audit references, and source-mutation mismatches
 
 Must not own:
 - Social Trust scoring, weights, display levels, or recovery ceilings
@@ -122,6 +127,21 @@ Must not own:
 - Social Trust mutation facts, scoring, weights, ranks, display levels, narrowing, freeze, or recovery behavior
 - Relationship Depth, proof, room progression, discovery, recommendation, settlement, Promise, payment, Support, or operator-review behavior
 - projection refresh or projection-derived authority
+
+### `musubi_backend::services::social_trust_mutation`
+Owns:
+- backend-local persistence for C2 bounded Promise reliability accepted source references
+- backend-local persistence for accepted C2 categorical Social Trust mutation facts
+- database-enforced duplicate delivery and payload-drift checks for accepted C2 categorical facts
+- writer-first account reference checks for Ordinary Account subjects before new fact persistence
+- deterministic tests proving accepted mapping, rejected sources, projection-only authority, unresolved boundaries, replay, and idempotency drift fail closed
+
+Must not own:
+- HTTP handlers, public API routes, mobile UI, or app-state exposure
+- Social Trust scores, weights, ranks, public display levels, recovery ceilings, discovery boosts, recommendation priority, contact unlock, room transition, or settlement progression
+- Relationship Depth, proof runtime, room progression, discovery, recommendation, settlement, Promise runtime, payment, Support, or operator-review behavior
+- projection refresh or projection-derived authority
+- raw PII, raw evidence payloads, provider callbacks, operator notes, support tickets, issue comments, popularity metrics, or engagement telemetry
 
 ### `musubi_orchestration`
 Owns:

--- a/apps/backend/docs/schema_skeleton.md
+++ b/apps/backend/docs/schema_skeleton.md
@@ -45,10 +45,13 @@ Owns:
 - C1 Social Trust intake decision records for rejected attempts and `CandidateForWriterPersistence`
 - database-enforced idempotency / replay posture for proposed mutation attempts
 - minimized reason, evidence-posture, reviewability, retention-class, and audit metadata for intake decisions
+- C2 bounded Promise reliability accepted source references
+- C2 bounded Promise reliability categorical Social Trust mutation facts
+- database-enforced idempotency / replay posture for accepted C2 categorical fact persistence
+- minimized Promise, Consent, block / Withdrawal, Age Assurance, Legal Hold, Critical Harm, account lifecycle, anti-abuse, safety, evidence-level, reason, retention, and audit references for C2 categorical fact persistence
 
 Must not own:
-- actual Social Trust mutation facts
-- Social Trust scores, weights, ranks, display levels, narrowing, freeze, or recovery facts
+- Social Trust scores, weights, ranks, display levels, recovery ceilings, public levels, recommendation boosts, discovery priorities, contact unlocks, room transitions, or settlement progression facts
 - Relationship Depth facts
 - projection refresh state
 - raw PII, raw evidence payloads, payment behavior, popularity metrics, engagement telemetry, operator notes, support tickets, or issue comments
@@ -213,3 +216,23 @@ The architectural boundary is strict:
 - retention is mapped to the ADR-0012 category `Social Trust evidence or future Social Trust writer facts` without inventing concrete retention durations
 - rejected attempts and candidates do not emit projection refresh work
 - no Social Trust mutation fact, score, weight, rank, display level, Relationship Depth fact, public API, or mobile UI is introduced
+
+## C2 bounded Promise reliability categorical persistence additions
+
+Design source: `docs/readiness/c2_bounded_promise_reliability_implementation_handoff_gate.md` in `musubi-foundation` PR #108.
+
+Migration `0021_c2_categorical_social_trust_fact_persistence.sql` adds the narrow C2 bounded Promise reliability persistence baseline:
+- `social_trust.categorical_source_references`
+- `social_trust.categorical_mutation_facts`
+
+The architectural boundary is strict:
+- only the accepted C2 source labels from the foundation handoff can be persisted
+- only the accepted C2 categorical mutation labels can be persisted
+- source-to-mutation mapping is enforced by domain code and PostgreSQL checks
+- durable idempotency is enforced by PostgreSQL unique indexes over the subject, policy version, and fact idempotency key
+- duplicate delivery with payload drift fails closed through stored payload hashes
+- accepted facts use minimized references rather than raw PII or raw evidence payloads
+- accepted facts do not create Social Trust scores, weights, ranks, public display, projection refresh, Relationship Depth, discovery / recommendation use, room progression, settlement behavior, Promise runtime behavior, public API, or mobile UI
+- rejected sources and projection-only authority fail closed before persistence
+- unresolved Consent / block / Withdrawal / Age Assurance / Legal Hold / Critical Harm / lifecycle / safety boundaries block positive contribution; only the exact `promise_reliability_outcome.review_required_boundary_intersection` source may persist the categorical freeze fact
+- persisted freeze source references store the boundary intersection label so later review does not need projection, display, or narrative text to distinguish why the source path is frozen

--- a/apps/backend/migrations/0021_c2_categorical_social_trust_fact_persistence.sql
+++ b/apps/backend/migrations/0021_c2_categorical_social_trust_fact_persistence.sql
@@ -1,0 +1,248 @@
+COMMENT ON SCHEMA social_trust IS
+'Writer-owned Social Trust intake and C2 categorical mutation fact persistence. This schema does not contain numeric Social Trust scores, weights, ranks, display levels, Relationship Depth facts, or projection truth.';
+
+CREATE TABLE IF NOT EXISTS social_trust.categorical_source_references (
+    source_reference_id UUID PRIMARY KEY,
+    subject_account_id UUID NOT NULL REFERENCES core.accounts(account_id),
+    source_fact_label TEXT NOT NULL CHECK (
+        source_fact_label IN (
+            'promise_reliability_outcome.completed_as_agreed',
+            'promise_reliability_outcome.completed_after_governed_review',
+            'promise_reliability_outcome.valid_excused_exit',
+            'promise_reliability_outcome.source_fact_corrected',
+            'promise_reliability_outcome.review_required_boundary_intersection',
+            'promise_reliability_outcome.source_scope_limited_after_review',
+            'promise_reliability_outcome.freeze_or_narrowing_reversed_after_review'
+        )
+    ),
+    writer_source_reference TEXT NOT NULL CHECK (char_length(trim(writer_source_reference)) > 0),
+    promise_reference TEXT NOT NULL CHECK (char_length(trim(promise_reference)) > 0),
+    realm_reference TEXT CHECK (
+        realm_reference IS NULL
+        OR char_length(trim(realm_reference)) > 0
+    ),
+    boundary_intersection_label TEXT CHECK (
+        boundary_intersection_label IS NULL
+        OR boundary_intersection_label IN (
+            'consent',
+            'block_mute_refusal_or_withdrawal',
+            'age_assurance',
+            'legal_hold',
+            'critical_harm',
+            'account_lifecycle',
+            'appeal_correction_or_safety_review',
+            'anti_abuse_suppression',
+            'collusion_scam_or_coercion',
+            'sensitive_exposure'
+        )
+    ),
+    promise_terms_reference TEXT NOT NULL CHECK (char_length(trim(promise_terms_reference)) > 0),
+    consent_at_formation_reference TEXT NOT NULL CHECK (
+        char_length(trim(consent_at_formation_reference)) > 0
+    ),
+    consent_at_resolution_reference TEXT NOT NULL CHECK (
+        char_length(trim(consent_at_resolution_reference)) > 0
+    ),
+    block_withdrawal_state_reference TEXT NOT NULL CHECK (
+        char_length(trim(block_withdrawal_state_reference)) > 0
+    ),
+    age_assurance_state_reference TEXT NOT NULL CHECK (
+        char_length(trim(age_assurance_state_reference)) > 0
+    ),
+    legal_hold_intersection_reference TEXT NOT NULL CHECK (
+        char_length(trim(legal_hold_intersection_reference)) > 0
+    ),
+    critical_harm_case_reference TEXT NOT NULL CHECK (
+        char_length(trim(critical_harm_case_reference)) > 0
+    ),
+    account_lifecycle_reference TEXT NOT NULL CHECK (
+        char_length(trim(account_lifecycle_reference)) > 0
+    ),
+    anti_abuse_continuity_reference TEXT NOT NULL CHECK (
+        char_length(trim(anti_abuse_continuity_reference)) > 0
+    ),
+    safety_case_reference TEXT NOT NULL CHECK (char_length(trim(safety_case_reference)) > 0),
+    evidence_level_reference TEXT NOT NULL CHECK (char_length(trim(evidence_level_reference)) > 0),
+    reason_fact_reference TEXT NOT NULL CHECK (char_length(trim(reason_fact_reference)) > 0),
+    audit_reference TEXT NOT NULL CHECK (char_length(trim(audit_reference)) > 0),
+    fact_idempotency_key TEXT NOT NULL CHECK (char_length(trim(fact_idempotency_key)) > 0),
+    policy_version INTEGER NOT NULL CHECK (policy_version > 0),
+    request_payload_hash TEXT NOT NULL CHECK (request_payload_hash ~ '^[0-9a-f]{64}$'),
+    evidence_posture TEXT NOT NULL CHECK (evidence_posture IN ('bounded')),
+    reviewability_posture TEXT NOT NULL CHECK (reviewability_posture IN ('reviewable')),
+    retention_record_family TEXT NOT NULL CHECK (
+        retention_record_family = 'Social Trust evidence or future Social Trust writer facts'
+    ),
+    retention_class_reference TEXT NOT NULL CHECK (
+        retention_class_reference = 'R4 Trust / moderation / case'
+    ),
+    authority_posture TEXT NOT NULL CHECK (authority_posture IN ('writer_truth_only')),
+    recorded_by_system TEXT NOT NULL DEFAULT 'social_trust_categorical_fact_persistence' CHECK (
+        char_length(trim(recorded_by_system)) > 0
+    ),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CHECK (
+        (
+            source_fact_label = 'promise_reliability_outcome.review_required_boundary_intersection'
+            AND boundary_intersection_label IS NOT NULL
+        )
+        OR (
+            source_fact_label <> 'promise_reliability_outcome.review_required_boundary_intersection'
+            AND boundary_intersection_label IS NULL
+        )
+    )
+);
+
+COMMENT ON TABLE social_trust.categorical_source_references IS
+'C2 bounded Promise reliability accepted source references. These rows reference writer-owned source facts; they do not implement Promise runtime behavior or create source truth by themselves.';
+
+COMMENT ON COLUMN social_trust.categorical_source_references.request_payload_hash IS
+'SHA-256 hash of minimized C2 source-reference meaning used for deterministic duplicate-delivery drift checks. Raw PII and raw evidence do not belong here.';
+
+CREATE UNIQUE INDEX IF NOT EXISTS social_trust_categorical_source_dedupe_unique
+    ON social_trust.categorical_source_references (
+        subject_account_id,
+        policy_version,
+        fact_idempotency_key
+    );
+
+COMMENT ON INDEX social_trust.social_trust_categorical_source_dedupe_unique IS
+'Durable database-enforced idempotency boundary for C2 bounded Promise reliability categorical source references.';
+
+CREATE INDEX IF NOT EXISTS social_trust_categorical_source_subject_created_idx
+    ON social_trust.categorical_source_references (subject_account_id, created_at);
+
+CREATE INDEX IF NOT EXISTS social_trust_categorical_source_retention_idx
+    ON social_trust.categorical_source_references (
+        retention_record_family,
+        retention_class_reference
+    );
+
+CREATE TABLE IF NOT EXISTS social_trust.categorical_mutation_facts (
+    mutation_fact_id UUID PRIMARY KEY,
+    source_reference_id UUID NOT NULL UNIQUE REFERENCES social_trust.categorical_source_references(source_reference_id),
+    subject_account_id UUID NOT NULL REFERENCES core.accounts(account_id),
+    source_fact_label TEXT NOT NULL CHECK (
+        source_fact_label IN (
+            'promise_reliability_outcome.completed_as_agreed',
+            'promise_reliability_outcome.completed_after_governed_review',
+            'promise_reliability_outcome.valid_excused_exit',
+            'promise_reliability_outcome.source_fact_corrected',
+            'promise_reliability_outcome.review_required_boundary_intersection',
+            'promise_reliability_outcome.source_scope_limited_after_review',
+            'promise_reliability_outcome.freeze_or_narrowing_reversed_after_review'
+        )
+    ),
+    mutation_fact_label TEXT NOT NULL CHECK (
+        mutation_fact_label IN (
+            'social_trust_mutation.bounded_promise_reliability_positive',
+            'social_trust_mutation.no_effect_valid_excused_exit',
+            'social_trust_mutation.bounded_promise_reliability_correction',
+            'social_trust_mutation.bounded_promise_reliability_freeze',
+            'social_trust_mutation.bounded_promise_reliability_narrowing',
+            'social_trust_mutation.bounded_promise_reliability_recovery'
+        )
+    ),
+    mutation_direction TEXT NOT NULL CHECK (
+        mutation_direction IN (
+            'positive',
+            'no_effect',
+            'correction',
+            'freeze',
+            'narrowing',
+            'recovery'
+        )
+    ),
+    mutation_magnitude TEXT NOT NULL CHECK (
+        mutation_magnitude IN (
+            'categorical',
+            'no_effect',
+            'forward_correction',
+            'temporary_suppression',
+            'scope_limited_restriction',
+            'eligibility_restoration'
+        )
+    ),
+    fact_idempotency_key TEXT NOT NULL CHECK (char_length(trim(fact_idempotency_key)) > 0),
+    policy_version INTEGER NOT NULL CHECK (policy_version > 0),
+    decision_payload_hash TEXT NOT NULL CHECK (decision_payload_hash ~ '^[0-9a-f]{64}$'),
+    evidence_posture TEXT NOT NULL CHECK (evidence_posture IN ('bounded')),
+    reviewability_posture TEXT NOT NULL CHECK (reviewability_posture IN ('reviewable')),
+    retention_record_family TEXT NOT NULL CHECK (
+        retention_record_family = 'Social Trust evidence or future Social Trust writer facts'
+    ),
+    retention_class_reference TEXT NOT NULL CHECK (
+        retention_class_reference = 'R4 Trust / moderation / case'
+    ),
+    authority_posture TEXT NOT NULL CHECK (authority_posture IN ('writer_truth_only')),
+    recorded_by_system TEXT NOT NULL DEFAULT 'social_trust_categorical_fact_persistence' CHECK (
+        char_length(trim(recorded_by_system)) > 0
+    ),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CHECK (
+        (
+            source_fact_label IN (
+                'promise_reliability_outcome.completed_as_agreed',
+                'promise_reliability_outcome.completed_after_governed_review'
+            )
+            AND mutation_fact_label = 'social_trust_mutation.bounded_promise_reliability_positive'
+            AND mutation_direction = 'positive'
+            AND mutation_magnitude = 'categorical'
+        )
+        OR (
+            source_fact_label = 'promise_reliability_outcome.valid_excused_exit'
+            AND mutation_fact_label = 'social_trust_mutation.no_effect_valid_excused_exit'
+            AND mutation_direction = 'no_effect'
+            AND mutation_magnitude = 'no_effect'
+        )
+        OR (
+            source_fact_label = 'promise_reliability_outcome.source_fact_corrected'
+            AND mutation_fact_label = 'social_trust_mutation.bounded_promise_reliability_correction'
+            AND mutation_direction = 'correction'
+            AND mutation_magnitude = 'forward_correction'
+        )
+        OR (
+            source_fact_label = 'promise_reliability_outcome.review_required_boundary_intersection'
+            AND mutation_fact_label = 'social_trust_mutation.bounded_promise_reliability_freeze'
+            AND mutation_direction = 'freeze'
+            AND mutation_magnitude = 'temporary_suppression'
+        )
+        OR (
+            source_fact_label = 'promise_reliability_outcome.source_scope_limited_after_review'
+            AND mutation_fact_label = 'social_trust_mutation.bounded_promise_reliability_narrowing'
+            AND mutation_direction = 'narrowing'
+            AND mutation_magnitude = 'scope_limited_restriction'
+        )
+        OR (
+            source_fact_label = 'promise_reliability_outcome.freeze_or_narrowing_reversed_after_review'
+            AND mutation_fact_label = 'social_trust_mutation.bounded_promise_reliability_recovery'
+            AND mutation_direction = 'recovery'
+            AND mutation_magnitude = 'eligibility_restoration'
+        )
+    )
+);
+
+COMMENT ON TABLE social_trust.categorical_mutation_facts IS
+'C2 bounded Promise reliability categorical Social Trust mutation facts. These facts are internal writer truth only and do not calculate scores, weights, ranks, public levels, display surfaces, Relationship Depth, discovery, recommendation, room, settlement, Promise runtime behavior, or projection refresh.';
+
+COMMENT ON COLUMN social_trust.categorical_mutation_facts.decision_payload_hash IS
+'SHA-256 hash of the minimized C2 categorical mutation decision for deterministic replay checks.';
+
+CREATE UNIQUE INDEX IF NOT EXISTS social_trust_categorical_mutation_dedupe_unique
+    ON social_trust.categorical_mutation_facts (
+        subject_account_id,
+        policy_version,
+        fact_idempotency_key
+    );
+
+COMMENT ON INDEX social_trust.social_trust_categorical_mutation_dedupe_unique IS
+'Durable database-enforced idempotency boundary for C2 bounded Promise reliability categorical mutation facts.';
+
+CREATE INDEX IF NOT EXISTS social_trust_categorical_mutation_subject_created_idx
+    ON social_trust.categorical_mutation_facts (subject_account_id, created_at);
+
+CREATE INDEX IF NOT EXISTS social_trust_categorical_mutation_retention_idx
+    ON social_trust.categorical_mutation_facts (
+        retention_record_family,
+        retention_class_reference
+    );

--- a/apps/backend/src/services/mod.rs
+++ b/apps/backend/src/services/mod.rs
@@ -7,3 +7,4 @@ pub mod proof;
 pub mod realm_bootstrap;
 pub mod room_progression;
 pub mod social_trust_intake;
+pub mod social_trust_mutation;

--- a/apps/backend/src/services/social_trust_mutation/mod.rs
+++ b/apps/backend/src/services/social_trust_mutation/mod.rs
@@ -1,0 +1,9 @@
+mod repository;
+mod types;
+
+pub use repository::SocialTrustMutationStore;
+pub use types::{
+    C2BoundedPromiseReliabilityReplayStatus, C2BoundedPromiseReliabilitySnapshot,
+    RecordC2BoundedPromiseReliabilityMutationFactInput, SocialTrustMutationPersistenceError,
+    SocialTrustMutationPersistenceOutcome,
+};

--- a/apps/backend/src/services/social_trust_mutation/repository.rs
+++ b/apps/backend/src/services/social_trust_mutation/repository.rs
@@ -1,0 +1,771 @@
+use std::{fmt::Write as _, sync::Arc};
+
+use musubi_db_runtime::{DbConfig, connect_writer};
+use musubi_social_trust_domain::{
+    C2BoundedPromiseReliabilityMutationDecision, EvidencePosture,
+    ProposedC2BoundedPromiseReliabilityMutationFact, RetentionPosture, ReviewabilityPosture,
+    decide_c2_bounded_promise_reliability_mutation,
+};
+use sha2::{Digest, Sha256};
+use tokio::sync::Mutex;
+use tokio_postgres::{Client, GenericClient, Row, error::SqlState};
+use uuid::Uuid;
+
+use super::types::{
+    C2BoundedPromiseReliabilityReplayStatus, C2BoundedPromiseReliabilitySnapshot,
+    RecordC2BoundedPromiseReliabilityMutationFactInput, SocialTrustMutationPersistenceError,
+    SocialTrustMutationPersistenceOutcome,
+};
+
+const POLICY_VERSION: i32 = 1;
+const RETENTION_RECORD_FAMILY: &str = "Social Trust evidence or future Social Trust writer facts";
+const RETENTION_CLASS_REFERENCE: &str = "R4 Trust / moderation / case";
+
+#[derive(Clone)]
+pub struct SocialTrustMutationStore {
+    client: Arc<Mutex<Client>>,
+}
+
+struct NormalizedFact {
+    subject_account_id: Uuid,
+    source_fact_label: &'static str,
+    mutation_fact_label: &'static str,
+    mutation_direction: &'static str,
+    mutation_magnitude: &'static str,
+    boundary_intersection_label: Option<&'static str>,
+    writer_source_reference: String,
+    promise_reference: String,
+    realm_reference: Option<String>,
+    promise_terms_reference: String,
+    consent_at_formation_reference: String,
+    consent_at_resolution_reference: String,
+    block_withdrawal_state_reference: String,
+    age_assurance_state_reference: String,
+    legal_hold_intersection_reference: String,
+    critical_harm_case_reference: String,
+    account_lifecycle_reference: String,
+    anti_abuse_continuity_reference: String,
+    safety_case_reference: String,
+    evidence_level_reference: String,
+    reason_fact_reference: String,
+    audit_reference: String,
+    fact_idempotency_key: String,
+    evidence_posture: &'static str,
+    reviewability_posture: &'static str,
+    retention_class_reference: String,
+    authority_posture: &'static str,
+    request_payload_hash: String,
+    decision_payload_hash: String,
+}
+
+impl SocialTrustMutationStore {
+    pub async fn connect(config: &DbConfig) -> musubi_db_runtime::Result<Self> {
+        let client = connect_writer(config, "musubi-backend social-trust-mutation").await?;
+        Ok(Self {
+            client: Arc::new(Mutex::new(client)),
+        })
+    }
+
+    pub async fn record_c2_bounded_promise_reliability_fact(
+        &self,
+        input: RecordC2BoundedPromiseReliabilityMutationFactInput,
+    ) -> Result<SocialTrustMutationPersistenceOutcome, SocialTrustMutationPersistenceError> {
+        let subject_account_id = parse_uuid(&input.subject_account_id, "subject account id")?;
+        let decision = decide_c2_bounded_promise_reliability_mutation(&input.proposal);
+
+        if matches!(
+            decision,
+            C2BoundedPromiseReliabilityMutationDecision::Reject(_)
+        ) {
+            return Ok(
+                SocialTrustMutationPersistenceOutcome::RejectedBeforePersistence { decision },
+            );
+        }
+
+        let normalized = normalize_fact(
+            subject_account_id,
+            input.realm_reference.as_deref(),
+            &input.proposal,
+            &decision,
+        )?;
+        let mut client = self.client.lock().await;
+        let tx = client.transaction().await.map_err(db_error)?;
+
+        if let Some(existing) = find_existing_source_by_dedupe_tx(&tx, &normalized).await? {
+            let source_reference_id = replay_source_reference_id(existing, &normalized)?;
+            let snapshot = load_snapshot_by_source_reference_id_tx(
+                &tx,
+                &source_reference_id,
+                C2BoundedPromiseReliabilityReplayStatus::ReplayedIdentical,
+            )
+            .await?;
+            tx.commit().await.map_err(db_error)?;
+            return Ok(SocialTrustMutationPersistenceOutcome::Recorded(snapshot));
+        }
+
+        ensure_active_ordinary_account_exists_tx(&tx, &normalized.subject_account_id).await?;
+
+        let inserted_source_reference_id = Uuid::new_v4();
+        let inserted = tx
+            .query_opt(
+                "
+                INSERT INTO social_trust.categorical_source_references (
+                    source_reference_id,
+                    subject_account_id,
+                    source_fact_label,
+                    writer_source_reference,
+                    promise_reference,
+                    realm_reference,
+                    boundary_intersection_label,
+                    promise_terms_reference,
+                    consent_at_formation_reference,
+                    consent_at_resolution_reference,
+                    block_withdrawal_state_reference,
+                    age_assurance_state_reference,
+                    legal_hold_intersection_reference,
+                    critical_harm_case_reference,
+                    account_lifecycle_reference,
+                    anti_abuse_continuity_reference,
+                    safety_case_reference,
+                    evidence_level_reference,
+                    reason_fact_reference,
+                    audit_reference,
+                    fact_idempotency_key,
+                    policy_version,
+                    request_payload_hash,
+                    evidence_posture,
+                    reviewability_posture,
+                    retention_record_family,
+                    retention_class_reference,
+                    authority_posture
+                )
+                VALUES (
+                    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
+                    $11, $12, $13, $14, $15, $16, $17, $18, $19, $20,
+                    $21, $22, $23, $24, $25, $26, $27, $28
+                )
+                ON CONFLICT (
+                    subject_account_id,
+                    policy_version,
+                    fact_idempotency_key
+                ) DO NOTHING
+                RETURNING source_reference_id
+                ",
+                &[
+                    &inserted_source_reference_id,
+                    &normalized.subject_account_id,
+                    &normalized.source_fact_label,
+                    &normalized.writer_source_reference,
+                    &normalized.promise_reference,
+                    &normalized.realm_reference,
+                    &normalized.boundary_intersection_label,
+                    &normalized.promise_terms_reference,
+                    &normalized.consent_at_formation_reference,
+                    &normalized.consent_at_resolution_reference,
+                    &normalized.block_withdrawal_state_reference,
+                    &normalized.age_assurance_state_reference,
+                    &normalized.legal_hold_intersection_reference,
+                    &normalized.critical_harm_case_reference,
+                    &normalized.account_lifecycle_reference,
+                    &normalized.anti_abuse_continuity_reference,
+                    &normalized.safety_case_reference,
+                    &normalized.evidence_level_reference,
+                    &normalized.reason_fact_reference,
+                    &normalized.audit_reference,
+                    &normalized.fact_idempotency_key,
+                    &POLICY_VERSION,
+                    &normalized.request_payload_hash,
+                    &normalized.evidence_posture,
+                    &normalized.reviewability_posture,
+                    &RETENTION_RECORD_FAMILY,
+                    &normalized.retention_class_reference,
+                    &normalized.authority_posture,
+                ],
+            )
+            .await
+            .map_err(source_insert_error)?;
+
+        let (source_reference_id, replay_status) = match inserted {
+            Some(row) => {
+                let source_reference_id: Uuid = row.get("source_reference_id");
+                let mutation_fact_id = Uuid::new_v4();
+                tx.execute(
+                    "
+                    INSERT INTO social_trust.categorical_mutation_facts (
+                        mutation_fact_id,
+                        source_reference_id,
+                        subject_account_id,
+                        source_fact_label,
+                        mutation_fact_label,
+                        mutation_direction,
+                        mutation_magnitude,
+                        fact_idempotency_key,
+                        policy_version,
+                        decision_payload_hash,
+                        evidence_posture,
+                        reviewability_posture,
+                        retention_record_family,
+                        retention_class_reference,
+                        authority_posture
+                    )
+                    VALUES (
+                        $1, $2, $3, $4, $5, $6, $7, $8,
+                        $9, $10, $11, $12, $13, $14, $15
+                    )
+                    ",
+                    &[
+                        &mutation_fact_id,
+                        &source_reference_id,
+                        &normalized.subject_account_id,
+                        &normalized.source_fact_label,
+                        &normalized.mutation_fact_label,
+                        &normalized.mutation_direction,
+                        &normalized.mutation_magnitude,
+                        &normalized.fact_idempotency_key,
+                        &POLICY_VERSION,
+                        &normalized.decision_payload_hash,
+                        &normalized.evidence_posture,
+                        &normalized.reviewability_posture,
+                        &RETENTION_RECORD_FAMILY,
+                        &normalized.retention_class_reference,
+                        &normalized.authority_posture,
+                    ],
+                )
+                .await
+                .map_err(db_error)?;
+                (
+                    source_reference_id,
+                    C2BoundedPromiseReliabilityReplayStatus::Inserted,
+                )
+            }
+            None => {
+                let existing = find_existing_source_by_dedupe_tx(&tx, &normalized)
+                    .await?
+                    .ok_or_else(|| {
+                        SocialTrustMutationPersistenceError::Internal(
+                            "idempotency conflict did not return existing source reference"
+                                .to_owned(),
+                        )
+                    })?;
+                let source_reference_id = replay_source_reference_id(existing, &normalized)?;
+                (
+                    source_reference_id,
+                    C2BoundedPromiseReliabilityReplayStatus::ReplayedIdentical,
+                )
+            }
+        };
+
+        let snapshot =
+            load_snapshot_by_source_reference_id_tx(&tx, &source_reference_id, replay_status)
+                .await?;
+        tx.commit().await.map_err(db_error)?;
+        Ok(SocialTrustMutationPersistenceOutcome::Recorded(snapshot))
+    }
+}
+
+fn normalize_fact(
+    subject_account_id: Uuid,
+    realm_reference: Option<&str>,
+    proposal: &ProposedC2BoundedPromiseReliabilityMutationFact,
+    decision: &C2BoundedPromiseReliabilityMutationDecision,
+) -> Result<NormalizedFact, SocialTrustMutationPersistenceError> {
+    let C2BoundedPromiseReliabilityMutationDecision::Persist {
+        source_fact,
+        mutation_fact,
+        direction,
+        magnitude,
+    } = decision
+    else {
+        return Err(SocialTrustMutationPersistenceError::Internal(
+            "C2 mutation persistence requires an accepted mutation decision".to_owned(),
+        ));
+    };
+
+    let source_fact_label = source_fact.as_str();
+    let mutation_fact_label = mutation_fact.as_str();
+    let mutation_direction = direction.as_str();
+    let mutation_magnitude = magnitude.as_str();
+    let boundary_intersection_label = match proposal.boundary_posture {
+        musubi_social_trust_domain::C2BoundedPromiseReliabilityBoundaryPosture::Unresolved(
+            boundary,
+        ) => Some(boundary.as_str()),
+        musubi_social_trust_domain::C2BoundedPromiseReliabilityBoundaryPosture::Clear => None,
+    };
+    let writer_source_reference = required_ref(
+        proposal
+            .writer_source_reference
+            .as_ref()
+            .map(|reference| reference.as_str()),
+        "writer source reference",
+    )?;
+    let promise_reference = required_ref(
+        proposal
+            .promise_reference
+            .as_ref()
+            .map(|reference| reference.as_str()),
+        "Promise reference",
+    )?;
+    let realm_reference = optional_ref(realm_reference, "Realm reference")?;
+    let promise_terms_reference = required_ref(
+        proposal
+            .promise_terms_reference
+            .as_ref()
+            .map(|reference| reference.as_str()),
+        "Promise terms reference",
+    )?;
+    let consent_at_formation_reference = required_ref(
+        proposal
+            .consent_at_formation_reference
+            .as_ref()
+            .map(|reference| reference.as_str()),
+        "Consent state at Promise formation reference",
+    )?;
+    let consent_at_resolution_reference = required_ref(
+        proposal
+            .consent_at_resolution_reference
+            .as_ref()
+            .map(|reference| reference.as_str()),
+        "Consent state at resolution reference",
+    )?;
+    let block_withdrawal_state_reference = required_ref(
+        proposal
+            .block_withdrawal_state_reference
+            .as_ref()
+            .map(|reference| reference.as_str()),
+        "block or Withdrawal state reference",
+    )?;
+    let age_assurance_state_reference = required_ref(
+        proposal
+            .age_assurance_state_reference
+            .as_ref()
+            .map(|reference| reference.as_str()),
+        "Age Assurance state reference",
+    )?;
+    let legal_hold_intersection_reference = required_ref(
+        proposal
+            .legal_hold_intersection_reference
+            .as_ref()
+            .map(|reference| reference.as_str()),
+        "Legal Hold intersection reference",
+    )?;
+    let critical_harm_case_reference = required_ref(
+        proposal
+            .critical_harm_case_reference
+            .as_ref()
+            .map(|reference| reference.as_str()),
+        "Critical Harm case reference",
+    )?;
+    let account_lifecycle_reference = required_ref(
+        proposal
+            .account_lifecycle_reference
+            .as_ref()
+            .map(|reference| reference.as_str()),
+        "account lifecycle reference",
+    )?;
+    let anti_abuse_continuity_reference = required_ref(
+        proposal
+            .anti_abuse_continuity_reference
+            .as_ref()
+            .map(|reference| reference.as_str()),
+        "Anti-Abuse Continuity Marker reference",
+    )?;
+    let safety_case_reference = required_ref(
+        proposal
+            .safety_case_reference
+            .as_ref()
+            .map(|reference| reference.as_str()),
+        "safety case reference",
+    )?;
+    let evidence_level_reference = required_ref(
+        proposal
+            .evidence_level_reference
+            .as_ref()
+            .map(|reference| reference.as_str()),
+        "evidence-level reference",
+    )?;
+    let reason_fact_reference = required_ref(
+        proposal
+            .reason_fact
+            .as_ref()
+            .map(|reference| reference.as_str()),
+        "reason fact reference",
+    )?;
+    let audit_reference = required_ref(
+        proposal
+            .audit_reference
+            .as_ref()
+            .map(|reference| reference.as_str()),
+        "audit reference",
+    )?;
+    let fact_idempotency_key = required_ref(
+        proposal
+            .fact_idempotency_key
+            .as_ref()
+            .map(|reference| reference.as_str()),
+        "fact idempotency key",
+    )?;
+    let evidence_posture = evidence_posture(proposal)?;
+    let reviewability_posture = reviewability_posture(proposal)?;
+    let retention_class_reference = retention_class_reference(proposal)?;
+    let authority_posture = proposal.authority_posture.as_str();
+    let policy_version = POLICY_VERSION.to_string();
+    let subject = subject_account_id.to_string();
+    let (realm_reference_presence, realm) = match realm_reference.as_deref() {
+        Some(reference) => ("present", reference),
+        None => ("absent", ""),
+    };
+    let request_payload_hash = hash_parts(&[
+        (
+            "hash_kind",
+            "c2_categorical_social_trust_source_reference_request",
+        ),
+        ("policy_version", &policy_version),
+        ("subject_account_id", &subject),
+        ("source_fact_label", source_fact_label),
+        ("writer_source_reference", &writer_source_reference),
+        ("promise_reference", &promise_reference),
+        ("realm_reference_presence", realm_reference_presence),
+        ("realm_reference", realm),
+        (
+            "boundary_intersection_label",
+            boundary_intersection_label.unwrap_or("none"),
+        ),
+        ("promise_terms_reference", &promise_terms_reference),
+        (
+            "consent_at_formation_reference",
+            &consent_at_formation_reference,
+        ),
+        (
+            "consent_at_resolution_reference",
+            &consent_at_resolution_reference,
+        ),
+        (
+            "block_withdrawal_state_reference",
+            &block_withdrawal_state_reference,
+        ),
+        (
+            "age_assurance_state_reference",
+            &age_assurance_state_reference,
+        ),
+        (
+            "legal_hold_intersection_reference",
+            &legal_hold_intersection_reference,
+        ),
+        (
+            "critical_harm_case_reference",
+            &critical_harm_case_reference,
+        ),
+        ("account_lifecycle_reference", &account_lifecycle_reference),
+        (
+            "anti_abuse_continuity_reference",
+            &anti_abuse_continuity_reference,
+        ),
+        ("safety_case_reference", &safety_case_reference),
+        ("evidence_level_reference", &evidence_level_reference),
+        ("reason_fact_reference", &reason_fact_reference),
+        ("audit_reference", &audit_reference),
+        ("fact_idempotency_key", &fact_idempotency_key),
+        ("evidence_posture", evidence_posture),
+        ("reviewability_posture", reviewability_posture),
+        ("retention_record_family", RETENTION_RECORD_FAMILY),
+        ("retention_class_reference", &retention_class_reference),
+        ("authority_posture", authority_posture),
+    ]);
+    let decision_payload_hash = hash_parts(&[
+        ("hash_kind", "c2_categorical_social_trust_mutation_decision"),
+        ("request_payload_hash", &request_payload_hash),
+        ("decision_kind", decision.kind()),
+        ("mutation_fact_label", mutation_fact_label),
+        ("mutation_direction", mutation_direction),
+        ("mutation_magnitude", mutation_magnitude),
+        (
+            "rejection_reason_code",
+            decision.rejection_reason_code().unwrap_or("none"),
+        ),
+    ]);
+
+    Ok(NormalizedFact {
+        subject_account_id,
+        source_fact_label,
+        mutation_fact_label,
+        mutation_direction,
+        mutation_magnitude,
+        boundary_intersection_label,
+        writer_source_reference,
+        promise_reference,
+        realm_reference,
+        promise_terms_reference,
+        consent_at_formation_reference,
+        consent_at_resolution_reference,
+        block_withdrawal_state_reference,
+        age_assurance_state_reference,
+        legal_hold_intersection_reference,
+        critical_harm_case_reference,
+        account_lifecycle_reference,
+        anti_abuse_continuity_reference,
+        safety_case_reference,
+        evidence_level_reference,
+        reason_fact_reference,
+        audit_reference,
+        fact_idempotency_key,
+        evidence_posture,
+        reviewability_posture,
+        retention_class_reference,
+        authority_posture,
+        request_payload_hash,
+        decision_payload_hash,
+    })
+}
+
+fn evidence_posture(
+    proposal: &ProposedC2BoundedPromiseReliabilityMutationFact,
+) -> Result<&'static str, SocialTrustMutationPersistenceError> {
+    match proposal.evidence_posture.as_ref() {
+        Some(EvidencePosture::Bounded) => Ok(EvidencePosture::Bounded.as_str()),
+        None => Err(SocialTrustMutationPersistenceError::BadRequest(
+            "C2 bounded Promise reliability persistence requires evidence posture".to_owned(),
+        )),
+    }
+}
+
+fn reviewability_posture(
+    proposal: &ProposedC2BoundedPromiseReliabilityMutationFact,
+) -> Result<&'static str, SocialTrustMutationPersistenceError> {
+    match proposal.reviewability_posture.as_ref() {
+        Some(ReviewabilityPosture::Reviewable) => Ok(ReviewabilityPosture::Reviewable.as_str()),
+        None => Err(SocialTrustMutationPersistenceError::BadRequest(
+            "C2 bounded Promise reliability persistence requires reviewability posture".to_owned(),
+        )),
+    }
+}
+
+fn retention_class_reference(
+    proposal: &ProposedC2BoundedPromiseReliabilityMutationFact,
+) -> Result<String, SocialTrustMutationPersistenceError> {
+    match proposal.retention_posture.as_ref() {
+        Some(RetentionPosture::Classified(reference))
+            if reference.as_str().trim() == RETENTION_CLASS_REFERENCE =>
+        {
+            Ok(RETENTION_CLASS_REFERENCE.to_owned())
+        }
+        _ => Err(SocialTrustMutationPersistenceError::BadRequest(
+            "C2 bounded Promise reliability persistence requires R4 Trust / moderation / case retention"
+                .to_owned(),
+        )),
+    }
+}
+
+fn required_ref(
+    value: Option<&str>,
+    label: &'static str,
+) -> Result<String, SocialTrustMutationPersistenceError> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| {
+            SocialTrustMutationPersistenceError::BadRequest(format!(
+                "C2 bounded Promise reliability persistence requires {label}"
+            ))
+        })
+}
+
+fn optional_ref(
+    value: Option<&str>,
+    label: &'static str,
+) -> Result<Option<String>, SocialTrustMutationPersistenceError> {
+    value
+        .map(str::trim)
+        .map(|value| {
+            if value.is_empty() {
+                Err(SocialTrustMutationPersistenceError::BadRequest(format!(
+                    "C2 bounded Promise reliability persistence requires {label} when provided"
+                )))
+            } else {
+                Ok(value.to_owned())
+            }
+        })
+        .transpose()
+}
+
+async fn find_existing_source_by_dedupe_tx(
+    client: &impl GenericClient,
+    normalized: &NormalizedFact,
+) -> Result<Option<Row>, SocialTrustMutationPersistenceError> {
+    client
+        .query_opt(
+            "
+            SELECT source_reference_id, request_payload_hash
+            FROM social_trust.categorical_source_references
+            WHERE subject_account_id = $1
+              AND policy_version = $2
+              AND fact_idempotency_key = $3
+            ",
+            &[
+                &normalized.subject_account_id,
+                &POLICY_VERSION,
+                &normalized.fact_idempotency_key,
+            ],
+        )
+        .await
+        .map_err(db_error)
+}
+
+async fn load_snapshot_by_source_reference_id_tx(
+    client: &impl GenericClient,
+    source_reference_id: &Uuid,
+    replay_status: C2BoundedPromiseReliabilityReplayStatus,
+) -> Result<C2BoundedPromiseReliabilitySnapshot, SocialTrustMutationPersistenceError> {
+    let row = client
+        .query_one(
+            "
+            SELECT
+                source.source_reference_id,
+                mutation.mutation_fact_id,
+                source.subject_account_id,
+                source.source_fact_label,
+                mutation.mutation_fact_label,
+                mutation.mutation_direction,
+                mutation.mutation_magnitude,
+                source.request_payload_hash,
+                mutation.decision_payload_hash,
+                mutation.created_at
+            FROM social_trust.categorical_source_references source
+            JOIN social_trust.categorical_mutation_facts mutation
+              ON mutation.source_reference_id = source.source_reference_id
+            WHERE source.source_reference_id = $1
+            ",
+            &[source_reference_id],
+        )
+        .await
+        .map_err(db_error)?;
+
+    Ok(C2BoundedPromiseReliabilitySnapshot {
+        source_reference_id: row.get::<_, Uuid>("source_reference_id").to_string(),
+        mutation_fact_id: row.get::<_, Uuid>("mutation_fact_id").to_string(),
+        subject_account_id: row.get::<_, Uuid>("subject_account_id").to_string(),
+        source_fact_label: row.get("source_fact_label"),
+        mutation_fact_label: row.get("mutation_fact_label"),
+        mutation_direction: row.get("mutation_direction"),
+        mutation_magnitude: row.get("mutation_magnitude"),
+        request_payload_hash: row.get("request_payload_hash"),
+        decision_payload_hash: row.get("decision_payload_hash"),
+        replay_status,
+        created_at: row.get("created_at"),
+    })
+}
+
+fn replay_source_reference_id(
+    existing: Row,
+    normalized: &NormalizedFact,
+) -> Result<Uuid, SocialTrustMutationPersistenceError> {
+    let existing_hash: String = existing.get("request_payload_hash");
+    let existing_source_reference_id: Uuid = existing.get("source_reference_id");
+    if existing_hash != normalized.request_payload_hash {
+        return Err(SocialTrustMutationPersistenceError::IdempotencyConflict {
+            message: "duplicate C2 bounded Promise reliability fact has payload drift".to_owned(),
+            existing_source_reference_id: existing_source_reference_id.to_string(),
+        });
+    }
+    Ok(existing_source_reference_id)
+}
+
+async fn ensure_active_ordinary_account_exists_tx(
+    client: &impl GenericClient,
+    account_id: &Uuid,
+) -> Result<(), SocialTrustMutationPersistenceError> {
+    let Some(row) = client
+        .query_opt(
+            "
+            SELECT account_class, account_state
+            FROM core.accounts
+            WHERE account_id = $1
+            FOR UPDATE
+            ",
+            &[account_id],
+        )
+        .await
+        .map_err(db_error)?
+    else {
+        return Err(SocialTrustMutationPersistenceError::BadRequest(
+            "C2 bounded Promise reliability subject must reference an existing account writer fact"
+                .to_owned(),
+        ));
+    };
+    let account_class: String = row.get("account_class");
+    let account_state: String = row.get("account_state");
+
+    if account_class != "Ordinary Account" {
+        return Err(SocialTrustMutationPersistenceError::BadRequest(
+            "C2 bounded Promise reliability subject must be an Ordinary Account".to_owned(),
+        ));
+    }
+
+    if account_state != "active" {
+        return Err(SocialTrustMutationPersistenceError::BadRequest(
+            "C2 bounded Promise reliability subject account must be active".to_owned(),
+        ));
+    }
+
+    Ok(())
+}
+
+fn source_insert_error(error: tokio_postgres::Error) -> SocialTrustMutationPersistenceError {
+    if matches!(error.code(), Some(&SqlState::FOREIGN_KEY_VIOLATION)) {
+        return SocialTrustMutationPersistenceError::BadRequest(
+            "C2 bounded Promise reliability subject must reference an existing account writer fact"
+                .to_owned(),
+        );
+    }
+
+    db_error(error)
+}
+
+fn parse_uuid(
+    value: &str,
+    label: &'static str,
+) -> Result<Uuid, SocialTrustMutationPersistenceError> {
+    Uuid::parse_str(value).map_err(|_| {
+        SocialTrustMutationPersistenceError::BadRequest(format!("{label} must be a valid UUID"))
+    })
+}
+
+fn hash_parts(parts: &[(&str, &str)]) -> String {
+    let mut hasher = Sha256::new();
+    for (name, value) in parts {
+        hasher.update(name.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(value.len().to_string().as_bytes());
+        hasher.update(b":");
+        hasher.update(value.as_bytes());
+        hasher.update(b"\n");
+    }
+    hex_digest(hasher.finalize().as_slice())
+}
+
+fn hex_digest(bytes: &[u8]) -> String {
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        write!(&mut output, "{byte:02x}").expect("writing sha256 hex cannot fail");
+    }
+    output
+}
+
+fn db_error(error: tokio_postgres::Error) -> SocialTrustMutationPersistenceError {
+    let code = error.code().map(SqlState::code).map(ToOwned::to_owned);
+    let constraint = error
+        .as_db_error()
+        .and_then(|db_error| db_error.constraint())
+        .map(ToOwned::to_owned);
+    let retryable = matches!(
+        error.code(),
+        Some(&SqlState::T_R_SERIALIZATION_FAILURE) | Some(&SqlState::T_R_DEADLOCK_DETECTED)
+    );
+
+    SocialTrustMutationPersistenceError::Database {
+        message: error.to_string(),
+        code,
+        constraint,
+        retryable,
+    }
+}

--- a/apps/backend/src/services/social_trust_mutation/types.rs
+++ b/apps/backend/src/services/social_trust_mutation/types.rs
@@ -1,0 +1,67 @@
+use chrono::{DateTime, Utc};
+use musubi_social_trust_domain::{
+    C2BoundedPromiseReliabilityMutationDecision, ProposedC2BoundedPromiseReliabilityMutationFact,
+};
+
+#[derive(Debug)]
+pub enum SocialTrustMutationPersistenceError {
+    BadRequest(String),
+    IdempotencyConflict {
+        message: String,
+        existing_source_reference_id: String,
+    },
+    Database {
+        message: String,
+        code: Option<String>,
+        constraint: Option<String>,
+        retryable: bool,
+    },
+    Internal(String),
+}
+
+impl SocialTrustMutationPersistenceError {
+    pub fn message(&self) -> &str {
+        match self {
+            Self::BadRequest(message)
+            | Self::IdempotencyConflict { message, .. }
+            | Self::Database { message, .. }
+            | Self::Internal(message) => message,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct RecordC2BoundedPromiseReliabilityMutationFactInput {
+    pub subject_account_id: String,
+    pub realm_reference: Option<String>,
+    pub proposal: ProposedC2BoundedPromiseReliabilityMutationFact,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum C2BoundedPromiseReliabilityReplayStatus {
+    Inserted,
+    ReplayedIdentical,
+}
+
+#[derive(Clone, Debug)]
+pub enum SocialTrustMutationPersistenceOutcome {
+    Recorded(C2BoundedPromiseReliabilitySnapshot),
+    RejectedBeforePersistence {
+        decision: C2BoundedPromiseReliabilityMutationDecision,
+    },
+}
+
+#[derive(Clone, Debug)]
+pub struct C2BoundedPromiseReliabilitySnapshot {
+    pub source_reference_id: String,
+    pub mutation_fact_id: String,
+    pub subject_account_id: String,
+    pub source_fact_label: String,
+    pub mutation_fact_label: String,
+    pub mutation_direction: String,
+    pub mutation_magnitude: String,
+    pub request_payload_hash: String,
+    pub decision_payload_hash: String,
+    pub replay_status: C2BoundedPromiseReliabilityReplayStatus,
+    pub created_at: DateTime<Utc>,
+}

--- a/apps/backend/tests/c2_bounded_promise_reliability_persistence.rs
+++ b/apps/backend/tests/c2_bounded_promise_reliability_persistence.rs
@@ -1,0 +1,800 @@
+use std::path::PathBuf;
+
+use musubi_backend::{
+    new_test_state,
+    services::social_trust_mutation::{
+        C2BoundedPromiseReliabilityReplayStatus,
+        RecordC2BoundedPromiseReliabilityMutationFactInput, SocialTrustMutationPersistenceError,
+        SocialTrustMutationPersistenceOutcome, SocialTrustMutationStore,
+    },
+};
+use musubi_db_runtime::DbConfig;
+use musubi_social_trust_domain::{
+    AccountLifecycleReference, AgeAssuranceStateReference, AntiAbuseContinuityReference,
+    AuditReference, BlockWithdrawalStateReference, C2BoundedPromiseReliabilityBoundaryIntersection,
+    C2BoundedPromiseReliabilityBoundaryPosture, C2BoundedPromiseReliabilityFactIdempotencyKey,
+    C2BoundedPromiseReliabilityMutationFact, C2BoundedPromiseReliabilityMutationFactCandidate,
+    C2BoundedPromiseReliabilityRejection, C2BoundedPromiseReliabilitySourceFact,
+    C2BoundedPromiseReliabilitySourceFactCandidate, ConsentStateReference,
+    CriticalHarmCaseReference, EvidenceLevelReference, EvidencePosture,
+    LegalHoldIntersectionReference, PromiseReference, PromiseTermsReference,
+    ProposedC2BoundedPromiseReliabilityMutationFact, ReasonFactReference,
+    RejectedC2BoundedPromiseReliabilitySourceFact, RetentionClassReference, RetentionPosture,
+    ReviewabilityPosture, SafetyCaseReference, SocialTrustAuthorityPosture, WriterSourceReference,
+};
+use tokio_postgres::NoTls;
+use uuid::Uuid;
+
+fn lookup(database_url: &str, migrations_dir: &str, name: &'static str) -> Option<String> {
+    match name {
+        "APP_ENV" => Some("test".to_owned()),
+        "DATABASE_URL" => Some(database_url.to_owned()),
+        "MIGRATIONS_DIR" => Some(migrations_dir.to_owned()),
+        "REQUIRE_LATEST_SCHEMA" => Some("true".to_owned()),
+        _ => None,
+    }
+}
+
+#[tokio::test]
+async fn accepted_positive_fact_is_persisted_and_replayed_without_projection_refresh() {
+    let (_test_state, config, client) = test_context().await;
+    let subject_account_id = insert_account(&client, "Ordinary Account", "active").await;
+    let store = SocialTrustMutationStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let input = record_input(
+        subject_account_id,
+        complete_proposal(
+            "dedupe-positive",
+            C2BoundedPromiseReliabilitySourceFact::CompletedAsAgreed,
+            C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityPositive,
+        ),
+    );
+
+    let first = recorded(
+        store
+            .record_c2_bounded_promise_reliability_fact(input.clone())
+            .await
+            .expect("first categorical fact should persist"),
+    );
+    let replay = recorded(
+        store
+            .record_c2_bounded_promise_reliability_fact(input)
+            .await
+            .expect("identical duplicate should replay"),
+    );
+
+    assert_eq!(
+        first.source_fact_label,
+        "promise_reliability_outcome.completed_as_agreed"
+    );
+    assert_eq!(
+        first.mutation_fact_label,
+        "social_trust_mutation.bounded_promise_reliability_positive"
+    );
+    assert_eq!(first.mutation_direction, "positive");
+    assert_eq!(first.mutation_magnitude, "categorical");
+    assert_eq!(
+        first.replay_status,
+        C2BoundedPromiseReliabilityReplayStatus::Inserted
+    );
+    assert_eq!(
+        replay.replay_status,
+        C2BoundedPromiseReliabilityReplayStatus::ReplayedIdentical
+    );
+    assert_eq!(first.source_reference_id, replay.source_reference_id);
+    assert_eq!(first.mutation_fact_id, replay.mutation_fact_id);
+    assert_eq!(first.request_payload_hash, replay.request_payload_hash);
+    assert_eq!(
+        source_count_for_subject(&client, &subject_account_id).await,
+        1
+    );
+    assert_eq!(
+        mutation_count_for_subject(&client, &subject_account_id).await,
+        1
+    );
+    assert_eq!(
+        projection_trust_snapshot_count(&client, &subject_account_id).await,
+        0
+    );
+}
+
+#[tokio::test]
+async fn accepted_no_effect_correction_freeze_narrowing_and_recovery_are_categorical_only() {
+    let (_test_state, config, client) = test_context().await;
+    let subject_account_id = insert_account(&client, "Ordinary Account", "active").await;
+    let store = SocialTrustMutationStore::connect(&config)
+        .await
+        .expect("store should connect");
+
+    for (key, source, mutation, direction, magnitude) in [
+        (
+            "dedupe-no-effect",
+            C2BoundedPromiseReliabilitySourceFact::ValidExcusedExit,
+            C2BoundedPromiseReliabilityMutationFact::NoEffectValidExcusedExit,
+            "no_effect",
+            "no_effect",
+        ),
+        (
+            "dedupe-correction",
+            C2BoundedPromiseReliabilitySourceFact::SourceFactCorrected,
+            C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityCorrection,
+            "correction",
+            "forward_correction",
+        ),
+        (
+            "dedupe-freeze",
+            C2BoundedPromiseReliabilitySourceFact::ReviewRequiredBoundaryIntersection,
+            C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityFreeze,
+            "freeze",
+            "temporary_suppression",
+        ),
+        (
+            "dedupe-narrowing",
+            C2BoundedPromiseReliabilitySourceFact::SourceScopeLimitedAfterReview,
+            C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityNarrowing,
+            "narrowing",
+            "scope_limited_restriction",
+        ),
+        (
+            "dedupe-recovery",
+            C2BoundedPromiseReliabilitySourceFact::FreezeOrNarrowingReversedAfterReview,
+            C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityRecovery,
+            "recovery",
+            "eligibility_restoration",
+        ),
+    ] {
+        let mut proposal = complete_proposal(key, source, mutation);
+        if source == C2BoundedPromiseReliabilitySourceFact::ReviewRequiredBoundaryIntersection {
+            proposal.boundary_posture = C2BoundedPromiseReliabilityBoundaryPosture::Unresolved(
+                C2BoundedPromiseReliabilityBoundaryIntersection::AppealCorrectionOrSafetyReview,
+            );
+        }
+        let snapshot = recorded(
+            store
+                .record_c2_bounded_promise_reliability_fact(record_input(
+                    subject_account_id,
+                    proposal,
+                ))
+                .await
+                .expect("accepted C2 categorical fact should persist"),
+        );
+
+        assert_eq!(snapshot.mutation_fact_label, mutation.as_str());
+        assert_eq!(snapshot.mutation_direction, direction);
+        assert_eq!(snapshot.mutation_magnitude, magnitude);
+    }
+
+    assert_eq!(
+        source_count_for_subject(&client, &subject_account_id).await,
+        5
+    );
+    assert_eq!(
+        mutation_count_for_subject(&client, &subject_account_id).await,
+        5
+    );
+    assert_eq!(
+        projection_trust_snapshot_count(&client, &subject_account_id).await,
+        0
+    );
+}
+
+#[tokio::test]
+async fn review_required_boundary_intersection_persists_freeze_without_projection_refresh() {
+    let (_test_state, config, client) = test_context().await;
+    let subject_account_id = insert_account(&client, "Ordinary Account", "active").await;
+    let store = SocialTrustMutationStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let mut proposal = complete_proposal(
+        "dedupe-freeze-unresolved-legal-hold",
+        C2BoundedPromiseReliabilitySourceFact::ReviewRequiredBoundaryIntersection,
+        C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityFreeze,
+    );
+    proposal.boundary_posture = C2BoundedPromiseReliabilityBoundaryPosture::Unresolved(
+        C2BoundedPromiseReliabilityBoundaryIntersection::LegalHold,
+    );
+
+    let snapshot = recorded(
+        store
+            .record_c2_bounded_promise_reliability_fact(record_input(subject_account_id, proposal))
+            .await
+            .expect("review-required boundary source should persist a categorical freeze"),
+    );
+
+    assert_eq!(
+        snapshot.source_fact_label,
+        "promise_reliability_outcome.review_required_boundary_intersection"
+    );
+    assert_eq!(
+        snapshot.mutation_fact_label,
+        "social_trust_mutation.bounded_promise_reliability_freeze"
+    );
+    assert_eq!(snapshot.mutation_direction, "freeze");
+    assert_eq!(snapshot.mutation_magnitude, "temporary_suppression");
+    assert_eq!(
+        boundary_intersection_label(&client, &snapshot.source_reference_id).await,
+        Some("legal_hold".to_owned())
+    );
+    assert_eq!(
+        projection_trust_snapshot_count(&client, &subject_account_id).await,
+        0
+    );
+}
+
+#[tokio::test]
+async fn boundary_intersection_label_participates_in_duplicate_drift_detection() {
+    let (_test_state, config, client) = test_context().await;
+    let subject_account_id = insert_account(&client, "Ordinary Account", "active").await;
+    let store = SocialTrustMutationStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let mut first_proposal = complete_proposal(
+        "dedupe-freeze-boundary-drift",
+        C2BoundedPromiseReliabilitySourceFact::ReviewRequiredBoundaryIntersection,
+        C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityFreeze,
+    );
+    first_proposal.boundary_posture = C2BoundedPromiseReliabilityBoundaryPosture::Unresolved(
+        C2BoundedPromiseReliabilityBoundaryIntersection::LegalHold,
+    );
+    let mut drifted_proposal = complete_proposal(
+        "dedupe-freeze-boundary-drift",
+        C2BoundedPromiseReliabilitySourceFact::ReviewRequiredBoundaryIntersection,
+        C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityFreeze,
+    );
+    drifted_proposal.boundary_posture = C2BoundedPromiseReliabilityBoundaryPosture::Unresolved(
+        C2BoundedPromiseReliabilityBoundaryIntersection::CriticalHarm,
+    );
+
+    let _ = recorded(
+        store
+            .record_c2_bounded_promise_reliability_fact(record_input(
+                subject_account_id,
+                first_proposal,
+            ))
+            .await
+            .expect("first categorical freeze should persist"),
+    );
+    let error = store
+        .record_c2_bounded_promise_reliability_fact(record_input(
+            subject_account_id,
+            drifted_proposal,
+        ))
+        .await
+        .expect_err("boundary label drift must fail closed");
+
+    match error {
+        SocialTrustMutationPersistenceError::IdempotencyConflict { .. } => {}
+        other => panic!("expected idempotency conflict, got {other:?}"),
+    }
+    assert_eq!(
+        source_count_for_subject(&client, &subject_account_id).await,
+        1
+    );
+    assert_eq!(
+        mutation_count_for_subject(&client, &subject_account_id).await,
+        1
+    );
+}
+
+#[tokio::test]
+async fn missing_realm_and_literal_none_realm_do_not_collapse_in_duplicate_drift_detection() {
+    let (_test_state, config, client) = test_context().await;
+    let subject_account_id = insert_account(&client, "Ordinary Account", "active").await;
+    let store = SocialTrustMutationStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let proposal = complete_proposal(
+        "dedupe-realm-none-drift",
+        C2BoundedPromiseReliabilitySourceFact::CompletedAsAgreed,
+        C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityPositive,
+    );
+
+    let _ = recorded(
+        store
+            .record_c2_bounded_promise_reliability_fact(record_input_with_realm(
+                subject_account_id,
+                Some("none".to_owned()),
+                proposal.clone(),
+            ))
+            .await
+            .expect("first categorical fact should persist"),
+    );
+    let error = store
+        .record_c2_bounded_promise_reliability_fact(record_input_with_realm(
+            subject_account_id,
+            None,
+            proposal,
+        ))
+        .await
+        .expect_err("realm presence drift must fail closed");
+
+    match error {
+        SocialTrustMutationPersistenceError::IdempotencyConflict { .. } => {}
+        other => panic!("expected idempotency conflict, got {other:?}"),
+    }
+    assert_eq!(
+        source_count_for_subject(&client, &subject_account_id).await,
+        1
+    );
+    assert_eq!(
+        mutation_count_for_subject(&client, &subject_account_id).await,
+        1
+    );
+}
+
+#[tokio::test]
+async fn duplicate_delivery_with_payload_drift_fails_closed() {
+    let (_test_state, config, client) = test_context().await;
+    let subject_account_id = insert_account(&client, "Ordinary Account", "active").await;
+    let store = SocialTrustMutationStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let first = record_input(
+        subject_account_id,
+        complete_proposal(
+            "dedupe-drift",
+            C2BoundedPromiseReliabilitySourceFact::CompletedAfterGovernedReview,
+            C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityPositive,
+        ),
+    );
+    let mut drifted_proposal = complete_proposal(
+        "dedupe-drift",
+        C2BoundedPromiseReliabilitySourceFact::CompletedAfterGovernedReview,
+        C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityPositive,
+    );
+    drifted_proposal.audit_reference = Some(AuditReference::new("audit-drift"));
+    let drifted = record_input(subject_account_id, drifted_proposal);
+
+    let _ = recorded(
+        store
+            .record_c2_bounded_promise_reliability_fact(first)
+            .await
+            .expect("first categorical fact should persist"),
+    );
+    let error = store
+        .record_c2_bounded_promise_reliability_fact(drifted)
+        .await
+        .expect_err("payload drift must fail closed");
+
+    match error {
+        SocialTrustMutationPersistenceError::IdempotencyConflict { .. } => {}
+        other => panic!("expected idempotency conflict, got {other:?}"),
+    }
+    assert_eq!(
+        source_count_for_subject(&client, &subject_account_id).await,
+        1
+    );
+    assert_eq!(
+        mutation_count_for_subject(&client, &subject_account_id).await,
+        1
+    );
+}
+
+#[tokio::test]
+async fn identical_replay_survives_subject_account_suspension() {
+    let (_test_state, config, client) = test_context().await;
+    let subject_account_id = insert_account(&client, "Ordinary Account", "active").await;
+    let store = SocialTrustMutationStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let input = record_input(
+        subject_account_id,
+        complete_proposal(
+            "dedupe-after-suspension",
+            C2BoundedPromiseReliabilitySourceFact::CompletedAsAgreed,
+            C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityPositive,
+        ),
+    );
+
+    let first = recorded(
+        store
+            .record_c2_bounded_promise_reliability_fact(input.clone())
+            .await
+            .expect("first categorical fact should persist"),
+    );
+    set_account_state(&client, &subject_account_id, "suspended").await;
+    let replay = recorded(
+        store
+            .record_c2_bounded_promise_reliability_fact(input)
+            .await
+            .expect("duplicate categorical fact should replay despite later account suspension"),
+    );
+
+    assert_eq!(first.source_reference_id, replay.source_reference_id);
+    assert_eq!(
+        replay.replay_status,
+        C2BoundedPromiseReliabilityReplayStatus::ReplayedIdentical
+    );
+}
+
+#[tokio::test]
+async fn new_fact_requires_active_ordinary_account() {
+    let (_test_state, config, client) = test_context().await;
+    let subject_account_id = insert_account(&client, "Ordinary Account", "suspended").await;
+    let store = SocialTrustMutationStore::connect(&config)
+        .await
+        .expect("store should connect");
+
+    let error = store
+        .record_c2_bounded_promise_reliability_fact(record_input(
+            subject_account_id,
+            complete_proposal(
+                "dedupe-suspended-subject",
+                C2BoundedPromiseReliabilitySourceFact::CompletedAsAgreed,
+                C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityPositive,
+            ),
+        ))
+        .await
+        .expect_err("new categorical fact should reject inactive subjects");
+
+    assert!(matches!(
+        error,
+        SocialTrustMutationPersistenceError::BadRequest(_)
+    ));
+    assert_eq!(
+        source_count_for_subject(&client, &subject_account_id).await,
+        0
+    );
+    assert_eq!(
+        mutation_count_for_subject(&client, &subject_account_id).await,
+        0
+    );
+}
+
+#[tokio::test]
+async fn rejected_source_projection_only_and_unresolved_boundary_fail_before_persistence() {
+    let (_test_state, config, client) = test_context().await;
+    let subject_account_id = insert_account(&client, "Ordinary Account", "active").await;
+    let store = SocialTrustMutationStore::connect(&config)
+        .await
+        .expect("store should connect");
+
+    let mut rejected_source = complete_proposal(
+        "dedupe-rejected-promise-creation",
+        C2BoundedPromiseReliabilitySourceFact::CompletedAsAgreed,
+        C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityPositive,
+    );
+    rejected_source.source_fact = C2BoundedPromiseReliabilitySourceFactCandidate::Rejected(
+        RejectedC2BoundedPromiseReliabilitySourceFact::PromiseCreation,
+    );
+    assert_rejected_before_persistence(
+        store
+            .record_c2_bounded_promise_reliability_fact(record_input(
+                subject_account_id,
+                rejected_source,
+            ))
+            .await
+            .expect("rejected source should fail before persistence"),
+        C2BoundedPromiseReliabilityRejection::RejectedSourceFact {
+            source: RejectedC2BoundedPromiseReliabilitySourceFact::PromiseCreation,
+        },
+    );
+
+    let mut projection_only = complete_proposal(
+        "dedupe-projection-only",
+        C2BoundedPromiseReliabilitySourceFact::CompletedAsAgreed,
+        C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityPositive,
+    );
+    projection_only.authority_posture = SocialTrustAuthorityPosture::ProjectionOnly;
+    assert_rejected_before_persistence(
+        store
+            .record_c2_bounded_promise_reliability_fact(record_input(
+                subject_account_id,
+                projection_only,
+            ))
+            .await
+            .expect("projection-only posture should fail before persistence"),
+        C2BoundedPromiseReliabilityRejection::ProjectionOnlyAuthority,
+    );
+
+    let mut unresolved_boundary = complete_proposal(
+        "dedupe-unresolved-boundary",
+        C2BoundedPromiseReliabilitySourceFact::CompletedAsAgreed,
+        C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityPositive,
+    );
+    unresolved_boundary.boundary_posture = C2BoundedPromiseReliabilityBoundaryPosture::Unresolved(
+        C2BoundedPromiseReliabilityBoundaryIntersection::LegalHold,
+    );
+    assert_rejected_before_persistence(
+        store
+            .record_c2_bounded_promise_reliability_fact(record_input(
+                subject_account_id,
+                unresolved_boundary,
+            ))
+            .await
+            .expect("unresolved boundary should fail before persistence"),
+        C2BoundedPromiseReliabilityRejection::BoundaryUnresolved {
+            boundary: C2BoundedPromiseReliabilityBoundaryIntersection::LegalHold,
+        },
+    );
+
+    assert_eq!(
+        source_count_for_subject(&client, &subject_account_id).await,
+        0
+    );
+    assert_eq!(
+        mutation_count_for_subject(&client, &subject_account_id).await,
+        0
+    );
+}
+
+#[tokio::test]
+async fn categorical_schema_has_no_scores_or_projection_authority_columns() {
+    let (_test_state, _config, client) = test_context().await;
+
+    let row = client
+        .query_one(
+            "
+            SELECT COUNT(*)::bigint AS count
+            FROM information_schema.columns
+            WHERE table_schema = 'social_trust'
+              AND (
+                  column_name LIKE '%score%'
+                  OR column_name LIKE '%weight%'
+                  OR column_name LIKE '%rank%'
+                  OR column_name LIKE '%display%'
+                  OR column_name LIKE '%relationship_depth%'
+                  OR column_name LIKE '%projection%'
+              )
+            ",
+            &[],
+        )
+        .await
+        .expect("schema guard query should run");
+    let forbidden_column_count: i64 = row.get("count");
+
+    assert_eq!(forbidden_column_count, 0);
+}
+
+async fn test_context() -> (musubi_backend::TestState, DbConfig, tokio_postgres::Client) {
+    let test_state = new_test_state()
+        .await
+        .expect("test database state should initialize");
+    let database_url = std::env::var("MUSUBI_TEST_DATABASE_URL")
+        .or_else(|_| std::env::var("DATABASE_URL"))
+        .expect("integration tests require MUSUBI_TEST_DATABASE_URL or DATABASE_URL to be set");
+    let migrations_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("migrations")
+        .canonicalize()
+        .expect("migrations directory should resolve");
+    let migrations_dir = migrations_dir
+        .to_str()
+        .expect("migrations directory should be utf-8")
+        .to_owned();
+    let config = DbConfig::from_lookup(|name| lookup(&database_url, &migrations_dir, name))
+        .expect("test db config should parse");
+
+    let (client, connection) = tokio_postgres::connect(&database_url, NoTls)
+        .await
+        .expect("failed to connect to test database");
+    tokio::spawn(async move {
+        if let Err(error) = connection.await {
+            eprintln!("test database connection error: {error}");
+        }
+    });
+
+    (test_state, config, client)
+}
+
+fn complete_proposal(
+    idempotency_key: &str,
+    source: C2BoundedPromiseReliabilitySourceFact,
+    mutation: C2BoundedPromiseReliabilityMutationFact,
+) -> ProposedC2BoundedPromiseReliabilityMutationFact {
+    ProposedC2BoundedPromiseReliabilityMutationFact {
+        source_fact: C2BoundedPromiseReliabilitySourceFactCandidate::Accepted(source),
+        requested_mutation_fact: C2BoundedPromiseReliabilityMutationFactCandidate::Accepted(
+            mutation,
+        ),
+        writer_source_reference: Some(WriterSourceReference::new(format!(
+            "writer-source-{idempotency_key}"
+        ))),
+        promise_reference: Some(PromiseReference::new(format!("promise-{idempotency_key}"))),
+        promise_terms_reference: Some(PromiseTermsReference::new(format!(
+            "promise-terms-{idempotency_key}"
+        ))),
+        consent_at_formation_reference: Some(ConsentStateReference::new(format!(
+            "consent-formation-{idempotency_key}"
+        ))),
+        consent_at_resolution_reference: Some(ConsentStateReference::new(format!(
+            "consent-resolution-{idempotency_key}"
+        ))),
+        block_withdrawal_state_reference: Some(BlockWithdrawalStateReference::new(format!(
+            "block-withdrawal-clear-{idempotency_key}"
+        ))),
+        age_assurance_state_reference: Some(AgeAssuranceStateReference::new(format!(
+            "age-assurance-adult-eligible-{idempotency_key}"
+        ))),
+        legal_hold_intersection_reference: Some(LegalHoldIntersectionReference::new(format!(
+            "legal-hold-clear-{idempotency_key}"
+        ))),
+        critical_harm_case_reference: Some(CriticalHarmCaseReference::new(format!(
+            "critical-harm-clear-{idempotency_key}"
+        ))),
+        account_lifecycle_reference: Some(AccountLifecycleReference::new(format!(
+            "account-lifecycle-active-{idempotency_key}"
+        ))),
+        anti_abuse_continuity_reference: Some(AntiAbuseContinuityReference::new(format!(
+            "anti-abuse-clear-{idempotency_key}"
+        ))),
+        safety_case_reference: Some(SafetyCaseReference::new(format!(
+            "safety-case-clear-{idempotency_key}"
+        ))),
+        evidence_level_reference: Some(EvidenceLevelReference::new(format!(
+            "evidence-level-bounded-{idempotency_key}"
+        ))),
+        audit_reference: Some(AuditReference::new(format!("audit-{idempotency_key}"))),
+        reason_fact: Some(ReasonFactReference::new(format!(
+            "reason-fact-{idempotency_key}"
+        ))),
+        fact_idempotency_key: Some(C2BoundedPromiseReliabilityFactIdempotencyKey::new(
+            idempotency_key,
+        )),
+        evidence_posture: Some(EvidencePosture::Bounded),
+        reviewability_posture: Some(ReviewabilityPosture::Reviewable),
+        retention_posture: Some(RetentionPosture::Classified(RetentionClassReference::new(
+            "R4 Trust / moderation / case",
+        ))),
+        authority_posture: SocialTrustAuthorityPosture::WriterTruthOnly,
+        boundary_posture: C2BoundedPromiseReliabilityBoundaryPosture::Clear,
+    }
+}
+
+fn record_input(
+    subject_account_id: Uuid,
+    proposal: ProposedC2BoundedPromiseReliabilityMutationFact,
+) -> RecordC2BoundedPromiseReliabilityMutationFactInput {
+    record_input_with_realm(
+        subject_account_id,
+        Some("realm-reference-1".to_owned()),
+        proposal,
+    )
+}
+
+fn record_input_with_realm(
+    subject_account_id: Uuid,
+    realm_reference: Option<String>,
+    proposal: ProposedC2BoundedPromiseReliabilityMutationFact,
+) -> RecordC2BoundedPromiseReliabilityMutationFactInput {
+    RecordC2BoundedPromiseReliabilityMutationFactInput {
+        subject_account_id: subject_account_id.to_string(),
+        realm_reference,
+        proposal,
+    }
+}
+
+fn recorded(
+    outcome: SocialTrustMutationPersistenceOutcome,
+) -> musubi_backend::services::social_trust_mutation::C2BoundedPromiseReliabilitySnapshot {
+    match outcome {
+        SocialTrustMutationPersistenceOutcome::Recorded(snapshot) => snapshot,
+        SocialTrustMutationPersistenceOutcome::RejectedBeforePersistence { decision } => {
+            panic!("expected recorded C2 fact, got rejected before persistence: {decision:?}")
+        }
+    }
+}
+
+fn assert_rejected_before_persistence(
+    outcome: SocialTrustMutationPersistenceOutcome,
+    expected: C2BoundedPromiseReliabilityRejection,
+) {
+    match outcome {
+        SocialTrustMutationPersistenceOutcome::RejectedBeforePersistence {
+            decision:
+                musubi_social_trust_domain::C2BoundedPromiseReliabilityMutationDecision::Reject(actual),
+        } => assert_eq!(actual, expected),
+        other => panic!("expected rejected before persistence, got {other:?}"),
+    }
+}
+
+async fn insert_account(
+    client: &tokio_postgres::Client,
+    account_class: &str,
+    account_state: &str,
+) -> Uuid {
+    let account_id = Uuid::new_v4();
+    client
+        .execute(
+            "
+            INSERT INTO core.accounts (account_id, account_class, account_state)
+            VALUES ($1, $2, $3)
+            ",
+            &[&account_id, &account_class, &account_state],
+        )
+        .await
+        .expect("account insert should succeed");
+    account_id
+}
+
+async fn set_account_state(
+    client: &tokio_postgres::Client,
+    account_id: &Uuid,
+    account_state: &str,
+) {
+    client
+        .execute(
+            "
+            UPDATE core.accounts
+            SET account_state = $2
+            WHERE account_id = $1
+            ",
+            &[account_id, &account_state],
+        )
+        .await
+        .expect("account state update should succeed");
+}
+
+async fn source_count_for_subject(
+    client: &tokio_postgres::Client,
+    subject_account_id: &Uuid,
+) -> i64 {
+    let row = client
+        .query_one(
+            "
+            SELECT COUNT(*)::bigint AS count
+            FROM social_trust.categorical_source_references
+            WHERE subject_account_id = $1
+            ",
+            &[subject_account_id],
+        )
+        .await
+        .expect("source reference count should load");
+    row.get("count")
+}
+
+async fn mutation_count_for_subject(
+    client: &tokio_postgres::Client,
+    subject_account_id: &Uuid,
+) -> i64 {
+    let row = client
+        .query_one(
+            "
+            SELECT COUNT(*)::bigint AS count
+            FROM social_trust.categorical_mutation_facts
+            WHERE subject_account_id = $1
+            ",
+            &[subject_account_id],
+        )
+        .await
+        .expect("mutation fact count should load");
+    row.get("count")
+}
+
+async fn boundary_intersection_label(
+    client: &tokio_postgres::Client,
+    source_reference_id: &str,
+) -> Option<String> {
+    let source_reference_id =
+        Uuid::parse_str(source_reference_id).expect("snapshot source reference id should be UUID");
+    let row = client
+        .query_one(
+            "
+            SELECT boundary_intersection_label
+            FROM social_trust.categorical_source_references
+            WHERE source_reference_id = $1
+            ",
+            &[&source_reference_id],
+        )
+        .await
+        .expect("boundary intersection label should load");
+    row.get("boundary_intersection_label")
+}
+
+async fn projection_trust_snapshot_count(
+    client: &tokio_postgres::Client,
+    subject_account_id: &Uuid,
+) -> i64 {
+    let row = client
+        .query_one(
+            "
+            SELECT COUNT(*)::bigint AS count
+            FROM projection.trust_snapshots
+            WHERE account_id = $1
+            ",
+            &[subject_account_id],
+        )
+        .await
+        .expect("projection trust snapshot count should load");
+    row.get("count")
+}

--- a/docs/foundation_lock.md
+++ b/docs/foundation_lock.md
@@ -1,6 +1,6 @@
 # Foundation Lock
 
-Status: Draft; aligned to accepted foundation commit `00409c3`
+Status: Draft; aligned to accepted foundation commit `86362a6`
 Applies to: `mt4110/pi-musubi-core`
 Purpose: Pin the constitutional and architectural source of truth that this implementation repository must follow.
 
@@ -26,14 +26,14 @@ Upstream repository:
 Pinned reference for implementation work:
 
 - Foundation reference type: `commit`
-- Foundation commit SHA: `00409c3b7384b3e2330d662bba1a481e09d3b3ec`
-- Foundation commit title: `Merge pull request #104 from mt4110/feat/define-c2-bounded-promise-reliability-mutation-fact-gate`
-- Foundation PR title: `docs: define C2 bounded Promise reliability mutation-fact gate`
-- Foundation PR URL: `https://github.com/mt4110/musubi-foundation/pull/104`
+- Foundation commit SHA: `86362a6bf1b6bf15abc1125fb2e5b90ad022ebfb`
+- Foundation commit title: `Merge pull request #108 from mt4110/feat/define-c2-bounded-promise-reliability-implementation-handoff-gate`
+- Foundation PR title: `docs: define C2 bounded Promise reliability implementation handoff gate`
+- Foundation PR URL: `https://github.com/mt4110/musubi-foundation/pull/108`
 - Date pinned: `2026-05-13`
 - Pinned by: `Masaki Takemura`
-- Pinned commit URL: `https://github.com/mt4110/musubi-foundation/commit/00409c3b7384b3e2330d662bba1a481e09d3b3ec`
-- Previous pinned reference: `cff85a6` / `Merge pull request #94 from mt4110/feat/evaluate-c1-social-trust-intake-persistence-closeout`
+- Pinned commit URL: `https://github.com/mt4110/musubi-foundation/commit/86362a6bf1b6bf15abc1125fb2e5b90ad022ebfb`
+- Previous pinned reference: `00409c3` / `Merge pull request #104 from mt4110/feat/define-c2-bounded-promise-reliability-mutation-fact-gate`
 - Alignment scope source: `b554645` / `Merge pull request #106 from mt4110/feat/evaluate-c2-bounded-promise-reliability-foundation-lock-alignment-scope`
 
 No release tag is asserted for this alignment.
@@ -107,31 +107,32 @@ Before coding, read these upstream documents in order.
 52. `docs/readiness/c2_bounded_promise_reliability_mutation_prereqs.md`
 53. `docs/readiness/c2_bounded_promise_reliability_mutation_fact_gate_readiness.md`
 54. `docs/readiness/c2_bounded_promise_reliability_mutation_fact_gate.md`
+55. `docs/readiness/c2_bounded_promise_reliability_implementation_handoff_gate.md`
 
 ### Detail layer
-55. `docs/detail/accountability_matrix.md`
-56. `docs/detail/critical_incident_and_loss.md`
-57. `docs/detail/automated_decisioning_and_human_appeal.md`
-58. `docs/detail/youth_safety_and_age_assurance.md`
-59. `docs/detail/off_platform_handoff_and_scam_prevention.md`
-60. `docs/detail/data_deletion_vs_legal_hold.md`
-61. `docs/detail/realm_model.md`
-62. `docs/detail/data_scope_model.md`
-63. `docs/detail/mobility_model.md`
-64. `docs/detail/settlement_model.md`
-65. `docs/detail/settlement_backend_trait.md`
-66. `docs/detail/proof_of_infrastructure.md`
-67. `docs/detail/protected_groups_and_translation_safety.md`
+56. `docs/detail/accountability_matrix.md`
+57. `docs/detail/critical_incident_and_loss.md`
+58. `docs/detail/automated_decisioning_and_human_appeal.md`
+59. `docs/detail/youth_safety_and_age_assurance.md`
+60. `docs/detail/off_platform_handoff_and_scam_prevention.md`
+61. `docs/detail/data_deletion_vs_legal_hold.md`
+62. `docs/detail/realm_model.md`
+63. `docs/detail/data_scope_model.md`
+64. `docs/detail/mobility_model.md`
+65. `docs/detail/settlement_model.md`
+66. `docs/detail/settlement_backend_trait.md`
+67. `docs/detail/proof_of_infrastructure.md`
+68. `docs/detail/protected_groups_and_translation_safety.md`
 
 ### Whitepaper layer (contextual, not higher than detail/ADR)
-68. `docs/whitepaper/01_executive_summary.md`
-69. `docs/whitepaper/02_realm_model.md`
-70. `docs/whitepaper/03_experience_model.md`
-71. `docs/whitepaper/04_dm_shield.md`
-72. `docs/whitepaper/05_trust_model.md`
-73. `docs/whitepaper/06_promise_protocol.md`
-74. `docs/whitepaper/07_realm_economy.md`
-75. `docs/whitepaper/08_unlock_engine.md`
+69. `docs/whitepaper/01_executive_summary.md`
+70. `docs/whitepaper/02_realm_model.md`
+71. `docs/whitepaper/03_experience_model.md`
+72. `docs/whitepaper/04_dm_shield.md`
+73. `docs/whitepaper/05_trust_model.md`
+74. `docs/whitepaper/06_promise_protocol.md`
+75. `docs/whitepaper/07_realm_economy.md`
+76. `docs/whitepaper/08_unlock_engine.md`
 
 If any of the above are unavailable or materially inconsistent, stop and escalate.
 
@@ -156,8 +157,10 @@ Prompt 3 implementation may proceed only where all applicable foundation ADRs an
 The C1 Runtime Handoff Gate Decision remains accepted as a broad NO-GO record.
 The C1 Social Trust Intake Handoff Gate Decision remains accepted as the historical narrow GO record for one later implementation-repo PR only.
 The C1 Social Trust Intake Persistence Closeout Ledger records that the one later implementation-repo PR was consumed by `mt4110/pi-musubi-core` PR #82.
-The current runtime implementation gate result is NO-GO after that narrow intake persistence allowance was consumed.
-The closeout ledger does not authorize broad runtime implementation, pi-musubi-core changes, DDL, migrations, runtime tests, gate invocation, implementation handoff, Social Trust mutation facts, scores, weights, ranks, display levels, Relationship Depth work, proof / room / discovery / recommendation / settlement / Promise behavior, public API, mobile UI, or projection refresh work.
+The C2 bounded Promise reliability implementation handoff gate is accepted as a narrow GO for one later implementation-repo PR only.
+The current runtime implementation gate result is NARROW GO FOR ONE LATER IMPLEMENTATION-REPO PR, limited to C2 bounded Promise reliability categorical Social Trust mutation fact persistence in `mt4110/pi-musubi-core`.
+That one-use allowance authorizes additive `social_trust` schema persistence, backend-local Social Trust domain / service code, and deterministic backend tests only inside that narrow PR.
+It does not authorize broad runtime implementation, numeric Social Trust weights, score deltas, ranks, public display, projection refresh, discovery / recommendation use, room progression, settlement behavior, Promise runtime behavior, proof runtime behavior outside accepted source references, public API, mobile UI, Relationship Depth work, paid romantic advantage, or any implementation outside the C2 bounded Promise reliability persistence envelope.
 
 The C2 bounded Promise reliability readiness chain is accepted for docs-only foundation semantic scope:
 
@@ -166,13 +169,15 @@ The C2 bounded Promise reliability readiness chain is accepted for docs-only fou
 - `docs/readiness/c2_bounded_promise_reliability_mutation_prereqs.md`
 - `docs/readiness/c2_bounded_promise_reliability_mutation_fact_gate_readiness.md`
 - `docs/readiness/c2_bounded_promise_reliability_mutation_fact_gate.md`
+- `docs/readiness/c2_bounded_promise_reliability_implementation_handoff_gate.md`
 
 The accepted C2 gate records `bounded_promise_reliability` as the only positive Social Trust source-family candidate and accepts exact source facts and exact Social Trust mutation facts only as foundation semantic labels.
 Those labels are not runtime schema names, enum values, API names, migration names, module names, or test names.
-The C2 gate does not authorize runtime implementation, DDL, migrations, runtime tests, gate invocation, implementation handoff, numeric Social Trust weights, score deltas, public Social Trust display, projection refresh, discovery / recommendation use, room progression, settlement behavior, Promise runtime behavior, public API, mobile UI, or pi-musubi-core changes beyond this docs-only lock alignment.
+The C2 implementation handoff gate authorizes only categorical persistence of those accepted source and mutation facts in one later implementation-repo PR.
+Accepted source and mutation fact labels must remain categorical internal writer facts only; they must not become scores, weights, ranks, display levels, public status, projection refresh, discovery / recommendation inputs, room transitions, settlement progression, Promise runtime behavior, public API, mobile UI, or Relationship Depth behavior.
 
 Foundation PR #106 selected this repository and this file as the candidate downstream alignment scope after PR #104.
-PR #106 itself is a foundation-side scope record for this lock update; it does not add runtime implementation authority.
+Foundation PR #108 provides the narrow downstream implementation handoff authority for the C2 bounded Promise reliability persistence slice.
 
 Implementation merge history, issue order, branch ancestry, and existing code are not foundation design proof.
 
@@ -330,12 +335,12 @@ The C1 Social Trust Intake Persistence Closeout Ledger is accepted as a docs-onl
 
 - `docs/readiness/c1_social_trust_intake_persistence_closeout_ledger.md`
 
-The runtime implementation gate result is now `NO-GO`.
-The prior `NARROW GO FOR ONE LATER IMPLEMENTATION-REPO PR` has been consumed by `mt4110/pi-musubi-core` PR #82.
+The C1 runtime implementation gate result returned to `NO-GO` after the C1 intake allowance was consumed.
+The prior C1 `NARROW GO FOR ONE LATER IMPLEMENTATION-REPO PR` was consumed by `mt4110/pi-musubi-core` PR #82.
 The C1 intake persistence slice is closed.
 No remaining work may inherit permission from foundation PR #92 or implementation PR #82.
-Any next slice must be defined by a separate accepted foundation decision before implementation work proceeds.
-This lock update itself does not add runtime code, DDL, migrations, runtime tests, public API, mobile UI, projection refresh work, or Social Trust mutation behavior.
+The C2 bounded Promise reliability implementation handoff gate now provides a separate accepted narrow GO for one later implementation-repo PR only.
+That C2 allowance is limited to categorical Social Trust mutation fact persistence and excludes broad runtime code, public API, mobile UI, projection refresh, numeric Social Trust behavior, display, Relationship Depth, discovery, recommendation, room progression, settlement behavior, and Promise runtime behavior.
 
 ---
 
@@ -363,11 +368,11 @@ When updating:
 - Review completed by:
 
 ### Current drift note
-- Updated from foundation SHA: `cff85a6c55b9094cb5fcc223f3d0a7a918a29def` -> `00409c3b7384b3e2330d662bba1a481e09d3b3ec`
-- Reason: Align implementation-repo lock with the accepted foundation state after PR #104 (`docs: define C2 bounded Promise reliability mutation-fact gate`). Foundation PR #106 selected this downstream lock alignment scope.
-- New required docs: C1 to C2 Social Trust writer facts next-slice evaluation; C2 Social Trust source-family gate; C2 bounded Promise reliability mutation prerequisites; C2 bounded Promise reliability mutation-fact gate readiness; C2 bounded Promise reliability mutation-fact gate.
+- Updated from foundation SHA: `00409c3b7384b3e2330d662bba1a481e09d3b3ec` -> `86362a6bf1b6bf15abc1125fb2e5b90ad022ebfb`
+- Reason: Align implementation-repo lock with the accepted foundation state after PR #108 (`docs: define C2 bounded Promise reliability implementation handoff gate`).
+- New required docs: C2 bounded Promise reliability implementation handoff gate.
 - Removed docs: None.
-- Implementation impact: Docs-only lock alignment. The C2 gate accepts exact bounded Promise reliability source facts and exact Social Trust mutation facts only as foundation semantic labels. Runtime implementation remains NO-GO. Broad runtime implementation, pi-musubi-core changes beyond this lock alignment, DDL, migrations, runtime tests, gate invocation, implementation handoff, numeric Social Trust weights, score deltas, public display, projection refresh, Relationship Depth, proof-derived mutation paths outside the accepted gate, room progression, discovery, recommendation, settlement, Promise runtime behavior, public API, and mobile UI remain blocked.
+- Implementation impact: Narrow implementation handoff accepted for one later `pi-musubi-core` PR only. The allowed slice is C2 bounded Promise reliability categorical Social Trust mutation fact persistence, including additive `social_trust` schema persistence, backend-local domain / service code, and deterministic backend tests. Broad runtime implementation, numeric Social Trust weights, score deltas, ranks, public display, projection refresh, Relationship Depth, proof-derived mutation paths outside accepted source references, room progression, discovery, recommendation, settlement, Promise runtime behavior, public API, mobile UI, and paid romantic advantage remain blocked.
 - Review completed by: Masaki Takemura
 
 ---


### PR DESCRIPTION
## Summary
- Pin `docs/foundation_lock.md` to the accepted foundation PR #108 merge commit `86362a6bf1b6bf15abc1125fb2e5b90ad022ebfb`.
- Add the C2 bounded Promise reliability domain contract for exact accepted source facts, exact categorical mutation facts, rejected sources, and fail-closed boundary checks.
- Add backend-local persistence for C2 categorical Social Trust mutation facts under `social_trust`, with PostgreSQL-enforced idempotency, payload-drift checks, R4 retention, and no projection refresh.
- Preserve the exact freeze path: `promise_reliability_outcome.review_required_boundary_intersection` requires an unresolved boundary, may persist only `social_trust_mutation.bounded_promise_reliability_freeze`, and stores the exact `boundary_intersection_label` for replay/review.
- Include `boundary_intersection_label` in duplicate-delivery drift detection so the same idempotency key cannot silently change the frozen boundary reason.
- Document the C2 persistence envelope and update backend package/schema notes.

## Non-Authority
- No Social Trust score, weight, rank, public display, projection refresh, discovery/recommendation use, room progression, settlement behavior, Promise runtime behavior, public API, mobile UI, or Relationship Depth work.
- Rejected sources and projection-only authority fail before persistence.
- Unresolved Consent / block / Withdrawal / Age Assurance / Legal Hold / Critical Harm / lifecycle / safety boundaries cannot produce positive Social Trust; the accepted review-required boundary source produces only an internal categorical freeze fact.

## Checks
- `cargo test`
- `cargo check`
- `cargo test -p musubi_social_trust_domain`
- `cargo test --test c2_bounded_promise_reliability_persistence`
- fresh local schema reset for migration 0021 validation
- `git diff --check`

Closes #87