### PR TITLE
ci: run HTTP Day 1 smoke with existing infra

### DIFF
--- a/.github/workflows/backend-db-smoke.yml
+++ b/.github/workflows/backend-db-smoke.yml
@@ -31,7 +31,7 @@ jobs:
       REQUIRE_LATEST_SCHEMA: "true"
       MIGRATIONS_DIR: ./migrations
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - name: Bootstrap and migrate
         working-directory: apps/backend

--- a/.github/workflows/backend-db-smoke.yml
+++ b/.github/workflows/backend-db-smoke.yml
@@ -44,3 +44,6 @@ jobs:
         run: |
           cargo test -p musubi_db_runtime
           cargo test -p musubi_backend
+      - name: HTTP Day 1 smoke
+        working-directory: apps/backend
+        run: make http-day1-smoke-existing-infra

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BACKEND_DIR ?= apps/backend
 
-.PHONY: verify-local verify-local-http http-day1-smoke http-smoke http-happy-route-smoke http-funded-happy-route-smoke http-funded-replay-smoke http-funded-duplicate-receipt-smoke
+.PHONY: verify-local verify-local-http http-day1-smoke http-day1-smoke-existing-infra http-smoke http-happy-route-smoke http-funded-happy-route-smoke http-funded-replay-smoke http-funded-duplicate-receipt-smoke
 
 verify-local:
 	@$(MAKE) -C $(BACKEND_DIR) verify-local
@@ -10,6 +10,9 @@ verify-local-http:
 
 http-day1-smoke:
 	@$(MAKE) -C $(BACKEND_DIR) http-day1-smoke
+
+http-day1-smoke-existing-infra:
+	@$(MAKE) -C $(BACKEND_DIR) http-day1-smoke-existing-infra
 
 http-smoke:
 	@$(MAKE) -C $(BACKEND_DIR) http-smoke

--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ repo root から Day 1 HTTP smoke suite を一発で実行できます。
 make http-day1-smoke
 ```
 
+CI など、PostgreSQL service container などの既存 infra を使う場合は、
+Compose / `.env` を読まない target を使います。
+
+```bash
+make http-day1-smoke-existing-infra
+```
+
 backend の Rust test も含めて全部確認したい場合は、こちらを使います。
 
 ```bash

--- a/README_EN.md
+++ b/README_EN.md
@@ -25,6 +25,13 @@ From the repository root, run the Day 1 HTTP smoke suite with:
 make http-day1-smoke
 ```
 
+For CI or another environment that already provides PostgreSQL, use the
+existing-infra target. It does not start Docker Compose or load `.env`.
+
+```bash
+make http-day1-smoke-existing-infra
+```
+
 For the full local backend verification plus the HTTP suite, run:
 
 ```bash

--- a/apps/backend/Makefile
+++ b/apps/backend/Makefile
@@ -1,5 +1,6 @@
 DOCKER_COMPOSE ?= $(shell if docker compose version >/dev/null 2>&1; then printf 'docker compose'; elif command -v docker-compose >/dev/null 2>&1; then printf 'docker-compose'; else printf 'docker compose'; fi)
 ENV_FILE ?= .env
+HTTP_SMOKE_LOAD_ENV_FILE ?= true
 HTTP_SMOKE_HOST ?= 127.0.0.1
 HTTP_SMOKE_PORT ?= 18088
 HTTP_SMOKE_BASE_URL ?= http://$(HTTP_SMOKE_HOST):$(HTTP_SMOKE_PORT)
@@ -21,7 +22,7 @@ HTTP_FUNDED_DUPLICATE_RECEIPT_SMOKE_PORT ?= 18092
 HTTP_FUNDED_DUPLICATE_RECEIPT_SMOKE_BASE_URL ?= http://$(HTTP_FUNDED_DUPLICATE_RECEIPT_SMOKE_HOST):$(HTTP_FUNDED_DUPLICATE_RECEIPT_SMOKE_PORT)
 HTTP_FUNDED_DUPLICATE_RECEIPT_SMOKE_STARTUP_TIMEOUT_SECONDS ?= 120
 
