### PR TITLE
Add Day 1 HTTP smoke suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+BACKEND_DIR ?= apps/backend
+
+.PHONY: verify-local verify-local-http http-day1-smoke http-smoke http-happy-route-smoke http-funded-happy-route-smoke http-funded-replay-smoke http-funded-duplicate-receipt-smoke
+
+verify-local:
+	@$(MAKE) -C $(BACKEND_DIR) verify-local
+
+verify-local-http:
+	@$(MAKE) -C $(BACKEND_DIR) verify-local-http
+
+http-day1-smoke:
+	@$(MAKE) -C $(BACKEND_DIR) http-day1-smoke
+
+http-smoke:
+	@$(MAKE) -C $(BACKEND_DIR) http-smoke
+
+http-happy-route-smoke:
+	@$(MAKE) -C $(BACKEND_DIR) http-happy-route-smoke
+
+http-funded-happy-route-smoke:
+	@$(MAKE) -C $(BACKEND_DIR) http-funded-happy-route-smoke
+
+http-funded-replay-smoke:
+	@$(MAKE) -C $(BACKEND_DIR) http-funded-replay-smoke
+
+http-funded-duplicate-receipt-smoke:
+	@$(MAKE) -C $(BACKEND_DIR) http-funded-duplicate-receipt-smoke

--- a/README.md
+++ b/README.md
@@ -55,6 +55,23 @@ flutter run -d chrome --dart-define=API_BASE_URL=http://localhost:8088
 
 `REQUIRE_LATEST_SCHEMA=true` の場合、backend は pending / failed / checksum drift に加えて、DB 側にだけ存在する applied migration がある状態では起動しません。
 
+## ローカル検証
+
+repo root から Day 1 HTTP smoke suite を一発で実行できます。
+
+```bash
+make http-day1-smoke
+```
+
+backend の Rust test も含めて全部確認したい場合は、こちらを使います。
+
+```bash
+make verify-local-http
+```
+
+どちらも backend 側の Makefile に委譲します。Rust workspace の root は引き続き
+`apps/backend` です。
+
 ## Foundation alignment
 
 This repo is the canonical implementation repo for MUSUBI Day 1.

--- a/README_EN.md
+++ b/README_EN.md
@@ -16,3 +16,20 @@ M1 - Core Truth and Orchestration Baseline
 See `docs/foundation_lock.md` for the pinned design corpus.
 
 Implementation agents must treat `docs/foundation_lock.md` as the mandatory reading gateway before changing code.
+
+## Local verification
+
+From the repository root, run the Day 1 HTTP smoke suite with:
+
+```bash
+make http-day1-smoke
+```
+
+For the full local backend verification plus the HTTP suite, run:
+
+```bash
+make verify-local-http
+```
+
+These targets delegate to `apps/backend`. The Rust workspace root remains
+`apps/backend`.

--- a/apps/backend/Makefile
+++ b/apps/backend/Makefile
@@ -63,7 +63,12 @@ infra-up: env-check
 
 verify-local: infra-up db-bootstrap db-migrate db-status test
 
-verify-local-http: verify-local http-day1-smoke
+verify-local-http: verify-local
+	@$(MAKE) http-smoke
+	@$(MAKE) http-happy-route-smoke
+	@$(MAKE) http-funded-happy-route-smoke
+	@$(MAKE) http-funded-replay-smoke
+	@$(MAKE) http-funded-duplicate-receipt-smoke
 
 http-day1-smoke:
 	@$(MAKE) infra-up

--- a/apps/backend/Makefile
+++ b/apps/backend/Makefile
@@ -8,8 +8,20 @@ HTTP_HAPPY_ROUTE_SMOKE_HOST ?= 127.0.0.1
 HTTP_HAPPY_ROUTE_SMOKE_PORT ?= 18089
 HTTP_HAPPY_ROUTE_SMOKE_BASE_URL ?= http://$(HTTP_HAPPY_ROUTE_SMOKE_HOST):$(HTTP_HAPPY_ROUTE_SMOKE_PORT)
 HTTP_HAPPY_ROUTE_SMOKE_STARTUP_TIMEOUT_SECONDS ?= 120
