### PR TITLE
test: verify Controlled Exceptional Account subject rejection

### DIFF
--- a/apps/backend/tests/post_c2_categorical_fact_controlled_exceptional_account_subject.rs
+++ b/apps/backend/tests/post_c2_categorical_fact_controlled_exceptional_account_subject.rs
@@ -1,0 +1,562 @@
+use std::path::PathBuf;
+
+use axum::{
+    Router,
+    body::{Body, to_bytes},
+    http::{Request, StatusCode},
+};
+use musubi_backend::{
+    build_app, new_test_state,
+    services::social_trust_mutation::{
+        RecordC2BoundedPromiseReliabilityMutationFactInput, SocialTrustMutationPersistenceError,
+        SocialTrustMutationStore,
+    },
+};
+use musubi_db_runtime::DbConfig;
+use musubi_social_trust_domain::{
+    AccountLifecycleReference, AgeAssuranceStateReference, AntiAbuseContinuityReference,
+    AuditReference, BlockWithdrawalStateReference, C2BoundedPromiseReliabilityBoundaryPosture,
+    C2BoundedPromiseReliabilityFactIdempotencyKey, C2BoundedPromiseReliabilityMutationFact,
+    C2BoundedPromiseReliabilityMutationFactCandidate, C2BoundedPromiseReliabilitySourceFact,
+    C2BoundedPromiseReliabilitySourceFactCandidate, ConsentStateReference,
+    CriticalHarmCaseReference, EvidenceLevelReference, EvidencePosture,
+    LegalHoldIntersectionReference, PromiseReference, PromiseTermsReference,
+    ProposedC2BoundedPromiseReliabilityMutationFact, ReasonFactReference, RetentionClassReference,
+    RetentionPosture, ReviewabilityPosture, SafetyCaseReference, SocialTrustAuthorityPosture,
+    WriterSourceReference,
+};
+use serde_json::{Value, json};
+use tokio_postgres::NoTls;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+const REALM_REFERENCE: &str = "realm-reference-post-c2-controlled-exceptional-account-subject";
+
+#[tokio::test]
+async fn active_controlled_exceptional_account_subject_fails_closed_without_side_effects() {
+    let (_test_state, app, config, client) = test_context().await;
+    let subject_account_id =
+        insert_account(&client, "Controlled Exceptional Account", "active").await;
+    assert_active_controlled_exceptional_account(&client, &subject_account_id).await;
+    let before_coordination = coordination_counts(&client).await;
+    let before_runtime = runtime_surface_counts(&client).await;
+    let store = SocialTrustMutationStore::connect(&config)
+        .await
+        .expect("social trust mutation store should connect");
+
+    let error = store
+        .record_c2_bounded_promise_reliability_fact(record_input(
+            subject_account_id,
+            complete_proposal("post-c2-controlled-exceptional-account-subject"),
+        ))
+        .await
+        .expect_err("Controlled Exceptional Account subject must fail closed");
+
+    assert_controlled_exceptional_subject_rejected(error);
+    assert_no_writer_projection_or_coordination_side_effects(
+        &client,
+        &subject_account_id,
+        &before_coordination,
+    )
+    .await;
+    assert_eq!(runtime_surface_counts(&client).await, before_runtime);
+    assert_public_projection_not_visible(&app, &subject_account_id).await;
+    assert_no_score_display_or_relationship_depth_columns(&client).await;
+}
+
+async fn test_context() -> (
+    musubi_backend::TestState,
+    Router,
+    DbConfig,
+    tokio_postgres::Client,
+) {
+    let test_state = new_test_state()
+        .await
+        .expect("test database state should initialize");
+    let app = build_app(test_state.state.clone());
+    let database_url = std::env::var("MUSUBI_TEST_DATABASE_URL")
+        .or_else(|_| std::env::var("DATABASE_URL"))
+        .expect("integration tests require MUSUBI_TEST_DATABASE_URL or DATABASE_URL to be set");
+    let migrations_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("migrations")
+        .canonicalize()
+        .expect("migrations directory should resolve");
+    let migrations_dir = migrations_dir
+        .to_str()
+        .expect("migrations directory should be utf-8")
+        .to_owned();
+    let config = DbConfig::from_lookup(|name| match name {
+        "APP_ENV" => Some("test".to_owned()),
+        "DATABASE_URL" => Some(database_url.clone()),
+        "MIGRATIONS_DIR" => Some(migrations_dir.clone()),
+        "REQUIRE_LATEST_SCHEMA" => Some("true".to_owned()),
+        _ => None,
+    })
+    .expect("test db config should parse");
+
+    let (client, connection) = tokio_postgres::connect(&database_url, NoTls)
+        .await
+        .expect("failed to connect to test database");
+    tokio::spawn(async move {
+        if let Err(error) = connection.await {
+            eprintln!("test database connection error: {error}");
+        }
+    });
+
+    (test_state, app, config, client)
+}
+
+fn complete_proposal(idempotency_key: &str) -> ProposedC2BoundedPromiseReliabilityMutationFact {
+    ProposedC2BoundedPromiseReliabilityMutationFact {
+        source_fact: C2BoundedPromiseReliabilitySourceFactCandidate::Accepted(
+            C2BoundedPromiseReliabilitySourceFact::CompletedAsAgreed,
+        ),
+        requested_mutation_fact: C2BoundedPromiseReliabilityMutationFactCandidate::Accepted(
+            C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityPositive,
+        ),
+        writer_source_reference: Some(WriterSourceReference::new(format!(
+            "writer-source-{idempotency_key}"
+        ))),
+        promise_reference: Some(PromiseReference::new(format!("promise-{idempotency_key}"))),
+        promise_terms_reference: Some(PromiseTermsReference::new(format!(
+            "promise-terms-{idempotency_key}"
+        ))),
+        consent_at_formation_reference: Some(ConsentStateReference::new(format!(
+            "consent-formation-{idempotency_key}"
+        ))),
+        consent_at_resolution_reference: Some(ConsentStateReference::new(format!(
+            "consent-resolution-{idempotency_key}"
+        ))),
+        block_withdrawal_state_reference: Some(BlockWithdrawalStateReference::new(format!(
+            "block-withdrawal-clear-{idempotency_key}"
+        ))),
+        age_assurance_state_reference: Some(AgeAssuranceStateReference::new(format!(
+            "age-assurance-adult-eligible-{idempotency_key}"
+        ))),
+        legal_hold_intersection_reference: Some(LegalHoldIntersectionReference::new(format!(
+            "legal-hold-clear-{idempotency_key}"
+        ))),
+        critical_harm_case_reference: Some(CriticalHarmCaseReference::new(format!(
+            "critical-harm-clear-{idempotency_key}"
+        ))),
+        account_lifecycle_reference: Some(AccountLifecycleReference::new(format!(
+            "account-lifecycle-active-{idempotency_key}"
+        ))),
+        anti_abuse_continuity_reference: Some(AntiAbuseContinuityReference::new(format!(
+            "anti-abuse-clear-{idempotency_key}"
+        ))),
+        safety_case_reference: Some(SafetyCaseReference::new(format!(
+            "safety-case-clear-{idempotency_key}"
+        ))),
+        evidence_level_reference: Some(EvidenceLevelReference::new(format!(
+            "evidence-level-bounded-{idempotency_key}"
+        ))),
+        audit_reference: Some(AuditReference::new(format!("audit-{idempotency_key}"))),
+        reason_fact: Some(ReasonFactReference::new(format!(
+            "reason-fact-{idempotency_key}"
+        ))),
+        fact_idempotency_key: Some(C2BoundedPromiseReliabilityFactIdempotencyKey::new(
+            idempotency_key,
+        )),
+        evidence_posture: Some(EvidencePosture::Bounded),
+        reviewability_posture: Some(ReviewabilityPosture::Reviewable),
+        retention_posture: Some(RetentionPosture::Classified(RetentionClassReference::new(
+            "R4 Trust / moderation / case",
+        ))),
+        authority_posture: SocialTrustAuthorityPosture::WriterTruthOnly,
+        boundary_posture: C2BoundedPromiseReliabilityBoundaryPosture::Clear,
+    }
+}
+
+fn record_input(
+    subject_account_id: Uuid,
+    proposal: ProposedC2BoundedPromiseReliabilityMutationFact,
+) -> RecordC2BoundedPromiseReliabilityMutationFactInput {
+    RecordC2BoundedPromiseReliabilityMutationFactInput {
+        subject_account_id: subject_account_id.to_string(),
+        realm_reference: Some(REALM_REFERENCE.to_owned()),
+        proposal,
+    }
+}
+
+fn assert_controlled_exceptional_subject_rejected(error: SocialTrustMutationPersistenceError) {
+    match error {
+        SocialTrustMutationPersistenceError::BadRequest(message) => {
+            assert!(
+                message.contains("must be an Ordinary Account"),
+                "Controlled Exceptional Account subject rejection should name the Ordinary Account boundary; got {message:?}"
+            );
+        }
+        other => panic!("expected Ordinary Account boundary rejection, got {other:?}"),
+    }
+}
+
+async fn insert_account(
+    client: &tokio_postgres::Client,
+    account_class: &str,
+    account_state: &str,
+) -> Uuid {
+    let account_id = Uuid::new_v4();
+    client
+        .execute(
+            "
+            INSERT INTO core.accounts (account_id, account_class, account_state)
+            VALUES ($1, $2, $3)
+            ",
+            &[&account_id, &account_class, &account_state],
+        )
+        .await
+        .expect("account insert should succeed");
+    account_id
+}
+
+async fn assert_active_controlled_exceptional_account(
+    client: &tokio_postgres::Client,
+    account_id: &Uuid,
+) {
+    let row = client
+        .query_one(
+            "
+            SELECT account_class, account_state
+            FROM core.accounts
+            WHERE account_id = $1
+            ",
+            &[account_id],
+        )
+        .await
+        .expect("account classification should load");
+
+    assert_eq!(
+        row.get::<_, String>("account_class"),
+        "Controlled Exceptional Account"
+    );
+    assert_eq!(row.get::<_, String>("account_state"), "active");
+}
+
+async fn assert_no_writer_projection_or_coordination_side_effects(
+    client: &tokio_postgres::Client,
+    subject_account_id: &Uuid,
+    before_coordination: &CoordinationCounts,
+) {
+    assert_eq!(
+        source_count_for_subject(client, subject_account_id).await,
+        0
+    );
+    assert_eq!(
+        mutation_count_for_subject(client, subject_account_id).await,
+        0
+    );
+    assert_projection_absent_for_subject(client, subject_account_id).await;
+    assert_eq!(&coordination_counts(client).await, before_coordination);
+}
+
+async fn source_count_for_subject(
+    client: &tokio_postgres::Client,
+    subject_account_id: &Uuid,
+) -> i64 {
+    let row = client
+        .query_one(
+            "
+            SELECT COUNT(*)::bigint AS count
+            FROM social_trust.categorical_source_references
+            WHERE subject_account_id = $1
+            ",
+            &[subject_account_id],
+        )
+        .await
+        .expect("source reference count should load");
+    row.get("count")
+}
+
+async fn mutation_count_for_subject(
+    client: &tokio_postgres::Client,
+    subject_account_id: &Uuid,
+) -> i64 {
+    let row = client
+        .query_one(
+            "
+            SELECT COUNT(*)::bigint AS count
+            FROM social_trust.categorical_mutation_facts
+            WHERE subject_account_id = $1
+            ",
+            &[subject_account_id],
+        )
+        .await
+        .expect("mutation fact count should load");
+    row.get("count")
+}
+
+async fn assert_projection_absent_for_subject(
+    client: &tokio_postgres::Client,
+    subject_account_id: &Uuid,
+) {
+    let row = client
+        .query_one(
+            "
+            SELECT
+                (SELECT COUNT(*)::bigint
+                 FROM projection.trust_snapshots
+                 WHERE account_id = $1) AS trust_snapshot_count,
+                (SELECT COUNT(*)::bigint
+                 FROM projection.realm_trust_snapshots
+                 WHERE account_id = $1) AS realm_trust_snapshot_count
+            ",
+            &[subject_account_id],
+        )
+        .await
+        .expect("projection counts should load");
+
+    assert_eq!(row.get::<_, i64>("trust_snapshot_count"), 0);
+    assert_eq!(row.get::<_, i64>("realm_trust_snapshot_count"), 0);
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct CoordinationCounts {
+    outbox_events: i64,
+    outbox_attempts: i64,
+    command_inbox: i64,
+    recovery_runs: i64,
+    outbox_event_archive: i64,
+    outbox_attempt_archive: i64,
+    command_inbox_archive: i64,
+}
+
+async fn coordination_counts(client: &tokio_postgres::Client) -> CoordinationCounts {
+    let row = client
+        .query_one(
+            "
+            SELECT
+                (SELECT COUNT(*)::bigint FROM outbox.events) AS outbox_events,
+                (SELECT COUNT(*)::bigint FROM outbox.outbox_attempts) AS outbox_attempts,
+                (SELECT COUNT(*)::bigint FROM outbox.command_inbox) AS command_inbox,
+                (SELECT COUNT(*)::bigint FROM outbox.recovery_runs) AS recovery_runs,
+                (SELECT COUNT(*)::bigint FROM outbox.outbox_event_archive) AS outbox_event_archive,
+                (SELECT COUNT(*)::bigint FROM outbox.outbox_attempt_archive) AS outbox_attempt_archive,
+                (SELECT COUNT(*)::bigint FROM outbox.command_inbox_archive) AS command_inbox_archive
+            ",
+            &[],
+        )
+        .await
+        .expect("coordination counts should load");
+
+    CoordinationCounts {
+        outbox_events: row.get("outbox_events"),
+        outbox_attempts: row.get("outbox_attempts"),
+        command_inbox: row.get("command_inbox"),
+        recovery_runs: row.get("recovery_runs"),
+        outbox_event_archive: row.get("outbox_event_archive"),
+        outbox_attempt_archive: row.get("outbox_attempt_archive"),
+        command_inbox_archive: row.get("command_inbox_archive"),
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct RuntimeSurfaceCounts {
+    promise_intents: i64,
+    promise_intent_idempotency_keys: i64,
+    settlement_cases: i64,
+    settlement_intents: i64,
+    settlement_submissions: i64,
+    provider_attempts: i64,
+    settlement_observations: i64,
+    journal_entries: i64,
+    account_postings: i64,
+    promise_views: i64,
+    settlement_views: i64,
+    room_progression_tracks: i64,
+    room_progression_facts: i64,
+    room_progression_views: i64,
+    proposed_mutation_attempts: i64,
+    intake_decisions: i64,
+}
+
+async fn runtime_surface_counts(client: &tokio_postgres::Client) -> RuntimeSurfaceCounts {
+    let row = client
+        .query_one(
+            "
+            SELECT
+                (SELECT COUNT(*)::bigint FROM dao.promise_intents) AS promise_intents,
+                (SELECT COUNT(*)::bigint FROM dao.promise_intent_idempotency_keys) AS promise_intent_idempotency_keys,
+                (SELECT COUNT(*)::bigint FROM dao.settlement_cases) AS settlement_cases,
+                (SELECT COUNT(*)::bigint FROM dao.settlement_intents) AS settlement_intents,
+                (SELECT COUNT(*)::bigint FROM dao.settlement_submissions) AS settlement_submissions,
+                (SELECT COUNT(*)::bigint FROM dao.provider_attempts) AS provider_attempts,
+                (SELECT COUNT(*)::bigint FROM dao.settlement_observations) AS settlement_observations,
+                (SELECT COUNT(*)::bigint FROM ledger.journal_entries) AS journal_entries,
+                (SELECT COUNT(*)::bigint FROM ledger.account_postings) AS account_postings,
+                (SELECT COUNT(*)::bigint FROM projection.promise_views) AS promise_views,
+                (SELECT COUNT(*)::bigint FROM projection.settlement_views) AS settlement_views,
+                (SELECT COUNT(*)::bigint FROM dao.room_progression_tracks) AS room_progression_tracks,
+                (SELECT COUNT(*)::bigint FROM dao.room_progression_facts) AS room_progression_facts,
+                (SELECT COUNT(*)::bigint FROM projection.room_progression_views) AS room_progression_views,
+                (SELECT COUNT(*)::bigint FROM social_trust.proposed_mutation_attempts) AS proposed_mutation_attempts,
+                (SELECT COUNT(*)::bigint FROM social_trust.intake_decisions) AS intake_decisions
+            ",
+            &[],
+        )
+        .await
+        .expect("runtime surface counts should load");
+
+    RuntimeSurfaceCounts {
+        promise_intents: row.get("promise_intents"),
+        promise_intent_idempotency_keys: row.get("promise_intent_idempotency_keys"),
+        settlement_cases: row.get("settlement_cases"),
+        settlement_intents: row.get("settlement_intents"),
+        settlement_submissions: row.get("settlement_submissions"),
+        provider_attempts: row.get("provider_attempts"),
+        settlement_observations: row.get("settlement_observations"),
+        journal_entries: row.get("journal_entries"),
+        account_postings: row.get("account_postings"),
+        promise_views: row.get("promise_views"),
+        settlement_views: row.get("settlement_views"),
+        room_progression_tracks: row.get("room_progression_tracks"),
+        room_progression_facts: row.get("room_progression_facts"),
+        room_progression_views: row.get("room_progression_views"),
+        proposed_mutation_attempts: row.get("proposed_mutation_attempts"),
+        intake_decisions: row.get("intake_decisions"),
+    }
+}
+
+async fn assert_public_projection_not_visible(app: &Router, subject_account_id: &Uuid) {
+    let global = get_json(
+        app,
+        &format!("/api/projection/trust-snapshots/{subject_account_id}"),
+        None,
+    )
+    .await;
+    assert_ne!(global.status, StatusCode::OK);
+    assert_no_trust_or_lifecycle_exposure_fields(&global.body);
+
+    let realm = get_json(
+        app,
+        &format!("/api/projection/realm-trust-snapshots/{REALM_REFERENCE}/{subject_account_id}"),
+        None,
+    )
+    .await;
+    assert_ne!(realm.status, StatusCode::OK);
+    assert_no_trust_or_lifecycle_exposure_fields(&realm.body);
+}
+
+async fn assert_no_score_display_or_relationship_depth_columns(client: &tokio_postgres::Client) {
+    let rows = client
+        .query(
+            "
+            SELECT table_name, column_name
+            FROM information_schema.columns
+            WHERE table_schema = 'social_trust'
+              AND table_name IN (
+                  'categorical_source_references',
+                  'categorical_mutation_facts'
+              )
+              AND (
+                  column_name LIKE '%score%'
+                  OR column_name LIKE '%weight%'
+                  OR column_name LIKE '%rank%'
+                  OR column_name LIKE '%display%'
+                  OR column_name LIKE '%relationship_depth%'
+                  OR column_name LIKE '%projection%'
+              )
+            ",
+            &[],
+        )
+        .await
+        .expect("social trust column metadata should load");
+
+    assert!(
+        rows.is_empty(),
+        "C2 Controlled Exceptional Account subject boundary must not expose score/display/projection/Relationship Depth columns: {:?}",
+        rows.iter()
+            .map(|row| format!(
+                "{}.{}",
+                row.get::<_, String>("table_name"),
+                row.get::<_, String>("column_name")
+            ))
+            .collect::<Vec<_>>()
+    );
+}
+
+fn assert_no_trust_or_lifecycle_exposure_fields(body: &Value) {
+    for field in [
+        "trust_posture",
+        "reason_codes",
+        "trust_score",
+        "score",
+        "rank",
+        "trust_rank",
+        "trust_tier",
+        "display_level",
+        "public_level",
+        "recovery_ceiling",
+        "discovery_priority",
+        "recommendation_boost",
+        "contact_unlock",
+        "room_transition",
+        "settlement_progression",
+        "promise_runtime_outcome",
+        "proof_runtime_outcome",
+        "relationship_depth",
+        "mobile_ui_state",
+        "retention_action",
+        "pruning_action",
+        "archive_action",
+        "deletion_action",
+        "legal_hold_action",
+        "key_lifecycle_action",
+        "retry_action",
+        "queue_action",
+        "outbox_action",
+        "inbox_action",
+    ] {
+        assert!(
+            body.get(field).is_none(),
+            "C2 Controlled Exceptional Account subject boundary must not expose {field} in public API response"
+        );
+    }
+}
+
+struct JsonResponse {
+    status: StatusCode,
+    body: Value,
+}
+
+async fn get_json(app: &Router, path: &str, bearer_token: Option<&str>) -> JsonResponse {
+    request_json(app, "GET", path, bearer_token, None).await
+}
+
+async fn request_json(
+    app: &Router,
+    method: &str,
+    path: &str,
+    bearer_token: Option<&str>,
+    body: Option<Value>,
+) -> JsonResponse {
+    let mut builder = Request::builder().method(method).uri(path);
+    if let Some(token) = bearer_token {
+        builder = builder.header("authorization", format!("Bearer {token}"));
+    }
+
+    let request = builder
+        .header("content-type", "application/json")
+        .body(match body {
+            Some(body) => Body::from(body.to_string()),
+            None => Body::empty(),
+        })
+        .expect("request must build");
+
+    let response = app
+        .clone()
+        .oneshot(request)
+        .await
+        .expect("app should respond");
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body must be readable");
+    let body = if bytes.is_empty() {
+        json!({})
+    } else {
+        serde_json::from_slice(&bytes).expect("response body must be valid json")
+    };
+
+    JsonResponse { status, body }
+}

--- a/docs/foundation_lock.md
+++ b/docs/foundation_lock.md
@@ -1,6 +1,6 @@
 # Foundation Lock
 
-Status: Draft; aligned to accepted foundation commit `9910663`
+Status: Draft; aligned to accepted foundation commit `a171f24`
 Applies to: `mt4110/pi-musubi-core`
 Purpose: Pin the constitutional and architectural source of truth that this implementation repository must follow.
 
@@ -26,14 +26,14 @@ Upstream repository:
 Pinned reference for implementation work:
 
 - Foundation reference type: `commit`
-- Foundation commit SHA: `9910663b9a3f93fae55102db507d75ba578219b9`
-- Foundation commit title: `Merge pull request #166 from mt4110/feat/evaluate-post-c2-categorical-fact-subject-realm-idempotency-handoff`
-- Foundation PR title: `Evaluate post-C2 categorical fact subject and Realm idempotency handoff`
-- Foundation PR URL: `https://github.com/mt4110/musubi-foundation/pull/166`
-- Date pinned: `2026-05-14`
+- Foundation commit SHA: `a171f249b4daa279b6408b72747464dec297666b`
+- Foundation commit title: `Merge pull request #173 from mt4110/feat/evaluate-post-c2-controlled-exceptional-subject-handoff`
+- Foundation PR title: `docs: accept post-C2 Controlled Exceptional Account subject handoff`
+- Foundation PR URL: `https://github.com/mt4110/musubi-foundation/pull/173`
+- Date pinned: `2026-05-15`
 - Pinned by: `Masaki Takemura`
-- Pinned commit URL: `https://github.com/mt4110/musubi-foundation/commit/9910663b9a3f93fae55102db507d75ba578219b9`
-- Previous pinned reference: `650c254` / `Merge pull request #160 from mt4110/feat/evaluate-post-c2-categorical-fact-concurrent-idempotency-handoff`
+- Pinned commit URL: `https://github.com/mt4110/musubi-foundation/commit/a171f249b4daa279b6408b72747464dec297666b`
+- Previous pinned reference: `9910663` / `Merge pull request #166 from mt4110/feat/evaluate-post-c2-categorical-fact-subject-realm-idempotency-handoff`
 - Post-C2 evidence source: `cfdba28` / `Merge pull request #114 from mt4110/feat/post-c2-runtime-handoff-evidence-package`
 - Alignment allowance source: `69b7aa4` / `Merge pull request #116 from mt4110/feat/evaluate-post-c2-runtime-handoff-gate`
 - Post-C2 implementation handoff evidence source: `ef23e88` / `Merge pull request #122 from mt4110/feat/post-c2-implementation-handoff-evidence-package`
@@ -59,6 +59,9 @@ Pinned reference for implementation work:
 - Post-C2 categorical fact concurrent idempotency implementation closeout source: `aabbd36` / `Merge pull request #162 from mt4110/feat/close-post-c2-categorical-fact-concurrent-idempotency-handoff`
 - Post-C2 categorical fact subject and Realm idempotency scope evidence source: `a1027eb` / `Merge pull request #164 from mt4110/feat/post-c2-categorical-fact-subject-realm-idempotency-evidence`
 - Post-C2 categorical fact subject and Realm idempotency scope handoff source: `9910663` / `Merge pull request #166 from mt4110/feat/evaluate-post-c2-categorical-fact-subject-realm-idempotency-handoff`
+- Post-C2 categorical fact subject and Realm idempotency scope implementation closeout source: `76231d7` / `Merge pull request #168 from mt4110/feat/close-post-c2-categorical-fact-subject-realm-handoff`
+- Post-C2 categorical fact Controlled Exceptional Account subject evidence source: `104ce54` / `Merge pull request #170 from mt4110/feat/post-c2-controlled-exceptional-account-subject-evidence`
+- Post-C2 categorical fact Controlled Exceptional Account subject handoff source: `a171f24` / `Merge pull request #173 from mt4110/feat/evaluate-post-c2-controlled-exceptional-subject-handoff`
 
 No release tag is asserted for this alignment.
 Do not invent a foundation version label for this commit.
@@ -162,31 +165,34 @@ Before coding, read these upstream documents in order.
 83. `docs/readiness/post_c2_categorical_fact_concurrent_idempotency_implementation_closeout_ledger.md`
 84. `docs/readiness/post_c2_categorical_fact_subject_realm_idempotency_scope_evidence_package.md`
 85. `docs/readiness/post_c2_categorical_fact_subject_realm_idempotency_scope_handoff_gate_decision.md`
+86. `docs/readiness/post_c2_categorical_fact_subject_realm_idempotency_scope_implementation_closeout_ledger.md`
+87. `docs/readiness/post_c2_categorical_fact_controlled_exceptional_account_subject_evidence_package.md`
+88. `docs/readiness/post_c2_categorical_fact_controlled_exceptional_account_subject_handoff_gate_decision.md`
 
 ### Detail layer
-86. `docs/detail/accountability_matrix.md`
-87. `docs/detail/critical_incident_and_loss.md`
-88. `docs/detail/automated_decisioning_and_human_appeal.md`
-89. `docs/detail/youth_safety_and_age_assurance.md`
-90. `docs/detail/off_platform_handoff_and_scam_prevention.md`
-91. `docs/detail/data_deletion_vs_legal_hold.md`
-92. `docs/detail/realm_model.md`
-93. `docs/detail/data_scope_model.md`
-94. `docs/detail/mobility_model.md`
-95. `docs/detail/settlement_model.md`
-96. `docs/detail/settlement_backend_trait.md`
-97. `docs/detail/proof_of_infrastructure.md`
-98. `docs/detail/protected_groups_and_translation_safety.md`
+89. `docs/detail/accountability_matrix.md`
+90. `docs/detail/critical_incident_and_loss.md`
+91. `docs/detail/automated_decisioning_and_human_appeal.md`
+92. `docs/detail/youth_safety_and_age_assurance.md`
+93. `docs/detail/off_platform_handoff_and_scam_prevention.md`
+94. `docs/detail/data_deletion_vs_legal_hold.md`
+95. `docs/detail/realm_model.md`
+96. `docs/detail/data_scope_model.md`
+97. `docs/detail/mobility_model.md`
+98. `docs/detail/settlement_model.md`
+99. `docs/detail/settlement_backend_trait.md`
+100. `docs/detail/proof_of_infrastructure.md`
+101. `docs/detail/protected_groups_and_translation_safety.md`
 
 ### Whitepaper layer (contextual, not higher than detail/ADR)
-99. `docs/whitepaper/01_executive_summary.md`
-100. `docs/whitepaper/02_realm_model.md`
-101. `docs/whitepaper/03_experience_model.md`
-102. `docs/whitepaper/04_dm_shield.md`
-103. `docs/whitepaper/05_trust_model.md`
-104. `docs/whitepaper/06_promise_protocol.md`
-105. `docs/whitepaper/07_realm_economy.md`
-106. `docs/whitepaper/08_unlock_engine.md`
+102. `docs/whitepaper/01_executive_summary.md`
+103. `docs/whitepaper/02_realm_model.md`
+104. `docs/whitepaper/03_experience_model.md`
+105. `docs/whitepaper/04_dm_shield.md`
+106. `docs/whitepaper/05_trust_model.md`
+107. `docs/whitepaper/06_promise_protocol.md`
+108. `docs/whitepaper/07_realm_economy.md`
+109. `docs/whitepaper/08_unlock_engine.md`
 
 If any of the above are unavailable or materially inconsistent, stop and escalate.
 
@@ -216,7 +222,7 @@ That one-use C2 implementation allowance was consumed by `mt4110/pi-musubi-core`
 No remaining work may inherit permission from foundation PR #108 or implementation PR #88.
 The broad runtime implementation gate result remains NO-GO.
 Broad runtime implementation remains blocked.
-The current narrow downstream allowance is one implementation-repo test-only PR for post-C2 categorical Social Trust fact subject and Realm idempotency scope verification.
+The current narrow downstream allowance is one implementation-repo test-only PR for post-C2 categorical Social Trust fact Controlled Exceptional Account subject non-participation verification.
 
 The C2 bounded Promise reliability readiness and closeout chain is accepted for docs-only foundation semantic scope:
 
@@ -256,6 +262,9 @@ The C2 bounded Promise reliability readiness and closeout chain is accepted for 
 - `docs/readiness/post_c2_categorical_fact_concurrent_idempotency_implementation_closeout_ledger.md`
 - `docs/readiness/post_c2_categorical_fact_subject_realm_idempotency_scope_evidence_package.md`
 - `docs/readiness/post_c2_categorical_fact_subject_realm_idempotency_scope_handoff_gate_decision.md`
+- `docs/readiness/post_c2_categorical_fact_subject_realm_idempotency_scope_implementation_closeout_ledger.md`
+- `docs/readiness/post_c2_categorical_fact_controlled_exceptional_account_subject_evidence_package.md`
+- `docs/readiness/post_c2_categorical_fact_controlled_exceptional_account_subject_handoff_gate_decision.md`
 
 The accepted C2 gate records `bounded_promise_reliability` as the only positive Social Trust source-family candidate and accepts exact source facts and exact Social Trust mutation facts only as foundation semantic labels.
 Those labels are not runtime schema names, enum values, API names, migration names, module names, or test names.
@@ -289,9 +298,12 @@ Foundation PR #158 accepted the exact candidate test-only slice as post-C2 categ
 Foundation PR #160 provided the consumed narrow downstream test-only handoff authority for one later implementation-repo PR only, limited to post-C2 categorical Social Trust fact concurrent idempotency / replay / payload-drift verification.
 That allowance was consumed by `mt4110/pi-musubi-core` PR #104 and closed out by foundation PR #162.
 Foundation PR #164 accepted the exact candidate test-only slice as post-C2 categorical Social Trust fact subject and Realm idempotency scope verification.
-Foundation PR #166 provides the current narrow downstream test-only handoff authority for one later implementation-repo PR only.
+Foundation PR #166 provided the consumed narrow downstream test-only handoff authority for one later implementation-repo PR only.
+That allowance was consumed by `mt4110/pi-musubi-core` PR #106 and closed out by foundation PR #168.
+Foundation PR #170 accepted the exact candidate test-only slice as post-C2 categorical Social Trust fact Controlled Exceptional Account subject non-participation verification.
+Foundation PR #173 provides the current narrow downstream test-only handoff authority for one later implementation-repo PR only.
 This update is the required lock pin for that one-use allowance.
-It does not authorize implementation outside the PR #166 envelope.
+It does not authorize implementation outside the PR #173 envelope.
 It does not authorize new source facts, new mutation facts, DDL, migrations, backend runtime code, backend README updates, backend docs updates, public API changes, mobile UI, projection refresh, runtime orchestration, lifecycle runtime behavior, pruning, archive, deletion, Legal Hold runtime behavior, key lifecycle behavior, retry workers, queues, outbox changes, inbox changes, discovery, recommendation, room, settlement, Promise runtime, proof runtime, Relationship Depth, Social Trust scoring, public trust display, or any broader `pi-musubi-core` change.
 
 Implementation merge history, issue order, branch ancestry, and existing code are not foundation design proof.
@@ -472,9 +484,11 @@ The post-C2 categorical fact rejection boundary non-persistence evidence package
 That test-only allowance was consumed by `mt4110/pi-musubi-core` PR #102 and closed out by foundation PR #156.
 The post-C2 categorical fact concurrent idempotency evidence package and handoff gate authorized one later implementation-repo test-only PR only.
 That test-only allowance was consumed by `mt4110/pi-musubi-core` PR #104 and closed out by foundation PR #162.
-The post-C2 categorical fact subject and Realm idempotency scope evidence package and handoff gate now authorize one later implementation-repo test-only PR only.
-This test-only allowance is limited to `docs/foundation_lock.md` and `apps/backend/tests/post_c2_categorical_fact_subject_realm_idempotency_scope.rs`.
-It may verify that the already accepted `promise_reliability_outcome.completed_as_agreed` / `social_trust_mutation.bounded_promise_reliability_positive` C2 categorical Social Trust fact pair remains subject-scoped for duplicate fact idempotency keys, fails closed when Realm reference meaning drifts for the same subject and key, preserves later identical replay, and creates no projection, coordination, archive, public API, mobile UI, Social Trust score/display, Relationship Depth, discovery, recommendation, room, settlement, Promise runtime, proof runtime, lifecycle, retention, pruning, deletion, Legal Hold, key lifecycle, retry, queue, outbox, or inbox authority.
+The post-C2 categorical fact subject and Realm idempotency scope evidence package and handoff gate authorized one later implementation-repo test-only PR only.
+That test-only allowance was consumed by `mt4110/pi-musubi-core` PR #106 and closed out by foundation PR #168.
+The post-C2 categorical fact Controlled Exceptional Account subject evidence package and handoff gate now authorize one later implementation-repo test-only PR only.
+This test-only allowance is limited to `docs/foundation_lock.md` and `apps/backend/tests/post_c2_categorical_fact_controlled_exceptional_account_subject.rs`.
+It may verify that an active Controlled Exceptional Account is rejected as the subject of the already accepted `promise_reliability_outcome.completed_as_agreed` / `social_trust_mutation.bounded_promise_reliability_positive` C2 categorical Social Trust fact pair, and creates no categorical source reference, categorical mutation fact, projection, coordination, archive, public API, mobile UI, Social Trust score/display, Relationship Depth, discovery, recommendation, room, settlement, Promise runtime, proof runtime, lifecycle, retention, pruning, deletion, Legal Hold, key lifecycle, retry, queue, outbox, or inbox authority.
 It does not authorize new source facts, new mutation facts, DDL, migrations, backend runtime code, backend README updates, backend docs updates, public API changes, mobile UI, projection refresh, runtime orchestration, lifecycle runtime behavior, pruning, archive, deletion, Legal Hold runtime behavior, key lifecycle behavior, discovery, recommendation, room progression, settlement behavior, Promise runtime behavior, proof runtime behavior, Relationship Depth, Social Trust scoring, public trust display, or broad runtime implementation.
 
 ---
@@ -503,11 +517,11 @@ When updating:
 - Review completed by:
 
 ### Current drift note
-- Updated from foundation SHA: `650c25456ff5a3536ff7731dc8d46e9dfcd4a634` -> `9910663b9a3f93fae55102db507d75ba578219b9`
-- Reason: Align implementation-repo lock with the accepted foundation state after PR #166 (`Evaluate post-C2 categorical fact subject and Realm idempotency handoff`).
-- New required docs: Post-C2 categorical fact concurrent idempotency implementation closeout ledger; post-C2 categorical fact subject and Realm idempotency scope evidence package; post-C2 categorical fact subject and Realm idempotency scope handoff gate decision.
+- Updated from foundation SHA: `9910663b9a3f93fae55102db507d75ba578219b9` -> `a171f249b4daa279b6408b72747464dec297666b`
+- Reason: Align implementation-repo lock with the accepted foundation state after PR #173 (`docs: accept post-C2 Controlled Exceptional Account subject handoff`).
+- New required docs: Post-C2 categorical fact subject and Realm idempotency scope implementation closeout ledger; post-C2 categorical fact Controlled Exceptional Account subject evidence package; post-C2 categorical fact Controlled Exceptional Account subject handoff gate decision.
 - Removed docs: None.
-- Implementation impact: PR #166 authorizes one later implementation-repo test-only PR. This PR may update this foundation lock and add deterministic backend integration tests proving the accepted `promise_reliability_outcome.completed_as_agreed` / `social_trust_mutation.bounded_promise_reliability_positive` C2 categorical Social Trust fact pair remains subject-scoped for duplicate fact idempotency keys, fails closed when Realm reference meaning drifts for the same subject and key, preserves later identical replay, and does not create projection, coordination, archive, public API, mobile UI, Social Trust score/display, Relationship Depth, discovery, recommendation, room, settlement, Promise runtime, proof runtime, lifecycle, retention, pruning, deletion, Legal Hold, key lifecycle, retry, queue, outbox, or inbox authority. New source facts, new mutation facts, DDL, migrations, backend runtime code, backend README updates, backend docs updates, public API changes, mobile UI, projection refresh, runtime orchestration, lifecycle runtime behavior, pruning, archive, deletion, Legal Hold runtime behavior, key lifecycle behavior, Relationship Depth, proof runtime behavior, room progression, discovery, recommendation, settlement, Promise runtime behavior, Social Trust scoring, public trust display, and paid romantic advantage remain blocked.
+- Implementation impact: PR #173 authorizes one later implementation-repo test-only PR. This PR may update this foundation lock and add deterministic backend integration tests proving an active Controlled Exceptional Account is rejected as the subject of the accepted `promise_reliability_outcome.completed_as_agreed` / `social_trust_mutation.bounded_promise_reliability_positive` C2 categorical Social Trust fact pair, without creating categorical source references, categorical mutation facts, projection rows, coordination rows, archive rows, public API exposure, mobile UI state, Social Trust score/display behavior, Relationship Depth behavior, discovery behavior, recommendation behavior, room behavior, settlement behavior, Promise runtime behavior, proof runtime behavior, lifecycle authority, retention, pruning, deletion, Legal Hold, key lifecycle, retry, queue, outbox, or inbox authority. New source facts, new mutation facts, DDL, migrations, backend runtime code, backend README updates, backend docs updates, public API changes, mobile UI, projection refresh, runtime orchestration, lifecycle runtime behavior, pruning, archive, deletion, Legal Hold runtime behavior, key lifecycle behavior, Relationship Depth, proof runtime behavior, room progression, discovery, recommendation, settlement, Promise runtime behavior, Social Trust scoring, public trust display, and paid romantic advantage remain blocked.
 - Review completed by: Masaki Takemura
 
 ---


### PR DESCRIPTION
## Scope
- Consumes the one-use test-only allowance from mt4110/musubi-foundation#173.
- Updates `docs/foundation_lock.md` from foundation commit `9910663` to `a171f249b4daa279b6408b72747464dec297666b`.
- Adds one deterministic backend integration test for the exact allowed path: active Controlled Exceptional Account as the subject of the accepted C2 categorical Social Trust fact pair.

## Foundation Envelope
Allowed downstream files only:
- `docs/foundation_lock.md`
- `apps/backend/tests/post_c2_categorical_fact_controlled_exceptional_account_subject.rs`

This PR does not add source facts, mutation facts, DDL, migrations, backend runtime code, public API changes, mobile UI, projection refresh, runtime orchestration, retry workers, queues, outbox changes, inbox changes, lifecycle runtime behavior, pruning, archive, deletion, Legal Hold runtime behavior, key lifecycle behavior, discovery, recommendation, room, settlement, Promise runtime, proof runtime, Relationship Depth, Social Trust scoring, or public trust display.

## Verification
- `cargo test --test post_c2_categorical_fact_controlled_exceptional_account_subject`
- `git diff --cached --check`

Closes #107