-.PHONY: dev check test env-check infra-up verify-local verify-local-http http-day1-smoke http-smoke http-happy-route-smoke http-funded-happy-route-smoke http-funded-replay-smoke http-funded-duplicate-receipt-smoke db-bootstrap db-migrate db-status db-reset-local docker-up docker-down
+.PHONY: dev check test env-check infra-up verify-local verify-local-http http-day1-smoke http-day1-smoke-existing-infra http-smoke http-smoke-existing-infra http-smoke-run http-happy-route-smoke http-happy-route-smoke-existing-infra http-funded-happy-route-smoke http-funded-happy-route-smoke-existing-infra http-funded-replay-smoke http-funded-replay-smoke-existing-infra http-funded-duplicate-receipt-smoke http-funded-duplicate-receipt-smoke-existing-infra db-bootstrap db-bootstrap-existing-infra db-migrate db-migrate-existing-infra db-status db-status-existing-infra db-reset-local docker-up docker-down
 
 dev: env-check
 	@set -a; . ./$(ENV_FILE); set +a; cargo run -p musubi_backend
@@ -81,13 +82,30 @@ http-day1-smoke:
 	@$(MAKE) http-funded-replay-smoke
 	@$(MAKE) http-funded-duplicate-receipt-smoke
 
+http-day1-smoke-existing-infra:
+	@$(MAKE) db-bootstrap-existing-infra
+	@$(MAKE) db-migrate-existing-infra
+	@$(MAKE) db-status-existing-infra
+	@$(MAKE) http-smoke-existing-infra
+	@$(MAKE) http-happy-route-smoke-existing-infra
+	@$(MAKE) http-funded-happy-route-smoke-existing-infra
+	@$(MAKE) http-funded-replay-smoke-existing-infra
+	@$(MAKE) http-funded-duplicate-receipt-smoke-existing-infra
+
 http-smoke: env-check
+	@$(MAKE) http-smoke-run HTTP_SMOKE_LOAD_ENV_FILE=true
+
+http-smoke-existing-infra:
+	@$(MAKE) http-smoke-run HTTP_SMOKE_LOAD_ENV_FILE=false
+
+http-smoke-run:
 	@command -v curl >/dev/null 2>&1 || { echo "curl is required for http-smoke"; exit 1; }
 	@backend_log=$$(mktemp -t musubi-backend-http-smoke-log.XXXXXX); \
 	body_file=$$(mktemp -t musubi-backend-http-smoke-body.XXXXXX); \
 	backend_pid=""; \
 	trap 'status=$$?; if [ -n "$$backend_pid" ] && kill -0 "$$backend_pid" 2>/dev/null; then kill "$$backend_pid" >/dev/null 2>&1 || true; wait "$$backend_pid" 2>/dev/null || true; fi; rm -f "$$backend_log" "$$body_file"; exit $$status' EXIT INT TERM; \
-	set -a; . ./$(ENV_FILE); set +a; \
+	dotenv_skip_flag=false; \
+	if [ "$(HTTP_SMOKE_LOAD_ENV_FILE)" = "true" ]; then set -a; . ./$(ENV_FILE); set +a; elif [ "$(HTTP_SMOKE_LOAD_ENV_FILE)" = "false" ]; then dotenv_skip_flag=true; else echo "HTTP_SMOKE_LOAD_ENV_FILE must be true or false"; exit 1; fi; \
 	cargo build -p musubi_backend || exit 1; \
 	if curl -fsS --max-time 2 "$(HTTP_SMOKE_BASE_URL)/health" > "$$body_file" 2>/dev/null; then \
 		echo "HTTP smoke port already has a responding /health endpoint: $(HTTP_SMOKE_BASE_URL)"; \
@@ -95,7 +113,7 @@ http-smoke: env-check
 		exit 1; \
 	fi; \
 	echo "starting backend for HTTP smoke at $(HTTP_SMOKE_BASE_URL)"; \
