### PR TITLE
test: add guardrail sweep self-test

### DIFF
--- a/.github/workflows/backend-db-smoke.yml
+++ b/.github/workflows/backend-db-smoke.yml
@@ -33,6 +33,9 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
+      - name: Backend guardrail sweep self-test
+        working-directory: apps/backend
+        run: make guardrail-sweep-self-test
       - name: Backend guardrail sweep
         working-directory: apps/backend
         run: make guardrail-sweep

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BACKEND_DIR ?= apps/backend
 
-.PHONY: verify-local verify-local-http guardrail-sweep http-day1-smoke http-day1-smoke-existing-infra http-smoke http-happy-route-smoke http-funded-happy-route-smoke http-funded-replay-smoke http-funded-duplicate-receipt-smoke
+.PHONY: verify-local verify-local-http guardrail-sweep guardrail-sweep-self-test http-day1-smoke http-day1-smoke-existing-infra http-smoke http-happy-route-smoke http-funded-happy-route-smoke http-funded-replay-smoke http-funded-duplicate-receipt-smoke
 
 verify-local:
 	@$(MAKE) -C $(BACKEND_DIR) verify-local
@@ -10,6 +10,9 @@ verify-local-http:
 
 guardrail-sweep:
 	@$(MAKE) -C $(BACKEND_DIR) guardrail-sweep
+
+guardrail-sweep-self-test:
+	@$(MAKE) -C $(BACKEND_DIR) guardrail-sweep-self-test
 
 http-day1-smoke:
 	@$(MAKE) -C $(BACKEND_DIR) http-day1-smoke

--- a/README.md
+++ b/README.md
@@ -79,6 +79,13 @@ make verify-local-http
 どちらも backend 側の Makefile に委譲します。Rust workspace の root は引き続き
 `apps/backend` です。
 
+backend の architecture tripwire だけを infra なしで確認する場合は、こちらを使います。
+
+```bash
+make guardrail-sweep
+make guardrail-sweep-self-test
+```
+
 ## Foundation alignment
 
 This repo is the canonical implementation repo for MUSUBI Day 1.

--- a/apps/backend/Makefile
+++ b/apps/backend/Makefile
@@ -22,7 +22,7 @@ HTTP_FUNDED_DUPLICATE_RECEIPT_SMOKE_PORT ?= 18092
 HTTP_FUNDED_DUPLICATE_RECEIPT_SMOKE_BASE_URL ?= http://$(HTTP_FUNDED_DUPLICATE_RECEIPT_SMOKE_HOST):$(HTTP_FUNDED_DUPLICATE_RECEIPT_SMOKE_PORT)
 HTTP_FUNDED_DUPLICATE_RECEIPT_SMOKE_STARTUP_TIMEOUT_SECONDS ?= 120
 
-.PHONY: dev check test guardrail-sweep env-check infra-up verify-local verify-local-http http-day1-smoke http-day1-smoke-existing-infra http-smoke http-smoke-existing-infra http-smoke-run http-happy-route-smoke http-happy-route-smoke-existing-infra http-funded-happy-route-smoke http-funded-happy-route-smoke-existing-infra http-funded-replay-smoke http-funded-replay-smoke-existing-infra http-funded-duplicate-receipt-smoke http-funded-duplicate-receipt-smoke-existing-infra db-bootstrap db-bootstrap-existing-infra db-migrate db-migrate-existing-infra db-status db-status-existing-infra db-reset-local docker-up docker-down
+.PHONY: dev check test guardrail-sweep guardrail-sweep-self-test env-check infra-up verify-local verify-local-http http-day1-smoke http-day1-smoke-existing-infra http-smoke http-smoke-existing-infra http-smoke-run http-happy-route-smoke http-happy-route-smoke-existing-infra http-funded-happy-route-smoke http-funded-happy-route-smoke-existing-infra http-funded-replay-smoke http-funded-replay-smoke-existing-infra http-funded-duplicate-receipt-smoke http-funded-duplicate-receipt-smoke-existing-infra db-bootstrap db-bootstrap-existing-infra db-migrate db-migrate-existing-infra db-status db-status-existing-infra db-reset-local docker-up docker-down
 
 dev: env-check
 	@set -a; . ./$(ENV_FILE); set +a; cargo run -p musubi_backend
