### PR TITLE
fix: archive happy-route pruning evidence

### DIFF
--- a/apps/backend/docs/happy_route_walkthrough.md
+++ b/apps/backend/docs/happy_route_walkthrough.md
@@ -158,6 +158,9 @@ Outbox rows are explicit `OutboxMessageRecord` values with:
 
 Rows live in `outbox.events`.
 Consumer idempotency lives in `outbox.command_inbox`, with completed rows bounded by retain/prune metadata.
+When the happy-route drain prunes expired terminal coordination rows, it writes
+the terminal event or command summary to the outbox archive tables before
+removing the hot coordination row.
 
 ### Evidence observation
 

--- a/apps/backend/docs/orchestration_runtime.md
+++ b/apps/backend/docs/orchestration_runtime.md
@@ -81,6 +81,9 @@ The intended flow is:
 2. a manual or scheduled runner archives summary data
 3. the hot coordination row is pruned
 
+The current happy-route drain follows that same shape for its app-level
+coordination cleanup, including manual-review terminal outbox rows.
+
 This keeps dedupe and replay evidence long enough to be useful without letting coordination tables become eternal truth.
 
 ## Writer-first invariant

--- a/apps/backend/docs/raw_transaction_inventory.txt
+++ b/apps/backend/docs/raw_transaction_inventory.txt
@@ -1,7 +1,7 @@
 1 apps/backend/crates/db-runtime/src/migrations.rs
 4 apps/backend/crates/orchestration/src/postgres.rs
 3 apps/backend/crates/orchestration/tests/postgres_contract.rs
-35 apps/backend/src/services/happy_route/repository.rs
+37 apps/backend/src/services/happy_route/repository.rs
 6 apps/backend/src/services/operator_review/repository.rs
 7 apps/backend/src/services/realm_bootstrap/repository.rs
 4 apps/backend/src/services/room_progression/repository.rs

--- a/apps/backend/migrations/0022_outbox_manual_review_prune_index.sql
+++ b/apps/backend/migrations/0022_outbox_manual_review_prune_index.sql
@@ -1,0 +1,9 @@
+DROP INDEX IF EXISTS outbox.outbox_events_prune_idx;
+
+CREATE INDEX IF NOT EXISTS outbox_events_prune_idx
+    ON outbox.events (retain_until)
+    WHERE delivery_status IN ('published', 'quarantined', 'manual_review')
+      AND retain_until IS NOT NULL;
+
+COMMENT ON INDEX outbox.outbox_events_prune_idx IS
+'Supports archive-before-prune scans for terminal outbox coordination rows, including manual-review provider evidence.';