-	APP_HOST=$(HTTP_SMOKE_HOST) PORT=$(HTTP_SMOKE_PORT) ./target/debug/musubi_backend > "$$backend_log" 2>&1 & \
+	MUSUBI_SKIP_DOTENV=$$dotenv_skip_flag APP_HOST=$(HTTP_SMOKE_HOST) PORT=$(HTTP_SMOKE_PORT) ./target/debug/musubi_backend > "$$backend_log" 2>&1 & \
 	backend_pid=$$!; \
 	ready=0; \
 	for attempt in $$(seq 1 $(HTTP_SMOKE_STARTUP_TIMEOUT_SECONDS)); do \
@@ -131,6 +149,16 @@ http-smoke: env-check
 
 http-happy-route-smoke: env-check
 	@ENV_FILE="$(ENV_FILE)" \
+	HTTP_HAPPY_ROUTE_SMOKE_LOAD_ENV_FILE=true \
+	HTTP_HAPPY_ROUTE_SMOKE_HOST="$(HTTP_HAPPY_ROUTE_SMOKE_HOST)" \
+	HTTP_HAPPY_ROUTE_SMOKE_PORT="$(HTTP_HAPPY_ROUTE_SMOKE_PORT)" \
+	HTTP_HAPPY_ROUTE_SMOKE_BASE_URL="$(HTTP_HAPPY_ROUTE_SMOKE_BASE_URL)" \
+	HTTP_HAPPY_ROUTE_SMOKE_STARTUP_TIMEOUT_SECONDS="$(HTTP_HAPPY_ROUTE_SMOKE_STARTUP_TIMEOUT_SECONDS)" \
+	./scripts/http_happy_route_smoke.sh
+
+http-happy-route-smoke-existing-infra:
+	@ENV_FILE="$(ENV_FILE)" \
+	HTTP_HAPPY_ROUTE_SMOKE_LOAD_ENV_FILE=false \
 	HTTP_HAPPY_ROUTE_SMOKE_HOST="$(HTTP_HAPPY_ROUTE_SMOKE_HOST)" \
 	HTTP_HAPPY_ROUTE_SMOKE_PORT="$(HTTP_HAPPY_ROUTE_SMOKE_PORT)" \
 	HTTP_HAPPY_ROUTE_SMOKE_BASE_URL="$(HTTP_HAPPY_ROUTE_SMOKE_BASE_URL)" \
@@ -139,6 +167,16 @@ http-happy-route-smoke: env-check
 
 http-funded-happy-route-smoke: env-check
 	@ENV_FILE="$(ENV_FILE)" \
+	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_LOAD_ENV_FILE=true \
+	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_HOST="$(HTTP_FUNDED_HAPPY_ROUTE_SMOKE_HOST)" \
+	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_PORT="$(HTTP_FUNDED_HAPPY_ROUTE_SMOKE_PORT)" \
+	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_BASE_URL="$(HTTP_FUNDED_HAPPY_ROUTE_SMOKE_BASE_URL)" \
+	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_STARTUP_TIMEOUT_SECONDS="$(HTTP_FUNDED_HAPPY_ROUTE_SMOKE_STARTUP_TIMEOUT_SECONDS)" \
+	./scripts/http_funded_happy_route_smoke.sh
+
+http-funded-happy-route-smoke-existing-infra:
+	@ENV_FILE="$(ENV_FILE)" \
+	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_LOAD_ENV_FILE=false \
 	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_HOST="$(HTTP_FUNDED_HAPPY_ROUTE_SMOKE_HOST)" \
 	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_PORT="$(HTTP_FUNDED_HAPPY_ROUTE_SMOKE_PORT)" \
 	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_BASE_URL="$(HTTP_FUNDED_HAPPY_ROUTE_SMOKE_BASE_URL)" \
@@ -147,6 +185,20 @@ http-funded-happy-route-smoke: env-check
 
 http-funded-replay-smoke: env-check
 	@ENV_FILE="$(ENV_FILE)" \