@@ -35,6 +35,9 @@ test: env-check
 
 guardrail-sweep:
 	@bash ./scripts/guardrail_sweep.sh
+
+guardrail-sweep-self-test:
+	@bash ./scripts/guardrail_sweep.sh --self-test
 
 env-check:
 	@if [ ! -f $(ENV_FILE) ]; then cp .env.example $(ENV_FILE); fi

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -281,6 +281,13 @@ cd apps/backend
 make guardrail-sweep
 ```
 
+To verify that the sweep catches representative forbidden fixtures, run:
+
+```bash
+cd apps/backend
+make guardrail-sweep-self-test
+```
+
 ## Database skeleton
 
 Issue #3 adds plain SQL migration scaffolding under `migrations/`.

--- a/apps/backend/docs/guardrails.md
+++ b/apps/backend/docs/guardrails.md
@@ -21,6 +21,18 @@ checks. It fails if backend source, backend crates, or migrations introduce:
 This sweep is intentionally narrow. It is a tripwire for known high-risk drift,
 not a complete static proof of architectural correctness.
 
+`make guardrail-sweep-self-test` creates a temporary Git repository with
+representative forbidden fixtures and verifies that the sweep patterns detect:
+
+- floating-point money primitives;
+- word-boundary network clients such as `reqwest`;
+- namespace-style network clients such as `curl::`;
+- `WriterReadSource::ReadReplica` outside its allowlist;
+- tracked `.codex` files and `.codex/` ignore-rule detection.
+
+The self-test does not scan production source. It proves that the tripwire
+itself has not silently lost detection coverage before the real sweep runs.
+
 ### 1. Writer-first state-changing reads
 
 The orchestration boundary encodes writer-only progression through `WriterReadSource`.

--- a/apps/backend/scripts/guardrail_sweep.sh
+++ b/apps/backend/scripts/guardrail_sweep.sh
@@ -128,9 +128,13 @@ run_sweep() {
 run_self_test() {
   local temp_dir
   temp_dir="$(mktemp -d)"
-  trap 'rm -rf "$temp_dir"' RETURN
 
   if ! (
+    cleanup_self_test() {
+      rm -rf "$temp_dir"
+    }
+    trap cleanup_self_test EXIT
+
     cd "$temp_dir"
     git init -q
 

--- a/apps/backend/scripts/guardrail_sweep.sh
+++ b/apps/backend/scripts/guardrail_sweep.sh
@@ -3,13 +3,23 @@ set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "${script_dir}/../../.." && pwd)"
-cd "$repo_root"
 
 failures=0
+
+FLOAT_MONEY_PATTERN='\b(f32|f64)\b|double[[:space:]]+precision|\breal\b|\bfloat[0-9]*\b'
+NETWORK_CLIENT_PATTERN='\b(reqwest|ureq|surf|hyper::Client|awc::Client|TcpStream|tokio::net::TcpStream|isahc)\b|curl::'
+READ_REPLICA_TOKEN='WriterReadSource::ReadReplica'
 
 report_failure() {
   echo "::error::$1" >&2
   failures=1
+}
+
+grep_matches() {
+  local pattern="$1"
+  shift
+
+  git grep -n --perl-regexp "$pattern" -- "$@" || true
 }
 
 check_no_matches() {
@@ -18,7 +28,7 @@ check_no_matches() {
   shift 2
 
   local matches
-  matches="$(git grep -n --perl-regexp "$pattern" -- "$@" || true)"
+  matches="$(grep_matches "$pattern" "$@")"
   if [ -n "$matches" ]; then
     echo "$matches" >&2
     report_failure "$description"
@@ -27,52 +37,188 @@ check_no_matches() {
   fi
 }
 
-check_no_matches \
-  "backend source and migrations must not introduce floating-point money primitives" \
-  '\b(f32|f64)\b|double[[:space:]]+precision|\breal\b|\bfloat[0-9]*\b' \
-  apps/backend/src \
-  apps/backend/crates \
-  apps/backend/migrations
+assert_matches() {
+  local description="$1"
+  local pattern="$2"
+  shift 2
 
-check_no_matches \
-  "backend source must not introduce direct external network clients outside an explicit reviewed boundary" \
-  '\b(reqwest|ureq|surf|hyper::Client|awc::Client|TcpStream|tokio::net::TcpStream|isahc)\b|curl::' \
-  apps/backend/Cargo.toml \
-  apps/backend/crates/*/Cargo.toml \
-  apps/backend/src \
-  apps/backend/crates
+  local matches
+  matches="$(grep_matches "$pattern" "$@")"
+  if [ -n "$matches" ]; then
+    echo "ok: $description"
+  else
+    report_failure "$description"
+  fi
+}
 
-read_replica_matches="$(
-  git grep -n 'WriterReadSource::ReadReplica' -- \
+assert_no_matches() {
+  local description="$1"
+  local pattern="$2"
+  shift 2
+
+  local matches
+  matches="$(grep_matches "$pattern" "$@")"
+  if [ -n "$matches" ]; then
+    echo "$matches" >&2
+    report_failure "$description"
+  else
+    echo "ok: $description"
+  fi
+}
+
+check_read_replica_boundary() {
+  local matches
+  matches="$(read_replica_boundary_matches)"
+  if [ -n "$matches" ]; then
+    echo "$matches" >&2
+    report_failure "ReadReplica must stay confined to the orchestration rejection implementation and tests"
+  else
+    echo "ok: ReadReplica stays confined to rejection implementation and tests"
+  fi
+}
+
+read_replica_boundary_matches() {
+  git grep -n "$READ_REPLICA_TOKEN" -- \
     apps/backend/src \
     apps/backend/crates \
     ':!apps/backend/crates/orchestration/src/store.rs' \
     ':!apps/backend/crates/orchestration/tests/runtime_contract.rs' \
     || true
-)"
-if [ -n "$read_replica_matches" ]; then
-  echo "$read_replica_matches" >&2
-  report_failure "ReadReplica must stay confined to the orchestration rejection implementation and tests"
-else
-  echo "ok: ReadReplica stays confined to rejection implementation and tests"
-fi
+}
 
-tracked_codex="$(git ls-files .codex)"
-if [ -n "$tracked_codex" ]; then
-  echo "$tracked_codex" >&2
-  report_failure ".codex is local agent state and must not be tracked"
-else
-  echo "ok: .codex is not tracked"
-fi
+check_codex_hygiene() {
+  local tracked_codex
+  tracked_codex="$(git ls-files .codex)"
+  if [ -n "$tracked_codex" ]; then
+    echo "$tracked_codex" >&2
+    report_failure ".codex is local agent state and must not be tracked"
+  else
+    echo "ok: .codex is not tracked"
+  fi
 
-if git grep -q -E '^\.codex/$' -- .gitignore; then
-  echo "ok: .codex remains ignored"
-else
-  report_failure ".gitignore must keep .codex/ ignored"
-fi
+  if git grep -q -E '^\.codex/$' -- .gitignore; then
+    echo "ok: .codex remains ignored"
+  else
+    report_failure ".gitignore must keep .codex/ ignored"
+  fi
+}
+
+run_sweep() {
+  cd "$repo_root"
+
+  check_no_matches \
+    "backend source and migrations must not introduce floating-point money primitives" \
+    "$FLOAT_MONEY_PATTERN" \
+    apps/backend/src \
+    apps/backend/crates \
+    apps/backend/migrations
+
+  check_no_matches \
+    "backend source must not introduce direct external network clients outside an explicit reviewed boundary" \
+    "$NETWORK_CLIENT_PATTERN" \
+    apps/backend/Cargo.toml \
+    apps/backend/crates/*/Cargo.toml \
+    apps/backend/src \
+    apps/backend/crates
+
+  check_read_replica_boundary
+  check_codex_hygiene
+}
+
+run_self_test() {
+  local temp_dir
+  temp_dir="$(mktemp -d)"
+  trap 'rm -rf "$temp_dir"' RETURN
+
+  if ! (
+    cd "$temp_dir"
+    git init -q
+
+    mkdir -p \
+      .codex \
+      apps/backend/src \
+      apps/backend/crates/orchestration/src \
+      apps/backend/crates/orchestration/tests \
+      apps/backend/migrations
+
+    printf '.codex/\n' > .gitignore
+    printf 'let amount: f64 = 1.0;\n' > apps/backend/src/float_money.rs
+    printf 'let label = "really reality token";\n' > apps/backend/src/word_boundary_safe.rs
+    printf 'let client = reqwest::Client::new();\n' > apps/backend/src/reqwest_client.rs
+    printf 'let client = curl::easy::Easy::new();\n' > apps/backend/src/curl_client.rs
+    printf 'let source = WriterReadSource::ReadReplica;\n' > apps/backend/crates/orchestration/src/replica_leak.rs
+    printf 'let source = WriterReadSource::ReadReplica;\n' > apps/backend/crates/orchestration/src/store.rs
+    printf 'let source = WriterReadSource::ReadReplica;\n' > apps/backend/crates/orchestration/tests/runtime_contract.rs
+    printf 'local state\n' > .codex/state
+
+    git add .gitignore apps
+    git add -f .codex/state
+
+    assert_matches \
+      "self-test catches floating-point money primitives" \
+      "$FLOAT_MONEY_PATTERN" \
+      apps/backend/src/float_money.rs
+
+    assert_no_matches \
+      "self-test keeps word boundaries from overmatching ordinary words" \
+      "$FLOAT_MONEY_PATTERN" \
+      apps/backend/src/word_boundary_safe.rs
+
+    assert_matches \
+      "self-test catches word-boundary network clients" \
+      "$NETWORK_CLIENT_PATTERN" \
+      apps/backend/src/reqwest_client.rs
+
+    assert_matches \
+      "self-test catches curl namespace clients" \
+      "$NETWORK_CLIENT_PATTERN" \
+      apps/backend/src/curl_client.rs
+
+    if [ -n "$(read_replica_boundary_matches)" ]; then
+      echo "ok: self-test catches ReadReplica outside the allowlist"
+    else
+      report_failure "self-test catches ReadReplica outside the allowlist"
+    fi
+
+    if [ -n "$(git ls-files .codex)" ]; then
+      echo "ok: self-test catches tracked .codex files"
+    else
+      report_failure "self-test catches tracked .codex files"
+    fi
+
+    if git grep -q -E '^\.codex/$' -- .gitignore; then
+      echo "ok: self-test verifies .codex/ ignore detection"
+    else
+      report_failure "self-test verifies .codex/ ignore detection"
+    fi
+
+    if [ "$failures" -ne 0 ]; then
+      exit 1
+    fi
+  ); then
+    failures=1
+  fi
+}
+
+case "${1:-}" in
+  "")
+    run_sweep
+    ;;
+  --self-test)
+    run_self_test
+    ;;
+  *)
+    echo "usage: $0 [--self-test]" >&2
+    exit 2
+    ;;
+esac
 
 if [ "$failures" -ne 0 ]; then
   exit 1
 fi
 
-echo "backend guardrail sweep passed"
+if [ "${1:-}" = "--self-test" ]; then
+  echo "backend guardrail sweep self-test passed"
+else
+  echo "backend guardrail sweep passed"
+fi


### PR DESCRIPTION
## Summary

- Add `make guardrail-sweep-self-test` at the repo root and backend level.
- Refactor the backend guardrail sweep script so the real sweep and self-test share the same detection patterns.
- Run the self-test before the real sweep in the backend DB smoke workflow.
- Document the self-test in the root README, backend README, and backend guardrails note.

## Why

The guardrail sweep should be verified for detection coverage, not only for passing against the current source tree. This self-test creates a temporary Git repository with representative forbidden fixtures and proves the sweep catches floating-point money primitives, network-client patterns, `ReadReplica` usage outside its allowlist, and `.codex` hygiene drift before the real sweep runs.

## Validation

- `bash -n apps/backend/scripts/guardrail_sweep.sh`
- `make guardrail-sweep-self-test`
- `make guardrail-sweep`
- `git diff --check`
