### PR TITLE
ci: guard raw transaction inventory

### DIFF
--- a/apps/backend/docs/guardrails.md
+++ b/apps/backend/docs/guardrails.md
@@ -14,6 +14,7 @@ checks. It fails if backend source, backend crates, or migrations introduce:
 
 - floating-point money primitives;
 - direct external network client usage outside an explicit reviewed boundary;
+- raw `tokio_postgres` transaction surface drift from the reviewed inventory;
 - `WriterReadSource::ReadReplica` usage outside the orchestration rejection
   implementation and its tests;
 - tracked `.codex` files or a missing `.codex/` ignore rule.
@@ -27,6 +28,7 @@ representative forbidden fixtures and verifies that the sweep patterns detect:
 - floating-point money primitives;
 - word-boundary network clients such as `reqwest`;
 - namespace-style network clients such as `curl::`;
+- raw transaction inventory construction;
 - `WriterReadSource::ReadReplica` outside its allowlist;
 - tracked `.codex` files and `.codex/` ignore-rule detection.
 
@@ -89,8 +91,14 @@ It now accepts only declarative SQL commands plus the outbox message, and it rej
 That removes the easiest place to smuggle remote `await` into a live authoritative transaction and also prevents "outbox only" use through that helper.
 
 What still remains review-sensitive:
-- code that takes a raw `tokio_postgres::Transaction<'_>` directly
+- code inside the existing reviewed raw transaction inventory
 - future service or adapter code that bypasses orchestration helpers entirely
+
+`apps/backend/docs/raw_transaction_inventory.txt` now fixes the current raw
+transaction surface by file and occurrence count. New or moved raw transaction
+usage must either remove an existing site or update that inventory deliberately
+after review. This is not a proof that existing transaction bodies are safe; it
+is a CI tripwire against silent surface growth.
 
 So the rule is still:
 - keep authoritative transaction code database-only

--- a/apps/backend/docs/raw_transaction_inventory.txt
+++ b/apps/backend/docs/raw_transaction_inventory.txt
@@ -1,0 +1,11 @@
+1 apps/backend/crates/db-runtime/src/migrations.rs
+4 apps/backend/crates/orchestration/src/postgres.rs
+3 apps/backend/crates/orchestration/tests/postgres_contract.rs
+35 apps/backend/src/services/happy_route/repository.rs
+6 apps/backend/src/services/operator_review/repository.rs
+7 apps/backend/src/services/realm_bootstrap/repository.rs
+4 apps/backend/src/services/room_progression/repository.rs
+1 apps/backend/src/services/social_trust_intake/repository.rs
+1 apps/backend/src/services/social_trust_mutation/repository.rs
+4 apps/backend/tests/happy_route.rs
+2 apps/backend/tests/realm_bootstrap.rs

--- a/apps/backend/scripts/guardrail_sweep.sh
+++ b/apps/backend/scripts/guardrail_sweep.sh
@@ -8,6 +8,8 @@ failures=0
 
 FLOAT_MONEY_PATTERN='\b(f32|f64)\b|double[[:space:]]+precision|\breal\b|\bfloat[0-9]*\b'
 NETWORK_CLIENT_PATTERN='\b(reqwest|ureq|surf|hyper::Client|awc::Client|TcpStream|tokio::net::TcpStream|isahc)\b|curl::'