+	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_LOAD_ENV_FILE=true \
+	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_HOST="$(HTTP_FUNDED_REPLAY_SMOKE_HOST)" \
+	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_PORT="$(HTTP_FUNDED_REPLAY_SMOKE_PORT)" \
+	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_BASE_URL="$(HTTP_FUNDED_REPLAY_SMOKE_BASE_URL)" \
+	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_STARTUP_TIMEOUT_SECONDS="$(HTTP_FUNDED_REPLAY_SMOKE_STARTUP_TIMEOUT_SECONDS)" \
+	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_INITIATOR_PI_UID="http-funded-replay-smoke-initiator" \
+	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_COUNTERPARTY_PI_UID="http-funded-replay-smoke-counterparty" \
+	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_REALM_ID="realm-http-funded-replay-smoke" \
+	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_VERIFY_REPLAY=true \
+	./scripts/http_funded_happy_route_smoke.sh
+
+http-funded-replay-smoke-existing-infra:
+	@ENV_FILE="$(ENV_FILE)" \
+	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_LOAD_ENV_FILE=false \
 	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_HOST="$(HTTP_FUNDED_REPLAY_SMOKE_HOST)" \
 	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_PORT="$(HTTP_FUNDED_REPLAY_SMOKE_PORT)" \
 	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_BASE_URL="$(HTTP_FUNDED_REPLAY_SMOKE_BASE_URL)" \
@@ -159,6 +211,20 @@ http-funded-replay-smoke: env-check
 
 http-funded-duplicate-receipt-smoke: env-check
 	@ENV_FILE="$(ENV_FILE)" \
+	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_LOAD_ENV_FILE=true \
+	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_HOST="$(HTTP_FUNDED_DUPLICATE_RECEIPT_SMOKE_HOST)" \
+	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_PORT="$(HTTP_FUNDED_DUPLICATE_RECEIPT_SMOKE_PORT)" \
+	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_BASE_URL="$(HTTP_FUNDED_DUPLICATE_RECEIPT_SMOKE_BASE_URL)" \
+	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_STARTUP_TIMEOUT_SECONDS="$(HTTP_FUNDED_DUPLICATE_RECEIPT_SMOKE_STARTUP_TIMEOUT_SECONDS)" \
+	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_INITIATOR_PI_UID="http-funded-duplicate-receipt-smoke-initiator" \
+	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_COUNTERPARTY_PI_UID="http-funded-duplicate-receipt-smoke-counterparty" \
+	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_REALM_ID="realm-http-funded-duplicate-receipt-smoke" \
+	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_VERIFY_DUPLICATE_RECEIPT=true \
+	./scripts/http_funded_happy_route_smoke.sh
+
+http-funded-duplicate-receipt-smoke-existing-infra:
+	@ENV_FILE="$(ENV_FILE)" \
+	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_LOAD_ENV_FILE=false \
 	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_HOST="$(HTTP_FUNDED_DUPLICATE_RECEIPT_SMOKE_HOST)" \
 	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_PORT="$(HTTP_FUNDED_DUPLICATE_RECEIPT_SMOKE_PORT)" \
 	HTTP_FUNDED_HAPPY_ROUTE_SMOKE_BASE_URL="$(HTTP_FUNDED_DUPLICATE_RECEIPT_SMOKE_BASE_URL)" \
@@ -172,11 +238,20 @@ http-funded-duplicate-receipt-smoke: env-check
 db-bootstrap: env-check
 	@set -a; . ./$(ENV_FILE); set +a; cargo run -p musubi-ops -- db bootstrap
 
+db-bootstrap-existing-infra:
+	MUSUBI_SKIP_DOTENV=true cargo run -p musubi-ops -- db bootstrap
+
 db-migrate: env-check
 	@set -a; . ./$(ENV_FILE); set +a; cargo run -p musubi-ops -- db migrate
 
+db-migrate-existing-infra:
+	MUSUBI_SKIP_DOTENV=true cargo run -p musubi-ops -- db migrate
+
 db-status: env-check
 	@set -a; . ./$(ENV_FILE); set +a; cargo run -p musubi-ops -- db status
+
+db-status-existing-infra:
+	MUSUBI_SKIP_DOTENV=true cargo run -p musubi-ops -- db status
 
 db-reset-local: env-check
 	@set -a; . ./$(ENV_FILE); set +a; cargo run -p musubi-ops -- db reset-local --confirm-reset-local

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -187,6 +187,18 @@ writer DB, checks migration status, then runs the HTTP health/readiness,
 pilot-gated Promise intent, funded happy-route, exact callback replay, and
 duplicate-receipt smoke targets in a fixed sequence.
 
