### PR TITLE
test: add post-C2 categorical fact PII retention coverage

### DIFF
--- a/apps/backend/tests/post_c2_categorical_fact_pii_retention_non_leakage.rs
+++ b/apps/backend/tests/post_c2_categorical_fact_pii_retention_non_leakage.rs
@@ -1,0 +1,596 @@
+use std::path::PathBuf;
+
+use axum::{
+    Router,
+    body::{Body, to_bytes},
+    http::{Request, StatusCode},
+};
+use musubi_backend::{
+    build_app, new_test_state,
+    services::social_trust_mutation::{
+        RecordC2BoundedPromiseReliabilityMutationFactInput, SocialTrustMutationPersistenceOutcome,
+        SocialTrustMutationStore,
+    },
+};
+use musubi_db_runtime::DbConfig;
+use musubi_social_trust_domain::{
+    AccountLifecycleReference, AgeAssuranceStateReference, AntiAbuseContinuityReference,
+    AuditReference, BlockWithdrawalStateReference, C2BoundedPromiseReliabilityBoundaryIntersection,
+    C2BoundedPromiseReliabilityBoundaryPosture, C2BoundedPromiseReliabilityFactIdempotencyKey,
+    C2BoundedPromiseReliabilityMutationFact, C2BoundedPromiseReliabilityMutationFactCandidate,
+    C2BoundedPromiseReliabilitySourceFact, C2BoundedPromiseReliabilitySourceFactCandidate,
+    ConsentStateReference, CriticalHarmCaseReference, EvidenceLevelReference, EvidencePosture,
+    LegalHoldIntersectionReference, PromiseReference, PromiseTermsReference,
+    ProposedC2BoundedPromiseReliabilityMutationFact, ReasonFactReference, RetentionClassReference,
+    RetentionPosture, ReviewabilityPosture, SafetyCaseReference, SocialTrustAuthorityPosture,
+    WriterSourceReference,
+};
+use serde_json::{Value, json};
+use tokio_postgres::NoTls;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+const RETENTION_RECORD_FAMILY: &str = "Social Trust evidence or future Social Trust writer facts";
+const RETENTION_CLASS_REFERENCE: &str = "R4 Trust / moderation / case";
+
+#[tokio::test]
+async fn c2_categorical_facts_remain_minimized_retention_classified_and_non_leaking() {
+    let (_test_state, app, config, client) = test_context().await;
+    let subject = sign_in(
+        &app,
+        "pi-user-post-c2-pii-retention",
+        "post-c2-pii-retention",
+    )
+    .await;
+    let subject_account_id = Uuid::parse_str(&subject.account_id).expect("account id is a UUID");
+    let before_coordination = coordination_counts(&client).await;
+    let store = SocialTrustMutationStore::connect(&config)
+        .await
+        .expect("social trust mutation store should connect");
+
+    for (index, (source, mutation)) in accepted_mappings().into_iter().enumerate() {
+        let idempotency_key = format!("post-c2-pii-retention-{index}");
+        let snapshot = recorded(
+            store
+                .record_c2_bounded_promise_reliability_fact(record_input(
+                    subject_account_id,
+                    Some("realm-reference-post-c2-pii-retention".to_owned()),
+                    complete_proposal(&idempotency_key, source, mutation),
+                ))
+                .await
+                .expect("accepted C2 categorical fact should persist"),
+        );
+
+        assert_eq!(snapshot.source_fact_label, source.as_str());
+        assert_eq!(snapshot.mutation_fact_label, mutation.as_str());
+        assert_sha256_hex(&snapshot.request_payload_hash);
+    }
+
+    assert_source_rows_are_minimized_and_retention_classified(&client, &subject_account_id).await;
+    assert_mutation_rows_are_minimized_and_retention_classified(&client, &subject_account_id).await;
+    assert_no_forbidden_social_trust_columns(&client).await;
+    assert_projection_absent_for_subject(&client, &subject_account_id).await;
+    assert_eq!(coordination_counts(&client).await, before_coordination);
+
+    let global = get_json(
+        &app,
+        &format!("/api/projection/trust-snapshots/{}", subject.account_id),
+        Some(subject.token.as_str()),
+    )
+    .await;
+    assert_eq!(global.status, StatusCode::NOT_FOUND);
+    assert_no_trust_or_lifecycle_exposure_fields(&global.body);
+
+    let realm = get_json(
+        &app,
+        &format!(
+            "/api/projection/realm-trust-snapshots/realm-reference-post-c2-pii-retention/{}",
+            subject.account_id
+        ),
+        Some(subject.token.as_str()),
+    )
+    .await;
+    assert_eq!(realm.status, StatusCode::NOT_FOUND);
+    assert_no_trust_or_lifecycle_exposure_fields(&realm.body);
+}
+
+async fn test_context() -> (
+    musubi_backend::TestState,
+    Router,
+    DbConfig,
+    tokio_postgres::Client,
+) {
+    let test_state = new_test_state()
+        .await
+        .expect("test database state should initialize");
+    let app = build_app(test_state.state.clone());
+    let database_url = std::env::var("MUSUBI_TEST_DATABASE_URL")
+        .or_else(|_| std::env::var("DATABASE_URL"))
+        .expect("integration tests require MUSUBI_TEST_DATABASE_URL or DATABASE_URL to be set");
+    let migrations_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("migrations")
+        .canonicalize()
+        .expect("migrations directory should resolve");
+    let migrations_dir = migrations_dir
+        .to_str()
+        .expect("migrations directory should be utf-8")
+        .to_owned();
+    let config = DbConfig::from_lookup(|name| match name {
+        "APP_ENV" => Some("test".to_owned()),
+        "DATABASE_URL" => Some(database_url.clone()),
+        "MIGRATIONS_DIR" => Some(migrations_dir.clone()),
+        "REQUIRE_LATEST_SCHEMA" => Some("true".to_owned()),
+        _ => None,
+    })
+    .expect("test db config should parse");
+
+    let (client, connection) = tokio_postgres::connect(&database_url, NoTls)
+        .await
+        .expect("failed to connect to test database");
+    tokio::spawn(async move {
+        if let Err(error) = connection.await {
+            eprintln!("test database connection error: {error}");
+        }
+    });
+
+    (test_state, app, config, client)
+}
+
+fn accepted_mappings() -> Vec<(
+    C2BoundedPromiseReliabilitySourceFact,
+    C2BoundedPromiseReliabilityMutationFact,
+)> {
+    vec![
+        (
+            C2BoundedPromiseReliabilitySourceFact::CompletedAsAgreed,
+            C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityPositive,
+        ),
+        (
+            C2BoundedPromiseReliabilitySourceFact::CompletedAfterGovernedReview,
+            C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityPositive,
+        ),
+        (
+            C2BoundedPromiseReliabilitySourceFact::ValidExcusedExit,
+            C2BoundedPromiseReliabilityMutationFact::NoEffectValidExcusedExit,
+        ),
+        (
+            C2BoundedPromiseReliabilitySourceFact::SourceFactCorrected,
+            C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityCorrection,
+        ),
+        (
+            C2BoundedPromiseReliabilitySourceFact::ReviewRequiredBoundaryIntersection,
+            C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityFreeze,
+        ),
+        (
+            C2BoundedPromiseReliabilitySourceFact::SourceScopeLimitedAfterReview,
+            C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityNarrowing,
+        ),
+        (
+            C2BoundedPromiseReliabilitySourceFact::FreezeOrNarrowingReversedAfterReview,
+            C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityRecovery,
+        ),
+    ]
+}
+
+fn complete_proposal(
+    idempotency_key: &str,
+    source: C2BoundedPromiseReliabilitySourceFact,
+    mutation: C2BoundedPromiseReliabilityMutationFact,
+) -> ProposedC2BoundedPromiseReliabilityMutationFact {
+    let boundary_posture =
+        if source == C2BoundedPromiseReliabilitySourceFact::ReviewRequiredBoundaryIntersection {
+            C2BoundedPromiseReliabilityBoundaryPosture::Unresolved(
+                C2BoundedPromiseReliabilityBoundaryIntersection::LegalHold,
+            )
+        } else {
+            C2BoundedPromiseReliabilityBoundaryPosture::Clear
+        };
+
+    ProposedC2BoundedPromiseReliabilityMutationFact {
+        source_fact: C2BoundedPromiseReliabilitySourceFactCandidate::Accepted(source),
+        requested_mutation_fact: C2BoundedPromiseReliabilityMutationFactCandidate::Accepted(
+            mutation,
+        ),
+        writer_source_reference: Some(WriterSourceReference::new(format!(
+            "writer-source-{idempotency_key}"
+        ))),
+        promise_reference: Some(PromiseReference::new(format!("promise-{idempotency_key}"))),
+        promise_terms_reference: Some(PromiseTermsReference::new(format!(
+            "promise-terms-{idempotency_key}"
+        ))),
+        consent_at_formation_reference: Some(ConsentStateReference::new(format!(
+            "consent-formation-{idempotency_key}"
+        ))),
+        consent_at_resolution_reference: Some(ConsentStateReference::new(format!(
+            "consent-resolution-{idempotency_key}"
+        ))),
+        block_withdrawal_state_reference: Some(BlockWithdrawalStateReference::new(format!(
+            "block-withdrawal-clear-{idempotency_key}"
+        ))),
+        age_assurance_state_reference: Some(AgeAssuranceStateReference::new(format!(
+            "age-assurance-adult-eligible-{idempotency_key}"
+        ))),
+        legal_hold_intersection_reference: Some(LegalHoldIntersectionReference::new(format!(
+            "legal-hold-clear-{idempotency_key}"
+        ))),
+        critical_harm_case_reference: Some(CriticalHarmCaseReference::new(format!(
+            "critical-harm-clear-{idempotency_key}"
+        ))),
+        account_lifecycle_reference: Some(AccountLifecycleReference::new(format!(
+            "account-lifecycle-active-{idempotency_key}"
+        ))),
+        anti_abuse_continuity_reference: Some(AntiAbuseContinuityReference::new(format!(
+            "anti-abuse-clear-{idempotency_key}"
+        ))),
+        safety_case_reference: Some(SafetyCaseReference::new(format!(
+            "safety-case-clear-{idempotency_key}"
+        ))),
+        evidence_level_reference: Some(EvidenceLevelReference::new(format!(
+            "evidence-level-bounded-{idempotency_key}"
+        ))),
+        audit_reference: Some(AuditReference::new(format!("audit-{idempotency_key}"))),
+        reason_fact: Some(ReasonFactReference::new(format!(
+            "reason-fact-{idempotency_key}"
+        ))),
+        fact_idempotency_key: Some(C2BoundedPromiseReliabilityFactIdempotencyKey::new(
+            idempotency_key,
+        )),
+        evidence_posture: Some(EvidencePosture::Bounded),
+        reviewability_posture: Some(ReviewabilityPosture::Reviewable),
+        retention_posture: Some(RetentionPosture::Classified(RetentionClassReference::new(
+            RETENTION_CLASS_REFERENCE,
+        ))),
+        authority_posture: SocialTrustAuthorityPosture::WriterTruthOnly,
+        boundary_posture,
+    }
+}
+
+fn record_input(
+    subject_account_id: Uuid,
+    realm_reference: Option<String>,
+    proposal: ProposedC2BoundedPromiseReliabilityMutationFact,
+) -> RecordC2BoundedPromiseReliabilityMutationFactInput {
+    RecordC2BoundedPromiseReliabilityMutationFactInput {
+        subject_account_id: subject_account_id.to_string(),
+        realm_reference,
+        proposal,
+    }
+}
+
+fn recorded(
+    outcome: SocialTrustMutationPersistenceOutcome,
+) -> musubi_backend::services::social_trust_mutation::C2BoundedPromiseReliabilitySnapshot {
+    match outcome {
+        SocialTrustMutationPersistenceOutcome::Recorded(snapshot) => snapshot,
+        SocialTrustMutationPersistenceOutcome::RejectedBeforePersistence { decision } => {
+            panic!("expected recorded C2 fact, got rejected before persistence: {decision:?}")
+        }
+    }
+}
+
+async fn assert_source_rows_are_minimized_and_retention_classified(
+    client: &tokio_postgres::Client,
+    subject_account_id: &Uuid,
+) {
+    let rows = client
+        .query(
+            "
+            SELECT
+                evidence_posture,
+                reviewability_posture,
+                retention_record_family,
+                retention_class_reference,
+                authority_posture,
+                request_payload_hash
+            FROM social_trust.categorical_source_references
+            WHERE subject_account_id = $1
+            ORDER BY fact_idempotency_key
+            ",
+            &[subject_account_id],
+        )
+        .await
+        .expect("source metadata rows should load");
+    assert_eq!(rows.len(), accepted_mappings().len());
+
+    for row in rows {
+        assert_eq!(row.get::<_, String>("evidence_posture"), "bounded");
+        assert_eq!(row.get::<_, String>("reviewability_posture"), "reviewable");
+        assert_eq!(
+            row.get::<_, String>("retention_record_family"),
+            RETENTION_RECORD_FAMILY
+        );
+        assert_eq!(
+            row.get::<_, String>("retention_class_reference"),
+            RETENTION_CLASS_REFERENCE
+        );
+        assert_eq!(
+            row.get::<_, String>("authority_posture"),
+            "writer_truth_only"
+        );
+        assert_sha256_hex(&row.get::<_, String>("request_payload_hash"));
+    }
+}
+
+async fn assert_mutation_rows_are_minimized_and_retention_classified(
+    client: &tokio_postgres::Client,
+    subject_account_id: &Uuid,
+) {
+    let rows = client
+        .query(
+            "
+            SELECT
+                evidence_posture,
+                reviewability_posture,
+                retention_record_family,
+                retention_class_reference,
+                authority_posture,
+                decision_payload_hash
+            FROM social_trust.categorical_mutation_facts
+            WHERE subject_account_id = $1
+            ORDER BY fact_idempotency_key
+            ",
+            &[subject_account_id],
+        )
+        .await
+        .expect("mutation metadata rows should load");
+    assert_eq!(rows.len(), accepted_mappings().len());
+
+    for row in rows {
+        assert_eq!(row.get::<_, String>("evidence_posture"), "bounded");
+        assert_eq!(row.get::<_, String>("reviewability_posture"), "reviewable");
+        assert_eq!(
+            row.get::<_, String>("retention_record_family"),
+            RETENTION_RECORD_FAMILY
+        );
+        assert_eq!(
+            row.get::<_, String>("retention_class_reference"),
+            RETENTION_CLASS_REFERENCE
+        );
+        assert_eq!(
+            row.get::<_, String>("authority_posture"),
+            "writer_truth_only"
+        );
+        assert_sha256_hex(&row.get::<_, String>("decision_payload_hash"));
+    }
+}
+
+async fn assert_no_forbidden_social_trust_columns(client: &tokio_postgres::Client) {
+    let rows = client
+        .query(
+            "
+            SELECT table_name, column_name
+            FROM information_schema.columns
+            WHERE table_schema = 'social_trust'
+              AND table_name IN (
+                  'categorical_source_references',
+                  'categorical_mutation_facts'
+              )
+              AND (
+                  lower(column_name) LIKE 'raw_%'
+                  OR lower(column_name) LIKE '%pi_uid%'
+                  OR lower(column_name) LIKE '%access_token%'
+                  OR lower(column_name) LIKE '%wallet%'
+                  OR lower(column_name) LIKE '%email%'
+                  OR lower(column_name) LIKE '%phone%'
+                  OR lower(column_name) LIKE '%username%'
+                  OR lower(column_name) IN (
+                      'payload_json',
+                      'request_payload',
+                      'decision_payload',
+                      'evidence_payload',
+                      'personal_data',
+                      'raw_pii',
+                      'raw_evidence'
+                  )
+              )
+            ",
+            &[],
+        )
+        .await
+        .expect("social_trust column metadata should load");
+
+    assert!(
+        rows.is_empty(),
+        "C2 categorical facts must not expose raw PII or raw evidence columns: {:?}",
+        rows.iter()
+            .map(|row| format!(
+                "{}.{}",
+                row.get::<_, String>("table_name"),
+                row.get::<_, String>("column_name")
+            ))
+            .collect::<Vec<_>>()
+    );
+}
+
+async fn assert_projection_absent_for_subject(
+    client: &tokio_postgres::Client,
+    subject_account_id: &Uuid,
+) {
+    let row = client
+        .query_one(
+            "
+            SELECT
+                (SELECT COUNT(*)::bigint
+                 FROM projection.trust_snapshots
+                 WHERE account_id = $1) AS trust_snapshot_count,
+                (SELECT COUNT(*)::bigint
+                 FROM projection.realm_trust_snapshots
+                 WHERE account_id = $1) AS realm_trust_snapshot_count
+            ",
+            &[subject_account_id],
+        )
+        .await
+        .expect("projection counts should load");
+
+    assert_eq!(row.get::<_, i64>("trust_snapshot_count"), 0);
+    assert_eq!(row.get::<_, i64>("realm_trust_snapshot_count"), 0);
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct CoordinationCounts {
+    outbox_events: i64,
+    outbox_attempts: i64,
+    command_inbox: i64,
+    outbox_event_archive: i64,
+    outbox_attempt_archive: i64,
+    command_inbox_archive: i64,
+}
+
+async fn coordination_counts(client: &tokio_postgres::Client) -> CoordinationCounts {
+    let row = client
+        .query_one(
+            "
+            SELECT
+                (SELECT COUNT(*)::bigint FROM outbox.events) AS outbox_events,
+                (SELECT COUNT(*)::bigint FROM outbox.outbox_attempts) AS outbox_attempts,
+                (SELECT COUNT(*)::bigint FROM outbox.command_inbox) AS command_inbox,
+                (SELECT COUNT(*)::bigint FROM outbox.outbox_event_archive) AS outbox_event_archive,
+                (SELECT COUNT(*)::bigint FROM outbox.outbox_attempt_archive) AS outbox_attempt_archive,
+                (SELECT COUNT(*)::bigint FROM outbox.command_inbox_archive) AS command_inbox_archive
+            ",
+            &[],
+        )
+        .await
+        .expect("coordination counts should load");
+
+    CoordinationCounts {
+        outbox_events: row.get("outbox_events"),
+        outbox_attempts: row.get("outbox_attempts"),
+        command_inbox: row.get("command_inbox"),
+        outbox_event_archive: row.get("outbox_event_archive"),
+        outbox_attempt_archive: row.get("outbox_attempt_archive"),
+        command_inbox_archive: row.get("command_inbox_archive"),
+    }
+}
+
+fn assert_sha256_hex(value: &str) {
+    assert_eq!(value.len(), 64);
+    assert!(
+        value.bytes().all(|byte| byte.is_ascii_hexdigit()),
+        "payload hash must be lowercase hex SHA-256"
+    );
+    assert_eq!(value, value.to_ascii_lowercase());
+}
+
+fn assert_no_trust_or_lifecycle_exposure_fields(body: &Value) {
+    for field in [
+        "trust_posture",
+        "reason_codes",
+        "trust_score",
+        "score",
+        "rank",
+        "trust_rank",
+        "trust_tier",
+        "display_level",
+        "public_level",
+        "recovery_ceiling",
+        "discovery_priority",
+        "recommendation_boost",
+        "contact_unlock",
+        "room_transition",
+        "settlement_progression",
+        "promise_runtime_outcome",
+        "proof_runtime_outcome",
+        "relationship_depth",
+        "mobile_ui_state",
+        "retention_action",
+        "pruning_action",
+        "archive_action",
+        "deletion_action",
+        "legal_hold_action",
+        "key_lifecycle_action",
+    ] {
+        assert!(
+            body.get(field).is_none(),
+            "C2 categorical facts must not expose {field} in public API response"
+        );
+    }
+}
+
+struct SignedInUser {
+    token: String,
+    account_id: String,
+}
+
+async fn sign_in(app: &Router, pi_uid: &str, username: &str) -> SignedInUser {
+    let response = post_json(
+        app,
+        "/api/auth/pi",
+        None,
+        json!({
+            "pi_uid": pi_uid,
+            "username": username,
+            "wallet_address": format!("wallet-{pi_uid}"),
+            "access_token": format!("access-token-{pi_uid}")
+        }),
+    )
+    .await;
+    assert_eq!(response.status, StatusCode::OK);
+
+    SignedInUser {
+        token: response.body["token"]
+            .as_str()
+            .expect("token must exist")
+            .to_owned(),
+        account_id: response.body["user"]["id"]
+            .as_str()
+            .expect("user id must exist")
+            .to_owned(),
+    }
+}
+
+struct JsonResponse {
+    status: StatusCode,
+    body: Value,
+}
+
+async fn post_json(
+    app: &Router,
+    path: &str,
+    bearer_token: Option<&str>,
+    body: Value,
+) -> JsonResponse {
+    request_json(app, "POST", path, bearer_token, Some(body)).await
+}
+
+async fn get_json(app: &Router, path: &str, bearer_token: Option<&str>) -> JsonResponse {
+    request_json(app, "GET", path, bearer_token, None).await
+}
+
+async fn request_json(
+    app: &Router,
+    method: &str,
+    path: &str,
+    bearer_token: Option<&str>,
+    body: Option<Value>,
+) -> JsonResponse {
+    let mut builder = Request::builder().method(method).uri(path);
+    if let Some(token) = bearer_token {
+        builder = builder.header("authorization", format!("Bearer {token}"));
+    }
+
+    let request = builder
+        .header("content-type", "application/json")
+        .body(match body {
+            Some(body) => Body::from(body.to_string()),
+            None => Body::empty(),
+        })
+        .expect("request must build");
+
+    let response = app
+        .clone()
+        .oneshot(request)
+        .await
+        .expect("app should respond");
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body must be readable");
+    let body = if bytes.is_empty() {
+        json!({})
+    } else {
+        serde_json::from_slice(&bytes).expect("response body must be valid json")
+    };
+
+    JsonResponse { status, body }
+}

--- a/docs/foundation_lock.md
+++ b/docs/foundation_lock.md
@@ -1,6 +1,6 @@
 # Foundation Lock
 
-Status: Draft; aligned to accepted foundation commit `c3c0ae0`
+Status: Draft; aligned to accepted foundation commit `19ce6c6`
 Applies to: `mt4110/pi-musubi-core`
 Purpose: Pin the constitutional and architectural source of truth that this implementation repository must follow.
 
@@ -26,14 +26,14 @@ Upstream repository:
 Pinned reference for implementation work:
 
 - Foundation reference type: `commit`
-- Foundation commit SHA: `c3c0ae0b3a0b9f09592b1056c7ca9997403e0830`
-- Foundation commit title: `Merge pull request #130 from mt4110/feat/evaluate-post-c2-categorical-fact-non-exposure-handoff`
-- Foundation PR title: `docs: evaluate post-C2 categorical fact non-exposure handoff`
-- Foundation PR URL: `https://github.com/mt4110/musubi-foundation/pull/130`
+- Foundation commit SHA: `19ce6c602d883158409be4238339c761d6aa3e8a`
+- Foundation commit title: `Merge pull request #136 from mt4110/feat/evaluate-post-c2-categorical-fact-pii-retention-handoff`
+- Foundation PR title: `docs: evaluate post-C2 categorical fact PII retention handoff`
+- Foundation PR URL: `https://github.com/mt4110/musubi-foundation/pull/136`
 - Date pinned: `2026-05-14`
 - Pinned by: `Masaki Takemura`
-- Pinned commit URL: `https://github.com/mt4110/musubi-foundation/commit/c3c0ae0b3a0b9f09592b1056c7ca9997403e0830`
-- Previous pinned reference: `64d6348` / `Merge pull request #124 from mt4110/feat/evaluate-post-c2-non-consumption-guard-handoff`
+- Pinned commit URL: `https://github.com/mt4110/musubi-foundation/commit/19ce6c602d883158409be4238339c761d6aa3e8a`
+- Previous pinned reference: `c3c0ae0` / `Merge pull request #130 from mt4110/feat/evaluate-post-c2-categorical-fact-non-exposure-handoff`
 - Post-C2 evidence source: `cfdba28` / `Merge pull request #114 from mt4110/feat/post-c2-runtime-handoff-evidence-package`
 - Alignment allowance source: `69b7aa4` / `Merge pull request #116 from mt4110/feat/evaluate-post-c2-runtime-handoff-gate`
 - Post-C2 implementation handoff evidence source: `ef23e88` / `Merge pull request #122 from mt4110/feat/post-c2-implementation-handoff-evidence-package`
@@ -41,6 +41,9 @@ Pinned reference for implementation work:
 - Post-C2 non-consumption guard implementation closeout source: `7a2c8a0` / `Merge pull request #126 from mt4110/feat/close-post-c2-non-consumption-guard-handoff`
 - Post-C2 categorical fact projection API non-exposure evidence source: `fd4465e` / `Merge pull request #128 from mt4110/feat/post-c2-categorical-fact-non-exposure-evidence`
 - Post-C2 categorical fact projection API non-exposure handoff source: `c3c0ae0` / `Merge pull request #130 from mt4110/feat/evaluate-post-c2-categorical-fact-non-exposure-handoff`
+- Post-C2 categorical fact projection API non-exposure implementation closeout source: `f1c2bc3` / `Merge pull request #132 from mt4110/feat/close-post-c2-categorical-fact-non-exposure-handoff`
+- Post-C2 categorical fact PII retention non-leakage evidence source: `1300a03` / `Merge pull request #134 from mt4110/feat/post-c2-categorical-fact-pii-retention-evidence`
+- Post-C2 categorical fact PII retention non-leakage handoff source: `19ce6c6` / `Merge pull request #136 from mt4110/feat/evaluate-post-c2-categorical-fact-pii-retention-handoff`
 
 No release tag is asserted for this alignment.
 Do not invent a foundation version label for this commit.
@@ -126,31 +129,34 @@ Before coding, read these upstream documents in order.
 65. `docs/readiness/post_c2_non_consumption_guard_implementation_closeout_ledger.md`
 66. `docs/readiness/post_c2_categorical_fact_projection_api_non_exposure_evidence_package.md`
 67. `docs/readiness/post_c2_categorical_fact_projection_api_non_exposure_handoff_gate_decision.md`
+68. `docs/readiness/post_c2_categorical_fact_projection_api_non_exposure_implementation_closeout_ledger.md`
+69. `docs/readiness/post_c2_categorical_fact_pii_retention_non_leakage_evidence_package.md`
+70. `docs/readiness/post_c2_categorical_fact_pii_retention_non_leakage_handoff_gate_decision.md`
 
 ### Detail layer
-68. `docs/detail/accountability_matrix.md`
-69. `docs/detail/critical_incident_and_loss.md`
-70. `docs/detail/automated_decisioning_and_human_appeal.md`
-71. `docs/detail/youth_safety_and_age_assurance.md`
-72. `docs/detail/off_platform_handoff_and_scam_prevention.md`
-73. `docs/detail/data_deletion_vs_legal_hold.md`
-74. `docs/detail/realm_model.md`
-75. `docs/detail/data_scope_model.md`
-76. `docs/detail/mobility_model.md`
-77. `docs/detail/settlement_model.md`
-78. `docs/detail/settlement_backend_trait.md`
-79. `docs/detail/proof_of_infrastructure.md`
-80. `docs/detail/protected_groups_and_translation_safety.md`
+71. `docs/detail/accountability_matrix.md`
+72. `docs/detail/critical_incident_and_loss.md`
+73. `docs/detail/automated_decisioning_and_human_appeal.md`
+74. `docs/detail/youth_safety_and_age_assurance.md`
+75. `docs/detail/off_platform_handoff_and_scam_prevention.md`
+76. `docs/detail/data_deletion_vs_legal_hold.md`
+77. `docs/detail/realm_model.md`
+78. `docs/detail/data_scope_model.md`
+79. `docs/detail/mobility_model.md`
+80. `docs/detail/settlement_model.md`
+81. `docs/detail/settlement_backend_trait.md`
+82. `docs/detail/proof_of_infrastructure.md`
+83. `docs/detail/protected_groups_and_translation_safety.md`
 
 ### Whitepaper layer (contextual, not higher than detail/ADR)
-81. `docs/whitepaper/01_executive_summary.md`
-82. `docs/whitepaper/02_realm_model.md`
-83. `docs/whitepaper/03_experience_model.md`
-84. `docs/whitepaper/04_dm_shield.md`
-85. `docs/whitepaper/05_trust_model.md`
-86. `docs/whitepaper/06_promise_protocol.md`
-87. `docs/whitepaper/07_realm_economy.md`
-88. `docs/whitepaper/08_unlock_engine.md`
+84. `docs/whitepaper/01_executive_summary.md`
+85. `docs/whitepaper/02_realm_model.md`
+86. `docs/whitepaper/03_experience_model.md`
+87. `docs/whitepaper/04_dm_shield.md`
+88. `docs/whitepaper/05_trust_model.md`
+89. `docs/whitepaper/06_promise_protocol.md`
+90. `docs/whitepaper/07_realm_economy.md`
+91. `docs/whitepaper/08_unlock_engine.md`
 
 If any of the above are unavailable or materially inconsistent, stop and escalate.
 
@@ -180,7 +186,7 @@ That one-use C2 implementation allowance was consumed by `mt4110/pi-musubi-core`
 No remaining work may inherit permission from foundation PR #108 or implementation PR #88.
 The broad runtime implementation gate result remains NO-GO.
 Broad runtime implementation remains blocked.
-The current narrow downstream allowance is one implementation-repo test-only PR for post-C2 categorical Social Trust fact projection API non-exposure verification.
+The current narrow downstream allowance is one implementation-repo test-only PR for post-C2 categorical Social Trust fact PII / retention / evidence-segregation non-leakage verification.
 
 The C2 bounded Promise reliability readiness and closeout chain is accepted for docs-only foundation semantic scope:
 
@@ -202,6 +208,9 @@ The C2 bounded Promise reliability readiness and closeout chain is accepted for 
 - `docs/readiness/post_c2_non_consumption_guard_implementation_closeout_ledger.md`
 - `docs/readiness/post_c2_categorical_fact_projection_api_non_exposure_evidence_package.md`
 - `docs/readiness/post_c2_categorical_fact_projection_api_non_exposure_handoff_gate_decision.md`
+- `docs/readiness/post_c2_categorical_fact_projection_api_non_exposure_implementation_closeout_ledger.md`
+- `docs/readiness/post_c2_categorical_fact_pii_retention_non_leakage_evidence_package.md`
+- `docs/readiness/post_c2_categorical_fact_pii_retention_non_leakage_handoff_gate_decision.md`
 
 The accepted C2 gate records `bounded_promise_reliability` as the only positive Social Trust source-family candidate and accepts exact source facts and exact Social Trust mutation facts only as foundation semantic labels.
 Those labels are not runtime schema names, enum values, API names, migration names, module names, or test names.
@@ -217,10 +226,13 @@ Foundation PR #122 accepted the exact candidate implementation slice as the post
 Foundation PR #124 provided the consumed narrow downstream implementation handoff authority for one later implementation-repo PR only, limited to the post-C2 Social Trust categorical fact non-consumption guard.
 That allowance was consumed by `mt4110/pi-musubi-core` PR #92 and closed out by foundation PR #126.
 Foundation PR #128 accepted the exact candidate test-only slice as post-C2 categorical Social Trust fact projection API non-exposure verification.
-Foundation PR #130 provides the current narrow downstream test-only handoff authority for one later implementation-repo PR only.
+Foundation PR #130 provided the consumed narrow downstream test-only handoff authority for one later implementation-repo PR only, limited to post-C2 categorical Social Trust fact projection API non-exposure verification.
+That allowance was consumed by `mt4110/pi-musubi-core` PR #94 and closed out by foundation PR #132.
+Foundation PR #134 accepted the exact candidate test-only slice as post-C2 categorical Social Trust fact PII / retention / evidence-segregation non-leakage verification.
+Foundation PR #136 provides the current narrow downstream test-only handoff authority for one later implementation-repo PR only.
 This update is the required lock pin for that one-use allowance.
-It does not authorize implementation outside the PR #130 envelope.
-It does not authorize new source facts, new mutation facts, DDL, migrations, backend runtime code, backend README updates, backend docs updates, public API changes, mobile UI, projection refresh, runtime orchestration, discovery, recommendation, room, settlement, Promise runtime, proof runtime, Relationship Depth, Social Trust scoring, public trust display, or any broader `pi-musubi-core` change.
+It does not authorize implementation outside the PR #136 envelope.
+It does not authorize new source facts, new mutation facts, DDL, migrations, backend runtime code, backend README updates, backend docs updates, public API changes, mobile UI, projection refresh, runtime orchestration, lifecycle runtime behavior, pruning, archive, deletion, Legal Hold runtime behavior, key lifecycle behavior, discovery, recommendation, room, settlement, Promise runtime, proof runtime, Relationship Depth, Social Trust scoring, public trust display, or any broader `pi-musubi-core` change.
 
 Implementation merge history, issue order, branch ancestry, and existing code are not foundation design proof.
 
@@ -388,10 +400,12 @@ The post-C2 runtime handoff evidence package and gate decision preserved runtime
 That post-C2 lock alignment allowance was consumed by `mt4110/pi-musubi-core` PR #90 and closed out by foundation PR #118.
 The post-C2 implementation handoff evidence package and handoff gate authorized one later implementation-repo PR only for the post-C2 Social Trust categorical fact non-consumption guard.
 That allowance was consumed by `mt4110/pi-musubi-core` PR #92 and closed out by foundation PR #126.
-The post-C2 categorical fact projection API non-exposure evidence package and handoff gate now authorize one later implementation-repo test-only PR only.
-This test-only allowance is limited to `docs/foundation_lock.md` and `apps/backend/tests/post_c2_categorical_fact_projection_api_non_exposure.rs`.
-It may verify that already accepted C2 categorical Social Trust facts alone do not create projection rows, public API visibility, mobile UI state, scores, weights, ranks, display levels, discovery / recommendation inputs, contact unlocks, room transitions, settlement progression, Promise runtime behavior, proof runtime behavior, or Relationship Depth behavior.
-It does not authorize new source facts, new mutation facts, DDL, migrations, backend runtime code, backend README updates, backend docs updates, public API changes, mobile UI, projection refresh, runtime orchestration, discovery, recommendation, room progression, settlement behavior, Promise runtime behavior, proof runtime behavior, Relationship Depth, Social Trust scoring, public trust display, or broad runtime implementation.
+The post-C2 categorical fact projection API non-exposure evidence package and handoff gate authorized one later implementation-repo test-only PR only.
+That test-only allowance was consumed by `mt4110/pi-musubi-core` PR #94 and closed out by foundation PR #132.
+The post-C2 categorical fact PII retention non-leakage evidence package and handoff gate now authorize one later implementation-repo test-only PR only.
+This test-only allowance is limited to `docs/foundation_lock.md` and `apps/backend/tests/post_c2_categorical_fact_pii_retention_non_leakage.rs`.
+It may verify that already accepted C2 categorical Social Trust facts remain minimized, retention-classified, reviewable, writer-truth-only, and segregated from raw PII, raw evidence, coordination logs, archive rows, projection rows, public API visibility, mobile UI state, Social Trust score/display behavior, Relationship Depth behavior, and lifecycle-authority surfaces.
+It does not authorize new source facts, new mutation facts, DDL, migrations, backend runtime code, backend README updates, backend docs updates, public API changes, mobile UI, projection refresh, runtime orchestration, lifecycle runtime behavior, pruning, archive, deletion, Legal Hold runtime behavior, key lifecycle behavior, discovery, recommendation, room progression, settlement behavior, Promise runtime behavior, proof runtime behavior, Relationship Depth, Social Trust scoring, public trust display, or broad runtime implementation.
 
 ---
 
@@ -419,11 +433,11 @@ When updating:
 - Review completed by:
 
 ### Current drift note
-- Updated from foundation SHA: `64d634862df48d725c4a13097d52f9c0455f6cee` -> `c3c0ae0b3a0b9f09592b1056c7ca9997403e0830`
-- Reason: Align implementation-repo lock with the accepted foundation state after PR #130 (`docs: evaluate post-C2 categorical fact non-exposure handoff`).
-- New required docs: Post-C2 non-consumption guard implementation closeout ledger; post-C2 categorical fact projection API non-exposure evidence package; post-C2 categorical fact projection API non-exposure handoff gate decision.
+- Updated from foundation SHA: `c3c0ae0b3a0b9f09592b1056c7ca9997403e0830` -> `19ce6c602d883158409be4238339c761d6aa3e8a`
+- Reason: Align implementation-repo lock with the accepted foundation state after PR #136 (`docs: evaluate post-C2 categorical fact PII retention handoff`).
+- New required docs: Post-C2 categorical fact projection API non-exposure implementation closeout ledger; post-C2 categorical fact PII retention non-leakage evidence package; post-C2 categorical fact PII retention non-leakage handoff gate decision.
 - Removed docs: None.
-- Implementation impact: PR #130 authorizes one later implementation-repo test-only PR. This PR may update this foundation lock and add deterministic backend integration tests proving accepted C2 categorical Social Trust facts alone do not create projection rows or public projection API visibility. New source facts, new mutation facts, DDL, migrations, backend runtime code, backend README updates, backend docs updates, public API changes, mobile UI, projection refresh, runtime orchestration, Relationship Depth, proof runtime behavior, room progression, discovery, recommendation, settlement, Promise runtime behavior, Social Trust scoring, public trust display, and paid romantic advantage remain blocked.
+- Implementation impact: PR #136 authorizes one later implementation-repo test-only PR. This PR may update this foundation lock and add deterministic backend integration tests proving accepted C2 categorical Social Trust facts remain minimized, retention-classified, reviewable, writer-truth-only, and segregated from raw PII, raw evidence, coordination logs, archive rows, projection rows, public API visibility, mobile UI state, Social Trust score/display behavior, Relationship Depth behavior, and lifecycle-authority surfaces. New source facts, new mutation facts, DDL, migrations, backend runtime code, backend README updates, backend docs updates, public API changes, mobile UI, projection refresh, runtime orchestration, lifecycle runtime behavior, pruning, archive, deletion, Legal Hold runtime behavior, key lifecycle behavior, Relationship Depth, proof runtime behavior, room progression, discovery, recommendation, settlement, Promise runtime behavior, Social Trust scoring, public trust display, and paid romantic advantage remain blocked.
 - Review completed by: Masaki Takemura
 
 ---


### PR DESCRIPTION
Closes #95

## Scope
- Pins docs/foundation_lock.md to foundation PR #136 / commit 19ce6c602d883158409be4238339c761d6aa3e8a.
- Adds a single backend integration test for post-C2 categorical Social Trust fact PII / retention / evidence-segregation non-leakage verification.
- Verifies accepted C2 categorical facts remain minimized, retention-classified, reviewable, writer-truth-only, hash-based, and non-exposed to coordination, archive, projection, public API, lifecycle, Social Trust display, or Relationship Depth surfaces.

## Non-Authorization
- No DDL, migrations, backend runtime code, public API changes, mobile UI, projection refresh, runtime orchestration, lifecycle runtime behavior, pruning, archive, deletion, Legal Hold runtime behavior, key lifecycle behavior, dependency changes, new source facts, or new mutation facts.

## Validation
- rustfmt --edition 2024 --check apps/backend/tests/post_c2_categorical_fact_pii_retention_non_leakage.rs
- cargo test --manifest-path apps/backend/Cargo.toml --test post_c2_categorical_fact_pii_retention_non_leakage
- cargo test --manifest-path apps/backend/Cargo.toml --test post_c2_categorical_fact_projection_api_non_exposure
- cargo test --manifest-path apps/backend/Cargo.toml --test c2_bounded_promise_reliability_persistence -- --test-threads=1
- cargo test --manifest-path apps/backend/crates/social-trust-domain/Cargo.toml
- git diff --check origin/main...HEAD

Note: an initial parallel run of c2_bounded_promise_reliability_persistence hit a PostgreSQL deadlock during test database initialization; the same suite passed when rerun serially.