+HTTP_FUNDED_HAPPY_ROUTE_SMOKE_HOST ?= 127.0.0.1
+HTTP_FUNDED_HAPPY_ROUTE_SMOKE_PORT ?= 18090
+HTTP_FUNDED_HAPPY_ROUTE_SMOKE_BASE_URL ?= http://$(HTTP_FUNDED_HAPPY_ROUTE_SMOKE_HOST):$(HTTP_FUNDED_HAPPY_ROUTE_SMOKE_PORT)
+HTTP_FUNDED_HAPPY_ROUTE_SMOKE_STARTUP_TIMEOUT_SECONDS ?= 120
+HTTP_FUNDED_REPLAY_SMOKE_HOST ?= 127.0.0.1
+HTTP_FUNDED_REPLAY_SMOKE_PORT ?= 18091
+HTTP_FUNDED_REPLAY_SMOKE_BASE_URL ?= http://$(HTTP_FUNDED_REPLAY_SMOKE_HOST):$(HTTP_FUNDED_REPLAY_SMOKE_PORT)
+HTTP_FUNDED_REPLAY_SMOKE_STARTUP_TIMEOUT_SECONDS ?= 120
+HTTP_FUNDED_DUPLICATE_RECEIPT_SMOKE_HOST ?= 127.0.0.1
+HTTP_FUNDED_DUPLICATE_RECEIPT_SMOKE_PORT ?= 18092
+HTTP_FUNDED_DUPLICATE_RECEIPT_SMOKE_BASE_URL ?= http://$(HTTP_FUNDED_DUPLICATE_RECEIPT_SMOKE_HOST):$(HTTP_FUNDED_DUPLICATE_RECEIPT_SMOKE_PORT)
+HTTP_FUNDED_DUPLICATE_RECEIPT_SMOKE_STARTUP_TIMEOUT_SECONDS ?= 120
 
-.PHONY: dev check test env-check infra-up verify-local http-smoke http-happy-route-smoke db-bootstrap db-migrate db-status db-reset-local docker-up docker-down
+.PHONY: dev check test env-check infra-up verify-local verify-local-http http-day1-smoke http-smoke http-happy-route-smoke http-funded-happy-route-smoke http-funded-replay-smoke http-funded-duplicate-receipt-smoke db-bootstrap db-migrate db-status db-reset-local docker-up docker-down
 
 dev: env-check
 	@set -a; . ./$(ENV_FILE); set +a; cargo run -p musubi_backend
@@ -50,6 +62,19 @@ infra-up: env-check
 	exit 1
 
 verify-local: infra-up db-bootstrap db-migrate db-status test
+
+verify-local-http: verify-local http-day1-smoke
+
+http-day1-smoke:
+	@$(MAKE) infra-up
+	@$(MAKE) db-bootstrap
+	@$(MAKE) db-migrate
+	@$(MAKE) db-status
+	@$(MAKE) http-smoke
+	@$(MAKE) http-happy-route-smoke
+	@$(MAKE) http-funded-happy-route-smoke
+	@$(MAKE) http-funded-replay-smoke
+	@$(MAKE) http-funded-duplicate-receipt-smoke
 
 http-smoke: env-check
 	@command -v curl >/dev/null 2>&1 || { echo "curl is required for http-smoke"; exit 1; }
@@ -106,6 +131,38 @@ http-happy-route-smoke: env-check
 	HTTP_HAPPY_ROUTE_SMOKE_BASE_URL="$(HTTP_HAPPY_ROUTE_SMOKE_BASE_URL)" \
 	HTTP_HAPPY_ROUTE_SMOKE_STARTUP_TIMEOUT_SECONDS="$(HTTP_HAPPY_ROUTE_SMOKE_STARTUP_TIMEOUT_SECONDS)" \
 	./scripts/http_happy_route_smoke.sh
