### PR TITLE
chore: add backend local verification target

### DIFF
--- a/apps/backend/Makefile
+++ b/apps/backend/Makefile
@@ -1,33 +1,62 @@
-COMPOSE ?= docker compose
+DOCKER_COMPOSE ?= $(shell if docker compose version >/dev/null 2>&1; then printf 'docker compose'; elif command -v docker-compose >/dev/null 2>&1; then printf 'docker-compose'; else printf 'docker compose'; fi)
 ENV_FILE ?= .env
 
-.PHONY: dev check db-bootstrap db-migrate db-status db-reset-local docker-up docker-down
+.PHONY: dev check test env-check infra-up verify-local db-bootstrap db-migrate db-status db-reset-local docker-up docker-down
 
-dev:
-	@if [ ! -f $(ENV_FILE) ]; then cp .env.example $(ENV_FILE); fi
+dev: env-check
 	@set -a; . ./$(ENV_FILE); set +a; cargo run -p musubi_backend
 
 check:
 	cargo check
 
-db-bootstrap:
+test: env-check
+	@set -a; . ./$(ENV_FILE); set +a; cargo test --workspace
+
+env-check:
 	@if [ ! -f $(ENV_FILE) ]; then cp .env.example $(ENV_FILE); fi
+	@missing=$$(awk -F= 'FNR==NR { if ($$1 ~ /^[A-Z0-9_]+$$/) required[$$1]=1; next } { if ($$1 ~ /^[A-Z0-9_]+$$/) present[$$1]=1 } END { for (key in required) if (!(key in present)) print key }' .env.example $(ENV_FILE)); \
+	if [ -n "$$missing" ]; then \
+		echo "missing required keys in $(ENV_FILE):"; \
+		echo "$$missing"; \
+		echo "copy missing defaults from .env.example"; \
+		exit 1; \
+	fi
+
+infra-up: env-check
+	$(DOCKER_COMPOSE) --env-file $(ENV_FILE) up -d postgres redis
+	@for attempt in $$(seq 1 60); do \
+		status=$$(docker inspect -f '{{.State.Health.Status}}' musubi_postgres 2>/dev/null || true); \
+		if [ "$$status" = "healthy" ]; then exit 0; fi; \
+		echo "waiting for postgres health ($$attempt/60): $${status:-missing}"; \
+		sleep 1; \
+	done; \
+	echo "postgres did not become healthy"; \
+	exit 1
+	@for attempt in $$(seq 1 60); do \
+		status=$$(docker inspect -f '{{.State.Health.Status}}' musubi_redis 2>/dev/null || true); \
+		if [ "$$status" = "healthy" ]; then exit 0; fi; \
+		echo "waiting for redis health ($$attempt/60): $${status:-missing}"; \
+		sleep 1; \
+	done; \
+	echo "redis did not become healthy"; \
+	exit 1
+
+verify-local: infra-up db-bootstrap db-migrate db-status test
+
+db-bootstrap: env-check
 	@set -a; . ./$(ENV_FILE); set +a; cargo run -p musubi-ops -- db bootstrap
 
-db-migrate:
-	@if [ ! -f $(ENV_FILE) ]; then cp .env.example $(ENV_FILE); fi
+db-migrate: env-check
 	@set -a; . ./$(ENV_FILE); set +a; cargo run -p musubi-ops -- db migrate
 
-db-status:
-	@if [ ! -f $(ENV_FILE) ]; then cp .env.example $(ENV_FILE); fi
+db-status: env-check
 	@set -a; . ./$(ENV_FILE); set +a; cargo run -p musubi-ops -- db status
 
-db-reset-local:
-	@if [ ! -f $(ENV_FILE) ]; then cp .env.example $(ENV_FILE); fi
+db-reset-local: env-check
 	@set -a; . ./$(ENV_FILE); set +a; cargo run -p musubi-ops -- db reset-local --confirm-reset-local
 
 docker-up:
-	$(COMPOSE) up --build
+	$(DOCKER_COMPOSE) --env-file $(ENV_FILE) up --build
 
 docker-down:
-	$(COMPOSE) down
+	$(DOCKER_COMPOSE) down

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -146,6 +146,23 @@ cargo test -p musubi_orchestration
 
 ### Run the backend checks
 
+For the full local backend verification path, including local Postgres/Redis,
+environment key validation, DB bootstrap, migrations, migration status, and
+the Rust test workspace:
+
+```bash
+cd apps/backend
+make verify-local
+```
+
+`make verify-local` checks that `.env` contains the keys currently required by
+`.env.example` before running DB commands. If `.env` is stale, copy the missing
+defaults from `.env.example` and rerun the target.
+The Makefile auto-detects `docker compose` first and falls back to
+`docker-compose`. If your local Docker setup needs a specific command, run
+`DOCKER_COMPOSE="docker-compose" make verify-local` or
+`DOCKER_COMPOSE="docker compose" make verify-local`.
+
 ```bash
 cd apps/backend
 cargo check


### PR DESCRIPTION
## Summary
- Add `make verify-local` for the backend local verification path: Postgres/Redis startup, environment key validation, DB bootstrap, migrations, migration status, and env-sourced `cargo test --workspace`.
- Add `make env-check`, `make infra-up`, and `make test` targets.
- Rename the compose command variable to `DOCKER_COMPOSE`, auto-detect Compose v2 first, fall back to `docker-compose`, and document explicit overrides.

## Why
This makes backend build progress reproducible from one command and catches stale `.env` files before DB commands fail late.

## Review follow-up
- `infra-up` now depends on `env-check` before starting containers.
- Compose receives `--env-file $(ENV_FILE)` so port mappings and DB URLs stay aligned.
- `infra-up` waits for Postgres and Redis health before DB commands run.
- The redundant `.env` copy in `dev` was removed.
- `make test` now sources `.env` before running `cargo test --workspace`, so DB-backed tests receive `MUSUBI_TEST_DATABASE_URL` instead of silently skipping.

## Non-goals
- No runtime behavior changes.
- No schema, DDL, migrations, product semantics, legal/privacy, DAO, blockchain, Legal Hold, evidence access, Social Trust scoring, Relationship Depth, discovery, or recommendation changes.

## Verification
- `make env-check`
- `ENV_FILE=.env.verify-local-review make infra-up`
- `make check`
- `make test`
- `make verify-local`

Closes #115.