+In CI or another environment that already provides PostgreSQL through the
+current process environment, use:
+
+```bash
+cd apps/backend
+make http-day1-smoke-existing-infra
+```
+
+This target bootstraps and migrates the existing writer DB, checks migration
+status, and runs the same HTTP suite without starting Docker Compose or loading
+`.env`.
+
 For the full local check plus the HTTP suite, run:
 
 ```bash

--- a/apps/backend/crates/ops/src/main.rs
+++ b/apps/backend/crates/ops/src/main.rs
@@ -2,12 +2,24 @@ use musubi_db_runtime::{DbConfig, LocalResetConfirmation, MigrationRunner, Migra
 
 #[tokio::main]
 async fn main() {
-    dotenvy::dotenv().ok();
+    if !env_flag_enabled("MUSUBI_SKIP_DOTENV") {
+        dotenvy::dotenv().ok();
+    }
 
     if let Err(error) = run().await {
         eprintln!("{error}");
         std::process::exit(1);
     }
+}
+
+fn env_flag_enabled(name: &str) -> bool {
+    std::env::var(name)
+        .ok()
+        .map(|value| {
+            let normalized = value.trim().to_ascii_lowercase();
+            normalized == "1" || normalized == "true" || normalized == "yes"
+        })
+        .unwrap_or(false)
 }
 
 async fn run() -> Result<(), OpsError> {

--- a/apps/backend/scripts/http_funded_happy_route_smoke.sh
+++ b/apps/backend/scripts/http_funded_happy_route_smoke.sh
@@ -10,6 +10,7 @@ new_smoke_run_id() {
 }
 
 ENV_FILE="${ENV_FILE:-.env}"
+LOAD_ENV_FILE="${HTTP_FUNDED_HAPPY_ROUTE_SMOKE_LOAD_ENV_FILE:-true}"
 HOST="${HTTP_FUNDED_HAPPY_ROUTE_SMOKE_HOST:-127.0.0.1}"
 PORT="${HTTP_FUNDED_HAPPY_ROUTE_SMOKE_PORT:-18090}"
 BASE_URL="${HTTP_FUNDED_HAPPY_ROUTE_SMOKE_BASE_URL:-http://${HOST}:${PORT}}"
@@ -33,6 +34,7 @@ command -v jq >/dev/null 2>&1 || { echo "jq is required for http-funded-happy-ro
 backend_log=""
 body_file=""
 backend_pid=""
+dotenv_skip_flag=false
 
 cleanup() {
   status=$?
@@ -74,9 +76,20 @@ trap cleanup EXIT INT TERM
 backend_log="$(mktemp -t musubi-backend-http-funded-happy-route-log.XXXXXX)"
 body_file="$(mktemp -t musubi-backend-http-funded-happy-route-body.XXXXXX)"
 
-set -a
-. "./${ENV_FILE}"
-set +a
+case "$LOAD_ENV_FILE" in
+  true)
+    set -a
+    . "./${ENV_FILE}"
+    set +a
+    ;;
+  false)
+    dotenv_skip_flag=true
+    ;;
+  *)
+    echo "HTTP_FUNDED_HAPPY_ROUTE_SMOKE_LOAD_ENV_FILE must be true or false"
+    exit 1
+    ;;
+esac
 
 cargo build -p musubi_backend
 
@@ -89,6 +102,7 @@ fi
 echo "starting backend for HTTP funded happy-route smoke at ${BASE_URL}"
 APP_HOST="$HOST" \
 PORT="$PORT" \
+MUSUBI_SKIP_DOTENV="$dotenv_skip_flag" \
 PROVIDER_MODE=sandbox \
 MUSUBI_LAUNCH_MODE=pilot \
 MUSUBI_LAUNCH_ALLOWLIST_PI_UIDS="${INITIATOR_PI_UID},${COUNTERPARTY_PI_UID}" \

--- a/apps/backend/scripts/http_happy_route_smoke.sh
+++ b/apps/backend/scripts/http_happy_route_smoke.sh
@@ -10,6 +10,7 @@ new_smoke_run_id() {
 }
 
 ENV_FILE="${ENV_FILE:-.env}"
+LOAD_ENV_FILE="${HTTP_HAPPY_ROUTE_SMOKE_LOAD_ENV_FILE:-true}"
 HOST="${HTTP_HAPPY_ROUTE_SMOKE_HOST:-127.0.0.1}"
 PORT="${HTTP_HAPPY_ROUTE_SMOKE_PORT:-18089}"
 BASE_URL="${HTTP_HAPPY_ROUTE_SMOKE_BASE_URL:-http://${HOST}:${PORT}}"
@@ -28,6 +29,7 @@ command -v jq >/dev/null 2>&1 || { echo "jq is required for http-happy-route-smo
 backend_log="$(mktemp -t musubi-backend-http-happy-route-log.XXXXXX)"
 body_file="$(mktemp -t musubi-backend-http-happy-route-body.XXXXXX)"
 backend_pid=""
+dotenv_skip_flag=false
 
 cleanup() {
   status=$?
@@ -46,9 +48,20 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 
-set -a
-. "./${ENV_FILE}"
-set +a
+case "$LOAD_ENV_FILE" in
+  true)
+    set -a
+    . "./${ENV_FILE}"
+    set +a
+    ;;
+  false)
+    dotenv_skip_flag=true
+    ;;
+  *)
+    echo "HTTP_HAPPY_ROUTE_SMOKE_LOAD_ENV_FILE must be true or false"
+    exit 1
+    ;;
+esac
 
 cargo build -p musubi_backend
 
@@ -61,6 +74,7 @@ fi
 echo "starting backend for HTTP happy-route smoke at ${BASE_URL}"
 APP_HOST="$HOST" \
 PORT="$PORT" \
+MUSUBI_SKIP_DOTENV="$dotenv_skip_flag" \
 MUSUBI_LAUNCH_MODE=pilot \
 MUSUBI_LAUNCH_ALLOWLIST_PI_UIDS="${INITIATOR_PI_UID},${COUNTERPARTY_PI_UID}" \
 MUSUBI_KILL_SWITCH_AUTH=false \

--- a/apps/backend/src/lib.rs
+++ b/apps/backend/src/lib.rs
@@ -426,6 +426,9 @@ fn env_flag_enabled(name: &str) -> bool {
 }
 
 fn load_env_files() {
+    if env_flag_enabled("MUSUBI_SKIP_DOTENV") {
+        return;
+    }
     dotenvy::dotenv().ok();
     dotenvy::from_path("apps/backend/.env").ok();
 }


### PR DESCRIPTION
## Summary
- Add `http-day1-smoke-existing-infra` targets that reuse an already-provided PostgreSQL writer instead of starting Docker Compose.
- Let HTTP smoke scripts skip `.env` loading for CI, and add `MUSUBI_SKIP_DOTENV` for backend/ops binaries on that path.
- Run the CI-native HTTP Day 1 smoke suite from the backend DB smoke workflow.
- Update `actions/checkout` to v5 so the workflow is on the Node 24-compatible action line.

## Validation
- `bash -n apps/backend/scripts/http_happy_route_smoke.sh apps/backend/scripts/http_funded_happy_route_smoke.sh`
- `git diff --check`
- `APP_ENV=test DATABASE_URL=postgres://musubi:musubi_local_dev@127.0.0.1:55432/musubi_test MUSUBI_TEST_DATABASE_URL=postgres://musubi:musubi_local_dev@127.0.0.1:55432/musubi_test REQUIRE_LATEST_SCHEMA=true MIGRATIONS_DIR=./migrations make -C apps/backend http-day1-smoke-existing-infra`
- `APP_ENV=test DATABASE_URL=postgres://musubi:musubi_local_dev@127.0.0.1:55432/musubi_test MUSUBI_TEST_DATABASE_URL=postgres://musubi:musubi_local_dev@127.0.0.1:55432/musubi_test REQUIRE_LATEST_SCHEMA=true MIGRATIONS_DIR=./migrations MUSUBI_SKIP_DOTENV=true cargo test -p musubi_db_runtime -p musubi_backend -p musubi-ops`