### PR TITLE
Add backend HTTP smoke target

### DIFF
--- a/apps/backend/Makefile
+++ b/apps/backend/Makefile
@@ -1,7 +1,11 @@
 DOCKER_COMPOSE ?= $(shell if docker compose version >/dev/null 2>&1; then printf 'docker compose'; elif command -v docker-compose >/dev/null 2>&1; then printf 'docker-compose'; else printf 'docker compose'; fi)
 ENV_FILE ?= .env
+HTTP_SMOKE_HOST ?= 127.0.0.1
+HTTP_SMOKE_PORT ?= 18088
+HTTP_SMOKE_BASE_URL ?= http://$(HTTP_SMOKE_HOST):$(HTTP_SMOKE_PORT)
+HTTP_SMOKE_STARTUP_TIMEOUT_SECONDS ?= 120
 
-.PHONY: dev check test env-check infra-up verify-local db-bootstrap db-migrate db-status db-reset-local docker-up docker-down
+.PHONY: dev check test env-check infra-up verify-local http-smoke db-bootstrap db-migrate db-status db-reset-local docker-up docker-down
 
 dev: env-check
 	@set -a; . ./$(ENV_FILE); set +a; cargo run -p musubi_backend
@@ -42,6 +46,54 @@ infra-up: env-check
 	exit 1
 
 verify-local: infra-up db-bootstrap db-migrate db-status test
+
+http-smoke: env-check
+	@command -v curl >/dev/null 2>&1 || { echo "curl is required for http-smoke"; exit 1; }
+	@backend_log=$$(mktemp -t musubi-backend-http-smoke-log.XXXXXX); \
+	body_file=$$(mktemp -t musubi-backend-http-smoke-body.XXXXXX); \
+	backend_pid=""; \
+	trap 'status=$$?; if [ -n "$$backend_pid" ] && kill -0 "$$backend_pid" 2>/dev/null; then kill "$$backend_pid" >/dev/null 2>&1 || true; wait "$$backend_pid" 2>/dev/null || true; fi; rm -f "$$backend_log" "$$body_file"; exit $$status' EXIT INT TERM; \
+	set -a; . ./$(ENV_FILE); set +a; \
+	cargo build -p musubi_backend || exit 1; \
+	if curl -fsS --max-time 2 "$(HTTP_SMOKE_BASE_URL)/health" > "$$body_file" 2>/dev/null; then \
+		echo "HTTP smoke port already has a responding /health endpoint: $(HTTP_SMOKE_BASE_URL)"; \
+		echo "stop the existing process or set HTTP_SMOKE_PORT to a free port"; \
+		exit 1; \
+	fi; \
+	echo "starting backend for HTTP smoke at $(HTTP_SMOKE_BASE_URL)"; \
+	APP_HOST=$(HTTP_SMOKE_HOST) PORT=$(HTTP_SMOKE_PORT) ./target/debug/musubi_backend > "$$backend_log" 2>&1 & \
+	backend_pid=$$!; \
+	ready=0; \
+	for attempt in $$(seq 1 $(HTTP_SMOKE_STARTUP_TIMEOUT_SECONDS)); do \
+		if curl -fsS --max-time 2 "$(HTTP_SMOKE_BASE_URL)/health" > "$$body_file" 2>/dev/null; then ready=1; break; fi; \
+		if ! kill -0 "$$backend_pid" 2>/dev/null; then \
+			echo "backend exited before HTTP smoke became ready"; \
+			cat "$$backend_log"; \
+			exit 1; \
+		fi; \
+		sleep 1; \
+	done; \
+	if [ "$$ready" != "1" ]; then \
+		echo "backend did not become ready within $(HTTP_SMOKE_STARTUP_TIMEOUT_SECONDS)s"; \
+		cat "$$backend_log"; \
+		exit 1; \
+	fi; \
+	if ! kill -0 "$$backend_pid" 2>/dev/null; then \
+		echo "backend exited after readiness probe succeeded"; \
+		cat "$$backend_log"; \
+		exit 1; \
+	fi; \
+	grep -q '"status":"ok"' "$$body_file" || { echo "/health did not report ok"; cat "$$body_file"; exit 1; }; \
+	curl -fsS --max-time 5 "$(HTTP_SMOKE_BASE_URL)/api/launch/posture" > "$$body_file" || { echo "/api/launch/posture request failed"; exit 1; }; \
+	grep -q '"launch_mode":' "$$body_file" || { echo "/api/launch/posture did not include launch_mode"; cat "$$body_file"; exit 1; }; \
+	grep -q '"message_code":' "$$body_file" || { echo "/api/launch/posture did not include message_code"; cat "$$body_file"; exit 1; }; \
+	curl -fsS --max-time 5 "$(HTTP_SMOKE_BASE_URL)/api/internal/ops/health" > "$$body_file" || { echo "/api/internal/ops/health request failed"; exit 1; }; \
+	grep -q '"status":"ok"' "$$body_file" || { echo "/api/internal/ops/health did not report ok"; cat "$$body_file"; exit 1; }; \
+	grep -q '"database":' "$$body_file" || { echo "/api/internal/ops/health did not include database"; cat "$$body_file"; exit 1; }; \
+	curl -fsS --max-time 5 "$(HTTP_SMOKE_BASE_URL)/api/internal/ops/readiness" > "$$body_file" || { echo "/api/internal/ops/readiness request failed"; exit 1; }; \
+	grep -q '"status":"ready"' "$$body_file" || { echo "/api/internal/ops/readiness did not report ready"; cat "$$body_file"; exit 1; }; \
+	grep -q '"pending_count":0' "$$body_file" || { echo "/api/internal/ops/readiness did not report zero pending migrations"; cat "$$body_file"; exit 1; }; \
+	echo "HTTP smoke passed at $(HTTP_SMOKE_BASE_URL)"
 
 db-bootstrap: env-check
 	@set -a; . ./$(ENV_FILE); set +a; cargo run -p musubi-ops -- db bootstrap

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -163,6 +163,18 @@ The Makefile auto-detects `docker compose` first and falls back to
 `DOCKER_COMPOSE="docker-compose" make verify-local` or
 `DOCKER_COMPOSE="docker compose" make verify-local`.
 
+To exercise the local Day 1 backend over HTTP after `make verify-local`, run:
+
+```bash
+cd apps/backend
+make http-smoke
+```
+
+`make http-smoke` starts the debug backend on `127.0.0.1:18088`, then checks
+`/health`, `/api/launch/posture`, `/api/internal/ops/health`, and
+`/api/internal/ops/readiness`. The internal ops calls rely on the local debug
+internal gate and do not add or widen any public API route.
+
 ```bash
 cd apps/backend
 cargo check


### PR DESCRIPTION
## Summary

- add `make http-smoke` for the backend local pilot baseline
- start the debug backend on `127.0.0.1:18088` and smoke existing HTTP surfaces
- document the HTTP smoke flow after `make verify-local`

## Boundary

This only exercises existing backend routes over HTTP. It does not add or widen public API routes, and it does not touch schema, migrations, Legal Hold, DAO, blockchain, Social Trust scoring, Relationship Depth, discovery, or recommendation behavior.

## Verification

- `make env-check`
- `make db-status`
- `make http-smoke`
- stale-port guard rejects an existing `/health` responder on `127.0.0.1:18088`
- `make check`
- `git diff --check`
