### PR TITLE
ci: add backend guardrail sweep

### DIFF
--- a/.github/workflows/backend-db-smoke.yml
+++ b/.github/workflows/backend-db-smoke.yml
@@ -33,6 +33,9 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
+      - name: Backend guardrail sweep
+        working-directory: apps/backend
+        run: make guardrail-sweep
       - name: Bootstrap and migrate
         working-directory: apps/backend
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,15 @@
 BACKEND_DIR ?= apps/backend
 
-.PHONY: verify-local verify-local-http http-day1-smoke http-day1-smoke-existing-infra http-smoke http-happy-route-smoke http-funded-happy-route-smoke http-funded-replay-smoke http-funded-duplicate-receipt-smoke
+.PHONY: verify-local verify-local-http guardrail-sweep http-day1-smoke http-day1-smoke-existing-infra http-smoke http-happy-route-smoke http-funded-happy-route-smoke http-funded-replay-smoke http-funded-duplicate-receipt-smoke
 
 verify-local:
 	@$(MAKE) -C $(BACKEND_DIR) verify-local
 
 verify-local-http:
 	@$(MAKE) -C $(BACKEND_DIR) verify-local-http
+
+guardrail-sweep:
+	@$(MAKE) -C $(BACKEND_DIR) guardrail-sweep
 
 http-day1-smoke:
 	@$(MAKE) -C $(BACKEND_DIR) http-day1-smoke

--- a/apps/backend/Makefile
+++ b/apps/backend/Makefile
@@ -22,7 +22,7 @@ HTTP_FUNDED_DUPLICATE_RECEIPT_SMOKE_PORT ?= 18092
 HTTP_FUNDED_DUPLICATE_RECEIPT_SMOKE_BASE_URL ?= http://$(HTTP_FUNDED_DUPLICATE_RECEIPT_SMOKE_HOST):$(HTTP_FUNDED_DUPLICATE_RECEIPT_SMOKE_PORT)
 HTTP_FUNDED_DUPLICATE_RECEIPT_SMOKE_STARTUP_TIMEOUT_SECONDS ?= 120
 
-.PHONY: dev check test env-check infra-up verify-local verify-local-http http-day1-smoke http-day1-smoke-existing-infra http-smoke http-smoke-existing-infra http-smoke-run http-happy-route-smoke http-happy-route-smoke-existing-infra http-funded-happy-route-smoke http-funded-happy-route-smoke-existing-infra http-funded-replay-smoke http-funded-replay-smoke-existing-infra http-funded-duplicate-receipt-smoke http-funded-duplicate-receipt-smoke-existing-infra db-bootstrap db-bootstrap-existing-infra db-migrate db-migrate-existing-infra db-status db-status-existing-infra db-reset-local docker-up docker-down
+.PHONY: dev check test guardrail-sweep env-check infra-up verify-local verify-local-http http-day1-smoke http-day1-smoke-existing-infra http-smoke http-smoke-existing-infra http-smoke-run http-happy-route-smoke http-happy-route-smoke-existing-infra http-funded-happy-route-smoke http-funded-happy-route-smoke-existing-infra http-funded-replay-smoke http-funded-replay-smoke-existing-infra http-funded-duplicate-receipt-smoke http-funded-duplicate-receipt-smoke-existing-infra db-bootstrap db-bootstrap-existing-infra db-migrate db-migrate-existing-infra db-status db-status-existing-infra db-reset-local docker-up docker-down
 
 dev: env-check
 	@set -a; . ./$(ENV_FILE); set +a; cargo run -p musubi_backend
@@ -32,6 +32,9 @@ check:
 
 test: env-check
 	@set -a; . ./$(ENV_FILE); set +a; cargo test --workspace
