### PR TITLE
Add post-C2 categorical fact concurrent idempotency tests

### DIFF
--- a/apps/backend/tests/post_c2_categorical_fact_concurrent_idempotency_boundary.rs
+++ b/apps/backend/tests/post_c2_categorical_fact_concurrent_idempotency_boundary.rs
@@ -1,0 +1,616 @@
+use std::{path::PathBuf, time::Duration};
+
+use axum::{
+    Router,
+    body::{Body, to_bytes},
+    http::{Request, StatusCode},
+};
+use musubi_backend::{
+    build_app, new_test_state,
+    services::social_trust_mutation::{
+        C2BoundedPromiseReliabilityReplayStatus, C2BoundedPromiseReliabilitySnapshot,
+        RecordC2BoundedPromiseReliabilityMutationFactInput, SocialTrustMutationPersistenceError,
+        SocialTrustMutationPersistenceOutcome, SocialTrustMutationStore,
+    },
+};
+use musubi_db_runtime::DbConfig;
+use musubi_social_trust_domain::{
+    AccountLifecycleReference, AgeAssuranceStateReference, AntiAbuseContinuityReference,
+    AuditReference, BlockWithdrawalStateReference, C2BoundedPromiseReliabilityBoundaryPosture,
+    C2BoundedPromiseReliabilityFactIdempotencyKey, C2BoundedPromiseReliabilityMutationFact,
+    C2BoundedPromiseReliabilityMutationFactCandidate, C2BoundedPromiseReliabilitySourceFact,
+    C2BoundedPromiseReliabilitySourceFactCandidate, ConsentStateReference,
+    CriticalHarmCaseReference, EvidenceLevelReference, EvidencePosture,
+    LegalHoldIntersectionReference, PromiseReference, PromiseTermsReference,
+    ProposedC2BoundedPromiseReliabilityMutationFact, ReasonFactReference, RetentionClassReference,
+    RetentionPosture, ReviewabilityPosture, SafetyCaseReference, SocialTrustAuthorityPosture,
+    WriterSourceReference,
+};
+use serde_json::{Value, json};
+use tokio::{task::yield_now, time::sleep};
+use tokio_postgres::NoTls;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+const REALM_REFERENCE: &str = "realm-reference-post-c2-concurrent-idempotency";
+
+#[tokio::test]
+async fn concurrent_identical_c2_delivery_creates_one_writer_fact_and_one_replay() {
+    let (_test_state, app, config, client) = test_context().await;
+    let subject = sign_in(
+        &app,
+        "pi-user-post-c2-concurrent-identical",
+        "post-c2-concurrent-identical",
+    )
+    .await;
+    let subject_account_id = Uuid::parse_str(&subject.account_id).expect("account id is a UUID");
+    let before_coordination = coordination_counts(&client).await;
+    let first_store = SocialTrustMutationStore::connect(&config)
+        .await
+        .expect("first social trust mutation store should connect");
+    let second_store = SocialTrustMutationStore::connect(&config)
+        .await
+        .expect("second social trust mutation store should connect");
+    let input = record_input(
+        subject_account_id,
+        complete_proposal("post-c2-concurrent-identical"),
+    );
+
+    let (first, second) = tokio::join!(
+        first_store.record_c2_bounded_promise_reliability_fact(input.clone()),
+        second_store.record_c2_bounded_promise_reliability_fact(input)
+    );
+    let snapshots = vec![
+        recorded(first.expect("first concurrent delivery should resolve")),
+        recorded(second.expect("second concurrent delivery should resolve")),
+    ];
+
+    assert_eq!(
+        snapshots
+            .iter()
+            .filter(|snapshot| {
+                snapshot.replay_status == C2BoundedPromiseReliabilityReplayStatus::Inserted
+            })
+            .count(),
+        1
+    );
+    assert_eq!(
+        snapshots
+            .iter()
+            .filter(|snapshot| {
+                snapshot.replay_status == C2BoundedPromiseReliabilityReplayStatus::ReplayedIdentical
+            })
+            .count(),
+        1
+    );
+    assert_same_writer_fact(&snapshots[0], &snapshots[1]);
+    assert_eq!(
+        source_count_for_subject(&client, &subject_account_id).await,
+        1
+    );
+    assert_eq!(
+        mutation_count_for_subject(&client, &subject_account_id).await,
+        1
+    );
+    assert_projection_absent_for_subject(&client, &subject_account_id).await;
+    assert_eq!(coordination_counts(&client).await, before_coordination);
+    assert_public_projection_not_visible(&app, &subject).await;
+    assert_no_score_display_or_relationship_depth_columns(&client).await;
+}
+
+#[tokio::test]
+async fn concurrent_payload_drift_preserves_first_writer_fact_and_later_identical_replay() {
+    let (_test_state, app, config, client) = test_context().await;
+    let subject = sign_in(
+        &app,
+        "pi-user-post-c2-concurrent-drift",
+        "post-c2-concurrent-drift",
+    )
+    .await;
+    let subject_account_id = Uuid::parse_str(&subject.account_id).expect("account id is a UUID");
+    let before_coordination = coordination_counts(&client).await;
+    let first_store = SocialTrustMutationStore::connect(&config)
+        .await
+        .expect("first social trust mutation store should connect");
+    let second_store = SocialTrustMutationStore::connect(&config)
+        .await
+        .expect("second social trust mutation store should connect");
+    let replay_store = SocialTrustMutationStore::connect(&config)
+        .await
+        .expect("replay social trust mutation store should connect");
+    let first_input = record_input(
+        subject_account_id,
+        complete_proposal("post-c2-concurrent-drift"),
+    );
+    let mut drifted_proposal = complete_proposal("post-c2-concurrent-drift");
+    drifted_proposal.audit_reference = Some(AuditReference::new("audit-concurrent-drift"));
+    let drifted_input = record_input(subject_account_id, drifted_proposal);
+
+    let (first, drifted) = tokio::join!(
+        first_store.record_c2_bounded_promise_reliability_fact(first_input.clone()),
+        async {
+            yield_now().await;
+            sleep(Duration::from_millis(10)).await;
+            second_store
+                .record_c2_bounded_promise_reliability_fact(drifted_input)
+                .await
+        }
+    );
+    let first_snapshot = recorded(first.expect("first concurrent delivery should persist"));
+    assert_eq!(
+        first_snapshot.replay_status,
+        C2BoundedPromiseReliabilityReplayStatus::Inserted
+    );
+    assert_idempotency_conflict(
+        drifted.expect_err("drifted concurrent delivery must fail closed"),
+        &first_snapshot.source_reference_id,
+    );
+    assert_eq!(
+        source_count_for_subject(&client, &subject_account_id).await,
+        1
+    );
+    assert_eq!(
+        mutation_count_for_subject(&client, &subject_account_id).await,
+        1
+    );
+    assert_projection_absent_for_subject(&client, &subject_account_id).await;
+    assert_eq!(coordination_counts(&client).await, before_coordination);
+
+    let replay = recorded(
+        replay_store
+            .record_c2_bounded_promise_reliability_fact(first_input)
+            .await
+            .expect("identical replay should remain possible after rejected drift"),
+    );
+    assert_eq!(
+        replay.replay_status,
+        C2BoundedPromiseReliabilityReplayStatus::ReplayedIdentical
+    );
+    assert_same_writer_fact(&first_snapshot, &replay);
+    assert_eq!(
+        source_count_for_subject(&client, &subject_account_id).await,
+        1
+    );
+    assert_eq!(
+        mutation_count_for_subject(&client, &subject_account_id).await,
+        1
+    );
+    assert_projection_absent_for_subject(&client, &subject_account_id).await;
+    assert_eq!(coordination_counts(&client).await, before_coordination);
+    assert_public_projection_not_visible(&app, &subject).await;
+    assert_no_score_display_or_relationship_depth_columns(&client).await;
+}
+
+async fn test_context() -> (
+    musubi_backend::TestState,
+    Router,
+    DbConfig,
+    tokio_postgres::Client,
+) {
+    let test_state = new_test_state()
+        .await
+        .expect("test database state should initialize");
+    let app = build_app(test_state.state.clone());
+    let database_url = std::env::var("MUSUBI_TEST_DATABASE_URL")
+        .or_else(|_| std::env::var("DATABASE_URL"))
+        .expect("integration tests require MUSUBI_TEST_DATABASE_URL or DATABASE_URL to be set");
+    let migrations_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("migrations")
+        .canonicalize()
+        .expect("migrations directory should resolve");
+    let migrations_dir = migrations_dir
+        .to_str()
+        .expect("migrations directory should be utf-8")
+        .to_owned();
+    let config = DbConfig::from_lookup(|name| match name {
+        "APP_ENV" => Some("test".to_owned()),
+        "DATABASE_URL" => Some(database_url.clone()),
+        "MIGRATIONS_DIR" => Some(migrations_dir.clone()),
+        "REQUIRE_LATEST_SCHEMA" => Some("true".to_owned()),
+        _ => None,
+    })
+    .expect("test db config should parse");
+
+    let (client, connection) = tokio_postgres::connect(&database_url, NoTls)
+        .await
+        .expect("failed to connect to test database");
+    tokio::spawn(async move {
+        if let Err(error) = connection.await {
+            eprintln!("test database connection error: {error}");
+        }
+    });
+
+    (test_state, app, config, client)
+}
+
+fn complete_proposal(idempotency_key: &str) -> ProposedC2BoundedPromiseReliabilityMutationFact {
+    ProposedC2BoundedPromiseReliabilityMutationFact {
+        source_fact: C2BoundedPromiseReliabilitySourceFactCandidate::Accepted(
+            C2BoundedPromiseReliabilitySourceFact::CompletedAsAgreed,
+        ),
+        requested_mutation_fact: C2BoundedPromiseReliabilityMutationFactCandidate::Accepted(
+            C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityPositive,
+        ),
+        writer_source_reference: Some(WriterSourceReference::new(format!(
+            "writer-source-{idempotency_key}"
+        ))),
+        promise_reference: Some(PromiseReference::new(format!("promise-{idempotency_key}"))),
+        promise_terms_reference: Some(PromiseTermsReference::new(format!(
+            "promise-terms-{idempotency_key}"
+        ))),
+        consent_at_formation_reference: Some(ConsentStateReference::new(format!(
+            "consent-formation-{idempotency_key}"
+        ))),
+        consent_at_resolution_reference: Some(ConsentStateReference::new(format!(
+            "consent-resolution-{idempotency_key}"
+        ))),
+        block_withdrawal_state_reference: Some(BlockWithdrawalStateReference::new(format!(
+            "block-withdrawal-clear-{idempotency_key}"
+        ))),
+        age_assurance_state_reference: Some(AgeAssuranceStateReference::new(format!(
+            "age-assurance-adult-eligible-{idempotency_key}"
+        ))),
+        legal_hold_intersection_reference: Some(LegalHoldIntersectionReference::new(format!(
+            "legal-hold-clear-{idempotency_key}"
+        ))),
+        critical_harm_case_reference: Some(CriticalHarmCaseReference::new(format!(
+            "critical-harm-clear-{idempotency_key}"
+        ))),
+        account_lifecycle_reference: Some(AccountLifecycleReference::new(format!(
+            "account-lifecycle-active-{idempotency_key}"
+        ))),
+        anti_abuse_continuity_reference: Some(AntiAbuseContinuityReference::new(format!(
+            "anti-abuse-clear-{idempotency_key}"
+        ))),
+        safety_case_reference: Some(SafetyCaseReference::new(format!(
+            "safety-case-clear-{idempotency_key}"
+        ))),
+        evidence_level_reference: Some(EvidenceLevelReference::new(format!(
+            "evidence-level-bounded-{idempotency_key}"
+        ))),
+        audit_reference: Some(AuditReference::new(format!("audit-{idempotency_key}"))),
+        reason_fact: Some(ReasonFactReference::new(format!(
+            "reason-fact-{idempotency_key}"
+        ))),
+        fact_idempotency_key: Some(C2BoundedPromiseReliabilityFactIdempotencyKey::new(
+            idempotency_key,
+        )),
+        evidence_posture: Some(EvidencePosture::Bounded),
+        reviewability_posture: Some(ReviewabilityPosture::Reviewable),
+        retention_posture: Some(RetentionPosture::Classified(RetentionClassReference::new(
+            "R4 Trust / moderation / case",
+        ))),
+        authority_posture: SocialTrustAuthorityPosture::WriterTruthOnly,
+        boundary_posture: C2BoundedPromiseReliabilityBoundaryPosture::Clear,
+    }
+}
+
+fn record_input(
+    subject_account_id: Uuid,
+    proposal: ProposedC2BoundedPromiseReliabilityMutationFact,
+) -> RecordC2BoundedPromiseReliabilityMutationFactInput {
+    RecordC2BoundedPromiseReliabilityMutationFactInput {
+        subject_account_id: subject_account_id.to_string(),
+        realm_reference: Some(REALM_REFERENCE.to_owned()),
+        proposal,
+    }
+}
+
+fn recorded(outcome: SocialTrustMutationPersistenceOutcome) -> C2BoundedPromiseReliabilitySnapshot {
+    match outcome {
+        SocialTrustMutationPersistenceOutcome::Recorded(snapshot) => snapshot,
+        SocialTrustMutationPersistenceOutcome::RejectedBeforePersistence { decision } => {
+            panic!("expected recorded C2 fact, got rejected before persistence: {decision:?}")
+        }
+    }
+}
+
+fn assert_same_writer_fact(
+    first: &C2BoundedPromiseReliabilitySnapshot,
+    second: &C2BoundedPromiseReliabilitySnapshot,
+) {
+    assert_eq!(first.source_reference_id, second.source_reference_id);
+    assert_eq!(first.mutation_fact_id, second.mutation_fact_id);
+    assert_eq!(first.source_fact_label, second.source_fact_label);
+    assert_eq!(first.mutation_fact_label, second.mutation_fact_label);
+    assert_eq!(first.request_payload_hash, second.request_payload_hash);
+    assert_eq!(first.decision_payload_hash, second.decision_payload_hash);
+}
+
+fn assert_idempotency_conflict(
+    error: SocialTrustMutationPersistenceError,
+    expected_source_reference_id: &str,
+) {
+    match error {
+        SocialTrustMutationPersistenceError::IdempotencyConflict {
+            existing_source_reference_id,
+            ..
+        } => assert_eq!(existing_source_reference_id, expected_source_reference_id),
+        other => panic!("expected idempotency conflict, got {other:?}"),
+    }
+}
+
+async fn source_count_for_subject(
+    client: &tokio_postgres::Client,
+    subject_account_id: &Uuid,
+) -> i64 {
+    let row = client
+        .query_one(
+            "
+            SELECT COUNT(*)::bigint AS count
+            FROM social_trust.categorical_source_references
+            WHERE subject_account_id = $1
+            ",
+            &[subject_account_id],
+        )
+        .await
+        .expect("source reference count should load");
+    row.get("count")
+}
+
+async fn mutation_count_for_subject(
+    client: &tokio_postgres::Client,
+    subject_account_id: &Uuid,
+) -> i64 {
+    let row = client
+        .query_one(
+            "
+            SELECT COUNT(*)::bigint AS count
+            FROM social_trust.categorical_mutation_facts
+            WHERE subject_account_id = $1
+            ",
+            &[subject_account_id],
+        )
+        .await
+        .expect("mutation fact count should load");
+    row.get("count")
+}
+
+async fn assert_projection_absent_for_subject(
+    client: &tokio_postgres::Client,
+    subject_account_id: &Uuid,
+) {
+    let row = client
+        .query_one(
+            "
+            SELECT
+                (SELECT COUNT(*)::bigint
+                 FROM projection.trust_snapshots
+                 WHERE account_id = $1) AS trust_snapshot_count,
+                (SELECT COUNT(*)::bigint
+                 FROM projection.realm_trust_snapshots
+                 WHERE account_id = $1) AS realm_trust_snapshot_count
+            ",
+            &[subject_account_id],
+        )
+        .await
+        .expect("projection counts should load");
+
+    assert_eq!(row.get::<_, i64>("trust_snapshot_count"), 0);
+    assert_eq!(row.get::<_, i64>("realm_trust_snapshot_count"), 0);
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct CoordinationCounts {
+    outbox_events: i64,
+    outbox_attempts: i64,
+    command_inbox: i64,
+    outbox_event_archive: i64,
+    outbox_attempt_archive: i64,
+    command_inbox_archive: i64,
+}
+
+async fn coordination_counts(client: &tokio_postgres::Client) -> CoordinationCounts {
+    let row = client
+        .query_one(
+            "
+            SELECT
+                (SELECT COUNT(*)::bigint FROM outbox.events) AS outbox_events,
+                (SELECT COUNT(*)::bigint FROM outbox.outbox_attempts) AS outbox_attempts,
+                (SELECT COUNT(*)::bigint FROM outbox.command_inbox) AS command_inbox,
+                (SELECT COUNT(*)::bigint FROM outbox.outbox_event_archive) AS outbox_event_archive,
+                (SELECT COUNT(*)::bigint FROM outbox.outbox_attempt_archive) AS outbox_attempt_archive,
+                (SELECT COUNT(*)::bigint FROM outbox.command_inbox_archive) AS command_inbox_archive
+            ",
+            &[],
+        )
+        .await
+        .expect("coordination counts should load");
+
+    CoordinationCounts {
+        outbox_events: row.get("outbox_events"),
+        outbox_attempts: row.get("outbox_attempts"),
+        command_inbox: row.get("command_inbox"),
+        outbox_event_archive: row.get("outbox_event_archive"),
+        outbox_attempt_archive: row.get("outbox_attempt_archive"),
+        command_inbox_archive: row.get("command_inbox_archive"),
+    }
+}
+
+async fn assert_public_projection_not_visible(app: &Router, subject: &SignedInUser) {
+    let global = get_json(
+        app,
+        &format!("/api/projection/trust-snapshots/{}", subject.account_id),
+        Some(subject.token.as_str()),
+    )
+    .await;
+    assert_ne!(global.status, StatusCode::OK);
+    assert_no_trust_or_lifecycle_exposure_fields(&global.body);
+
+    let realm = get_json(
+        app,
+        &format!(
+            "/api/projection/realm-trust-snapshots/{}/{}",
+            REALM_REFERENCE, subject.account_id
+        ),
+        Some(subject.token.as_str()),
+    )
+    .await;
+    assert_ne!(realm.status, StatusCode::OK);
+    assert_no_trust_or_lifecycle_exposure_fields(&realm.body);
+}
+
+async fn assert_no_score_display_or_relationship_depth_columns(client: &tokio_postgres::Client) {
+    let rows = client
+        .query(
+            "
+            SELECT table_name, column_name
+            FROM information_schema.columns
+            WHERE table_schema = 'social_trust'
+              AND table_name IN (
+                  'categorical_source_references',
+                  'categorical_mutation_facts'
+              )
+              AND (
+                  column_name LIKE '%score%'
+                  OR column_name LIKE '%weight%'
+                  OR column_name LIKE '%rank%'
+                  OR column_name LIKE '%display%'
+                  OR column_name LIKE '%relationship_depth%'
+                  OR column_name LIKE '%projection%'
+              )
+            ",
+            &[],
+        )
+        .await
+        .expect("social trust column metadata should load");
+
+    assert!(
+        rows.is_empty(),
+        "C2 concurrent idempotency must not expose score/display/projection/Relationship Depth columns: {:?}",
+        rows.iter()
+            .map(|row| format!(
+                "{}.{}",
+                row.get::<_, String>("table_name"),
+                row.get::<_, String>("column_name")
+            ))
+            .collect::<Vec<_>>()
+    );
+}
+
+fn assert_no_trust_or_lifecycle_exposure_fields(body: &Value) {
+    for field in [
+        "trust_posture",
+        "reason_codes",
+        "trust_score",
+        "score",
+        "rank",
+        "trust_rank",
+        "trust_tier",
+        "display_level",
+        "public_level",
+        "recovery_ceiling",
+        "discovery_priority",
+        "recommendation_boost",
+        "contact_unlock",
+        "room_transition",
+        "settlement_progression",
+        "promise_runtime_outcome",
+        "proof_runtime_outcome",
+        "relationship_depth",
+        "mobile_ui_state",
+        "retention_action",
+        "pruning_action",
+        "archive_action",
+        "deletion_action",
+        "legal_hold_action",
+        "key_lifecycle_action",
+        "retry_action",
+        "queue_action",
+        "outbox_action",
+        "inbox_action",
+    ] {
+        assert!(
+            body.get(field).is_none(),
+            "C2 concurrent idempotency must not expose {field} in public API response"
+        );
+    }
+}
+
+struct SignedInUser {
+    token: String,
+    account_id: String,
+}
+
+async fn sign_in(app: &Router, pi_uid: &str, username: &str) -> SignedInUser {
+    let response = post_json(
+        app,
+        "/api/auth/pi",
+        None,
+        json!({
+            "pi_uid": pi_uid,
+            "username": username,
+            "wallet_address": format!("wallet-{pi_uid}"),
+            "access_token": format!("access-token-{pi_uid}")
+        }),
+    )
+    .await;
+    assert_eq!(response.status, StatusCode::OK);
+
+    SignedInUser {
+        token: response.body["token"]
+            .as_str()
+            .expect("token must exist")
+            .to_owned(),
+        account_id: response.body["user"]["id"]
+            .as_str()
+            .expect("user id must exist")
+            .to_owned(),
+    }
+}
+
+struct JsonResponse {
+    status: StatusCode,
+    body: Value,
+}
+
+async fn post_json(
+    app: &Router,
+    path: &str,
+    bearer_token: Option<&str>,
+    body: Value,
+) -> JsonResponse {
+    request_json(app, "POST", path, bearer_token, Some(body)).await
+}
+
+async fn get_json(app: &Router, path: &str, bearer_token: Option<&str>) -> JsonResponse {
+    request_json(app, "GET", path, bearer_token, None).await
+}
+
+async fn request_json(
+    app: &Router,
+    method: &str,
+    path: &str,
+    bearer_token: Option<&str>,
+    body: Option<Value>,
+) -> JsonResponse {
+    let mut builder = Request::builder().method(method).uri(path);
+    if let Some(token) = bearer_token {
+        builder = builder.header("authorization", format!("Bearer {token}"));
+    }
+
+    let request = builder
+        .header("content-type", "application/json")
+        .body(match body {
+            Some(body) => Body::from(body.to_string()),
+            None => Body::empty(),
+        })
+        .expect("request must build");
+
+    let response = app
+        .clone()
+        .oneshot(request)
+        .await
+        .expect("app should respond");
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body must be readable");
+    let body = if bytes.is_empty() {
+        json!({})
+    } else {
+        serde_json::from_slice(&bytes).expect("response body must be valid json")
+    };
+
+    JsonResponse { status, body }
+}

--- a/docs/foundation_lock.md
+++ b/docs/foundation_lock.md
@@ -1,6 +1,6 @@
 # Foundation Lock
 
-Status: Draft; aligned to accepted foundation commit `37c17d2`
+Status: Draft; aligned to accepted foundation commit `650c254`
 Applies to: `mt4110/pi-musubi-core`
 Purpose: Pin the constitutional and architectural source of truth that this implementation repository must follow.
 
@@ -26,14 +26,14 @@ Upstream repository:
 Pinned reference for implementation work:
 
 - Foundation reference type: `commit`
-- Foundation commit SHA: `37c17d233f5134c0b2cebdf0f99150417840d795`
-- Foundation commit title: `Merge pull request #154 from mt4110/feat/evaluate-post-c2-categorical-fact-rejection-boundary-handoff`
-- Foundation PR title: `docs: evaluate post-C2 categorical fact rejection handoff`
-- Foundation PR URL: `https://github.com/mt4110/musubi-foundation/pull/154`
+- Foundation commit SHA: `650c25456ff5a3536ff7731dc8d46e9dfcd4a634`
+- Foundation commit title: `Merge pull request #160 from mt4110/feat/evaluate-post-c2-categorical-fact-concurrent-idempotency-handoff`
+- Foundation PR title: `docs: evaluate post-C2 categorical fact concurrent idempotency handoff`
+- Foundation PR URL: `https://github.com/mt4110/musubi-foundation/pull/160`
 - Date pinned: `2026-05-14`
 - Pinned by: `Masaki Takemura`
-- Pinned commit URL: `https://github.com/mt4110/musubi-foundation/commit/37c17d233f5134c0b2cebdf0f99150417840d795`
-- Previous pinned reference: `1d12729` / `Merge pull request #148 from mt4110/feat/evaluate-post-c2-categorical-fact-lifecycle-replay-handoff`
+- Pinned commit URL: `https://github.com/mt4110/musubi-foundation/commit/650c25456ff5a3536ff7731dc8d46e9dfcd4a634`
+- Previous pinned reference: `37c17d2` / `Merge pull request #154 from mt4110/feat/evaluate-post-c2-categorical-fact-rejection-boundary-handoff`
 - Post-C2 evidence source: `cfdba28` / `Merge pull request #114 from mt4110/feat/post-c2-runtime-handoff-evidence-package`
 - Alignment allowance source: `69b7aa4` / `Merge pull request #116 from mt4110/feat/evaluate-post-c2-runtime-handoff-gate`
 - Post-C2 implementation handoff evidence source: `ef23e88` / `Merge pull request #122 from mt4110/feat/post-c2-implementation-handoff-evidence-package`
@@ -53,6 +53,9 @@ Pinned reference for implementation work:
 - Post-C2 categorical fact lifecycle replay boundary implementation closeout source: `e177e10` / `Merge pull request #150 from mt4110/feat/close-post-c2-categorical-fact-lifecycle-replay-handoff`
 - Post-C2 categorical fact rejection boundary non-persistence evidence source: `1e93f9f` / `Merge pull request #152 from mt4110/feat/post-c2-categorical-fact-rejection-boundary-evidence`
 - Post-C2 categorical fact rejection boundary non-persistence handoff source: `37c17d2` / `Merge pull request #154 from mt4110/feat/evaluate-post-c2-categorical-fact-rejection-boundary-handoff`
+- Post-C2 categorical fact rejection boundary non-persistence implementation closeout source: `4106009` / `Merge pull request #156 from mt4110/feat/close-post-c2-categorical-fact-rejection-boundary-handoff`
+- Post-C2 categorical fact concurrent idempotency evidence source: `67a5ad6` / `Merge pull request #158 from mt4110/feat/post-c2-categorical-fact-concurrent-idempotency-evidence`
+- Post-C2 categorical fact concurrent idempotency handoff source: `650c254` / `Merge pull request #160 from mt4110/feat/evaluate-post-c2-categorical-fact-concurrent-idempotency-handoff`
 
 No release tag is asserted for this alignment.
 Do not invent a foundation version label for this commit.
@@ -150,31 +153,34 @@ Before coding, read these upstream documents in order.
 77. `docs/readiness/post_c2_categorical_fact_lifecycle_replay_boundary_implementation_closeout_ledger.md`
 78. `docs/readiness/post_c2_categorical_fact_rejection_boundary_non_persistence_evidence_package.md`
 79. `docs/readiness/post_c2_categorical_fact_rejection_boundary_non_persistence_handoff_gate_decision.md`
+80. `docs/readiness/post_c2_categorical_fact_rejection_boundary_non_persistence_implementation_closeout_ledger.md`
+81. `docs/readiness/post_c2_categorical_fact_concurrent_idempotency_evidence_package.md`
+82. `docs/readiness/post_c2_categorical_fact_concurrent_idempotency_handoff_gate_decision.md`
 
 ### Detail layer
-80. `docs/detail/accountability_matrix.md`
-81. `docs/detail/critical_incident_and_loss.md`
-82. `docs/detail/automated_decisioning_and_human_appeal.md`
-83. `docs/detail/youth_safety_and_age_assurance.md`
-84. `docs/detail/off_platform_handoff_and_scam_prevention.md`
-85. `docs/detail/data_deletion_vs_legal_hold.md`
-86. `docs/detail/realm_model.md`
-87. `docs/detail/data_scope_model.md`
-88. `docs/detail/mobility_model.md`
-89. `docs/detail/settlement_model.md`
-90. `docs/detail/settlement_backend_trait.md`
-91. `docs/detail/proof_of_infrastructure.md`
-92. `docs/detail/protected_groups_and_translation_safety.md`
+83. `docs/detail/accountability_matrix.md`
+84. `docs/detail/critical_incident_and_loss.md`
+85. `docs/detail/automated_decisioning_and_human_appeal.md`
+86. `docs/detail/youth_safety_and_age_assurance.md`
+87. `docs/detail/off_platform_handoff_and_scam_prevention.md`
+88. `docs/detail/data_deletion_vs_legal_hold.md`
+89. `docs/detail/realm_model.md`
+90. `docs/detail/data_scope_model.md`
+91. `docs/detail/mobility_model.md`
+92. `docs/detail/settlement_model.md`
+93. `docs/detail/settlement_backend_trait.md`
+94. `docs/detail/proof_of_infrastructure.md`
+95. `docs/detail/protected_groups_and_translation_safety.md`
 
 ### Whitepaper layer (contextual, not higher than detail/ADR)
-93. `docs/whitepaper/01_executive_summary.md`
-94. `docs/whitepaper/02_realm_model.md`
-95. `docs/whitepaper/03_experience_model.md`
-96. `docs/whitepaper/04_dm_shield.md`
-97. `docs/whitepaper/05_trust_model.md`
-98. `docs/whitepaper/06_promise_protocol.md`
-99. `docs/whitepaper/07_realm_economy.md`
-100. `docs/whitepaper/08_unlock_engine.md`
+96. `docs/whitepaper/01_executive_summary.md`
+97. `docs/whitepaper/02_realm_model.md`
+98. `docs/whitepaper/03_experience_model.md`
+99. `docs/whitepaper/04_dm_shield.md`
+100. `docs/whitepaper/05_trust_model.md`
+101. `docs/whitepaper/06_promise_protocol.md`
+102. `docs/whitepaper/07_realm_economy.md`
+103. `docs/whitepaper/08_unlock_engine.md`
 
 If any of the above are unavailable or materially inconsistent, stop and escalate.
 
@@ -204,7 +210,7 @@ That one-use C2 implementation allowance was consumed by `mt4110/pi-musubi-core`
 No remaining work may inherit permission from foundation PR #108 or implementation PR #88.
 The broad runtime implementation gate result remains NO-GO.
 Broad runtime implementation remains blocked.
-The current narrow downstream allowance is one implementation-repo test-only PR for post-C2 categorical Social Trust fact rejection boundary non-persistence verification.
+The current narrow downstream allowance is one implementation-repo test-only PR for post-C2 categorical Social Trust fact concurrent idempotency / replay / payload-drift verification.
 
 The C2 bounded Promise reliability readiness and closeout chain is accepted for docs-only foundation semantic scope:
 
@@ -238,6 +244,9 @@ The C2 bounded Promise reliability readiness and closeout chain is accepted for 
 - `docs/readiness/post_c2_categorical_fact_lifecycle_replay_boundary_implementation_closeout_ledger.md`
 - `docs/readiness/post_c2_categorical_fact_rejection_boundary_non_persistence_evidence_package.md`
 - `docs/readiness/post_c2_categorical_fact_rejection_boundary_non_persistence_handoff_gate_decision.md`
+- `docs/readiness/post_c2_categorical_fact_rejection_boundary_non_persistence_implementation_closeout_ledger.md`
+- `docs/readiness/post_c2_categorical_fact_concurrent_idempotency_evidence_package.md`
+- `docs/readiness/post_c2_categorical_fact_concurrent_idempotency_handoff_gate_decision.md`
 
 The accepted C2 gate records `bounded_promise_reliability` as the only positive Social Trust source-family candidate and accepts exact source facts and exact Social Trust mutation facts only as foundation semantic labels.
 Those labels are not runtime schema names, enum values, API names, migration names, module names, or test names.
@@ -265,9 +274,12 @@ Foundation PR #146 accepted the exact candidate test-only slice as post-C2 categ
 Foundation PR #148 provided the consumed narrow downstream test-only handoff authority for one later implementation-repo PR only, limited to post-C2 categorical Social Trust fact account-lifecycle replay boundary verification.
 That allowance was consumed by `mt4110/pi-musubi-core` PR #100 and closed out by foundation PR #150.
 Foundation PR #152 accepted the exact candidate test-only slice as post-C2 categorical Social Trust fact rejection boundary non-persistence verification.
-Foundation PR #154 provides the current narrow downstream test-only handoff authority for one later implementation-repo PR only.
+Foundation PR #154 provided the consumed narrow downstream test-only handoff authority for one later implementation-repo PR only, limited to post-C2 categorical Social Trust fact rejection boundary non-persistence verification.
+That allowance was consumed by `mt4110/pi-musubi-core` PR #102 and closed out by foundation PR #156.
+Foundation PR #158 accepted the exact candidate test-only slice as post-C2 categorical Social Trust fact concurrent idempotency / replay / payload-drift verification.
+Foundation PR #160 provides the current narrow downstream test-only handoff authority for one later implementation-repo PR only.
 This update is the required lock pin for that one-use allowance.
-It does not authorize implementation outside the PR #154 envelope.
+It does not authorize implementation outside the PR #160 envelope.
 It does not authorize new source facts, new mutation facts, DDL, migrations, backend runtime code, backend README updates, backend docs updates, public API changes, mobile UI, projection refresh, runtime orchestration, lifecycle runtime behavior, pruning, archive, deletion, Legal Hold runtime behavior, key lifecycle behavior, retry workers, queues, outbox changes, inbox changes, discovery, recommendation, room, settlement, Promise runtime, proof runtime, Relationship Depth, Social Trust scoring, public trust display, or any broader `pi-musubi-core` change.
 
 Implementation merge history, issue order, branch ancestry, and existing code are not foundation design proof.


### PR DESCRIPTION
## Summary
- Pins `docs/foundation_lock.md` to musubi-foundation PR #160 for the one-use concurrent idempotency test-only handoff.
- Adds deterministic backend integration coverage for concurrent identical delivery and concurrent payload drift on the accepted C2 completed-as-agreed / positive mutation pair.
- Verifies one writer fact, replay/conflict behavior, no projection/coordination/public API exposure, and no score/display or Relationship Depth behavior.

## Scope
- Closes #103
- Authorized by musubi-foundation PR #160 only.
- No DDL, migrations, backend runtime code, public API, mobile UI, projection refresh, outbox/inbox runtime behavior, or scoring/display changes.

## Validation
- `rustfmt --edition 2024 --check apps/backend/tests/post_c2_categorical_fact_concurrent_idempotency_boundary.rs`
- `cargo test --manifest-path apps/backend/Cargo.toml --test post_c2_categorical_fact_concurrent_idempotency_boundary -- --test-threads=1`
- `cargo test --manifest-path apps/backend/crates/social-trust-domain/Cargo.toml`
- `cargo test --manifest-path apps/backend/Cargo.toml --test post_c2_categorical_fact_idempotency_replay -- --test-threads=1`
- `cargo test --manifest-path apps/backend/Cargo.toml --test c2_bounded_promise_reliability_persistence -- --test-threads=1`
- `cargo test --manifest-path apps/backend/Cargo.toml --test post_c2_categorical_fact_rejection_boundary_non_persistence -- --test-threads=1`