+
+http-funded-happy-route-smoke: env-check
+	@ENV_FILE="$(ENV_FILE)" \
+	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_HOST="$(HTTP_FUNDED_HAPPY_ROUTE_SMOKE_HOST)" \
+	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_PORT="$(HTTP_FUNDED_HAPPY_ROUTE_SMOKE_PORT)" \
+	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_BASE_URL="$(HTTP_FUNDED_HAPPY_ROUTE_SMOKE_BASE_URL)" \
+	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_STARTUP_TIMEOUT_SECONDS="$(HTTP_FUNDED_HAPPY_ROUTE_SMOKE_STARTUP_TIMEOUT_SECONDS)" \
+	./scripts/http_funded_happy_route_smoke.sh
+
+http-funded-replay-smoke: env-check
+	@ENV_FILE="$(ENV_FILE)" \
+	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_HOST="$(HTTP_FUNDED_REPLAY_SMOKE_HOST)" \
+	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_PORT="$(HTTP_FUNDED_REPLAY_SMOKE_PORT)" \
+	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_BASE_URL="$(HTTP_FUNDED_REPLAY_SMOKE_BASE_URL)" \
+	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_STARTUP_TIMEOUT_SECONDS="$(HTTP_FUNDED_REPLAY_SMOKE_STARTUP_TIMEOUT_SECONDS)" \
+	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_INITIATOR_PI_UID="http-funded-replay-smoke-initiator" \
+	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_COUNTERPARTY_PI_UID="http-funded-replay-smoke-counterparty" \
+	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_REALM_ID="realm-http-funded-replay-smoke" \
+	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_VERIFY_REPLAY=true \
+	./scripts/http_funded_happy_route_smoke.sh
+
+http-funded-duplicate-receipt-smoke: env-check
+	@ENV_FILE="$(ENV_FILE)" \
+	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_HOST="$(HTTP_FUNDED_DUPLICATE_RECEIPT_SMOKE_HOST)" \
+	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_PORT="$(HTTP_FUNDED_DUPLICATE_RECEIPT_SMOKE_PORT)" \
+	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_BASE_URL="$(HTTP_FUNDED_DUPLICATE_RECEIPT_SMOKE_BASE_URL)" \
+	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_STARTUP_TIMEOUT_SECONDS="$(HTTP_FUNDED_DUPLICATE_RECEIPT_SMOKE_STARTUP_TIMEOUT_SECONDS)" \
+	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_INITIATOR_PI_UID="http-funded-duplicate-receipt-smoke-initiator" \
+	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_COUNTERPARTY_PI_UID="http-funded-duplicate-receipt-smoke-counterparty" \
+	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_REALM_ID="realm-http-funded-duplicate-receipt-smoke" \
+	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_VERIFY_DUPLICATE_RECEIPT=true \
+	./scripts/http_funded_happy_route_smoke.sh
 
 db-bootstrap: env-check
 	@set -a; . ./$(ENV_FILE); set +a; cargo run -p musubi-ops -- db bootstrap

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -175,6 +175,25 @@ make http-smoke
 `/api/internal/ops/readiness`. The internal ops calls rely on the local debug
 internal gate and do not add or widen any public API route.
 
+To run the local Day 1 HTTP smoke suite in one command, run:
+
+```bash
+cd apps/backend
+make http-day1-smoke
+```
+
+`make http-day1-smoke` brings up local infra, bootstraps and migrates the
+writer DB, checks migration status, then runs the HTTP health/readiness,
+pilot-gated Promise intent, funded happy-route, exact callback replay, and
+duplicate-receipt smoke targets in a fixed sequence.
+
+For the full local check plus the HTTP suite, run:
+
+```bash
+cd apps/backend
+make verify-local-http
+```
+
 To exercise the first pilot-gated product write path over HTTP, run:
 
 ```bash
@@ -188,6 +207,53 @@ Promise intent through `POST /api/promise/intents`. It checks the immediate
 `pending_funding` response only; provider submission, callbacks, ledger
 funding, projection rebuild, and orchestration drain stay outside this smoke
 target.
+
+To exercise the funded local happy route over HTTP, run:
+
+```bash
+cd apps/backend
+make http-funded-happy-route-smoke
+```
+
+`make http-funded-happy-route-smoke` starts the debug backend on
+`127.0.0.1:18090` with a local pilot allowlist, creates the Promise intent,
+drains `OPEN_HOLD_INTENT` through the sandbox provider submission boundary,
+accepts a raw `POST /api/payment/callback`, drains callback ingestion plus
+projection refresh, and verifies `GET /api/projection/settlement-views/{id}`
+reports `funded` with the expected integer minor-unit amount and ledger journal
+reference.
+
+To exercise exact callback replay idempotency over HTTP, run:
+
+```bash
+cd apps/backend
+make http-funded-replay-smoke
+```
+
+`make http-funded-replay-smoke` starts the debug backend on `127.0.0.1:18091`,
+runs the funded local happy route, submits the exact same raw callback again,
+drains callback ingestion, and verifies the settlement view remains `funded`
+without a second funded amount or a new latest journal reference.
+
+To exercise duplicate receipt idempotency with a distinct raw callback over
+HTTP, run:
+
+```bash
+cd apps/backend
+make http-funded-duplicate-receipt-smoke
+```
+
+`make http-funded-duplicate-receipt-smoke` starts the debug backend on
+`127.0.0.1:18092`, runs the funded local happy route, submits a second callback
+with the same provider payment id and a different `txid`, drains callback
+ingestion, and verifies the settlement view remains `funded` without a second
+funded amount or a new latest journal reference.
+
+The funded HTTP smoke targets share the local writer DB and internal outbox
+drain, so the script rejects concurrent funded-smoke runs instead of letting
+them race one another.
+
+For focused Rust checks while iterating on backend code, run:
 
 ```bash
 cd apps/backend