+
+guardrail-sweep:
+	@bash ./scripts/guardrail_sweep.sh
 
 env-check:
 	@if [ ! -f $(ENV_FILE) ]; then cp .env.example $(ENV_FILE); fi

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -273,6 +273,14 @@ cargo check
 cargo test
 ```
 
+To run the deterministic backend architecture tripwires without starting local
+infra, run:
+
+```bash
+cd apps/backend
+make guardrail-sweep
+```
+
 ## Database skeleton
 
 Issue #3 adds plain SQL migration scaffolding under `migrations/`.

--- a/apps/backend/docs/guardrails.md
+++ b/apps/backend/docs/guardrails.md
@@ -7,6 +7,20 @@ The goal is to make the most failure-prone MUSUBI laws mechanically harder to vi
 
 ## Mechanically enforced now
 
+### 0. CI guardrail sweep
+
+`make guardrail-sweep` runs a deterministic source scan before DB-backed CI
+checks. It fails if backend source, backend crates, or migrations introduce:
+
+- floating-point money primitives;
+- direct external network client usage outside an explicit reviewed boundary;
+- `WriterReadSource::ReadReplica` usage outside the orchestration rejection
+  implementation and its tests;
+- tracked `.codex` files or a missing `.codex/` ignore rule.
+
+This sweep is intentionally narrow. It is a tripwire for known high-risk drift,
+not a complete static proof of architectural correctness.
+
 ### 1. Writer-first state-changing reads
 
 The orchestration boundary encodes writer-only progression through `WriterReadSource`.

--- a/apps/backend/scripts/guardrail_sweep.sh
+++ b/apps/backend/scripts/guardrail_sweep.sh
@@ -18,7 +18,7 @@ check_no_matches() {
   shift 2
 
   local matches
-  matches="$(git grep -n -E "$pattern" -- "$@" || true)"
+  matches="$(git grep -n --perl-regexp "$pattern" -- "$@" || true)"
   if [ -n "$matches" ]; then
     echo "$matches" >&2
     report_failure "$description"
@@ -36,7 +36,7 @@ check_no_matches \
 
 check_no_matches \
   "backend source must not introduce direct external network clients outside an explicit reviewed boundary" \
-  '\b(reqwest|ureq|surf|hyper::Client|awc::Client|TcpStream|tokio::net::TcpStream|isahc|curl::)\b' \
+  '\b(reqwest|ureq|surf|hyper::Client|awc::Client|TcpStream|tokio::net::TcpStream|isahc)\b|curl::' \
   apps/backend/Cargo.toml \
   apps/backend/crates/*/Cargo.toml \
   apps/backend/src \

--- a/apps/backend/scripts/guardrail_sweep.sh
+++ b/apps/backend/scripts/guardrail_sweep.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../../.." && pwd)"
+cd "$repo_root"
+
+failures=0
+
+report_failure() {
+  echo "::error::$1" >&2
+  failures=1
+}
+
+check_no_matches() {
+  local description="$1"
+  local pattern="$2"
+  shift 2
+
+  local matches
+  matches="$(git grep -n -E "$pattern" -- "$@" || true)"
+  if [ -n "$matches" ]; then
+    echo "$matches" >&2
+    report_failure "$description"
+  else
+    echo "ok: $description"
+  fi
+}
+
+check_no_matches \
+  "backend source and migrations must not introduce floating-point money primitives" \
+  '\b(f32|f64)\b|double[[:space:]]+precision|\breal\b|\bfloat[0-9]*\b' \
+  apps/backend/src \
+  apps/backend/crates \
+  apps/backend/migrations
+
+check_no_matches \
+  "backend source must not introduce direct external network clients outside an explicit reviewed boundary" \
+  '\b(reqwest|ureq|surf|hyper::Client|awc::Client|TcpStream|tokio::net::TcpStream|isahc|curl::)\b' \
+  apps/backend/Cargo.toml \
+  apps/backend/crates/*/Cargo.toml \
+  apps/backend/src \
+  apps/backend/crates
+
+read_replica_matches="$(
+  git grep -n 'WriterReadSource::ReadReplica' -- \
+    apps/backend/src \
+    apps/backend/crates \
+    ':!apps/backend/crates/orchestration/src/store.rs' \
+    ':!apps/backend/crates/orchestration/tests/runtime_contract.rs' \
+    || true
+)"
+if [ -n "$read_replica_matches" ]; then
+  echo "$read_replica_matches" >&2
+  report_failure "ReadReplica must stay confined to the orchestration rejection implementation and tests"
+else
+  echo "ok: ReadReplica stays confined to rejection implementation and tests"
+fi
+
+tracked_codex="$(git ls-files .codex)"
+if [ -n "$tracked_codex" ]; then
+  echo "$tracked_codex" >&2
+  report_failure ".codex is local agent state and must not be tracked"
+else
+  echo "ok: .codex is not tracked"
+fi
+
+if git grep -q -E '^\.codex/$' -- .gitignore; then
+  echo "ok: .codex remains ignored"
+else
+  report_failure ".gitignore must keep .codex/ ignored"
+fi
+
+if [ "$failures" -ne 0 ]; then
+  exit 1
+fi
+
+echo "backend guardrail sweep passed"


### PR DESCRIPTION
## Summary

- Add `make guardrail-sweep` as a backend and repo-level deterministic guardrail target.
- Run the sweep at the start of the backend DB smoke workflow before DB-backed checks.
- Document the guardrail scope in backend README and guardrails docs.

## Why

This adds a CI-native tripwire for high-risk backend drift that does not require local infra: floating-point money primitives, direct external network clients without an explicit reviewed boundary, unintended `WriterReadSource::ReadReplica` usage, and `.codex/` hygiene.

## Validation

- `bash -n apps/backend/scripts/guardrail_sweep.sh`
- `make guardrail-sweep`
- `git diff --check`
- `make -C apps/backend infra-up`
- `APP_ENV=test DATABASE_URL=postgres://musubi:musubi_local_dev@127.0.0.1:55432/musubi_test MUSUBI_TEST_DATABASE_URL=postgres://musubi:musubi_local_dev@127.0.0.1:55432/musubi_test REQUIRE_LATEST_SCHEMA=true MIGRATIONS_DIR=./migrations make -C apps/backend http-day1-smoke-existing-infra`
- `APP_ENV=test DATABASE_URL=postgres://musubi:musubi_local_dev@127.0.0.1:55432/musubi_test MUSUBI_TEST_DATABASE_URL=postgres://musubi:musubi_local_dev@127.0.0.1:55432/musubi_test REQUIRE_LATEST_SCHEMA=true MIGRATIONS_DIR=./migrations MUSUBI_SKIP_DOTENV=true cargo test -p musubi_db_runtime -p musubi_backend -p musubi-ops`
