### PR TITLE
test: verify Controlled Exceptional Account reclassification replay

### DIFF
--- a/apps/backend/tests/post_c2_categorical_fact_controlled_exceptional_account_reclassification_replay.rs
+++ b/apps/backend/tests/post_c2_categorical_fact_controlled_exceptional_account_reclassification_replay.rs
@@ -1,0 +1,693 @@
+use std::path::PathBuf;
+
+use axum::{
+    body::{to_bytes, Body},
+    http::{Request, StatusCode},
+    Router,
+};
+use musubi_backend::{
+    build_app, new_test_state,
+    services::social_trust_mutation::{
+        C2BoundedPromiseReliabilityReplayStatus, C2BoundedPromiseReliabilitySnapshot,
+        RecordC2BoundedPromiseReliabilityMutationFactInput, SocialTrustMutationPersistenceError,
+        SocialTrustMutationPersistenceOutcome, SocialTrustMutationStore,
+    },
+};
+use musubi_db_runtime::DbConfig;
+use musubi_social_trust_domain::{
+    AccountLifecycleReference, AgeAssuranceStateReference, AntiAbuseContinuityReference,
+    AuditReference, BlockWithdrawalStateReference, C2BoundedPromiseReliabilityBoundaryPosture,
+    C2BoundedPromiseReliabilityFactIdempotencyKey, C2BoundedPromiseReliabilityMutationFact,
+    C2BoundedPromiseReliabilityMutationFactCandidate, C2BoundedPromiseReliabilitySourceFact,
+    C2BoundedPromiseReliabilitySourceFactCandidate, ConsentStateReference,
+    CriticalHarmCaseReference, EvidenceLevelReference, EvidencePosture,
+    LegalHoldIntersectionReference, PromiseReference, PromiseTermsReference,
+    ProposedC2BoundedPromiseReliabilityMutationFact, ReasonFactReference, RetentionClassReference,
+    RetentionPosture, ReviewabilityPosture, SafetyCaseReference, SocialTrustAuthorityPosture,
+    WriterSourceReference,
+};
+use serde_json::{json, Value};
+use tokio_postgres::NoTls;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+const REALM_REFERENCE: &str = "realm-reference-post-c2-controlled-exceptional-reclassification";
+
+#[tokio::test]
+async fn reclassification_replay_preserves_writer_truth_and_rejects_new_fact() {
+    let (_test_state, app, config, client) = test_context().await;
+    let subject = sign_in(
+        &app,
+        "pi-user-post-c2-controlled-exceptional-reclassification",
+        "post-c2-controlled-exceptional-reclassification",
+    )
+    .await;
+    let subject_account_id = Uuid::parse_str(&subject.account_id).expect("account id is a UUID");
+    assert_account_class_and_state(&client, &subject_account_id, "Ordinary Account", "active")
+        .await;
+
+    let before_coordination = coordination_counts(&client).await;
+    let before_runtime = runtime_surface_counts(&client).await;
+    let store = SocialTrustMutationStore::connect(&config)
+        .await
+        .expect("social trust mutation store should connect");
+    let original_input = record_input(
+        subject_account_id,
+        complete_proposal("post-c2-controlled-exceptional-reclassification-replay"),
+    );
+
+    let first = recorded(
+        store
+            .record_c2_bounded_promise_reliability_fact(original_input.clone())
+            .await
+            .expect("first C2 categorical fact for active Ordinary Account should persist"),
+    );
+
+    assert_eq!(
+        first.replay_status,
+        C2BoundedPromiseReliabilityReplayStatus::Inserted
+    );
+    assert_eq!(
+        first.source_fact_label,
+        C2BoundedPromiseReliabilitySourceFact::CompletedAsAgreed.as_str()
+    );
+    assert_eq!(
+        first.mutation_fact_label,
+        C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityPositive.as_str()
+    );
+    assert_eq!(
+        source_count_for_subject(&client, &subject_account_id).await,
+        1
+    );
+    assert_eq!(
+        mutation_count_for_subject(&client, &subject_account_id).await,
+        1
+    );
+    assert_projection_absent_for_subject(&client, &subject_account_id).await;
+    assert_eq!(coordination_counts(&client).await, before_coordination);
+    assert_eq!(runtime_surface_counts(&client).await, before_runtime);
+
+    set_account_class(
+        &client,
+        &subject_account_id,
+        "Controlled Exceptional Account",
+    )
+    .await;
+    assert_account_class_and_state(
+        &client,
+        &subject_account_id,
+        "Controlled Exceptional Account",
+        "active",
+    )
+    .await;
+
+    let replay = recorded(
+        store
+            .record_c2_bounded_promise_reliability_fact(original_input)
+            .await
+            .expect("identical replay after reclassification should preserve writer truth"),
+    );
+
+    assert_eq!(
+        replay.replay_status,
+        C2BoundedPromiseReliabilityReplayStatus::ReplayedIdentical
+    );
+    assert_same_writer_fact(&first, &replay);
+    assert_eq!(
+        source_count_for_subject(&client, &subject_account_id).await,
+        1
+    );
+    assert_eq!(
+        mutation_count_for_subject(&client, &subject_account_id).await,
+        1
+    );
+    assert_projection_absent_for_subject(&client, &subject_account_id).await;
+    assert_eq!(coordination_counts(&client).await, before_coordination);
+    assert_eq!(runtime_surface_counts(&client).await, before_runtime);
+
+    let new_fact_error = store
+        .record_c2_bounded_promise_reliability_fact(record_input(
+            subject_account_id,
+            complete_proposal("post-c2-controlled-exceptional-reclassification-new-fact"),
+        ))
+        .await
+        .expect_err("new post-classification C2 fact must fail closed");
+
+    assert_controlled_exceptional_subject_rejected(new_fact_error);
+    assert_eq!(
+        source_count_for_subject(&client, &subject_account_id).await,
+        1
+    );
+    assert_eq!(
+        mutation_count_for_subject(&client, &subject_account_id).await,
+        1
+    );
+    assert_projection_absent_for_subject(&client, &subject_account_id).await;
+    assert_eq!(coordination_counts(&client).await, before_coordination);
+    assert_eq!(runtime_surface_counts(&client).await, before_runtime);
+    assert_public_projection_not_visible(&app, &subject).await;
+    assert_no_score_display_or_relationship_depth_columns(&client).await;
+}
+
+async fn test_context() -> (
+    musubi_backend::TestState,
+    Router,
+    DbConfig,
+    tokio_postgres::Client,
+) {
+    let test_state = new_test_state()
+        .await
+        .expect("test database state should initialize");
+    let app = build_app(test_state.state.clone());
+    let database_url = std::env::var("MUSUBI_TEST_DATABASE_URL")
+        .or_else(|_| std::env::var("DATABASE_URL"))
+        .expect("integration tests require MUSUBI_TEST_DATABASE_URL or DATABASE_URL to be set");
+    let migrations_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("migrations")
+        .canonicalize()
+        .expect("migrations directory should resolve");
+    let migrations_dir = migrations_dir
+        .to_str()
+        .expect("migrations directory should be utf-8")
+        .to_owned();
+    let config = DbConfig::from_lookup(|name| match name {
+        "APP_ENV" => Some("test".to_owned()),
+        "DATABASE_URL" => Some(database_url.clone()),
+        "MIGRATIONS_DIR" => Some(migrations_dir.clone()),
+        "REQUIRE_LATEST_SCHEMA" => Some("true".to_owned()),
+        _ => None,
+    })
+    .expect("test db config should parse");
+
+    let (client, connection) = tokio_postgres::connect(&database_url, NoTls)
+        .await
+        .expect("failed to connect to test database");
+    tokio::spawn(async move {
+        if let Err(error) = connection.await {
+            eprintln!("test database connection error: {error}");
+        }
+    });
+
+    (test_state, app, config, client)
+}
+
+fn complete_proposal(idempotency_key: &str) -> ProposedC2BoundedPromiseReliabilityMutationFact {
+    ProposedC2BoundedPromiseReliabilityMutationFact {
+        source_fact: C2BoundedPromiseReliabilitySourceFactCandidate::Accepted(
+            C2BoundedPromiseReliabilitySourceFact::CompletedAsAgreed,
+        ),
+        requested_mutation_fact: C2BoundedPromiseReliabilityMutationFactCandidate::Accepted(
+            C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityPositive,
+        ),
+        writer_source_reference: Some(WriterSourceReference::new(format!(
+            "writer-source-{idempotency_key}"
+        ))),
+        promise_reference: Some(PromiseReference::new(format!("promise-{idempotency_key}"))),
+        promise_terms_reference: Some(PromiseTermsReference::new(format!(
+            "promise-terms-{idempotency_key}"
+        ))),
+        consent_at_formation_reference: Some(ConsentStateReference::new(format!(
+            "consent-formation-{idempotency_key}"
+        ))),
+        consent_at_resolution_reference: Some(ConsentStateReference::new(format!(
+            "consent-resolution-{idempotency_key}"
+        ))),
+        block_withdrawal_state_reference: Some(BlockWithdrawalStateReference::new(format!(
+            "block-withdrawal-clear-{idempotency_key}"
+        ))),
+        age_assurance_state_reference: Some(AgeAssuranceStateReference::new(format!(
+            "age-assurance-adult-eligible-{idempotency_key}"
+        ))),
+        legal_hold_intersection_reference: Some(LegalHoldIntersectionReference::new(format!(
+            "legal-hold-clear-{idempotency_key}"
+        ))),
+        critical_harm_case_reference: Some(CriticalHarmCaseReference::new(format!(
+            "critical-harm-clear-{idempotency_key}"
+        ))),
+        account_lifecycle_reference: Some(AccountLifecycleReference::new(format!(
+            "account-lifecycle-active-{idempotency_key}"
+        ))),
+        anti_abuse_continuity_reference: Some(AntiAbuseContinuityReference::new(format!(
+            "anti-abuse-clear-{idempotency_key}"
+        ))),
+        safety_case_reference: Some(SafetyCaseReference::new(format!(
+            "safety-case-clear-{idempotency_key}"
+        ))),
+        evidence_level_reference: Some(EvidenceLevelReference::new(format!(
+            "evidence-level-bounded-{idempotency_key}"
+        ))),
+        audit_reference: Some(AuditReference::new(format!("audit-{idempotency_key}"))),
+        reason_fact: Some(ReasonFactReference::new(format!(
+            "reason-fact-{idempotency_key}"
+        ))),
+        fact_idempotency_key: Some(C2BoundedPromiseReliabilityFactIdempotencyKey::new(
+            idempotency_key,
+        )),
+        evidence_posture: Some(EvidencePosture::Bounded),
+        reviewability_posture: Some(ReviewabilityPosture::Reviewable),
+        retention_posture: Some(RetentionPosture::Classified(RetentionClassReference::new(
+            "R4 Trust / moderation / case",
+        ))),
+        authority_posture: SocialTrustAuthorityPosture::WriterTruthOnly,
+        boundary_posture: C2BoundedPromiseReliabilityBoundaryPosture::Clear,
+    }
+}
+
+fn record_input(
+    subject_account_id: Uuid,
+    proposal: ProposedC2BoundedPromiseReliabilityMutationFact,
+) -> RecordC2BoundedPromiseReliabilityMutationFactInput {
+    RecordC2BoundedPromiseReliabilityMutationFactInput {
+        subject_account_id: subject_account_id.to_string(),
+        realm_reference: Some(REALM_REFERENCE.to_owned()),
+        proposal,
+    }
+}
+
+fn recorded(outcome: SocialTrustMutationPersistenceOutcome) -> C2BoundedPromiseReliabilitySnapshot {
+    match outcome {
+        SocialTrustMutationPersistenceOutcome::Recorded(snapshot) => snapshot,
+        SocialTrustMutationPersistenceOutcome::RejectedBeforePersistence { decision } => {
+            panic!("expected recorded C2 fact, got rejected before persistence: {decision:?}")
+        }
+    }
+}
+
+fn assert_same_writer_fact(
+    first: &C2BoundedPromiseReliabilitySnapshot,
+    second: &C2BoundedPromiseReliabilitySnapshot,
+) {
+    assert_eq!(first.source_reference_id, second.source_reference_id);
+    assert_eq!(first.mutation_fact_id, second.mutation_fact_id);
+    assert_eq!(first.source_fact_label, second.source_fact_label);
+    assert_eq!(first.mutation_fact_label, second.mutation_fact_label);
+    assert_eq!(first.request_payload_hash, second.request_payload_hash);
+    assert_eq!(first.decision_payload_hash, second.decision_payload_hash);
+}
+
+fn assert_controlled_exceptional_subject_rejected(error: SocialTrustMutationPersistenceError) {
+    match error {
+        SocialTrustMutationPersistenceError::BadRequest(message) => {
+            assert!(
+                message.contains("must be an Ordinary Account"),
+                "Controlled Exceptional Account subject rejection should name the Ordinary Account boundary; got {message:?}"
+            );
+        }
+        other => panic!("expected Ordinary Account boundary rejection, got {other:?}"),
+    }
+}
+
+async fn assert_account_class_and_state(
+    client: &tokio_postgres::Client,
+    account_id: &Uuid,
+    expected_class: &str,
+    expected_state: &str,
+) {
+    let row = client
+        .query_one(
+            "
+            SELECT account_class, account_state
+            FROM core.accounts
+            WHERE account_id = $1
+            ",
+            &[account_id],
+        )
+        .await
+        .expect("account classification should load");
+
+    assert_eq!(row.get::<_, String>("account_class"), expected_class);
+    assert_eq!(row.get::<_, String>("account_state"), expected_state);
+}
+
+async fn set_account_class(
+    client: &tokio_postgres::Client,
+    account_id: &Uuid,
+    account_class: &str,
+) {
+    client
+        .execute(
+            "
+            UPDATE core.accounts
+            SET account_class = $2
+            WHERE account_id = $1
+            ",
+            &[account_id, &account_class],
+        )
+        .await
+        .expect("account class update should succeed");
+}
+
+async fn source_count_for_subject(
+    client: &tokio_postgres::Client,
+    subject_account_id: &Uuid,
+) -> i64 {
+    let row = client
+        .query_one(
+            "
+            SELECT COUNT(*)::bigint AS count
+            FROM social_trust.categorical_source_references
+            WHERE subject_account_id = $1
+            ",
+            &[subject_account_id],
+        )
+        .await
+        .expect("source reference count should load");
+    row.get("count")
+}
+
+async fn mutation_count_for_subject(
+    client: &tokio_postgres::Client,
+    subject_account_id: &Uuid,
+) -> i64 {
+    let row = client
+        .query_one(
+            "
+            SELECT COUNT(*)::bigint AS count
+            FROM social_trust.categorical_mutation_facts
+            WHERE subject_account_id = $1
+            ",
+            &[subject_account_id],
+        )
+        .await
+        .expect("mutation fact count should load");
+    row.get("count")
+}
+
+async fn assert_projection_absent_for_subject(
+    client: &tokio_postgres::Client,
+    subject_account_id: &Uuid,
+) {
+    let row = client
+        .query_one(
+            "
+            SELECT
+                (SELECT COUNT(*)::bigint
+                 FROM projection.trust_snapshots
+                 WHERE account_id = $1) AS trust_snapshot_count,
+                (SELECT COUNT(*)::bigint
+                 FROM projection.realm_trust_snapshots
+                 WHERE account_id = $1) AS realm_trust_snapshot_count
+            ",
+            &[subject_account_id],
+        )
+        .await
+        .expect("projection counts should load");
+
+    assert_eq!(row.get::<_, i64>("trust_snapshot_count"), 0);
+    assert_eq!(row.get::<_, i64>("realm_trust_snapshot_count"), 0);
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct CoordinationCounts {
+    outbox_events: i64,
+    outbox_attempts: i64,
+    command_inbox: i64,
+    recovery_runs: i64,
+    outbox_event_archive: i64,
+    outbox_attempt_archive: i64,
+    command_inbox_archive: i64,
+}
+
+async fn coordination_counts(client: &tokio_postgres::Client) -> CoordinationCounts {
+    let row = client
+        .query_one(
+            "
+            SELECT
+                (SELECT COUNT(*)::bigint FROM outbox.events) AS outbox_events,
+                (SELECT COUNT(*)::bigint FROM outbox.outbox_attempts) AS outbox_attempts,
+                (SELECT COUNT(*)::bigint FROM outbox.command_inbox) AS command_inbox,
+                (SELECT COUNT(*)::bigint FROM outbox.recovery_runs) AS recovery_runs,
+                (SELECT COUNT(*)::bigint FROM outbox.outbox_event_archive) AS outbox_event_archive,
+                (SELECT COUNT(*)::bigint FROM outbox.outbox_attempt_archive) AS outbox_attempt_archive,
+                (SELECT COUNT(*)::bigint FROM outbox.command_inbox_archive) AS command_inbox_archive
+            ",
+            &[],
+        )
+        .await
+        .expect("coordination counts should load");
+
+    CoordinationCounts {
+        outbox_events: row.get("outbox_events"),
+        outbox_attempts: row.get("outbox_attempts"),
+        command_inbox: row.get("command_inbox"),
+        recovery_runs: row.get("recovery_runs"),
+        outbox_event_archive: row.get("outbox_event_archive"),
+        outbox_attempt_archive: row.get("outbox_attempt_archive"),
+        command_inbox_archive: row.get("command_inbox_archive"),
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct RuntimeSurfaceCounts {
+    promise_intents: i64,
+    promise_intent_idempotency_keys: i64,
+    settlement_cases: i64,
+    settlement_intents: i64,
+    settlement_submissions: i64,
+    provider_attempts: i64,
+    settlement_observations: i64,
+    journal_entries: i64,
+    account_postings: i64,
+    promise_views: i64,
+    settlement_views: i64,
+    room_progression_tracks: i64,
+    room_progression_facts: i64,
+    room_progression_views: i64,
+    proposed_mutation_attempts: i64,
+    intake_decisions: i64,
+}
+
+async fn runtime_surface_counts(client: &tokio_postgres::Client) -> RuntimeSurfaceCounts {
+    let row = client
+        .query_one(
+            "
+            SELECT
+                (SELECT COUNT(*)::bigint FROM dao.promise_intents) AS promise_intents,
+                (SELECT COUNT(*)::bigint FROM dao.promise_intent_idempotency_keys) AS promise_intent_idempotency_keys,
+                (SELECT COUNT(*)::bigint FROM dao.settlement_cases) AS settlement_cases,
+                (SELECT COUNT(*)::bigint FROM dao.settlement_intents) AS settlement_intents,
+                (SELECT COUNT(*)::bigint FROM dao.settlement_submissions) AS settlement_submissions,
+                (SELECT COUNT(*)::bigint FROM dao.provider_attempts) AS provider_attempts,
+                (SELECT COUNT(*)::bigint FROM dao.settlement_observations) AS settlement_observations,
+                (SELECT COUNT(*)::bigint FROM ledger.journal_entries) AS journal_entries,
+                (SELECT COUNT(*)::bigint FROM ledger.account_postings) AS account_postings,
+                (SELECT COUNT(*)::bigint FROM projection.promise_views) AS promise_views,
+                (SELECT COUNT(*)::bigint FROM projection.settlement_views) AS settlement_views,
+                (SELECT COUNT(*)::bigint FROM dao.room_progression_tracks) AS room_progression_tracks,
+                (SELECT COUNT(*)::bigint FROM dao.room_progression_facts) AS room_progression_facts,
+                (SELECT COUNT(*)::bigint FROM projection.room_progression_views) AS room_progression_views,
+                (SELECT COUNT(*)::bigint FROM social_trust.proposed_mutation_attempts) AS proposed_mutation_attempts,
+                (SELECT COUNT(*)::bigint FROM social_trust.intake_decisions) AS intake_decisions
+            ",
+            &[],
+        )
+        .await
+        .expect("runtime surface counts should load");
+
+    RuntimeSurfaceCounts {
+        promise_intents: row.get("promise_intents"),
+        promise_intent_idempotency_keys: row.get("promise_intent_idempotency_keys"),
+        settlement_cases: row.get("settlement_cases"),
+        settlement_intents: row.get("settlement_intents"),
+        settlement_submissions: row.get("settlement_submissions"),
+        provider_attempts: row.get("provider_attempts"),
+        settlement_observations: row.get("settlement_observations"),
+        journal_entries: row.get("journal_entries"),
+        account_postings: row.get("account_postings"),
+        promise_views: row.get("promise_views"),
+        settlement_views: row.get("settlement_views"),
+        room_progression_tracks: row.get("room_progression_tracks"),
+        room_progression_facts: row.get("room_progression_facts"),
+        room_progression_views: row.get("room_progression_views"),
+        proposed_mutation_attempts: row.get("proposed_mutation_attempts"),
+        intake_decisions: row.get("intake_decisions"),
+    }
+}
+
+async fn assert_public_projection_not_visible(app: &Router, subject: &SignedInUser) {
+    let global = get_json(
+        app,
+        &format!("/api/projection/trust-snapshots/{}", subject.account_id),
+        Some(subject.token.as_str()),
+    )
+    .await;
+    assert_ne!(global.status, StatusCode::OK);
+    assert_no_trust_or_lifecycle_exposure_fields(&global.body);
+
+    let realm = get_json(
+        app,
+        &format!(
+            "/api/projection/realm-trust-snapshots/{}/{}",
+            REALM_REFERENCE, subject.account_id
+        ),
+        Some(subject.token.as_str()),
+    )
+    .await;
+    assert_ne!(realm.status, StatusCode::OK);
+    assert_no_trust_or_lifecycle_exposure_fields(&realm.body);
+}
+
+async fn assert_no_score_display_or_relationship_depth_columns(client: &tokio_postgres::Client) {
+    let rows = client
+        .query(
+            "
+            SELECT table_name, column_name
+            FROM information_schema.columns
+            WHERE table_schema = 'social_trust'
+              AND table_name IN (
+                  'categorical_source_references',
+                  'categorical_mutation_facts'
+              )
+              AND (
+                  column_name LIKE '%score%'
+                  OR column_name LIKE '%weight%'
+                  OR column_name LIKE '%rank%'
+                  OR column_name LIKE '%display%'
+                  OR column_name LIKE '%relationship_depth%'
+                  OR column_name LIKE '%projection%'
+              )
+            ",
+            &[],
+        )
+        .await
+        .expect("social trust column metadata should load");
+
+    assert!(
+        rows.is_empty(),
+        "C2 Controlled Exceptional Account reclassification replay boundary must not expose score/display/projection/Relationship Depth columns: {:?}",
+        rows.iter()
+            .map(|row| format!(
+                "{}.{}",
+                row.get::<_, String>("table_name"),
+                row.get::<_, String>("column_name")
+            ))
+            .collect::<Vec<_>>()
+    );
+}
+
+fn assert_no_trust_or_lifecycle_exposure_fields(body: &Value) {
+    for field in [
+        "trust_posture",
+        "reason_codes",
+        "trust_score",
+        "score",
+        "rank",
+        "trust_rank",
+        "trust_tier",
+        "display_level",
+        "public_level",
+        "recovery_ceiling",
+        "discovery_priority",
+        "recommendation_boost",
+        "contact_unlock",
+        "room_transition",
+        "settlement_progression",
+        "promise_runtime_outcome",
+        "proof_runtime_outcome",
+        "relationship_depth",
+        "mobile_ui_state",
+        "retention_action",
+        "pruning_action",
+        "archive_action",
+        "deletion_action",
+        "legal_hold_action",
+        "key_lifecycle_action",
+        "retry_action",
+        "queue_action",
+        "outbox_action",
+        "inbox_action",
+    ] {
+        assert!(
+            body.get(field).is_none(),
+            "C2 Controlled Exceptional Account reclassification replay boundary must not expose {field} in public API response"
+        );
+    }
+}
+
+struct SignedInUser {
+    token: String,
+    account_id: String,
+}
+
+async fn sign_in(app: &Router, pi_uid: &str, username: &str) -> SignedInUser {
+    let response = post_json(
+        app,
+        "/api/auth/pi",
+        None,
+        json!({
+            "pi_uid": pi_uid,
+            "username": username,
+            "wallet_address": format!("wallet-{pi_uid}"),
+            "access_token": format!("access-token-{pi_uid}")
+        }),
+    )
+    .await;
+    assert_eq!(response.status, StatusCode::OK);
+
+    SignedInUser {
+        token: response.body["token"]
+            .as_str()
+            .expect("token must exist")
+            .to_owned(),
+        account_id: response.body["user"]["id"]
+            .as_str()
+            .expect("user id must exist")
+            .to_owned(),
+    }
+}
+
+struct JsonResponse {
+    status: StatusCode,
+    body: Value,
+}
+
+async fn post_json(
+    app: &Router,
+    path: &str,
+    bearer_token: Option<&str>,
+    body: Value,
+) -> JsonResponse {
+    request_json(app, "POST", path, bearer_token, Some(body)).await
+}
+
+async fn get_json(app: &Router, path: &str, bearer_token: Option<&str>) -> JsonResponse {
+    request_json(app, "GET", path, bearer_token, None).await
+}
+
+async fn request_json(
+    app: &Router,
+    method: &str,
+    path: &str,
+    bearer_token: Option<&str>,
+    body: Option<Value>,
+) -> JsonResponse {
+    let mut builder = Request::builder().method(method).uri(path);
+    if let Some(token) = bearer_token {
+        builder = builder.header("authorization", format!("Bearer {token}"));
+    }
+
+    let request = builder
+        .header("content-type", "application/json")
+        .body(match body {
+            Some(body) => Body::from(body.to_string()),
+            None => Body::empty(),
+        })
+        .expect("request must build");
+
+    let response = app
+        .clone()
+        .oneshot(request)
+        .await
+        .expect("app should respond");
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body must be readable");
+    let body = if bytes.is_empty() {
+        json!({})
+    } else {
+        serde_json::from_slice(&bytes).expect("response body must be valid json")
+    };
+
+    JsonResponse { status, body }
+}

--- a/docs/foundation_lock.md
+++ b/docs/foundation_lock.md
@@ -1,6 +1,6 @@
 # Foundation Lock
 
-Status: Draft; aligned to accepted foundation commit `a171f24`
+Status: Draft; aligned to accepted foundation commit `2aced2a`
 Applies to: `mt4110/pi-musubi-core`
 Purpose: Pin the constitutional and architectural source of truth that this implementation repository must follow.
 
@@ -26,14 +26,14 @@ Upstream repository:
 Pinned reference for implementation work:
 
 - Foundation reference type: `commit`
-- Foundation commit SHA: `a171f249b4daa279b6408b72747464dec297666b`
-- Foundation commit title: `Merge pull request #173 from mt4110/feat/evaluate-post-c2-controlled-exceptional-subject-handoff`
-- Foundation PR title: `docs: accept post-C2 Controlled Exceptional Account subject handoff`
-- Foundation PR URL: `https://github.com/mt4110/musubi-foundation/pull/173`
+- Foundation commit SHA: `2aced2a6dd57dbea96a959a2376c6305339e7d2d`
+- Foundation commit title: `Merge pull request #181 from mt4110/feat/post-c2-categorical-fact-controlled-exceptional-account-reclassification-replay-handoff`
+- Foundation PR title: `docs: evaluate post-C2 Controlled Exceptional Account reclassification replay handoff`
+- Foundation PR URL: `https://github.com/mt4110/musubi-foundation/pull/181`
 - Date pinned: `2026-05-15`
 - Pinned by: `Masaki Takemura`
-- Pinned commit URL: `https://github.com/mt4110/musubi-foundation/commit/a171f249b4daa279b6408b72747464dec297666b`
-- Previous pinned reference: `9910663` / `Merge pull request #166 from mt4110/feat/evaluate-post-c2-categorical-fact-subject-realm-idempotency-handoff`
+- Pinned commit URL: `https://github.com/mt4110/musubi-foundation/commit/2aced2a6dd57dbea96a959a2376c6305339e7d2d`
+- Previous pinned reference: `a171f24` / `Merge pull request #173 from mt4110/feat/evaluate-post-c2-controlled-exceptional-subject-handoff`
 - Post-C2 evidence source: `cfdba28` / `Merge pull request #114 from mt4110/feat/post-c2-runtime-handoff-evidence-package`
 - Alignment allowance source: `69b7aa4` / `Merge pull request #116 from mt4110/feat/evaluate-post-c2-runtime-handoff-gate`
 - Post-C2 implementation handoff evidence source: `ef23e88` / `Merge pull request #122 from mt4110/feat/post-c2-implementation-handoff-evidence-package`
@@ -62,6 +62,10 @@ Pinned reference for implementation work:
 - Post-C2 categorical fact subject and Realm idempotency scope implementation closeout source: `76231d7` / `Merge pull request #168 from mt4110/feat/close-post-c2-categorical-fact-subject-realm-handoff`
 - Post-C2 categorical fact Controlled Exceptional Account subject evidence source: `104ce54` / `Merge pull request #170 from mt4110/feat/post-c2-controlled-exceptional-account-subject-evidence`
 - Post-C2 categorical fact Controlled Exceptional Account subject handoff source: `a171f24` / `Merge pull request #173 from mt4110/feat/evaluate-post-c2-controlled-exceptional-subject-handoff`
+- Post-C2 categorical fact Controlled Exceptional Account subject implementation closeout source: `28885e0` / `Merge pull request #175 from mt4110/feat/close-post-c2-controlled-exceptional-account-subject-handoff`
+- Post-C2 categorical fact Controlled Exceptional Account reclassification replay evidence source: `f0b3882` / `Merge pull request #177 from mt4110/feat/post-c2-controlled-exceptional-reclassification-evidence`
+- Readiness routine runner source: `5fa5bdf` / `Merge pull request #179 from mt4110/feat/readiness-routine-runner`
+- Post-C2 categorical fact Controlled Exceptional Account reclassification replay handoff source: `2aced2a` / `Merge pull request #181 from mt4110/feat/post-c2-categorical-fact-controlled-exceptional-account-reclassification-replay-handoff`
 
 No release tag is asserted for this alignment.
 Do not invent a foundation version label for this commit.
@@ -168,31 +172,34 @@ Before coding, read these upstream documents in order.
 86. `docs/readiness/post_c2_categorical_fact_subject_realm_idempotency_scope_implementation_closeout_ledger.md`
 87. `docs/readiness/post_c2_categorical_fact_controlled_exceptional_account_subject_evidence_package.md`
 88. `docs/readiness/post_c2_categorical_fact_controlled_exceptional_account_subject_handoff_gate_decision.md`
+89. `docs/readiness/post_c2_categorical_fact_controlled_exceptional_account_subject_implementation_closeout_ledger.md`
+90. `docs/readiness/post_c2_categorical_fact_controlled_exceptional_account_reclassification_replay_evidence_package.md`
+91. `docs/readiness/post_c2_categorical_fact_controlled_exceptional_account_reclassification_replay_handoff_gate_decision.md`
 
 ### Detail layer
-89. `docs/detail/accountability_matrix.md`
-90. `docs/detail/critical_incident_and_loss.md`
-91. `docs/detail/automated_decisioning_and_human_appeal.md`
-92. `docs/detail/youth_safety_and_age_assurance.md`
-93. `docs/detail/off_platform_handoff_and_scam_prevention.md`
-94. `docs/detail/data_deletion_vs_legal_hold.md`
-95. `docs/detail/realm_model.md`
-96. `docs/detail/data_scope_model.md`
-97. `docs/detail/mobility_model.md`
-98. `docs/detail/settlement_model.md`
-99. `docs/detail/settlement_backend_trait.md`
-100. `docs/detail/proof_of_infrastructure.md`
-101. `docs/detail/protected_groups_and_translation_safety.md`
+92. `docs/detail/accountability_matrix.md`
+93. `docs/detail/critical_incident_and_loss.md`
+94. `docs/detail/automated_decisioning_and_human_appeal.md`
+95. `docs/detail/youth_safety_and_age_assurance.md`
+96. `docs/detail/off_platform_handoff_and_scam_prevention.md`
+97. `docs/detail/data_deletion_vs_legal_hold.md`
+98. `docs/detail/realm_model.md`
+99. `docs/detail/data_scope_model.md`
+100. `docs/detail/mobility_model.md`
+101. `docs/detail/settlement_model.md`
+102. `docs/detail/settlement_backend_trait.md`
+103. `docs/detail/proof_of_infrastructure.md`
+104. `docs/detail/protected_groups_and_translation_safety.md`
 
 ### Whitepaper layer (contextual, not higher than detail/ADR)
-102. `docs/whitepaper/01_executive_summary.md`
-103. `docs/whitepaper/02_realm_model.md`
-104. `docs/whitepaper/03_experience_model.md`
-105. `docs/whitepaper/04_dm_shield.md`
-106. `docs/whitepaper/05_trust_model.md`
-107. `docs/whitepaper/06_promise_protocol.md`
-108. `docs/whitepaper/07_realm_economy.md`
-109. `docs/whitepaper/08_unlock_engine.md`
+105. `docs/whitepaper/01_executive_summary.md`
+106. `docs/whitepaper/02_realm_model.md`
+107. `docs/whitepaper/03_experience_model.md`
+108. `docs/whitepaper/04_dm_shield.md`
+109. `docs/whitepaper/05_trust_model.md`
+110. `docs/whitepaper/06_promise_protocol.md`
+111. `docs/whitepaper/07_realm_economy.md`
+112. `docs/whitepaper/08_unlock_engine.md`
 
 If any of the above are unavailable or materially inconsistent, stop and escalate.
 
@@ -222,7 +229,7 @@ That one-use C2 implementation allowance was consumed by `mt4110/pi-musubi-core`
 No remaining work may inherit permission from foundation PR #108 or implementation PR #88.
 The broad runtime implementation gate result remains NO-GO.
 Broad runtime implementation remains blocked.
-The current narrow downstream allowance is one implementation-repo test-only PR for post-C2 categorical Social Trust fact Controlled Exceptional Account subject non-participation verification.
+The current narrow downstream allowance is one implementation-repo test-only PR for post-C2 categorical Social Trust fact Controlled Exceptional Account reclassification replay boundary verification.
 
 The C2 bounded Promise reliability readiness and closeout chain is accepted for docs-only foundation semantic scope:
 
@@ -301,9 +308,13 @@ Foundation PR #164 accepted the exact candidate test-only slice as post-C2 categ
 Foundation PR #166 provided the consumed narrow downstream test-only handoff authority for one later implementation-repo PR only.
 That allowance was consumed by `mt4110/pi-musubi-core` PR #106 and closed out by foundation PR #168.
 Foundation PR #170 accepted the exact candidate test-only slice as post-C2 categorical Social Trust fact Controlled Exceptional Account subject non-participation verification.
-Foundation PR #173 provides the current narrow downstream test-only handoff authority for one later implementation-repo PR only.
+Foundation PR #173 provided the consumed narrow downstream test-only handoff authority for one later implementation-repo PR only.
+That allowance was consumed by `mt4110/pi-musubi-core` PR #108 and closed out by foundation PR #175.
+Foundation PR #177 accepted the exact candidate test-only slice as post-C2 categorical Social Trust fact Controlled Exceptional Account reclassification replay boundary verification.
+Foundation PR #179 added an advisory readiness routine runner and did not grant GO, implementation handoff, or implementation authority.
+Foundation PR #181 provides the current narrow downstream test-only handoff authority for one later implementation-repo PR only.
 This update is the required lock pin for that one-use allowance.
-It does not authorize implementation outside the PR #173 envelope.
+It does not authorize implementation outside the PR #181 envelope.
 It does not authorize new source facts, new mutation facts, DDL, migrations, backend runtime code, backend README updates, backend docs updates, public API changes, mobile UI, projection refresh, runtime orchestration, lifecycle runtime behavior, pruning, archive, deletion, Legal Hold runtime behavior, key lifecycle behavior, retry workers, queues, outbox changes, inbox changes, discovery, recommendation, room, settlement, Promise runtime, proof runtime, Relationship Depth, Social Trust scoring, public trust display, or any broader `pi-musubi-core` change.
 
 Implementation merge history, issue order, branch ancestry, and existing code are not foundation design proof.
@@ -486,9 +497,11 @@ The post-C2 categorical fact concurrent idempotency evidence package and handoff
 That test-only allowance was consumed by `mt4110/pi-musubi-core` PR #104 and closed out by foundation PR #162.
 The post-C2 categorical fact subject and Realm idempotency scope evidence package and handoff gate authorized one later implementation-repo test-only PR only.
 That test-only allowance was consumed by `mt4110/pi-musubi-core` PR #106 and closed out by foundation PR #168.
-The post-C2 categorical fact Controlled Exceptional Account subject evidence package and handoff gate now authorize one later implementation-repo test-only PR only.
-This test-only allowance is limited to `docs/foundation_lock.md` and `apps/backend/tests/post_c2_categorical_fact_controlled_exceptional_account_subject.rs`.
-It may verify that an active Controlled Exceptional Account is rejected as the subject of the already accepted `promise_reliability_outcome.completed_as_agreed` / `social_trust_mutation.bounded_promise_reliability_positive` C2 categorical Social Trust fact pair, and creates no categorical source reference, categorical mutation fact, projection, coordination, archive, public API, mobile UI, Social Trust score/display, Relationship Depth, discovery, recommendation, room, settlement, Promise runtime, proof runtime, lifecycle, retention, pruning, deletion, Legal Hold, key lifecycle, retry, queue, outbox, or inbox authority.
+The post-C2 categorical fact Controlled Exceptional Account subject evidence package and handoff gate authorized one later implementation-repo test-only PR only.
+That test-only allowance was consumed by `mt4110/pi-musubi-core` PR #108 and closed out by foundation PR #175.
+The post-C2 categorical fact Controlled Exceptional Account reclassification replay evidence package and handoff gate now authorize one later implementation-repo test-only PR only.
+This test-only allowance is limited to `docs/foundation_lock.md` and `apps/backend/tests/post_c2_categorical_fact_controlled_exceptional_account_reclassification_replay.rs`.
+It may verify that the already accepted `promise_reliability_outcome.completed_as_agreed` / `social_trust_mutation.bounded_promise_reliability_positive` C2 categorical Social Trust fact pair first accepted while the subject is an active Ordinary Account replays identically after that subject is later classified as a Controlled Exceptional Account, that a new post-classification fact fails closed because the subject is no longer an Ordinary Account, and that no duplicate categorical source reference, duplicate categorical mutation fact, projection, coordination, archive, public API, mobile UI, Social Trust score/display, Relationship Depth, discovery, recommendation, room, settlement, Promise runtime, proof runtime, lifecycle, retention, pruning, deletion, Legal Hold, key lifecycle, retry, queue, outbox, or inbox authority is created.
 It does not authorize new source facts, new mutation facts, DDL, migrations, backend runtime code, backend README updates, backend docs updates, public API changes, mobile UI, projection refresh, runtime orchestration, lifecycle runtime behavior, pruning, archive, deletion, Legal Hold runtime behavior, key lifecycle behavior, discovery, recommendation, room progression, settlement behavior, Promise runtime behavior, proof runtime behavior, Relationship Depth, Social Trust scoring, public trust display, or broad runtime implementation.
 
 ---
@@ -517,11 +530,11 @@ When updating:
 - Review completed by:
 
 ### Current drift note
-- Updated from foundation SHA: `9910663b9a3f93fae55102db507d75ba578219b9` -> `a171f249b4daa279b6408b72747464dec297666b`
-- Reason: Align implementation-repo lock with the accepted foundation state after PR #173 (`docs: accept post-C2 Controlled Exceptional Account subject handoff`).
-- New required docs: Post-C2 categorical fact subject and Realm idempotency scope implementation closeout ledger; post-C2 categorical fact Controlled Exceptional Account subject evidence package; post-C2 categorical fact Controlled Exceptional Account subject handoff gate decision.
+- Updated from foundation SHA: `a171f249b4daa279b6408b72747464dec297666b` -> `2aced2a6dd57dbea96a959a2376c6305339e7d2d`
+- Reason: Align implementation-repo lock with the accepted foundation state after PR #181 (`docs: evaluate post-C2 Controlled Exceptional Account reclassification replay handoff`).
+- New required docs: Post-C2 categorical fact Controlled Exceptional Account subject implementation closeout ledger; post-C2 categorical fact Controlled Exceptional Account reclassification replay evidence package; post-C2 categorical fact Controlled Exceptional Account reclassification replay handoff gate decision.
 - Removed docs: None.
-- Implementation impact: PR #173 authorizes one later implementation-repo test-only PR. This PR may update this foundation lock and add deterministic backend integration tests proving an active Controlled Exceptional Account is rejected as the subject of the accepted `promise_reliability_outcome.completed_as_agreed` / `social_trust_mutation.bounded_promise_reliability_positive` C2 categorical Social Trust fact pair, without creating categorical source references, categorical mutation facts, projection rows, coordination rows, archive rows, public API exposure, mobile UI state, Social Trust score/display behavior, Relationship Depth behavior, discovery behavior, recommendation behavior, room behavior, settlement behavior, Promise runtime behavior, proof runtime behavior, lifecycle authority, retention, pruning, deletion, Legal Hold, key lifecycle, retry, queue, outbox, or inbox authority. New source facts, new mutation facts, DDL, migrations, backend runtime code, backend README updates, backend docs updates, public API changes, mobile UI, projection refresh, runtime orchestration, lifecycle runtime behavior, pruning, archive, deletion, Legal Hold runtime behavior, key lifecycle behavior, Relationship Depth, proof runtime behavior, room progression, discovery, recommendation, settlement, Promise runtime behavior, Social Trust scoring, public trust display, and paid romantic advantage remain blocked.
+- Implementation impact: PR #181 authorizes one later implementation-repo test-only PR. This PR may update this foundation lock and add deterministic backend integration tests proving the accepted `promise_reliability_outcome.completed_as_agreed` / `social_trust_mutation.bounded_promise_reliability_positive` C2 categorical Social Trust fact pair first accepted while the subject is an active Ordinary Account replays identically after that subject is later classified as a Controlled Exceptional Account, and that a new post-classification fact fails closed because the subject is no longer an Ordinary Account, without creating duplicate categorical source references, duplicate categorical mutation facts, projection rows, coordination rows, archive rows, public API exposure, mobile UI state, Social Trust score/display behavior, Relationship Depth behavior, discovery behavior, recommendation behavior, room behavior, settlement behavior, Promise runtime behavior, proof runtime behavior, lifecycle authority, retention, pruning, deletion, Legal Hold, key lifecycle, retry, queue, outbox, or inbox authority. New source facts, new mutation facts, DDL, migrations, backend runtime code, backend README updates, backend docs updates, public API changes, mobile UI, projection refresh, runtime orchestration, lifecycle runtime behavior, pruning, archive, deletion, Legal Hold runtime behavior, key lifecycle behavior, Relationship Depth, proof runtime behavior, room progression, discovery, recommendation, settlement, Promise runtime behavior, Social Trust scoring, public trust display, and paid romantic advantage remain blocked.
 - Review completed by: Masaki Takemura
 
 ---


### PR DESCRIPTION
Closes #109

## Scope
- Pins docs/foundation_lock.md to mt4110/musubi-foundation PR #181 merge commit 2aced2a6dd57dbea96a959a2376c6305339e7d2d.
- Adds one deterministic backend integration test file for the post-C2 Controlled Exceptional Account reclassification replay boundary.
- Uses only the accepted C2 source / mutation pair: promise_reliability_outcome.completed_as_agreed / social_trust_mutation.bounded_promise_reliability_positive.

## Verified behavior
- A C2 categorical Social Trust fact first accepted while the subject is an active Ordinary Account replays identically after that subject is later classified as a Controlled Exceptional Account.
- The replay preserves source reference identity, mutation fact identity, request payload hash, and decision payload hash.
- A new post-classification C2 categorical Social Trust fact for the same subject fails closed because the subject is no longer an Ordinary Account.
- No duplicate writer facts, projection rows, coordination rows, public API visibility, mobile UI state, Social Trust score/display behavior, Relationship Depth behavior, or other unauthorized runtime side effects are created.

## Safety boundary
- No DDL or migrations.
- No backend runtime code changes.
- No dependency changes.
- No public API, mobile UI, projection refresh, lifecycle, retry, queue, outbox, inbox, discovery, recommendation, room, settlement, Promise runtime, proof runtime, Relationship Depth, or Social Trust scoring/display changes.
- This consumes the one-use test-only allowance from foundation PR #181; a separate foundation closeout ledger is required after merge or abandonment.

## Validation
- rustfmt --edition 2021 --check apps/backend/tests/post_c2_categorical_fact_controlled_exceptional_account_reclassification_replay.rs
- git diff --check
- cargo test --test post_c2_categorical_fact_controlled_exceptional_account_reclassification_replay