--- a/apps/backend/scripts/http_funded_happy_route_smoke.sh
+++ b/apps/backend/scripts/http_funded_happy_route_smoke.sh
@@ -1,0 +1,308 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+new_smoke_run_id() {
+  if command -v uuidgen >/dev/null 2>&1; then
+    uuidgen | tr '[:upper:]' '[:lower:]'
+  else
+    printf '%s-%s' "$(date -u +%Y%m%d%H%M%S)" "$$"
+  fi
+}
+
+ENV_FILE="${ENV_FILE:-.env}"
+HOST="${HTTP_FUNDED_HAPPY_ROUTE_SMOKE_HOST:-127.0.0.1}"
+PORT="${HTTP_FUNDED_HAPPY_ROUTE_SMOKE_PORT:-18090}"
+BASE_URL="${HTTP_FUNDED_HAPPY_ROUTE_SMOKE_BASE_URL:-http://${HOST}:${PORT}}"
+STARTUP_TIMEOUT_SECONDS="${HTTP_FUNDED_HAPPY_ROUTE_SMOKE_STARTUP_TIMEOUT_SECONDS:-120}"
+SMOKE_RUN_ID="${HTTP_FUNDED_HAPPY_ROUTE_SMOKE_RUN_ID:-$(new_smoke_run_id)}"
+INITIATOR_PI_UID="${HTTP_FUNDED_HAPPY_ROUTE_SMOKE_INITIATOR_PI_UID:-http-funded-smoke-initiator}"
+COUNTERPARTY_PI_UID="${HTTP_FUNDED_HAPPY_ROUTE_SMOKE_COUNTERPARTY_PI_UID:-http-funded-smoke-counterparty}"
+REALM_ID="${HTTP_FUNDED_HAPPY_ROUTE_SMOKE_REALM_ID:-realm-http-funded-smoke}"
+PROMISE_IDEMPOTENCY_KEY="${HTTP_FUNDED_HAPPY_ROUTE_SMOKE_PROMISE_IDEMPOTENCY_KEY:-http-funded-smoke-promise-${SMOKE_RUN_ID}}"
+DEPOSIT_MINOR_UNITS="${HTTP_FUNDED_HAPPY_ROUTE_SMOKE_DEPOSIT_MINOR_UNITS:-10000}"
+CURRENCY_CODE="${HTTP_FUNDED_HAPPY_ROUTE_SMOKE_CURRENCY_CODE:-PI}"
+TXID="${HTTP_FUNDED_HAPPY_ROUTE_SMOKE_TXID:-pi-tx-funded-${SMOKE_RUN_ID}}"
+VERIFY_REPLAY="${HTTP_FUNDED_HAPPY_ROUTE_SMOKE_VERIFY_REPLAY:-false}"
+VERIFY_DUPLICATE_RECEIPT="${HTTP_FUNDED_HAPPY_ROUTE_SMOKE_VERIFY_DUPLICATE_RECEIPT:-false}"
+DUPLICATE_TXID="${HTTP_FUNDED_HAPPY_ROUTE_SMOKE_DUPLICATE_TXID:-pi-tx-duplicate-${SMOKE_RUN_ID}}"
+SMOKE_LOCK_DIR="${HTTP_FUNDED_HAPPY_ROUTE_SMOKE_LOCK_DIR:-${TMPDIR:-/tmp}/musubi-http-funded-happy-route-smoke.lock}"
+
+command -v curl >/dev/null 2>&1 || { echo "curl is required for http-funded-happy-route-smoke"; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "jq is required for http-funded-happy-route-smoke"; exit 1; }
+
+if ! mkdir "$SMOKE_LOCK_DIR" 2>/dev/null; then
+  echo "another HTTP funded happy-route smoke is already running; run funded smoke targets one at a time"
+  exit 1
+fi
+
+backend_log="$(mktemp -t musubi-backend-http-funded-happy-route-log.XXXXXX)"
+body_file="$(mktemp -t musubi-backend-http-funded-happy-route-body.XXXXXX)"
+backend_pid=""
+
+cleanup() {
+  status=$?
+  if [ -n "$backend_pid" ] && kill -0 "$backend_pid" 2>/dev/null; then
+    kill "$backend_pid" >/dev/null 2>&1 || true
+    wait "$backend_pid" 2>/dev/null || true
+  fi
+  if [ "$status" -ne 0 ]; then
+    echo "HTTP funded happy-route smoke failed; last response body:" >&2
+    cat "$body_file" >&2 || true
+    echo "HTTP funded happy-route smoke failed; backend log (tail):" >&2
+    tail -n 200 "$backend_log" >&2 || true
+  fi
+  rmdir "$SMOKE_LOCK_DIR" >/dev/null 2>&1 || true
+  rm -f "$backend_log" "$body_file"
+  exit "$status"
+}
+trap cleanup EXIT INT TERM
+
+set -a
+. "./${ENV_FILE}"
+set +a
+
+cargo build -p musubi_backend
+
+if curl -fsS --max-time 2 "${BASE_URL}/health" > "$body_file" 2>/dev/null; then
+  echo "HTTP funded happy-route smoke port already has a responding /health endpoint: ${BASE_URL}"
+  echo "stop the existing process or set HTTP_FUNDED_HAPPY_ROUTE_SMOKE_PORT to a free port"
+  exit 1
+fi
+
+echo "starting backend for HTTP funded happy-route smoke at ${BASE_URL}"
+APP_HOST="$HOST" \
+PORT="$PORT" \
+PROVIDER_MODE=sandbox \
+MUSUBI_LAUNCH_MODE=pilot \
+MUSUBI_LAUNCH_ALLOWLIST_PI_UIDS="${INITIATOR_PI_UID},${COUNTERPARTY_PI_UID}" \
+MUSUBI_KILL_SWITCH_AUTH=false \
+MUSUBI_KILL_SWITCH_PROMISE_CREATION=false \
+./target/debug/musubi_backend > "$backend_log" 2>&1 &
+backend_pid=$!
+
+ready=0
+for _attempt in $(seq 1 "$STARTUP_TIMEOUT_SECONDS"); do
+  if ! kill -0 "$backend_pid" 2>/dev/null; then
+    echo "backend exited before HTTP funded happy-route smoke became ready"
+    cat "$backend_log"
+    exit 1
+  fi
+  if curl -fsS --max-time 2 "${BASE_URL}/health" > "$body_file" 2>/dev/null; then
+    ready=1
+    break
+  fi
+  sleep 1
+done
+
+if [ "$ready" != "1" ]; then
+  echo "backend did not become ready within ${STARTUP_TIMEOUT_SECONDS}s"
+  cat "$backend_log"
+  exit 1
+fi
+if ! kill -0 "$backend_pid" 2>/dev/null; then
+  echo "backend exited after readiness probe succeeded"
+  cat "$backend_log"
+  exit 1
+fi
+jq -e '.status == "ok"' "$body_file" >/dev/null
+
+curl -fsS --max-time 5 "${BASE_URL}/api/launch/posture" > "$body_file"
+jq -e '.launch_mode == "pilot" and .participant_posture == "pilot_only" and .message_code == "launch_pilot_not_allowed"' "$body_file" >/dev/null
+
+initiator_payload="$(jq -cn \
+  --arg pi_uid "$INITIATOR_PI_UID" \
+  --arg username "$INITIATOR_PI_UID" \
+  --arg wallet_address "wallet-${INITIATOR_PI_UID}" \
+  --arg access_token "access-token-${INITIATOR_PI_UID}" \
+  '{pi_uid:$pi_uid, username:$username, wallet_address:$wallet_address, access_token:$access_token}')"
+curl -fsS --max-time 5 \
+  -H "content-type: application/json" \
+  --data "$initiator_payload" \
+  "${BASE_URL}/api/auth/pi" > "$body_file"
+initiator_token="$(jq -er '.token' "$body_file")"
+jq -e --arg pi_uid "$INITIATOR_PI_UID" '.user.pi_uid == $pi_uid and (.user.id | type == "string" and length > 0)' "$body_file" >/dev/null
+
+counterparty_payload="$(jq -cn \
+  --arg pi_uid "$COUNTERPARTY_PI_UID" \
+  --arg username "$COUNTERPARTY_PI_UID" \
+  --arg wallet_address "wallet-${COUNTERPARTY_PI_UID}" \
+  --arg access_token "access-token-${COUNTERPARTY_PI_UID}" \
+  '{pi_uid:$pi_uid, username:$username, wallet_address:$wallet_address, access_token:$access_token}')"
+curl -fsS --max-time 5 \
+  -H "content-type: application/json" \
+  --data "$counterparty_payload" \
+  "${BASE_URL}/api/auth/pi" > "$body_file"
+counterparty_account_id="$(jq -er '.user.id' "$body_file")"
+jq -e --arg pi_uid "$COUNTERPARTY_PI_UID" '.user.pi_uid == $pi_uid and (.token | type == "string" and length > 0)' "$body_file" >/dev/null
+
+promise_payload="$(jq -cn \
+  --arg key "$PROMISE_IDEMPOTENCY_KEY" \
+  --arg realm_id "$REALM_ID" \
+  --arg counterparty_account_id "$counterparty_account_id" \
+  --argjson deposit_amount_minor_units "$DEPOSIT_MINOR_UNITS" \
+  --arg currency_code "$CURRENCY_CODE" \
+  '{internal_idempotency_key:$key, realm_id:$realm_id, counterparty_account_id:$counterparty_account_id, deposit_amount_minor_units:$deposit_amount_minor_units, currency_code:$currency_code}')"
+curl -fsS --max-time 5 \
+  -H "authorization: Bearer ${initiator_token}" \
+  -H "content-type: application/json" \
+  --data "$promise_payload" \
+  "${BASE_URL}/api/promise/intents" > "$body_file"
+jq -e '
+  .case_status == "pending_funding"
+  and (.promise_intent_id | type == "string" and length > 0)
+  and (.settlement_case_id | type == "string" and length > 0)
+  and .replayed_intent == false
+  and (.outbox_event_ids | type == "array" and length > 0)
+' "$body_file" >/dev/null
+settlement_case_id="$(jq -er '.settlement_case_id' "$body_file")"
+
+curl -fsS --max-time 10 \
+  -H "content-type: application/json" \
+  --data '{}' \
+  "${BASE_URL}/api/internal/orchestration/drain" > "$body_file"
+payment_id="$(jq -er --arg settlement_case_id "$settlement_case_id" '
+  .processed_messages
+  | map(select(
+      .event_type == "OPEN_HOLD_INTENT"
+      and .aggregate_id == $settlement_case_id
+      and (.provider_submission_id | type == "string" and length > 0)
+    ))
+  | first.provider_submission_id
+' "$body_file")"
+
+curl -fsS --max-time 5 \
+  -H "authorization: Bearer ${initiator_token}" \
+  "${BASE_URL}/api/projection/settlement-views/${settlement_case_id}" > "$body_file"
+jq -e '
+  .current_settlement_status == "pending_funding"
+  and .total_funded_minor_units == 0
+  and .latest_journal_entry_id == null
+' "$body_file" >/dev/null
+
+callback_payload="$(jq -cn \
+  --arg payment_id "$payment_id" \
+  --arg payer_pi_uid "$INITIATOR_PI_UID" \
+  --argjson amount_minor_units "$DEPOSIT_MINOR_UNITS" \
+  --arg currency_code "$CURRENCY_CODE" \
+  --arg txid "$TXID" \
+  '{payment_id:$payment_id, payer_pi_uid:$payer_pi_uid, amount_minor_units:$amount_minor_units, currency_code:$currency_code, txid:$txid, status:"completed"}')"
+curl -fsS --max-time 5 \
+  -H "content-type: application/json" \
+  --data "$callback_payload" \
+  "${BASE_URL}/api/payment/callback" > "$body_file"
+jq -e '
+  (.raw_callback_id | type == "string" and length > 0)
+  and .duplicate_callback == false
+  and (.outbox_event_ids | type == "array" and length == 1)
+' "$body_file" >/dev/null
+
+curl -fsS --max-time 10 \
+  -H "content-type: application/json" \
+  --data '{}' \
+  "${BASE_URL}/api/internal/orchestration/drain" > "$body_file"
+jq -e --arg payment_id "$payment_id" '
+  .processed_messages
+  | any(.event_type == "INGEST_PROVIDER_CALLBACK" and .provider_submission_id == $payment_id)
+' "$body_file" >/dev/null
+
+curl -fsS --max-time 5 \
+  -H "authorization: Bearer ${initiator_token}" \
+  "${BASE_URL}/api/projection/settlement-views/${settlement_case_id}" > "$body_file"
+jq -e --argjson deposit_amount_minor_units "$DEPOSIT_MINOR_UNITS" --arg currency_code "$CURRENCY_CODE" '
+  .current_settlement_status == "funded"
+  and .total_funded_minor_units == $deposit_amount_minor_units
+  and .currency_code == $currency_code
+  and (.latest_journal_entry_id | type == "string" and length > 0)
+' "$body_file" >/dev/null
+funded_journal_entry_id="$(jq -er '.latest_journal_entry_id' "$body_file")"
+
+if [ "$VERIFY_REPLAY" = "true" ]; then
+  curl -fsS --max-time 5 \
+    -H "content-type: application/json" \
+    --data "$callback_payload" \
+    "${BASE_URL}/api/payment/callback" > "$body_file"
+  jq -e '
+    (.raw_callback_id | type == "string" and length > 0)
+    and .duplicate_callback == true
+    and (.outbox_event_ids | type == "array" and length == 1)
+  ' "$body_file" >/dev/null
+
+  curl -fsS --max-time 10 \
+    -H "content-type: application/json" \
+    --data '{}' \
+    "${BASE_URL}/api/internal/orchestration/drain" > "$body_file"
+  jq -e --arg payment_id "$payment_id" '
+    .processed_messages
+    | any(
+        .event_type == "INGEST_PROVIDER_CALLBACK"
+        and .provider_submission_id == $payment_id
+        and .already_processed == true
+      )
+  ' "$body_file" >/dev/null
+
+  curl -fsS --max-time 5 \
+    -H "authorization: Bearer ${initiator_token}" \
+    "${BASE_URL}/api/projection/settlement-views/${settlement_case_id}" > "$body_file"
+  jq -e \
+    --argjson deposit_amount_minor_units "$DEPOSIT_MINOR_UNITS" \
+    --arg currency_code "$CURRENCY_CODE" \
+    --arg funded_journal_entry_id "$funded_journal_entry_id" '
+    .current_settlement_status == "funded"
+    and .total_funded_minor_units == $deposit_amount_minor_units
+    and .currency_code == $currency_code
+    and .latest_journal_entry_id == $funded_journal_entry_id
+  ' "$body_file" >/dev/null
+
+  echo "HTTP funded replay smoke passed at ${BASE_URL}"
+  exit 0
+fi
+
+if [ "$VERIFY_DUPLICATE_RECEIPT" = "true" ]; then
+  duplicate_callback_payload="$(jq -cn \
+    --arg payment_id "$payment_id" \
+    --arg payer_pi_uid "$INITIATOR_PI_UID" \
+    --argjson amount_minor_units "$DEPOSIT_MINOR_UNITS" \
+    --arg currency_code "$CURRENCY_CODE" \
+    --arg txid "$DUPLICATE_TXID" \
+    '{payment_id:$payment_id, payer_pi_uid:$payer_pi_uid, amount_minor_units:$amount_minor_units, currency_code:$currency_code, txid:$txid, status:"completed"}')"
+  curl -fsS --max-time 5 \
+    -H "content-type: application/json" \
+    --data "$duplicate_callback_payload" \
+    "${BASE_URL}/api/payment/callback" > "$body_file"
+  jq -e '
+    (.raw_callback_id | type == "string" and length > 0)
+    and .duplicate_callback == false
+    and (.outbox_event_ids | type == "array" and length == 1)
+  ' "$body_file" >/dev/null
+
+  curl -fsS --max-time 10 \
+    -H "content-type: application/json" \
+    --data '{}' \
+    "${BASE_URL}/api/internal/orchestration/drain" > "$body_file"
+  jq -e --arg payment_id "$payment_id" '
+    .processed_messages
+    | any(
+        .event_type == "INGEST_PROVIDER_CALLBACK"
+        and .provider_submission_id == $payment_id
+        and .already_processed == true
+      )
+  ' "$body_file" >/dev/null
+
+  curl -fsS --max-time 5 \
+    -H "authorization: Bearer ${initiator_token}" \
+    "${BASE_URL}/api/projection/settlement-views/${settlement_case_id}" > "$body_file"
+  jq -e \
+    --argjson deposit_amount_minor_units "$DEPOSIT_MINOR_UNITS" \
+    --arg currency_code "$CURRENCY_CODE" \
+    --arg funded_journal_entry_id "$funded_journal_entry_id" '
+    .current_settlement_status == "funded"
+    and .total_funded_minor_units == $deposit_amount_minor_units
+    and .currency_code == $currency_code
+    and .latest_journal_entry_id == $funded_journal_entry_id
+  ' "$body_file" >/dev/null
+
+  echo "HTTP funded duplicate-receipt smoke passed at ${BASE_URL}"
+  exit 0
+fi
+
+echo "HTTP funded happy-route smoke passed at ${BASE_URL}"

