### PR TITLE
feat: add post-C2 Social Trust non-consumption guard

### DIFF
--- a/apps/backend/crates/social-trust-domain/src/lib.rs
+++ b/apps/backend/crates/social-trust-domain/src/lib.rs
@@ -587,6 +587,113 @@ impl C2BoundedPromiseReliabilityMutationDecision {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct C2CategoricalFactConsumptionAttempt {
+    pub source_fact: C2BoundedPromiseReliabilitySourceFact,
+    pub mutation_fact: C2BoundedPromiseReliabilityMutationFact,
+    pub target: C2CategoricalFactConsumptionTarget,
+    pub authority_posture: SocialTrustAuthorityPosture,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum C2CategoricalFactConsumptionTarget {
+    InternalWriterFactReference,
+    NumericSocialTrustScore,
+    SocialTrustScoreDelta,
+    SocialTrustWeight,
+    SocialTrustRank,
+    SocialTrustDisplayLevel,
+    SocialTrustPublicLevel,
+    PublicSocialTrustDisplay,
+    RecoveryCeiling,
+    DiscoveryPriority,
+    RecommendationBoost,
+    ContactUnlock,
+    RoomTransition,
+    SettlementProgression,
+    PromiseRuntimeOutcome,
+    ProofRuntimeOutcome,
+    RelationshipDepthFact,
+    ProjectionRefresh,
+    PublicApiResponse,
+    MobileUiState,
+}
+
+impl C2CategoricalFactConsumptionTarget {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::InternalWriterFactReference => "internal_writer_fact_reference",
+            Self::NumericSocialTrustScore => "numeric_social_trust_score",
+            Self::SocialTrustScoreDelta => "social_trust_score_delta",
+            Self::SocialTrustWeight => "social_trust_weight",
+            Self::SocialTrustRank => "social_trust_rank",
+            Self::SocialTrustDisplayLevel => "social_trust_display_level",
+            Self::SocialTrustPublicLevel => "social_trust_public_level",
+            Self::PublicSocialTrustDisplay => "public_social_trust_display",
+            Self::RecoveryCeiling => "recovery_ceiling",
+            Self::DiscoveryPriority => "discovery_priority",
+            Self::RecommendationBoost => "recommendation_boost",
+            Self::ContactUnlock => "contact_unlock",
+            Self::RoomTransition => "room_transition",
+            Self::SettlementProgression => "settlement_progression",
+            Self::PromiseRuntimeOutcome => "promise_runtime_outcome",
+            Self::ProofRuntimeOutcome => "proof_runtime_outcome",
+            Self::RelationshipDepthFact => "relationship_depth_fact",
+            Self::ProjectionRefresh => "projection_refresh",
+            Self::PublicApiResponse => "public_api_response",
+            Self::MobileUiState => "mobile_ui_state",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum C2CategoricalFactConsumptionDecision {
+    AllowInternalWriterFactReference {
+        source_fact: C2BoundedPromiseReliabilitySourceFact,
+        mutation_fact: C2BoundedPromiseReliabilityMutationFact,
+    },
+    Reject(C2CategoricalFactConsumptionRejection),
+}
+
+impl C2CategoricalFactConsumptionDecision {
+    pub const fn kind(&self) -> &'static str {
+        match self {
+            Self::AllowInternalWriterFactReference { .. } => "allow_internal_writer_fact_reference",
+            Self::Reject(_) => "rejected",
+        }
+    }
+
+    pub const fn rejection_reason_code(&self) -> Option<&'static str> {
+        match self {
+            Self::AllowInternalWriterFactReference { .. } => None,
+            Self::Reject(rejection) => Some(rejection.as_str()),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum C2CategoricalFactConsumptionRejection {
+    SourceMutationMismatch {
+        source: C2BoundedPromiseReliabilitySourceFact,
+        requested: C2BoundedPromiseReliabilityMutationFact,
+        expected: C2BoundedPromiseReliabilityMutationFact,
+    },
+    ProjectionOnlyAuthority,
+    BlockedConsumptionTarget {
+        target: C2CategoricalFactConsumptionTarget,
+    },
+}
+
+impl C2CategoricalFactConsumptionRejection {
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::SourceMutationMismatch { .. } => "source_mutation_mismatch",
+            Self::ProjectionOnlyAuthority => "projection_only_authority",
+            Self::BlockedConsumptionTarget { .. } => "blocked_consumption_target",
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum C2BoundedPromiseReliabilityRejection {
     RejectedSourceFact {
@@ -1044,6 +1151,41 @@ pub fn decide_c2_bounded_promise_reliability_mutation(
         mutation_fact: requested_mutation,
         direction: requested_mutation.direction(),
         magnitude: requested_mutation.magnitude(),
+    }
+}
+
+#[must_use]
+pub fn decide_c2_categorical_fact_consumption(
+    attempt: &C2CategoricalFactConsumptionAttempt,
+) -> C2CategoricalFactConsumptionDecision {
+    let expected_mutation = attempt.source_fact.expected_mutation();
+    if attempt.mutation_fact != expected_mutation {
+        return C2CategoricalFactConsumptionDecision::Reject(
+            C2CategoricalFactConsumptionRejection::SourceMutationMismatch {
+                source: attempt.source_fact,
+                requested: attempt.mutation_fact,
+                expected: expected_mutation,
+            },
+        );
+    }
+
+    if attempt.authority_posture == SocialTrustAuthorityPosture::ProjectionOnly {
+        return C2CategoricalFactConsumptionDecision::Reject(
+            C2CategoricalFactConsumptionRejection::ProjectionOnlyAuthority,
+        );
+    }
+
+    if attempt.target != C2CategoricalFactConsumptionTarget::InternalWriterFactReference {
+        return C2CategoricalFactConsumptionDecision::Reject(
+            C2CategoricalFactConsumptionRejection::BlockedConsumptionTarget {
+                target: attempt.target,
+            },
+        );
+    }
+
+    C2CategoricalFactConsumptionDecision::AllowInternalWriterFactReference {
+        source_fact: attempt.source_fact,
+        mutation_fact: attempt.mutation_fact,
     }
 }
 

--- a/apps/backend/crates/social-trust-domain/tests/post_c2_non_consumption_guard_contract.rs
+++ b/apps/backend/crates/social-trust-domain/tests/post_c2_non_consumption_guard_contract.rs
@@ -1,0 +1,214 @@
+use musubi_social_trust_domain::{
+    C2BoundedPromiseReliabilityMutationFact, C2BoundedPromiseReliabilitySourceFact,
+    C2CategoricalFactConsumptionAttempt, C2CategoricalFactConsumptionDecision,
+    C2CategoricalFactConsumptionRejection, C2CategoricalFactConsumptionTarget,
+    SocialTrustAuthorityPosture, decide_c2_categorical_fact_consumption,
+};
+
+#[test]
+fn exact_c2_pairs_may_remain_internal_writer_fact_references_only() {
+    for (source_fact, mutation_fact) in accepted_mappings() {
+        let attempt = attempt(
+            source_fact,
+            mutation_fact,
+            C2CategoricalFactConsumptionTarget::InternalWriterFactReference,
+        );
+
+        assert_eq!(
+            decide_c2_categorical_fact_consumption(&attempt),
+            C2CategoricalFactConsumptionDecision::AllowInternalWriterFactReference {
+                source_fact,
+                mutation_fact,
+            }
+        );
+    }
+}
+
+#[test]
+fn wrong_source_mutation_pair_fails_closed() {
+    for (source_fact, expected) in accepted_mappings() {
+        for requested in accepted_mutation_facts() {
+            if requested == expected {
+                continue;
+            }
+
+            let attempt = attempt(
+                source_fact,
+                requested,
+                C2CategoricalFactConsumptionTarget::InternalWriterFactReference,
+            );
+
+            assert_eq!(
+                decide_c2_categorical_fact_consumption(&attempt),
+                C2CategoricalFactConsumptionDecision::Reject(
+                    C2CategoricalFactConsumptionRejection::SourceMutationMismatch {
+                        source: source_fact,
+                        requested,
+                        expected,
+                    }
+                )
+            );
+        }
+    }
+}
+
+#[test]
+fn blocked_consumption_targets_fail_closed_for_all_c2_facts() {
+    for (source_fact, mutation_fact) in accepted_mappings() {
+        for target in blocked_targets() {
+            let attempt = attempt(source_fact, mutation_fact, target);
+
+            assert_eq!(
+                decide_c2_categorical_fact_consumption(&attempt),
+                C2CategoricalFactConsumptionDecision::Reject(
+                    C2CategoricalFactConsumptionRejection::BlockedConsumptionTarget { target }
+                ),
+                "target {} must remain blocked for {} / {}",
+                target.as_str(),
+                source_fact.as_str(),
+                mutation_fact.as_str(),
+            );
+        }
+    }
+}
+
+#[test]
+fn no_effect_freeze_narrowing_and_recovery_do_not_escape_to_external_effects() {
+    for (source_fact, mutation_fact) in [
+        (
+            C2BoundedPromiseReliabilitySourceFact::ValidExcusedExit,
+            C2BoundedPromiseReliabilityMutationFact::NoEffectValidExcusedExit,
+        ),
+        (
+            C2BoundedPromiseReliabilitySourceFact::ReviewRequiredBoundaryIntersection,
+            C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityFreeze,
+        ),
+        (
+            C2BoundedPromiseReliabilitySourceFact::SourceScopeLimitedAfterReview,
+            C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityNarrowing,
+        ),
+        (
+            C2BoundedPromiseReliabilitySourceFact::FreezeOrNarrowingReversedAfterReview,
+            C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityRecovery,
+        ),
+    ] {
+        for target in [
+            C2CategoricalFactConsumptionTarget::NumericSocialTrustScore,
+            C2CategoricalFactConsumptionTarget::PublicSocialTrustDisplay,
+            C2CategoricalFactConsumptionTarget::RecommendationBoost,
+            C2CategoricalFactConsumptionTarget::ContactUnlock,
+            C2CategoricalFactConsumptionTarget::RelationshipDepthFact,
+            C2CategoricalFactConsumptionTarget::ProjectionRefresh,
+        ] {
+            let attempt = attempt(source_fact, mutation_fact, target);
+
+            assert_eq!(
+                decide_c2_categorical_fact_consumption(&attempt),
+                C2CategoricalFactConsumptionDecision::Reject(
+                    C2CategoricalFactConsumptionRejection::BlockedConsumptionTarget { target }
+                )
+            );
+        }
+    }
+}
+
+#[test]
+fn projection_only_authority_fails_closed_even_for_internal_reference() {
+    let mut attempt = attempt(
+        C2BoundedPromiseReliabilitySourceFact::CompletedAsAgreed,
+        C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityPositive,
+        C2CategoricalFactConsumptionTarget::InternalWriterFactReference,
+    );
+    attempt.authority_posture = SocialTrustAuthorityPosture::ProjectionOnly;
+
+    assert_eq!(
+        decide_c2_categorical_fact_consumption(&attempt),
+        C2CategoricalFactConsumptionDecision::Reject(
+            C2CategoricalFactConsumptionRejection::ProjectionOnlyAuthority
+        )
+    );
+}
+
+fn attempt(
+    source_fact: C2BoundedPromiseReliabilitySourceFact,
+    mutation_fact: C2BoundedPromiseReliabilityMutationFact,
+    target: C2CategoricalFactConsumptionTarget,
+) -> C2CategoricalFactConsumptionAttempt {
+    C2CategoricalFactConsumptionAttempt {
+        source_fact,
+        mutation_fact,
+        target,
+        authority_posture: SocialTrustAuthorityPosture::WriterTruthOnly,
+    }
+}
+
+fn accepted_mappings() -> Vec<(
+    C2BoundedPromiseReliabilitySourceFact,
+    C2BoundedPromiseReliabilityMutationFact,
+)> {
+    vec![
+        (
+            C2BoundedPromiseReliabilitySourceFact::CompletedAsAgreed,
+            C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityPositive,
+        ),
+        (
+            C2BoundedPromiseReliabilitySourceFact::CompletedAfterGovernedReview,
+            C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityPositive,
+        ),
+        (
+            C2BoundedPromiseReliabilitySourceFact::ValidExcusedExit,
+            C2BoundedPromiseReliabilityMutationFact::NoEffectValidExcusedExit,
+        ),
+        (
+            C2BoundedPromiseReliabilitySourceFact::SourceFactCorrected,
+            C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityCorrection,
+        ),
+        (
+            C2BoundedPromiseReliabilitySourceFact::ReviewRequiredBoundaryIntersection,
+            C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityFreeze,
+        ),
+        (
+            C2BoundedPromiseReliabilitySourceFact::SourceScopeLimitedAfterReview,
+            C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityNarrowing,
+        ),
+        (
+            C2BoundedPromiseReliabilitySourceFact::FreezeOrNarrowingReversedAfterReview,
+            C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityRecovery,
+        ),
+    ]
+}
+
+fn accepted_mutation_facts() -> Vec<C2BoundedPromiseReliabilityMutationFact> {
+    vec![
+        C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityPositive,
+        C2BoundedPromiseReliabilityMutationFact::NoEffectValidExcusedExit,
+        C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityCorrection,
+        C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityFreeze,
+        C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityNarrowing,
+        C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityRecovery,
+    ]
+}
+
+fn blocked_targets() -> Vec<C2CategoricalFactConsumptionTarget> {
+    vec![
+        C2CategoricalFactConsumptionTarget::NumericSocialTrustScore,
+        C2CategoricalFactConsumptionTarget::SocialTrustScoreDelta,
+        C2CategoricalFactConsumptionTarget::SocialTrustWeight,
+        C2CategoricalFactConsumptionTarget::SocialTrustRank,
+        C2CategoricalFactConsumptionTarget::SocialTrustDisplayLevel,
+        C2CategoricalFactConsumptionTarget::SocialTrustPublicLevel,
+        C2CategoricalFactConsumptionTarget::PublicSocialTrustDisplay,
+        C2CategoricalFactConsumptionTarget::RecoveryCeiling,
+        C2CategoricalFactConsumptionTarget::DiscoveryPriority,
+        C2CategoricalFactConsumptionTarget::RecommendationBoost,
+        C2CategoricalFactConsumptionTarget::ContactUnlock,
+        C2CategoricalFactConsumptionTarget::RoomTransition,
+        C2CategoricalFactConsumptionTarget::SettlementProgression,
+        C2CategoricalFactConsumptionTarget::PromiseRuntimeOutcome,
+        C2CategoricalFactConsumptionTarget::ProofRuntimeOutcome,
+        C2CategoricalFactConsumptionTarget::RelationshipDepthFact,
+        C2CategoricalFactConsumptionTarget::ProjectionRefresh,
+        C2CategoricalFactConsumptionTarget::PublicApiResponse,
+        C2CategoricalFactConsumptionTarget::MobileUiState,
+    ]
+}

--- a/apps/backend/docs/post_c2_social_trust_categorical_fact_non_consumption_guard.md
+++ b/apps/backend/docs/post_c2_social_trust_categorical_fact_non_consumption_guard.md
@@ -1,0 +1,59 @@
+# Post-C2 Social Trust Categorical Fact Non-Consumption Guard
+
+Status: implementation note for the narrow post-C2 non-consumption guard slice.
+
+Design source:
+- `docs/foundation_lock.md`
+- upstream `docs/readiness/post_c2_implementation_handoff_evidence_package.md`
+- upstream `docs/readiness/post_c2_non_consumption_guard_handoff_gate_decision.md`
+
+This note describes only backend-local guard behavior.
+It is not a new source-fact design, mutation-fact design, persistence design, migration design, public API design, projection refresh design, display design, scoring design, Relationship Depth design, or implementation handoff for another slice.
+
+## Scope
+
+This slice guards only already accepted C2 categorical Social Trust facts:
+
+- accepted C2 bounded Promise reliability source fact labels
+- accepted C2 categorical Social Trust mutation fact labels
+
+The implementation lives in:
+
+- `musubi_social_trust_domain` for the pure non-consumption decision contract
+- deterministic social-trust-domain contract tests
+
+It does not add database records, migrations, handlers, projection refresh, public API routes, mobile UI, runtime orchestration, new crates, or new dependencies.
+
+## Allowed Internal Use
+
+Accepted C2 categorical facts may remain internal writer fact references.
+
+They may not become:
+
+- numeric Social Trust score
+- Social Trust score delta
+- Social Trust weight
+- Social Trust rank
+- Social Trust display level
+- public Social Trust display
+- recovery ceiling
+- discovery priority
+- recommendation boost
+- contact unlock
+- room transition
+- settlement progression
+- Promise runtime outcome
+- proof runtime outcome
+- Relationship Depth fact
+- projection refresh trigger
+- public API response
+- mobile UI state
+
+## Non-Authority
+
+Projection, analytics, observability, model output, client state, frontend state, payment, Support, popularity, engagement, recommendation, discovery, proof callback alone, vendor callback alone, operator notes, support tickets, issue comments, and implementation convenience remain non-authority.
+
+Social Trust and Relationship Depth remain distinct.
+Accepted C2 categorical Social Trust facts do not deepen Relationship Depth.
+
+Everything outside this non-consumption guard remains blocked until a later accepted foundation decision narrows it.

--- a/docs/foundation_lock.md
+++ b/docs/foundation_lock.md
@@ -1,6 +1,6 @@
 # Foundation Lock
 
-Status: Draft; aligned to accepted foundation commit `69b7aa4`
+Status: Draft; aligned to accepted foundation commit `64d6348`
 Applies to: `mt4110/pi-musubi-core`
 Purpose: Pin the constitutional and architectural source of truth that this implementation repository must follow.
 
@@ -26,16 +26,18 @@ Upstream repository:
 Pinned reference for implementation work:
 
 - Foundation reference type: `commit`
-- Foundation commit SHA: `69b7aa49c3239780b8722c2f09f7e5213a0f6355`
-- Foundation commit title: `Merge pull request #116 from mt4110/feat/evaluate-post-c2-runtime-handoff-gate`
-- Foundation PR title: `docs: evaluate post-C2 runtime handoff gate`
-- Foundation PR URL: `https://github.com/mt4110/musubi-foundation/pull/116`
+- Foundation commit SHA: `64d634862df48d725c4a13097d52f9c0455f6cee`
+- Foundation commit title: `Merge pull request #124 from mt4110/feat/evaluate-post-c2-non-consumption-guard-handoff`
+- Foundation PR title: `docs: evaluate post-C2 non-consumption guard handoff`
+- Foundation PR URL: `https://github.com/mt4110/musubi-foundation/pull/124`
 - Date pinned: `2026-05-14`
 - Pinned by: `Masaki Takemura`
-- Pinned commit URL: `https://github.com/mt4110/musubi-foundation/commit/69b7aa49c3239780b8722c2f09f7e5213a0f6355`
-- Previous pinned reference: `86362a6` / `Merge pull request #108 from mt4110/feat/define-c2-bounded-promise-reliability-implementation-handoff-gate`
+- Pinned commit URL: `https://github.com/mt4110/musubi-foundation/commit/64d634862df48d725c4a13097d52f9c0455f6cee`
+- Previous pinned reference: `69b7aa4` / `Merge pull request #116 from mt4110/feat/evaluate-post-c2-runtime-handoff-gate`
 - Post-C2 evidence source: `cfdba28` / `Merge pull request #114 from mt4110/feat/post-c2-runtime-handoff-evidence-package`
 - Alignment allowance source: `69b7aa4` / `Merge pull request #116 from mt4110/feat/evaluate-post-c2-runtime-handoff-gate`
+- Post-C2 implementation handoff evidence source: `ef23e88` / `Merge pull request #122 from mt4110/feat/post-c2-implementation-handoff-evidence-package`
+- Post-C2 non-consumption guard handoff source: `64d6348` / `Merge pull request #124 from mt4110/feat/evaluate-post-c2-non-consumption-guard-handoff`
 
 No release tag is asserted for this alignment.
 Do not invent a foundation version label for this commit.
@@ -114,31 +116,35 @@ Before coding, read these upstream documents in order.
 58. `docs/readiness/post_c2_next_foundation_slice_evaluation.md`
 59. `docs/readiness/post_c2_runtime_handoff_evidence_package.md`
 60. `docs/readiness/post_c2_runtime_handoff_gate_decision.md`
+61. `docs/readiness/post_c2_foundation_lock_alignment_closeout_ledger.md`
+62. `docs/readiness/post_c2_implementation_handoff_gate_decision.md`
+63. `docs/readiness/post_c2_implementation_handoff_evidence_package.md`
+64. `docs/readiness/post_c2_non_consumption_guard_handoff_gate_decision.md`
 
 ### Detail layer
-61. `docs/detail/accountability_matrix.md`
-62. `docs/detail/critical_incident_and_loss.md`
-63. `docs/detail/automated_decisioning_and_human_appeal.md`
-64. `docs/detail/youth_safety_and_age_assurance.md`
-65. `docs/detail/off_platform_handoff_and_scam_prevention.md`
-66. `docs/detail/data_deletion_vs_legal_hold.md`
-67. `docs/detail/realm_model.md`
-68. `docs/detail/data_scope_model.md`
-69. `docs/detail/mobility_model.md`
-70. `docs/detail/settlement_model.md`
-71. `docs/detail/settlement_backend_trait.md`
-72. `docs/detail/proof_of_infrastructure.md`
-73. `docs/detail/protected_groups_and_translation_safety.md`
+65. `docs/detail/accountability_matrix.md`
+66. `docs/detail/critical_incident_and_loss.md`
+67. `docs/detail/automated_decisioning_and_human_appeal.md`
+68. `docs/detail/youth_safety_and_age_assurance.md`
+69. `docs/detail/off_platform_handoff_and_scam_prevention.md`
+70. `docs/detail/data_deletion_vs_legal_hold.md`
+71. `docs/detail/realm_model.md`
+72. `docs/detail/data_scope_model.md`
+73. `docs/detail/mobility_model.md`
+74. `docs/detail/settlement_model.md`
+75. `docs/detail/settlement_backend_trait.md`
+76. `docs/detail/proof_of_infrastructure.md`
+77. `docs/detail/protected_groups_and_translation_safety.md`
 
 ### Whitepaper layer (contextual, not higher than detail/ADR)
-74. `docs/whitepaper/01_executive_summary.md`
-75. `docs/whitepaper/02_realm_model.md`
-76. `docs/whitepaper/03_experience_model.md`
-77. `docs/whitepaper/04_dm_shield.md`
-78. `docs/whitepaper/05_trust_model.md`
-79. `docs/whitepaper/06_promise_protocol.md`
-80. `docs/whitepaper/07_realm_economy.md`
-81. `docs/whitepaper/08_unlock_engine.md`
+78. `docs/whitepaper/01_executive_summary.md`
+79. `docs/whitepaper/02_realm_model.md`
+80. `docs/whitepaper/03_experience_model.md`
+81. `docs/whitepaper/04_dm_shield.md`
+82. `docs/whitepaper/05_trust_model.md`
+83. `docs/whitepaper/06_promise_protocol.md`
+84. `docs/whitepaper/07_realm_economy.md`
+85. `docs/whitepaper/08_unlock_engine.md`
 
 If any of the above are unavailable or materially inconsistent, stop and escalate.
 
@@ -182,6 +188,10 @@ The C2 bounded Promise reliability readiness and closeout chain is accepted for 
 - `docs/readiness/post_c2_next_foundation_slice_evaluation.md`
 - `docs/readiness/post_c2_runtime_handoff_evidence_package.md`
 - `docs/readiness/post_c2_runtime_handoff_gate_decision.md`
+- `docs/readiness/post_c2_foundation_lock_alignment_closeout_ledger.md`
+- `docs/readiness/post_c2_implementation_handoff_gate_decision.md`
+- `docs/readiness/post_c2_implementation_handoff_evidence_package.md`
+- `docs/readiness/post_c2_non_consumption_guard_handoff_gate_decision.md`
 
 The accepted C2 gate records `bounded_promise_reliability` as the only positive Social Trust source-family candidate and accepts exact source facts and exact Social Trust mutation facts only as foundation semantic labels.
 Those labels are not runtime schema names, enum values, API names, migration names, module names, or test names.
@@ -190,10 +200,14 @@ Accepted source and mutation fact labels must remain categorical internal writer
 
 Foundation PR #106 selected this repository and this file as the candidate downstream alignment scope after PR #104.
 Foundation PR #108 provided the consumed narrow downstream implementation handoff authority for the C2 bounded Promise reliability persistence slice.
-Foundation PR #116 provides the current narrow downstream allowance for one docs-only foundation lock alignment PR in this repository, limited to `docs/foundation_lock.md`.
-This alignment update is the intended downstream consumer of that one-use allowance.
-It does not authorize implementation handoff, runtime implementation, DDL, migrations, runtime tests, backend code, public API, mobile UI, projection refresh, runtime orchestration, discovery, recommendation, room, settlement, Promise runtime, proof runtime, Relationship Depth, Social Trust scoring, public trust display, or any broader `pi-musubi-core` change.
-After this alignment PR is merged, foundation must record a closeout ledger before any implementation handoff gate may be considered.
+Foundation PR #116 provided the narrow downstream allowance for one docs-only foundation lock alignment PR in this repository, limited to `docs/foundation_lock.md`.
+That allowance was consumed by `mt4110/pi-musubi-core` PR #90 and closed out by foundation PR #118.
+Foundation PR #120 preserved implementation handoff NO-GO until exact slice evidence existed.
+Foundation PR #122 accepted the exact candidate implementation slice as the post-C2 Social Trust categorical fact non-consumption guard.
+Foundation PR #124 provides the current narrow downstream implementation handoff authority for one later implementation-repo PR only, limited to the post-C2 Social Trust categorical fact non-consumption guard.
+This update is the required lock pin for that one-use allowance.
+It does not authorize implementation outside the PR #124 envelope.
+It does not authorize new source facts, new mutation facts, DDL, migrations, backend README updates, public API, mobile UI, projection refresh, runtime orchestration, discovery, recommendation, room, settlement, Promise runtime, proof runtime, Relationship Depth, Social Trust scoring, public trust display, or any broader `pi-musubi-core` change.
 
 Implementation merge history, issue order, branch ancestry, and existing code are not foundation design proof.
 
@@ -357,9 +371,11 @@ The C1 intake persistence slice is closed.
 No remaining work may inherit permission from foundation PR #92 or implementation PR #82.
 The C2 bounded Promise reliability implementation handoff gate provided a separate accepted narrow GO for one later implementation-repo PR only.
 That C2 implementation allowance was consumed by `mt4110/pi-musubi-core` PR #88 and is closed.
-The post-C2 runtime handoff evidence package and gate decision now preserve runtime NO-GO while allowing only one downstream docs-only foundation lock alignment PR in this repository.
-This lock alignment update is limited to `docs/foundation_lock.md`.
-It does not authorize runtime code, backend code, public API, mobile UI, projection refresh, numeric Social Trust behavior, display, Relationship Depth, discovery, recommendation, room progression, settlement behavior, Promise runtime behavior, proof runtime behavior, DDL, migrations, or runtime tests.
+The post-C2 runtime handoff evidence package and gate decision preserved runtime NO-GO while allowing only one downstream docs-only foundation lock alignment PR in this repository.
+That post-C2 lock alignment allowance was consumed by `mt4110/pi-musubi-core` PR #90 and closed out by foundation PR #118.
+The post-C2 implementation handoff evidence package and handoff gate now authorize one later implementation-repo PR only for the post-C2 Social Trust categorical fact non-consumption guard.
+This implementation is limited to backend-local guard behavior and deterministic verification that already accepted C2 categorical Social Trust facts cannot be consumed as scores, weights, ranks, display, projection refresh, discovery / recommendation inputs, contact unlocks, room transitions, settlement progression, Promise runtime behavior, proof runtime behavior, public API, mobile UI, or Relationship Depth behavior.
+It does not authorize new source facts, new mutation facts, DDL, migrations, backend README updates, public API, mobile UI, projection refresh, runtime orchestration, discovery, recommendation, room progression, settlement behavior, Promise runtime behavior, proof runtime behavior, Relationship Depth, Social Trust scoring, public trust display, or broad runtime implementation.
 
 ---
 
@@ -387,11 +403,11 @@ When updating:
 - Review completed by:
 
 ### Current drift note
-- Updated from foundation SHA: `86362a6bf1b6bf15abc1125fb2e5b90ad022ebfb` -> `69b7aa49c3239780b8722c2f09f7e5213a0f6355`
-- Reason: Align implementation-repo lock with the accepted foundation state after PR #116 (`docs: evaluate post-C2 runtime handoff gate`).
-- New required docs: C2 bounded Promise reliability foundation lock alignment scope; C2 bounded Promise reliability mutation fact persistence closeout ledger; post-C2 next foundation slice evaluation; post-C2 runtime handoff evidence package; post-C2 runtime handoff gate decision.
+- Updated from foundation SHA: `69b7aa49c3239780b8722c2f09f7e5213a0f6355` -> `64d634862df48d725c4a13097d52f9c0455f6cee`
+- Reason: Align implementation-repo lock with the accepted foundation state after PR #124 (`docs: evaluate post-C2 non-consumption guard handoff`).
+- New required docs: Post-C2 foundation lock alignment closeout ledger; post-C2 implementation handoff gate decision; post-C2 implementation handoff evidence package; post-C2 non-consumption guard handoff gate decision.
 - Removed docs: None.
-- Implementation impact: The prior C2 narrow implementation allowance was consumed by `mt4110/pi-musubi-core` PR #88 and is closed. Runtime implementation is NO-GO. PR #116 authorizes only one docs-only foundation lock alignment PR in `mt4110/pi-musubi-core`, limited to `docs/foundation_lock.md`; this update is the intended consumer of that allowance. Implementation handoff, DDL, migrations, runtime tests, backend code, public API, mobile UI, projection refresh, runtime orchestration, Relationship Depth, proof runtime behavior, room progression, discovery, recommendation, settlement, Promise runtime behavior, Social Trust scoring, public trust display, and paid romantic advantage remain blocked.
+- Implementation impact: PR #124 authorizes one later implementation-repo PR only for the post-C2 Social Trust categorical fact non-consumption guard. This PR may add backend-local guard behavior and deterministic verification inside the PR #124 envelope. New source facts, new mutation facts, DDL, migrations, backend README updates, public API, mobile UI, projection refresh, runtime orchestration, Relationship Depth, proof runtime behavior, room progression, discovery, recommendation, settlement, Promise runtime behavior, Social Trust scoring, public trust display, and paid romantic advantage remain blocked.
 - Review completed by: Masaki Takemura
 
 ---


### PR DESCRIPTION
## Summary
- pins docs/foundation_lock.md to musubi-foundation PR #124 / commit 64d634862df48d725c4a13097d52f9c0455f6cee
- adds a pure social-trust-domain guard that allows accepted C2 categorical facts to remain internal writer fact references only
- adds deterministic tests proving C2 categorical facts fail closed for score, display, projection refresh, discovery/recommendation, contact, room, settlement, Promise/proof runtime, public API, mobile UI, and Relationship Depth targets
- documents the backend-local non-consumption guard boundary

## Scope
- authorized by musubi-foundation PR #124
- no new source facts or mutation facts
- no DDL or migrations
- no backend README update
- no public API, mobile UI, projection refresh, runtime orchestration, discovery, recommendation, room, settlement, Promise runtime, proof runtime, Relationship Depth, or Social Trust scoring/display

## Validation
- cargo fmt --manifest-path crates/social-trust-domain/Cargo.toml --check
- cargo test -p musubi_social_trust_domain
- git diff --check

Closes #91