+RAW_TRANSACTION_PATTERN="\\.transaction\\(|\\bTransaction<'_>|tokio_postgres::Transaction<'_>"
+RAW_TRANSACTION_INVENTORY_PATH='apps/backend/docs/raw_transaction_inventory.txt'
 READ_REPLICA_TOKEN='WriterReadSource::ReadReplica'
 
 report_failure() {
@@ -77,6 +79,37 @@ check_read_replica_boundary() {
   fi
 }
 
+raw_transaction_inventory() {
+  grep_matches \
+    "$RAW_TRANSACTION_PATTERN" \
+    apps/backend/src \
+    apps/backend/crates \
+    apps/backend/tests |
+    awk -F: '{ count[$1]++ } END { for (path in count) printf "%d %s\n", count[path], path }' |
+    sort -k2,2
+}
+
+check_raw_transaction_inventory() {
+  local expected_path="$repo_root/$RAW_TRANSACTION_INVENTORY_PATH"
+  local actual_path
+  actual_path="$(mktemp)"
+
+  if [ ! -f "$expected_path" ]; then
+    rm -f "$actual_path"
+    report_failure "raw transaction inventory file is missing"
+    return
+  fi
+
+  raw_transaction_inventory > "$actual_path"
+  if diff -u "$expected_path" "$actual_path"; then
+    echo "ok: raw transaction inventory matches the reviewed baseline"
+  else
+    report_failure "raw transaction inventory changed; review DB transaction surface before updating baseline"
+  fi
+
+  rm -f "$actual_path"
+}
+
 read_replica_boundary_matches() {
   git grep -n "$READ_REPLICA_TOKEN" -- \
     apps/backend/src \
@@ -121,6 +154,7 @@ run_sweep() {
     apps/backend/src \
     apps/backend/crates
 
+  check_raw_transaction_inventory
   check_read_replica_boundary
   check_codex_hygiene
 }
@@ -143,6 +177,7 @@ run_self_test() {
       apps/backend/src \
       apps/backend/crates/orchestration/src \
       apps/backend/crates/orchestration/tests \
+      apps/backend/tests \
       apps/backend/migrations
 
     printf '.codex/\n' > .gitignore
@@ -150,6 +185,8 @@ run_self_test() {
     printf 'let label = "really reality token";\n' > apps/backend/src/word_boundary_safe.rs
     printf 'let client = reqwest::Client::new();\n' > apps/backend/src/reqwest_client.rs
     printf 'let client = curl::easy::Easy::new();\n' > apps/backend/src/curl_client.rs
+    printf 'let tx = client.transaction().await?;\n' > apps/backend/src/raw_transaction.rs
+    printf "tx: &tokio_postgres::Transaction<'_>,\n" > apps/backend/tests/raw_transaction_ref.rs
     printf 'let source = WriterReadSource::ReadReplica;\n' > apps/backend/crates/orchestration/src/replica_leak.rs
     printf 'let source = WriterReadSource::ReadReplica;\n' > apps/backend/crates/orchestration/src/store.rs
     printf 'let source = WriterReadSource::ReadReplica;\n' > apps/backend/crates/orchestration/tests/runtime_contract.rs
@@ -177,6 +214,13 @@ run_self_test() {
       "self-test catches curl namespace clients" \
       "$NETWORK_CLIENT_PATTERN" \
       apps/backend/src/curl_client.rs
+
+    if [ "$(raw_transaction_inventory)" = "$(printf '1 apps/backend/src/raw_transaction.rs\n1 apps/backend/tests/raw_transaction_ref.rs')" ]; then
+      echo "ok: self-test builds the raw transaction inventory"
+    else
+      raw_transaction_inventory >&2
+      report_failure "self-test builds the raw transaction inventory"
+    fi
 
     if [ -n "$(read_replica_boundary_matches)" ]; then
       echo "ok: self-test catches ReadReplica outside the allowlist"

--- a/apps/backend/scripts/guardrail_sweep.sh
+++ b/apps/backend/scripts/guardrail_sweep.sh
@@ -8,7 +8,7 @@ failures=0
 
 FLOAT_MONEY_PATTERN='\b(f32|f64)\b|double[[:space:]]+precision|\breal\b|\bfloat[0-9]*\b'
 NETWORK_CLIENT_PATTERN='\b(reqwest|ureq|surf|hyper::Client|awc::Client|TcpStream|tokio::net::TcpStream|isahc)\b|curl::'
-RAW_TRANSACTION_PATTERN="\\.transaction\\(|\\bTransaction<'_>|tokio_postgres::Transaction<'_>"
+RAW_TRANSACTION_PATTERN="\\.transaction\\(|\\b(?:tokio_postgres::)?Transaction<'[A-Za-z_][A-Za-z0-9_]*>"
 RAW_TRANSACTION_INVENTORY_PATH='apps/backend/docs/raw_transaction_inventory.txt'
 READ_REPLICA_TOKEN='WriterReadSource::ReadReplica'
 
@@ -186,7 +186,8 @@ run_self_test() {
     printf 'let client = reqwest::Client::new();\n' > apps/backend/src/reqwest_client.rs
     printf 'let client = curl::easy::Easy::new();\n' > apps/backend/src/curl_client.rs
     printf 'let tx = client.transaction().await?;\n' > apps/backend/src/raw_transaction.rs
-    printf "tx: &tokio_postgres::Transaction<'_>,\n" > apps/backend/tests/raw_transaction_ref.rs
+    printf "tx: &tokio_postgres::Transaction<'tx>,\n" > apps/backend/tests/raw_transaction_ref.rs
+    printf "tx: &Transaction<'txn>,\n" > apps/backend/tests/raw_transaction_imported_ref.rs
     printf 'let source = WriterReadSource::ReadReplica;\n' > apps/backend/crates/orchestration/src/replica_leak.rs
     printf 'let source = WriterReadSource::ReadReplica;\n' > apps/backend/crates/orchestration/src/store.rs
     printf 'let source = WriterReadSource::ReadReplica;\n' > apps/backend/crates/orchestration/tests/runtime_contract.rs
@@ -215,7 +216,7 @@ run_self_test() {
       "$NETWORK_CLIENT_PATTERN" \
       apps/backend/src/curl_client.rs
 
-    if [ "$(raw_transaction_inventory)" = "$(printf '1 apps/backend/src/raw_transaction.rs\n1 apps/backend/tests/raw_transaction_ref.rs')" ]; then
+    if [ "$(raw_transaction_inventory)" = "$(printf '1 apps/backend/src/raw_transaction.rs\n1 apps/backend/tests/raw_transaction_imported_ref.rs\n1 apps/backend/tests/raw_transaction_ref.rs')" ]; then
       echo "ok: self-test builds the raw transaction inventory"
     else
       raw_transaction_inventory >&2


### PR DESCRIPTION
## Summary

- Add a reviewed raw transaction inventory under `apps/backend/docs/raw_transaction_inventory.txt`.
- Extend `make guardrail-sweep` so CI fails when raw transaction usage drifts from the reviewed inventory.
- Extend the guardrail self-test so the raw transaction inventory builder is covered by forbidden fixtures.
- Update backend guardrail docs to describe the inventory boundary and remaining review-sensitive areas.

## Why

The backend guardrails already document raw `tokio_postgres` transaction usage outside orchestration seams as a review-sensitive surface. This change makes silent growth of that surface mechanically visible in CI without pretending the existing transaction bodies are fully statically proven safe.

## Validation

- `bash -n apps/backend/scripts/guardrail_sweep.sh`
- `make guardrail-sweep-self-test`
- `make guardrail-sweep`
- `git diff --check`
