### PR TITLE
test: verify Controlled Exceptional Account Promise participant exclusion

### DIFF
--- a/apps/backend/tests/post_c2_controlled_exceptional_account_promise_participant_exclusion.rs
+++ b/apps/backend/tests/post_c2_controlled_exceptional_account_promise_participant_exclusion.rs
@@ -1,0 +1,567 @@
+use axum::{
+    Router,
+    body::{Body, to_bytes},
+    http::{Request, StatusCode},
+};
+use musubi_backend::{build_app, new_test_state};
+use serde_json::{Value, json};
+use tokio_postgres::NoTls;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+#[tokio::test]
+async fn controlled_exceptional_account_cannot_create_promise_as_initiating_participant() {
+    let (_test_state, app, client) = test_context().await;
+    let controlled = sign_in(
+        &app,
+        "pi-user-post-c2-promise-participant-controlled-initiator",
+        "post-c2-controlled-initiator",
+    )
+    .await;
+    let ordinary = sign_in(
+        &app,
+        "pi-user-post-c2-promise-participant-ordinary-counterparty",
+        "post-c2-ordinary-counterparty",
+    )
+    .await;
+    let controlled_account_id =
+        Uuid::parse_str(&controlled.account_id).expect("controlled account id must be a UUID");
+
+    set_account_class(
+        &client,
+        &controlled_account_id,
+        "Controlled Exceptional Account",
+    )
+    .await;
+    assert_account_class_and_state(
+        &client,
+        &controlled_account_id,
+        "Controlled Exceptional Account",
+        "active",
+    )
+    .await;
+
+    let before = boundary_counts(&client).await;
+    let create_promise = post_json(
+        &app,
+        "/api/promise/intents",
+        Some(controlled.token.as_str()),
+        json!({
+            "internal_idempotency_key": "post-c2-controlled-initiator-promise",
+            "realm_id": "realm-post-c2-controlled-initiator-promise",
+            "counterparty_account_id": ordinary.account_id,
+            "deposit_amount_minor_units": 10000,
+            "currency_code": "PI"
+        }),
+    )
+    .await;
+
+    assert_fail_closed(
+        &create_promise,
+        "initiator account must be an Ordinary Account",
+    );
+    assert_eq!(boundary_counts(&client).await, before);
+    assert_account_class_and_state(
+        &client,
+        &controlled_account_id,
+        "Controlled Exceptional Account",
+        "active",
+    )
+    .await;
+    assert_public_trust_projection_not_visible(
+        &app,
+        &controlled,
+        "realm-post-c2-controlled-initiator-promise",
+    )
+    .await;
+    assert_no_score_display_or_relationship_depth_columns(&client).await;
+}
+
+#[tokio::test]
+async fn controlled_exceptional_account_cannot_be_promise_counterparty_participant() {
+    let (_test_state, app, client) = test_context().await;
+    let ordinary = sign_in(
+        &app,
+        "pi-user-post-c2-promise-participant-ordinary-initiator",
+        "post-c2-ordinary-initiator",
+    )
+    .await;
+    let controlled = sign_in(
+        &app,
+        "pi-user-post-c2-promise-participant-controlled-counterparty",
+        "post-c2-controlled-counterparty",
+    )
+    .await;
+    let controlled_account_id =
+        Uuid::parse_str(&controlled.account_id).expect("controlled account id must be a UUID");
+
+    set_account_class(
+        &client,
+        &controlled_account_id,
+        "Controlled Exceptional Account",
+    )
+    .await;
+    assert_account_class_and_state(
+        &client,
+        &controlled_account_id,
+        "Controlled Exceptional Account",
+        "active",
+    )
+    .await;
+
+    let before = boundary_counts(&client).await;
+    let create_promise = post_json(
+        &app,
+        "/api/promise/intents",
+        Some(ordinary.token.as_str()),
+        json!({
+            "internal_idempotency_key": "post-c2-controlled-counterparty-promise",
+            "realm_id": "realm-post-c2-controlled-counterparty-promise",
+            "counterparty_account_id": controlled.account_id,
+            "deposit_amount_minor_units": 10000,
+            "currency_code": "PI"
+        }),
+    )
+    .await;
+
+    assert_fail_closed(
+        &create_promise,
+        "counterparty account must be an Ordinary Account",
+    );
+    assert_eq!(boundary_counts(&client).await, before);
+    assert_account_class_and_state(
+        &client,
+        &controlled_account_id,
+        "Controlled Exceptional Account",
+        "active",
+    )
+    .await;
+    assert_public_trust_projection_not_visible(
+        &app,
+        &controlled,
+        "realm-post-c2-controlled-counterparty-promise",
+    )
+    .await;
+    assert_no_score_display_or_relationship_depth_columns(&client).await;
+}
+
+async fn test_context() -> (musubi_backend::TestState, Router, tokio_postgres::Client) {
+    let test_state = new_test_state()
+        .await
+        .expect("test database state should initialize");
+    let app = build_app(test_state.state.clone());
+    let database_url = std::env::var("MUSUBI_TEST_DATABASE_URL")
+        .or_else(|_| std::env::var("DATABASE_URL"))
+        .expect("integration tests require MUSUBI_TEST_DATABASE_URL or DATABASE_URL to be set");
+    let (client, connection) = tokio_postgres::connect(&database_url, NoTls)
+        .await
+        .expect("failed to connect to test database");
+    tokio::spawn(async move {
+        if let Err(error) = connection.await {
+            eprintln!("test database connection error: {error}");
+        }
+    });
+
+    (test_state, app, client)
+}
+
+async fn set_account_class(
+    client: &tokio_postgres::Client,
+    account_id: &Uuid,
+    account_class: &str,
+) {
+    client
+        .execute(
+            "
+            UPDATE core.accounts
+            SET account_class = $2
+            WHERE account_id = $1
+            ",
+            &[account_id, &account_class],
+        )
+        .await
+        .expect("account class fixture should update");
+}
+
+async fn assert_account_class_and_state(
+    client: &tokio_postgres::Client,
+    account_id: &Uuid,
+    expected_class: &str,
+    expected_state: &str,
+) {
+    let row = client
+        .query_one(
+            "
+            SELECT account_class, account_state
+            FROM core.accounts
+            WHERE account_id = $1
+            ",
+            &[account_id],
+        )
+        .await
+        .expect("account classification should load");
+
+    assert_eq!(row.get::<_, String>("account_class"), expected_class);
+    assert_eq!(row.get::<_, String>("account_state"), expected_state);
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct BoundaryCounts {
+    promise_intents: i64,
+    promise_intent_idempotency_keys: i64,
+    settlement_cases: i64,
+    settlement_intents: i64,
+    settlement_submissions: i64,
+    provider_attempts: i64,
+    settlement_observations: i64,
+    journal_entries: i64,
+    account_postings: i64,
+    promise_views: i64,
+    settlement_views: i64,
+    trust_snapshots: i64,
+    realm_trust_snapshots: i64,
+    room_progression_tracks: i64,
+    room_progression_facts: i64,
+    room_progression_views: i64,
+    proposed_mutation_attempts: i64,
+    intake_decisions: i64,
+    categorical_source_references: i64,
+    categorical_mutation_facts: i64,
+    outbox_events: i64,
+    outbox_attempts: i64,
+    command_inbox: i64,
+    recovery_runs: i64,
+    outbox_event_archive: i64,
+    outbox_attempt_archive: i64,
+    command_inbox_archive: i64,
+    review_cases: i64,
+    evidence_bundles: i64,
+    evidence_access_grants: i64,
+    operator_decision_facts: i64,
+    appeal_cases: i64,
+    review_status_views: i64,
+    realm_requests: i64,
+    realms: i64,
+    realm_sponsor_records: i64,
+    bootstrap_corridors: i64,
+    realm_admissions: i64,
+    realm_admission_idempotency_keys: i64,
+    realm_review_triggers: i64,
+    realm_bootstrap_views: i64,
+    realm_admission_views: i64,
+    realm_review_summaries: i64,
+}
+
+async fn boundary_counts(client: &tokio_postgres::Client) -> BoundaryCounts {
+    let row = client
+        .query_one(
+            "
+            SELECT
+                (SELECT COUNT(*)::bigint FROM dao.promise_intents) AS promise_intents,
+                (SELECT COUNT(*)::bigint FROM dao.promise_intent_idempotency_keys) AS promise_intent_idempotency_keys,
+                (SELECT COUNT(*)::bigint FROM dao.settlement_cases) AS settlement_cases,
+                (SELECT COUNT(*)::bigint FROM dao.settlement_intents) AS settlement_intents,
+                (SELECT COUNT(*)::bigint FROM dao.settlement_submissions) AS settlement_submissions,
+                (SELECT COUNT(*)::bigint FROM dao.provider_attempts) AS provider_attempts,
+                (SELECT COUNT(*)::bigint FROM dao.settlement_observations) AS settlement_observations,
+                (SELECT COUNT(*)::bigint FROM ledger.journal_entries) AS journal_entries,
+                (SELECT COUNT(*)::bigint FROM ledger.account_postings) AS account_postings,
+                (SELECT COUNT(*)::bigint FROM projection.promise_views) AS promise_views,
+                (SELECT COUNT(*)::bigint FROM projection.settlement_views) AS settlement_views,
+                (SELECT COUNT(*)::bigint FROM projection.trust_snapshots) AS trust_snapshots,
+                (SELECT COUNT(*)::bigint FROM projection.realm_trust_snapshots) AS realm_trust_snapshots,
+                (SELECT COUNT(*)::bigint FROM dao.room_progression_tracks) AS room_progression_tracks,
+                (SELECT COUNT(*)::bigint FROM dao.room_progression_facts) AS room_progression_facts,
+                (SELECT COUNT(*)::bigint FROM projection.room_progression_views) AS room_progression_views,
+                (SELECT COUNT(*)::bigint FROM social_trust.proposed_mutation_attempts) AS proposed_mutation_attempts,
+                (SELECT COUNT(*)::bigint FROM social_trust.intake_decisions) AS intake_decisions,
+                (SELECT COUNT(*)::bigint FROM social_trust.categorical_source_references) AS categorical_source_references,
+                (SELECT COUNT(*)::bigint FROM social_trust.categorical_mutation_facts) AS categorical_mutation_facts,
+                (SELECT COUNT(*)::bigint FROM outbox.events) AS outbox_events,
+                (SELECT COUNT(*)::bigint FROM outbox.outbox_attempts) AS outbox_attempts,
+                (SELECT COUNT(*)::bigint FROM outbox.command_inbox) AS command_inbox,
+                (SELECT COUNT(*)::bigint FROM outbox.recovery_runs) AS recovery_runs,
+                (SELECT COUNT(*)::bigint FROM outbox.outbox_event_archive) AS outbox_event_archive,
+                (SELECT COUNT(*)::bigint FROM outbox.outbox_attempt_archive) AS outbox_attempt_archive,
+                (SELECT COUNT(*)::bigint FROM outbox.command_inbox_archive) AS command_inbox_archive,
+                (SELECT COUNT(*)::bigint FROM dao.review_cases) AS review_cases,
+                (SELECT COUNT(*)::bigint FROM dao.evidence_bundles) AS evidence_bundles,
+                (SELECT COUNT(*)::bigint FROM dao.evidence_access_grants) AS evidence_access_grants,
+                (SELECT COUNT(*)::bigint FROM dao.operator_decision_facts) AS operator_decision_facts,
+                (SELECT COUNT(*)::bigint FROM dao.appeal_cases) AS appeal_cases,
+                (SELECT COUNT(*)::bigint FROM projection.review_status_views) AS review_status_views,
+                (SELECT COUNT(*)::bigint FROM dao.realm_requests) AS realm_requests,
+                (SELECT COUNT(*)::bigint FROM dao.realms) AS realms,
+                (SELECT COUNT(*)::bigint FROM dao.realm_sponsor_records) AS realm_sponsor_records,
+                (SELECT COUNT(*)::bigint FROM dao.bootstrap_corridors) AS bootstrap_corridors,
+                (SELECT COUNT(*)::bigint FROM dao.realm_admissions) AS realm_admissions,
+                (SELECT COUNT(*)::bigint FROM dao.realm_admission_idempotency_keys) AS realm_admission_idempotency_keys,
+                (SELECT COUNT(*)::bigint FROM dao.realm_review_triggers) AS realm_review_triggers,
+                (SELECT COUNT(*)::bigint FROM projection.realm_bootstrap_views) AS realm_bootstrap_views,
+                (SELECT COUNT(*)::bigint FROM projection.realm_admission_views) AS realm_admission_views,
+                (SELECT COUNT(*)::bigint FROM projection.realm_review_summaries) AS realm_review_summaries
+            ",
+            &[],
+        )
+        .await
+        .expect("boundary counts should load");
+
+    BoundaryCounts {
+        promise_intents: row.get("promise_intents"),
+        promise_intent_idempotency_keys: row.get("promise_intent_idempotency_keys"),
+        settlement_cases: row.get("settlement_cases"),
+        settlement_intents: row.get("settlement_intents"),
+        settlement_submissions: row.get("settlement_submissions"),
+        provider_attempts: row.get("provider_attempts"),
+        settlement_observations: row.get("settlement_observations"),
+        journal_entries: row.get("journal_entries"),
+        account_postings: row.get("account_postings"),
+        promise_views: row.get("promise_views"),
+        settlement_views: row.get("settlement_views"),
+        trust_snapshots: row.get("trust_snapshots"),
+        realm_trust_snapshots: row.get("realm_trust_snapshots"),
+        room_progression_tracks: row.get("room_progression_tracks"),
+        room_progression_facts: row.get("room_progression_facts"),
+        room_progression_views: row.get("room_progression_views"),
+        proposed_mutation_attempts: row.get("proposed_mutation_attempts"),
+        intake_decisions: row.get("intake_decisions"),
+        categorical_source_references: row.get("categorical_source_references"),
+        categorical_mutation_facts: row.get("categorical_mutation_facts"),
+        outbox_events: row.get("outbox_events"),
+        outbox_attempts: row.get("outbox_attempts"),
+        command_inbox: row.get("command_inbox"),
+        recovery_runs: row.get("recovery_runs"),
+        outbox_event_archive: row.get("outbox_event_archive"),
+        outbox_attempt_archive: row.get("outbox_attempt_archive"),
+        command_inbox_archive: row.get("command_inbox_archive"),
+        review_cases: row.get("review_cases"),
+        evidence_bundles: row.get("evidence_bundles"),
+        evidence_access_grants: row.get("evidence_access_grants"),
+        operator_decision_facts: row.get("operator_decision_facts"),
+        appeal_cases: row.get("appeal_cases"),
+        review_status_views: row.get("review_status_views"),
+        realm_requests: row.get("realm_requests"),
+        realms: row.get("realms"),
+        realm_sponsor_records: row.get("realm_sponsor_records"),
+        bootstrap_corridors: row.get("bootstrap_corridors"),
+        realm_admissions: row.get("realm_admissions"),
+        realm_admission_idempotency_keys: row.get("realm_admission_idempotency_keys"),
+        realm_review_triggers: row.get("realm_review_triggers"),
+        realm_bootstrap_views: row.get("realm_bootstrap_views"),
+        realm_admission_views: row.get("realm_admission_views"),
+        realm_review_summaries: row.get("realm_review_summaries"),
+    }
+}
+
+fn assert_fail_closed(response: &JsonResponse, expected_error: &str) {
+    assert_eq!(response.status, StatusCode::BAD_REQUEST);
+    assert_eq!(response.body["error"], expected_error);
+    assert_no_participant_authority_fields(&response.body);
+}
+
+async fn assert_public_trust_projection_not_visible(
+    app: &Router,
+    subject: &SignedInUser,
+    realm_id: &str,
+) {
+    let global = get_json(
+        app,
+        &format!("/api/projection/trust-snapshots/{}", subject.account_id),
+        Some(subject.token.as_str()),
+    )
+    .await;
+    assert_ne!(global.status, StatusCode::OK);
+    assert_no_participant_authority_fields(&global.body);
+
+    let realm = get_json(
+        app,
+        &format!(
+            "/api/projection/realm-trust-snapshots/{realm_id}/{}",
+            subject.account_id
+        ),
+        Some(subject.token.as_str()),
+    )
+    .await;
+    assert_ne!(realm.status, StatusCode::OK);
+    assert_no_participant_authority_fields(&realm.body);
+}
+
+async fn assert_no_score_display_or_relationship_depth_columns(client: &tokio_postgres::Client) {
+    let rows = client
+        .query(
+            "
+            SELECT table_name, column_name
+            FROM information_schema.columns
+            WHERE table_schema = 'social_trust'
+              AND table_name IN (
+                  'categorical_source_references',
+                  'categorical_mutation_facts'
+              )
+              AND (
+                  column_name LIKE '%score%'
+                  OR column_name LIKE '%weight%'
+                  OR column_name LIKE '%rank%'
+                  OR column_name LIKE '%display%'
+                  OR column_name LIKE '%relationship_depth%'
+                  OR column_name LIKE '%projection%'
+                  OR column_name LIKE '%discovery%'
+                  OR column_name LIKE '%recommendation%'
+                  OR column_name LIKE '%ordinary_cohort%'
+              )
+            ",
+            &[],
+        )
+        .await
+        .expect("social trust column metadata should load");
+
+    assert!(
+        rows.is_empty(),
+        "Controlled Exceptional Account Promise participant exclusion must not expose score/display/Relationship Depth/discovery/recommendation columns: {:?}",
+        rows.iter()
+            .map(|row| format!(
+                "{}.{}",
+                row.get::<_, String>("table_name"),
+                row.get::<_, String>("column_name")
+            ))
+            .collect::<Vec<_>>()
+    );
+}
+
+fn assert_no_participant_authority_fields(body: &Value) {
+    for field in [
+        "promise_intent_id",
+        "settlement_case_id",
+        "initiator_account_id",
+        "counterparty_account_id",
+        "participant_account_id",
+        "participant_state",
+        "current_intent_status",
+        "case_status",
+        "outbox_event_ids",
+        "replayed_intent",
+        "trust_posture",
+        "reason_codes",
+        "trust_score",
+        "score",
+        "rank",
+        "trust_rank",
+        "trust_tier",
+        "display_level",
+        "public_level",
+        "recovery_ceiling",
+        "discovery_priority",
+        "recommendation_boost",
+        "recommendation_input",
+        "ordinary_cohort_evidence",
+        "contact_unlock",
+        "room_transition",
+        "settlement_progression",
+        "promise_runtime_outcome",
+        "proof_runtime_outcome",
+        "relationship_depth",
+        "mobile_ui_state",
+        "retention_action",
+        "pruning_action",
+        "archive_action",
+        "deletion_action",
+        "legal_hold_action",
+        "key_lifecycle_action",
+        "retry_action",
+        "queue_action",
+        "outbox_action",
+        "inbox_action",
+    ] {
+        assert!(
+            body.get(field).is_none(),
+            "Controlled Exceptional Account Promise participant exclusion must not expose {field} in public API response"
+        );
+    }
+}
+
+struct SignedInUser {
+    token: String,
+    account_id: String,
+}
+
+async fn sign_in(app: &Router, pi_uid: &str, username: &str) -> SignedInUser {
+    let response = post_json(
+        app,
+        "/api/auth/pi",
+        None,
+        json!({
+            "pi_uid": pi_uid,
+            "username": username,
+            "wallet_address": format!("wallet-{pi_uid}"),
+            "access_token": format!("access-token-{pi_uid}")
+        }),
+    )
+    .await;
+    assert_eq!(response.status, StatusCode::OK);
+
+    SignedInUser {
+        token: response.body["token"]
+            .as_str()
+            .expect("token must exist")
+            .to_owned(),
+        account_id: response.body["user"]["id"]
+            .as_str()
+            .expect("user id must exist")
+            .to_owned(),
+    }
+}
+
+struct JsonResponse {
+    status: StatusCode,
+    body: Value,
+}
+
+async fn post_json(
+    app: &Router,
+    path: &str,
+    bearer_token: Option<&str>,
+    body: Value,
+) -> JsonResponse {
+    request_json(app, "POST", path, bearer_token, Some(body)).await
+}
+
+async fn get_json(app: &Router, path: &str, bearer_token: Option<&str>) -> JsonResponse {
+    request_json(app, "GET", path, bearer_token, None).await
+}
+
+async fn request_json(
+    app: &Router,
+    method: &str,
+    path: &str,
+    bearer_token: Option<&str>,
+    body: Option<Value>,
+) -> JsonResponse {
+    let mut builder = Request::builder().method(method).uri(path);
+    if let Some(token) = bearer_token {
+        builder = builder.header("authorization", format!("Bearer {token}"));
+    }
+
+    let request = builder
+        .header("content-type", "application/json")
+        .body(match body {
+            Some(body) => Body::from(body.to_string()),
+            None => Body::empty(),
+        })
+        .expect("request must build");
+
+    let response = app
+        .clone()
+        .oneshot(request)
+        .await
+        .expect("app should respond");
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body must be readable");
+    let body = if bytes.is_empty() {
+        json!({})
+    } else {
+        serde_json::from_slice(&bytes).expect("response body must be valid json")
+    };
+
+    JsonResponse { status, body }
+}

--- a/docs/foundation_lock.md
+++ b/docs/foundation_lock.md
@@ -1,6 +1,6 @@
 # Foundation Lock
 
-Status: Draft; aligned to accepted foundation commit `2aced2a`
+Status: Draft; aligned to accepted foundation commit `f5e8576`
 Applies to: `mt4110/pi-musubi-core`
 Purpose: Pin the constitutional and architectural source of truth that this implementation repository must follow.
 
@@ -26,14 +26,14 @@ Upstream repository:
 Pinned reference for implementation work:
 
 - Foundation reference type: `commit`
-- Foundation commit SHA: `2aced2a6dd57dbea96a959a2376c6305339e7d2d`
-- Foundation commit title: `Merge pull request #181 from mt4110/feat/post-c2-categorical-fact-controlled-exceptional-account-reclassification-replay-handoff`
-- Foundation PR title: `docs: evaluate post-C2 Controlled Exceptional Account reclassification replay handoff`
-- Foundation PR URL: `https://github.com/mt4110/musubi-foundation/pull/181`
-- Date pinned: `2026-05-15`
+- Foundation commit SHA: `f5e8576ce5be43455146f08e6f1871d4956ac2b5`
+- Foundation commit title: `Merge pull request #191 from mt4110/feat/post-c2-controlled-exceptional-account-promise-participant-exclusion-handoff`
+- Foundation PR title: `docs: evaluate post-C2 Controlled Exceptional Account promise participant exclusion handoff`
+- Foundation PR URL: `https://github.com/mt4110/musubi-foundation/pull/191`
+- Date pinned: `2026-05-18`
 - Pinned by: `Masaki Takemura`
-- Pinned commit URL: `https://github.com/mt4110/musubi-foundation/commit/2aced2a6dd57dbea96a959a2376c6305339e7d2d`
-- Previous pinned reference: `a171f24` / `Merge pull request #173 from mt4110/feat/evaluate-post-c2-controlled-exceptional-subject-handoff`
+- Pinned commit URL: `https://github.com/mt4110/musubi-foundation/commit/f5e8576ce5be43455146f08e6f1871d4956ac2b5`
+- Previous pinned reference: `2aced2a` / `Merge pull request #181 from mt4110/feat/post-c2-categorical-fact-controlled-exceptional-account-reclassification-replay-handoff`
 - Post-C2 evidence source: `cfdba28` / `Merge pull request #114 from mt4110/feat/post-c2-runtime-handoff-evidence-package`
 - Alignment allowance source: `69b7aa4` / `Merge pull request #116 from mt4110/feat/evaluate-post-c2-runtime-handoff-gate`
 - Post-C2 implementation handoff evidence source: `ef23e88` / `Merge pull request #122 from mt4110/feat/post-c2-implementation-handoff-evidence-package`
@@ -66,6 +66,10 @@ Pinned reference for implementation work:
 - Post-C2 categorical fact Controlled Exceptional Account reclassification replay evidence source: `f0b3882` / `Merge pull request #177 from mt4110/feat/post-c2-controlled-exceptional-reclassification-evidence`
 - Readiness routine runner source: `5fa5bdf` / `Merge pull request #179 from mt4110/feat/readiness-routine-runner`
 - Post-C2 categorical fact Controlled Exceptional Account reclassification replay handoff source: `2aced2a` / `Merge pull request #181 from mt4110/feat/post-c2-categorical-fact-controlled-exceptional-account-reclassification-replay-handoff`
+- Post-C2 categorical fact Controlled Exceptional Account reclassification replay implementation closeout source: `777c4dc` / `Merge pull request #183 from mt4110/feat/close-post-c2-controlled-exceptional-account-reclassification-replay-handoff`
+- Post-C2 Controlled Exceptional Account Promise participant exclusion evidence source: `dd81d7f` / `Merge pull request #185 from mt4110/feat/post-c2-controlled-exceptional-account-promise-participant-exclusion-evidence`
+- RunAlways Stage 0 report-only runner source: `0a754ad` / `Merge pull request #189 from mt4110/feat/runalways-stage0-report-runner`
+- Post-C2 Controlled Exceptional Account Promise participant exclusion handoff source: `f5e8576` / `Merge pull request #191 from mt4110/feat/post-c2-controlled-exceptional-account-promise-participant-exclusion-handoff`
 
 No release tag is asserted for this alignment.
 Do not invent a foundation version label for this commit.
@@ -175,31 +179,38 @@ Before coding, read these upstream documents in order.
 89. `docs/readiness/post_c2_categorical_fact_controlled_exceptional_account_subject_implementation_closeout_ledger.md`
 90. `docs/readiness/post_c2_categorical_fact_controlled_exceptional_account_reclassification_replay_evidence_package.md`
 91. `docs/readiness/post_c2_categorical_fact_controlled_exceptional_account_reclassification_replay_handoff_gate_decision.md`
+92. `docs/readiness/post_c2_categorical_fact_controlled_exceptional_account_reclassification_replay_implementation_closeout_ledger.md`
+93. `docs/readiness/post_c2_controlled_exceptional_account_promise_participant_exclusion_evidence_package.md`
+94. `docs/readiness/post_c2_controlled_exceptional_account_promise_participant_exclusion_handoff_gate_decision.md`
+
+### Operations layer
+95. `docs/operations/runalways_readiness_orchestrator_design.md`
+96. `docs/operations/runalways_readiness_orchestrator_stage0.md`
 
 ### Detail layer
-92. `docs/detail/accountability_matrix.md`
-93. `docs/detail/critical_incident_and_loss.md`
-94. `docs/detail/automated_decisioning_and_human_appeal.md`
-95. `docs/detail/youth_safety_and_age_assurance.md`
-96. `docs/detail/off_platform_handoff_and_scam_prevention.md`
-97. `docs/detail/data_deletion_vs_legal_hold.md`
-98. `docs/detail/realm_model.md`
-99. `docs/detail/data_scope_model.md`
-100. `docs/detail/mobility_model.md`
-101. `docs/detail/settlement_model.md`
-102. `docs/detail/settlement_backend_trait.md`
-103. `docs/detail/proof_of_infrastructure.md`
-104. `docs/detail/protected_groups_and_translation_safety.md`
+97. `docs/detail/accountability_matrix.md`
+98. `docs/detail/critical_incident_and_loss.md`
+99. `docs/detail/automated_decisioning_and_human_appeal.md`
+100. `docs/detail/youth_safety_and_age_assurance.md`
+101. `docs/detail/off_platform_handoff_and_scam_prevention.md`
+102. `docs/detail/data_deletion_vs_legal_hold.md`
+103. `docs/detail/realm_model.md`
+104. `docs/detail/data_scope_model.md`
+105. `docs/detail/mobility_model.md`
+106. `docs/detail/settlement_model.md`
+107. `docs/detail/settlement_backend_trait.md`
+108. `docs/detail/proof_of_infrastructure.md`
+109. `docs/detail/protected_groups_and_translation_safety.md`
 
 ### Whitepaper layer (contextual, not higher than detail/ADR)
-105. `docs/whitepaper/01_executive_summary.md`
-106. `docs/whitepaper/02_realm_model.md`
-107. `docs/whitepaper/03_experience_model.md`
-108. `docs/whitepaper/04_dm_shield.md`
-109. `docs/whitepaper/05_trust_model.md`
-110. `docs/whitepaper/06_promise_protocol.md`
-111. `docs/whitepaper/07_realm_economy.md`
-112. `docs/whitepaper/08_unlock_engine.md`
+110. `docs/whitepaper/01_executive_summary.md`
+111. `docs/whitepaper/02_realm_model.md`
+112. `docs/whitepaper/03_experience_model.md`
+113. `docs/whitepaper/04_dm_shield.md`
+114. `docs/whitepaper/05_trust_model.md`
+115. `docs/whitepaper/06_promise_protocol.md`
+116. `docs/whitepaper/07_realm_economy.md`
+117. `docs/whitepaper/08_unlock_engine.md`
 
 If any of the above are unavailable or materially inconsistent, stop and escalate.
 
@@ -229,7 +240,7 @@ That one-use C2 implementation allowance was consumed by `mt4110/pi-musubi-core`
 No remaining work may inherit permission from foundation PR #108 or implementation PR #88.
 The broad runtime implementation gate result remains NO-GO.
 Broad runtime implementation remains blocked.
-The current narrow downstream allowance is one implementation-repo test-only PR for post-C2 categorical Social Trust fact Controlled Exceptional Account reclassification replay boundary verification.
+The current narrow downstream allowance is one implementation-repo test-only PR for post-C2 Controlled Exceptional Account Promise participant exclusion verification.
 
 The C2 bounded Promise reliability readiness and closeout chain is accepted for docs-only foundation semantic scope:
 
@@ -272,6 +283,14 @@ The C2 bounded Promise reliability readiness and closeout chain is accepted for 
 - `docs/readiness/post_c2_categorical_fact_subject_realm_idempotency_scope_implementation_closeout_ledger.md`
 - `docs/readiness/post_c2_categorical_fact_controlled_exceptional_account_subject_evidence_package.md`
 - `docs/readiness/post_c2_categorical_fact_controlled_exceptional_account_subject_handoff_gate_decision.md`
+- `docs/readiness/post_c2_categorical_fact_controlled_exceptional_account_subject_implementation_closeout_ledger.md`
+- `docs/readiness/post_c2_categorical_fact_controlled_exceptional_account_reclassification_replay_evidence_package.md`
+- `docs/readiness/post_c2_categorical_fact_controlled_exceptional_account_reclassification_replay_handoff_gate_decision.md`
+- `docs/readiness/post_c2_categorical_fact_controlled_exceptional_account_reclassification_replay_implementation_closeout_ledger.md`
+- `docs/readiness/post_c2_controlled_exceptional_account_promise_participant_exclusion_evidence_package.md`
+- `docs/readiness/post_c2_controlled_exceptional_account_promise_participant_exclusion_handoff_gate_decision.md`
+- `docs/operations/runalways_readiness_orchestrator_design.md`
+- `docs/operations/runalways_readiness_orchestrator_stage0.md`
 
 The accepted C2 gate records `bounded_promise_reliability` as the only positive Social Trust source-family candidate and accepts exact source facts and exact Social Trust mutation facts only as foundation semantic labels.
 Those labels are not runtime schema names, enum values, API names, migration names, module names, or test names.
@@ -312,10 +331,14 @@ Foundation PR #173 provided the consumed narrow downstream test-only handoff aut
 That allowance was consumed by `mt4110/pi-musubi-core` PR #108 and closed out by foundation PR #175.
 Foundation PR #177 accepted the exact candidate test-only slice as post-C2 categorical Social Trust fact Controlled Exceptional Account reclassification replay boundary verification.
 Foundation PR #179 added an advisory readiness routine runner and did not grant GO, implementation handoff, or implementation authority.
-Foundation PR #181 provides the current narrow downstream test-only handoff authority for one later implementation-repo PR only.
+Foundation PR #181 provided the consumed narrow downstream test-only handoff authority for one later implementation-repo PR only.
+That allowance was consumed by `mt4110/pi-musubi-core` PR #110 and closed out by foundation PR #183.
+Foundation PR #185 accepted the exact candidate test-only slice as post-C2 Controlled Exceptional Account Promise participant exclusion verification.
+Foundation PR #189 added the Stage 0 report-only RunAlways runner and did not grant GO, implementation handoff, implementation authority, or automation authority.
+Foundation PR #191 provides the current narrow downstream test-only handoff authority for one later implementation-repo PR only.
 This update is the required lock pin for that one-use allowance.
-It does not authorize implementation outside the PR #181 envelope.
-It does not authorize new source facts, new mutation facts, DDL, migrations, backend runtime code, backend README updates, backend docs updates, public API changes, mobile UI, projection refresh, runtime orchestration, lifecycle runtime behavior, pruning, archive, deletion, Legal Hold runtime behavior, key lifecycle behavior, retry workers, queues, outbox changes, inbox changes, discovery, recommendation, room, settlement, Promise runtime, proof runtime, Relationship Depth, Social Trust scoring, public trust display, or any broader `pi-musubi-core` change.
+It does not authorize implementation outside the PR #191 envelope.
+It does not authorize new Promise types, new Social Trust source facts, new Social Trust mutation facts, Relationship Depth facts, discovery or recommendation signals, DDL, migrations, backend runtime code, backend README updates, backend docs updates, public API changes, mobile UI, projection refresh, runtime orchestration, lifecycle runtime behavior, pruning, archive, deletion, Legal Hold runtime behavior, key lifecycle behavior, retry workers, queues, outbox changes, inbox changes, room, settlement, Promise runtime, proof runtime, Social Trust scoring, public trust display, or any broader `pi-musubi-core` change.
 
 Implementation merge history, issue order, branch ancestry, and existing code are not foundation design proof.
 
@@ -499,10 +522,12 @@ The post-C2 categorical fact subject and Realm idempotency scope evidence packag
 That test-only allowance was consumed by `mt4110/pi-musubi-core` PR #106 and closed out by foundation PR #168.
 The post-C2 categorical fact Controlled Exceptional Account subject evidence package and handoff gate authorized one later implementation-repo test-only PR only.
 That test-only allowance was consumed by `mt4110/pi-musubi-core` PR #108 and closed out by foundation PR #175.
-The post-C2 categorical fact Controlled Exceptional Account reclassification replay evidence package and handoff gate now authorize one later implementation-repo test-only PR only.
-This test-only allowance is limited to `docs/foundation_lock.md` and `apps/backend/tests/post_c2_categorical_fact_controlled_exceptional_account_reclassification_replay.rs`.
-It may verify that the already accepted `promise_reliability_outcome.completed_as_agreed` / `social_trust_mutation.bounded_promise_reliability_positive` C2 categorical Social Trust fact pair first accepted while the subject is an active Ordinary Account replays identically after that subject is later classified as a Controlled Exceptional Account, that a new post-classification fact fails closed because the subject is no longer an Ordinary Account, and that no duplicate categorical source reference, duplicate categorical mutation fact, projection, coordination, archive, public API, mobile UI, Social Trust score/display, Relationship Depth, discovery, recommendation, room, settlement, Promise runtime, proof runtime, lifecycle, retention, pruning, deletion, Legal Hold, key lifecycle, retry, queue, outbox, or inbox authority is created.
-It does not authorize new source facts, new mutation facts, DDL, migrations, backend runtime code, backend README updates, backend docs updates, public API changes, mobile UI, projection refresh, runtime orchestration, lifecycle runtime behavior, pruning, archive, deletion, Legal Hold runtime behavior, key lifecycle behavior, discovery, recommendation, room progression, settlement behavior, Promise runtime behavior, proof runtime behavior, Relationship Depth, Social Trust scoring, public trust display, or broad runtime implementation.
+The post-C2 categorical fact Controlled Exceptional Account reclassification replay evidence package and handoff gate authorized one later implementation-repo test-only PR only.
+That test-only allowance was consumed by `mt4110/pi-musubi-core` PR #110 and closed out by foundation PR #183.
+The post-C2 Controlled Exceptional Account Promise participant exclusion evidence package and handoff gate now authorize one later implementation-repo test-only PR only.
+This test-only allowance is limited to `docs/foundation_lock.md` and `apps/backend/tests/post_c2_controlled_exceptional_account_promise_participant_exclusion.rs`.
+It may add deterministic backend integration tests proving that an active Controlled Exceptional Account fails closed as a Promise initiating participant and as a Promise counterparty participant because the account is not an Ordinary Account, without creating Promise writer facts, settlement cases, room progression state, projection rows, public API-visible participant state, mobile UI state, Social Trust source facts, Social Trust mutation facts, Relationship Depth facts, discovery demand, recommendation input, ordinary cohort evidence, retry authority, queue authority, outbox authority, inbox authority, coordination archive rows, score, weight, rank, display, public level, recovery ceiling, lifecycle authority, retention runtime behavior, pruning runtime behavior, archive runtime behavior, deletion runtime behavior, Legal Hold runtime behavior, key lifecycle behavior, settlement progression, Promise runtime behavior, or proof runtime behavior.
+It does not authorize new Promise types, new Social Trust source facts, new Social Trust mutation facts, DDL, migrations, backend runtime code, backend README updates, backend docs updates, public API changes, mobile UI, projection refresh, runtime orchestration, lifecycle runtime behavior, pruning, archive, deletion, Legal Hold runtime behavior, key lifecycle behavior, discovery, recommendation, room progression, settlement behavior, Promise runtime behavior, proof runtime behavior, Relationship Depth, Social Trust scoring, public trust display, or broad runtime implementation.
 
 ---
 
@@ -530,11 +555,11 @@ When updating:
 - Review completed by:
 
 ### Current drift note
-- Updated from foundation SHA: `a171f249b4daa279b6408b72747464dec297666b` -> `2aced2a6dd57dbea96a959a2376c6305339e7d2d`
-- Reason: Align implementation-repo lock with the accepted foundation state after PR #181 (`docs: evaluate post-C2 Controlled Exceptional Account reclassification replay handoff`).
-- New required docs: Post-C2 categorical fact Controlled Exceptional Account subject implementation closeout ledger; post-C2 categorical fact Controlled Exceptional Account reclassification replay evidence package; post-C2 categorical fact Controlled Exceptional Account reclassification replay handoff gate decision.
+- Updated from foundation SHA: `2aced2a6dd57dbea96a959a2376c6305339e7d2d` -> `f5e8576ce5be43455146f08e6f1871d4956ac2b5`
+- Reason: Align implementation-repo lock with the accepted foundation state after PR #191 (`docs: evaluate post-C2 Controlled Exceptional Account promise participant exclusion handoff`).
+- New required docs: Post-C2 categorical fact Controlled Exceptional Account reclassification replay implementation closeout ledger; Post-C2 Controlled Exceptional Account Promise participant exclusion evidence package; Post-C2 Controlled Exceptional Account Promise participant exclusion handoff gate decision; RunAlways readiness orchestrator design; RunAlways readiness orchestrator Stage 0 report-only runner.
 - Removed docs: None.
-- Implementation impact: PR #181 authorizes one later implementation-repo test-only PR. This PR may update this foundation lock and add deterministic backend integration tests proving the accepted `promise_reliability_outcome.completed_as_agreed` / `social_trust_mutation.bounded_promise_reliability_positive` C2 categorical Social Trust fact pair first accepted while the subject is an active Ordinary Account replays identically after that subject is later classified as a Controlled Exceptional Account, and that a new post-classification fact fails closed because the subject is no longer an Ordinary Account, without creating duplicate categorical source references, duplicate categorical mutation facts, projection rows, coordination rows, archive rows, public API exposure, mobile UI state, Social Trust score/display behavior, Relationship Depth behavior, discovery behavior, recommendation behavior, room behavior, settlement behavior, Promise runtime behavior, proof runtime behavior, lifecycle authority, retention, pruning, deletion, Legal Hold, key lifecycle, retry, queue, outbox, or inbox authority. New source facts, new mutation facts, DDL, migrations, backend runtime code, backend README updates, backend docs updates, public API changes, mobile UI, projection refresh, runtime orchestration, lifecycle runtime behavior, pruning, archive, deletion, Legal Hold runtime behavior, key lifecycle behavior, Relationship Depth, proof runtime behavior, room progression, discovery, recommendation, settlement, Promise runtime behavior, Social Trust scoring, public trust display, and paid romantic advantage remain blocked.
+- Implementation impact: PR #191 authorizes one later implementation-repo test-only PR. This PR may update this foundation lock and add deterministic backend integration tests proving that an active Controlled Exceptional Account fails closed as a Promise initiating participant and as a Promise counterparty participant because the account is not an Ordinary Account, without creating Promise writer facts, settlement cases, room progression state, projection rows, public API-visible participant state, mobile UI state, Social Trust source facts, Social Trust mutation facts, Relationship Depth facts, discovery demand, recommendation input, ordinary cohort evidence, retry authority, queue authority, outbox authority, inbox authority, coordination archive rows, score, weight, rank, display, public level, recovery ceiling, lifecycle authority, retention runtime behavior, pruning runtime behavior, archive runtime behavior, deletion runtime behavior, Legal Hold runtime behavior, key lifecycle behavior, settlement progression, Promise runtime behavior, or proof runtime behavior. New Promise types, new Social Trust source facts, new Social Trust mutation facts, DDL, migrations, backend runtime code, backend README updates, backend docs updates, public API changes, mobile UI, projection refresh, runtime orchestration, lifecycle runtime behavior, pruning, archive, deletion, Legal Hold runtime behavior, key lifecycle behavior, Relationship Depth, proof runtime behavior, room progression, discovery, recommendation, settlement, Promise runtime behavior, Social Trust scoring, public trust display, broad runtime implementation, and paid romantic advantage remain blocked.
 - Review completed by: Masaki Takemura
 
 ---


### PR DESCRIPTION
## Summary
- Pin `docs/foundation_lock.md` to the accepted foundation PR #191 handoff commit.
- Record the PR #183 closeout, PR #185 evidence, and PR #189 Stage 0 report-only runner context without expanding runtime authority.
- Add deterministic backend integration tests proving Controlled Exceptional Accounts fail closed as Promise initiator and counterparty participants without writer, projection, coordination, review, realm, Social Trust, Relationship Depth, discovery, recommendation, queue, outbox, or inbox side effects.

## Scope
This stays inside the exact downstream write scope authorized by `mt4110/musubi-foundation#191`:
- `docs/foundation_lock.md`
- `apps/backend/tests/post_c2_controlled_exceptional_account_promise_participant_exclusion.rs`

No DDL, migrations, backend runtime code, public API changes, mobile UI, projection refresh behavior, runtime orchestration, or broad runtime implementation are included.

## Validation
- `rustfmt --edition 2024 --check apps/backend/tests/post_c2_controlled_exceptional_account_promise_participant_exclusion.rs`
- `cargo test --test post_c2_controlled_exceptional_account_promise_participant_exclusion`
- `git diff --check`

## Note
`cargo fmt --check` currently reports formatting diffs in unrelated existing files outside the PR #191 write scope, so those files were left untouched.