--- a/apps/backend/src/services/happy_route/repository.rs
+++ b/apps/backend/src/services/happy_route/repository.rs
@@ -872,40 +872,210 @@ impl HappyRouteStore {
     }
 
     pub(super) async fn prune_processed_command_inbox(&self) -> Result<(), HappyRouteError> {
-        let client = self.client.lock().await;
-        client
-            .execute(
-                "
-                DELETE FROM outbox.command_inbox
-                WHERE status IN ('completed', 'quarantined')
-                  AND retain_until IS NOT NULL
-                  AND retain_until < CURRENT_TIMESTAMP
-                ",
-                &[],
+        let mut client = self.client.lock().await;
+        let tx = client.transaction().await.map_err(db_error)?;
+
+        tx.execute(
+            "
+            INSERT INTO outbox.command_inbox_archive (
+                consumer_name,
+                command_id,
+                source_event_id,
+                archived_at,
+                command_type,
+                schema_version,
+                status,
+                attempt_count,
+                payload_checksum,
+                received_at,
+                processed_at,
+                completed_at,
+                last_error_class,
+                last_error_code,
+                last_error_detail,
+                quarantine_reason,
+                result_type,
+                result_json,
+                retain_until
             )
-            .await
-            .map_err(db_error)?;
+            SELECT
+                consumer_name,
+                command_id,
+                source_event_id,
+                CURRENT_TIMESTAMP,
+                command_type,
+                schema_version,
+                status,
+                attempt_count,
+                payload_checksum,
+                received_at,
+                processed_at,
+                completed_at,
+                last_error_class,
+                last_error_code,
+                last_error_detail,
+                quarantine_reason,
+                result_type,
+                result_json,
+                retain_until
+            FROM outbox.command_inbox
+            WHERE status IN ('completed', 'quarantined')
+              AND retain_until IS NOT NULL
+              AND retain_until < CURRENT_TIMESTAMP
+            ON CONFLICT (consumer_name, command_id) DO NOTHING
+            ",
+            &[],
+        )
+        .await
+        .map_err(db_error)?;
+
+        tx.execute(
+            "
+            DELETE FROM outbox.command_inbox
+            WHERE status IN ('completed', 'quarantined')
+              AND retain_until IS NOT NULL
+              AND retain_until < CURRENT_TIMESTAMP
+            ",
+            &[],
+        )
+        .await
+        .map_err(db_error)?;
+
+        tx.commit().await.map_err(db_error)?;
         Ok(())
     }
 
     pub(super) async fn prune_terminal_outbox_events(&self) -> Result<(), HappyRouteError> {
-        let client = self.client.lock().await;
-        client
-            .execute(
-                "
+        let mut client = self.client.lock().await;
+        let tx = client.transaction().await.map_err(db_error)?;
+
+        tx.execute(
+            "
+            INSERT INTO outbox.outbox_event_archive (
+                event_id,
+                archived_at,
+                stream_key,
+                aggregate_type,
+                aggregate_id,
+                event_type,
+                schema_version,
+                payload_json,
+                payload_hash,
+                final_status,
+                attempt_count,
+                causal_order,
+                available_at,
+                created_at,
+                published_at,
+                quarantined_at,
+                last_attempt_at,
+                last_error_class,
+                last_error_code,
+                last_error_detail,
+                quarantine_reason,
+                retain_until,
+                published_external_idempotency_key
+            )
+            SELECT
+                event_id,
+                CURRENT_TIMESTAMP,
+                stream_key,
+                aggregate_type,
+                aggregate_id,
+                event_type,
+                schema_version,
+                payload_json,
+                payload_hash,
+                delivery_status,
+                attempt_count,
+                causal_order,
+                available_at,
+                created_at,
+                published_at,
+                quarantined_at,
+                last_attempt_at,
+                last_error_class,
+                last_error_code,
+                last_error_detail,
+                quarantine_reason,
+                retain_until,
+                published_external_idempotency_key
+            FROM outbox.events
+            WHERE delivery_status IN ($1, $2, $3)
+              AND retain_until IS NOT NULL
+              AND retain_until < CURRENT_TIMESTAMP
+            ON CONFLICT (event_id) DO NOTHING
+            ",
+            &[
+                &OUTBOX_PUBLISHED,
+                &OUTBOX_QUARANTINED,
+                &OUTBOX_MANUAL_REVIEW,
+            ],
+        )
+        .await
+        .map_err(db_error)?;
+
+        tx.execute(
+            "
+            INSERT INTO outbox.outbox_attempt_archive (
+                event_id,
+                attempt_number,
+                archived_at,
+                relay_name,
+                claimed_at,
+                claimed_until,
+                finished_at,
+                failure_class,
+                failure_code,
+                failure_detail,
+                external_idempotency_key
+            )
+            SELECT
+                attempts.event_id,
+                attempts.attempt_number,
+                CURRENT_TIMESTAMP,
+                attempts.relay_name,
+                attempts.claimed_at,
+                attempts.claimed_until,
+                attempts.finished_at,
+                attempts.failure_class,
+                attempts.failure_code,
+                attempts.failure_detail,
+                attempts.external_idempotency_key
+            FROM outbox.outbox_attempts AS attempts
+            JOIN outbox.events AS events
+              ON events.event_id = attempts.event_id
+            WHERE events.delivery_status IN ($1, $2, $3)
+              AND events.retain_until IS NOT NULL
+              AND events.retain_until < CURRENT_TIMESTAMP
+            ON CONFLICT (event_id, attempt_number) DO NOTHING
+            ",
+            &[
+                &OUTBOX_PUBLISHED,
+                &OUTBOX_QUARANTINED,
+                &OUTBOX_MANUAL_REVIEW,
+            ],
+        )
+        .await
+        .map_err(db_error)?;
+
+        tx.execute(
+            "
                 DELETE FROM outbox.events
                 WHERE delivery_status IN ($1, $2, $3)
                   AND retain_until IS NOT NULL
                   AND retain_until < CURRENT_TIMESTAMP
                 ",
-                &[
-                    &OUTBOX_PUBLISHED,
-                    &OUTBOX_QUARANTINED,
-                    &OUTBOX_MANUAL_REVIEW,
-                ],
-            )
-            .await
-            .map_err(db_error)?;
+            &[
+                &OUTBOX_PUBLISHED,
+                &OUTBOX_QUARANTINED,
+                &OUTBOX_MANUAL_REVIEW,
+            ],
+        )
+        .await
+        .map_err(db_error)?;
+
+        tx.commit().await.map_err(db_error)?;
         Ok(())
     }
 

--- a/apps/backend/tests/happy_route.rs
+++ b/apps/backend/tests/happy_route.rs
@@ -3923,6 +3923,27 @@ async fn drain_outbox_quarantines_invalid_payloads_and_continues() {
         .expect("invalid outbox row count must be queryable")
         .get("count");
     assert_eq!(pruned_count, 0);
+
+    let archive_row = client
+        .query_one(
+            "
+            SELECT final_status, last_error_class, last_error_detail
+            FROM outbox.outbox_event_archive
+            WHERE event_id = $1
+            ",
+            &[&invalid_event_id],
+        )
+        .await
+        .expect("pruned quarantined event must be archived");
+    assert_eq!(archive_row.get::<_, String>("final_status"), "quarantined");
+    assert_eq!(
+        archive_row.get::<_, Option<String>>("last_error_class"),
+        Some("permanent".to_owned())
+    );
+    assert_eq!(
+        archive_row.get::<_, Option<String>>("last_error_detail"),
+        Some("outbox payload for OPEN_HOLD_INTENT is missing settlement_case_id".to_owned())
+    );
 }
 
 #[tokio::test]
@@ -4021,6 +4042,18 @@ async fn oversized_callback_amount_is_retained_as_raw_evidence() {
     client
         .execute(
             "
+            UPDATE outbox.events
+            SET retain_until = CURRENT_TIMESTAMP - interval '1 minute'
+            WHERE event_id = $1
+            ",
+            &[&callback_event_id],
+        )
+        .await
+        .expect("expired manual-review outbox row must be updateable");
+
+    client
+        .execute(
+            "
             UPDATE outbox.command_inbox
             SET retain_until = CURRENT_TIMESTAMP - interval '1 minute'
             WHERE consumer_name = 'provider-callback-consumer'
@@ -4050,6 +4083,35 @@ async fn oversized_callback_amount_is_retained_as_raw_evidence() {
         .expect("terminal command row count must be queryable")
         .get("count");
     assert_eq!(pruned_count, 0);
+
+    let archived_event_status = client
+        .query_one(
+            "
+            SELECT final_status
+            FROM outbox.outbox_event_archive
+            WHERE event_id = $1
+            ",
+            &[&callback_event_id],
+        )
+        .await
+        .expect("manual-review outbox event must be archived before pruning")
+        .get::<_, String>("final_status");
+    assert_eq!(archived_event_status, "manual_review");
+
+    let archived_command_status = client
+        .query_one(
+            "
+            SELECT status
+            FROM outbox.command_inbox_archive
+            WHERE consumer_name = 'provider-callback-consumer'
+              AND command_id = $1
+            ",
+            &[&callback_event_id],
+        )
+        .await
+        .expect("quarantined command inbox row must be archived before pruning")
+        .get::<_, String>("status");
+    assert_eq!(archived_command_status, "quarantined");
 }
 
 #[tokio::test]
@@ -4095,6 +4157,12 @@ async fn drain_outbox_prunes_expired_published_events() {
         .get::<_, i64>("count");
     assert!(before > 0);
 
+    let archive_cutoff = client
+        .query_one("SELECT CURRENT_TIMESTAMP AS archive_cutoff", &[])
+        .await
+        .expect("archive cutoff timestamp")
+        .get::<_, chrono::DateTime<chrono::Utc>>("archive_cutoff");
+
     let outcome = happy_route::drain_outbox(&test_state.state)
         .await
         .expect("drain should prune expired published rows");
@@ -4106,6 +4174,21 @@ async fn drain_outbox_prunes_expired_published_events() {
         .expect("outbox count after prune")
         .get::<_, i64>("count");
     assert_eq!(after, 0);
+
+    let archived = client
+        .query_one(
+            "
+            SELECT count(*) AS count
+            FROM outbox.outbox_event_archive
+            WHERE final_status = 'published'
+              AND archived_at >= $1
+            ",
+            &[&archive_cutoff],
+        )
+        .await
+        .expect("published outbox archive count")
+        .get::<_, i64>("count");
+    assert_eq!(archived, before);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Archive happy-route terminal outbox rows before pruning them from the hot coordination table.
- Archive completed or quarantined command-inbox rows before pruning them from the hot coordination table.
- Extend happy-route pruning tests to assert archived evidence for published, quarantined, manual-review, and command-inbox terminal rows.
- Broaden the outbox prune partial index so manual-review terminal rows stay on the indexed pruning path.
- Update the raw transaction inventory and pruning docs for the new archive-before-delete transactions.

## Why
Outbox and inbox rows are coordination data, not eternal truth, but pruning should still preserve bounded terminal evidence in the existing archive landing zones. This aligns the happy-route drain with the Day 1 orchestration pruning shape instead of deleting terminal coordination rows directly.

## Validation
- `rustfmt --check --edition 2024 src/services/happy_route/repository.rs tests/happy_route.rs`
- `cargo test -p musubi_backend --test happy_route drain_outbox_quarantines_invalid_payloads_and_continues -- --exact`
- `cargo test -p musubi_backend --test happy_route drain_outbox_prunes_expired_published_events -- --exact`
- `cargo test -p musubi_backend --test happy_route oversized_callback_amount_is_retained_as_raw_evidence -- --exact`
- `make guardrail-sweep-self-test`
- `make guardrail-sweep`
- `git diff --check`