--- a/apps/backend/scripts/http_funded_happy_route_smoke.sh
+++ b/apps/backend/scripts/http_funded_happy_route_smoke.sh
@@ -30,32 +30,49 @@ SMOKE_LOCK_DIR="${HTTP_FUNDED_HAPPY_ROUTE_SMOKE_LOCK_DIR:-${TMPDIR:-/tmp}/musubi
 command -v curl >/dev/null 2>&1 || { echo "curl is required for http-funded-happy-route-smoke"; exit 1; }
 command -v jq >/dev/null 2>&1 || { echo "jq is required for http-funded-happy-route-smoke"; exit 1; }
 
-if ! mkdir "$SMOKE_LOCK_DIR" 2>/dev/null; then
-  echo "another HTTP funded happy-route smoke is already running; run funded smoke targets one at a time"
-  exit 1
-fi
-
-backend_log="$(mktemp -t musubi-backend-http-funded-happy-route-log.XXXXXX)"
-body_file="$(mktemp -t musubi-backend-http-funded-happy-route-body.XXXXXX)"
+backend_log=""
+body_file=""
 backend_pid=""
 
 cleanup() {
   status=$?
+  trap - EXIT INT TERM
   if [ -n "$backend_pid" ] && kill -0 "$backend_pid" 2>/dev/null; then
     kill "$backend_pid" >/dev/null 2>&1 || true
     wait "$backend_pid" 2>/dev/null || true
   fi
   if [ "$status" -ne 0 ]; then
     echo "HTTP funded happy-route smoke failed; last response body:" >&2
-    cat "$body_file" >&2 || true
+    if [ -n "$body_file" ] && [ -f "$body_file" ]; then
+      cat "$body_file" >&2 || true
+    else
+      echo "(no response body captured)" >&2
+    fi
     echo "HTTP funded happy-route smoke failed; backend log (tail):" >&2
-    tail -n 200 "$backend_log" >&2 || true
+    if [ -n "$backend_log" ] && [ -f "$backend_log" ]; then
+      tail -n 200 "$backend_log" >&2 || true
+    else
+      echo "(no backend log captured)" >&2
+    fi
   fi
   rmdir "$SMOKE_LOCK_DIR" >/dev/null 2>&1 || true
-  rm -f "$backend_log" "$body_file"
+  if [ -n "$backend_log" ]; then
+    rm -f "$backend_log"
+  fi
+  if [ -n "$body_file" ]; then
+    rm -f "$body_file"
+  fi
   exit "$status"
 }
+
+if ! mkdir "$SMOKE_LOCK_DIR" 2>/dev/null; then
+  echo "another HTTP funded happy-route smoke is already running; run funded smoke targets one at a time"
+  exit 1
+fi
 trap cleanup EXIT INT TERM
+
+backend_log="$(mktemp -t musubi-backend-http-funded-happy-route-log.XXXXXX)"
+body_file="$(mktemp -t musubi-backend-http-funded-happy-route-body.XXXXXX)"
 
 set -a
 . "./${ENV_FILE}"


### PR DESCRIPTION
## Summary

- Add a repository-root Makefile that delegates Day 1 backend verification targets to `apps/backend`.
- Add funded happy-route HTTP smoke coverage for provider submission, payment callback ingestion, orchestration drain, ledger receipt, and settlement projection refresh.
- Add replay and duplicate-receipt HTTP smoke variants to verify idempotent callback handling.
- Document the new root and backend smoke targets.

## Validation

- `make http-day1-smoke`
- `git diff --check`
- `bash -n apps/backend/scripts/http_funded_happy_route_smoke.sh`