### PR TITLE
ci: guard coordination prune inventory

### DIFF
--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -283,7 +283,8 @@ make guardrail-sweep
 
 The sweep checks high-risk backend drift, including floating-point money
 primitives, direct network clients, raw transaction inventory drift, provider
-adapter inventory drift, `ReadReplica` boundary leaks, and `.codex/` hygiene.
+adapter inventory drift, coordination hot-table prune/delete inventory drift,
+`ReadReplica` boundary leaks, and `.codex/` hygiene.
 
 To verify that the sweep catches representative forbidden fixtures, run:
 

--- a/apps/backend/docs/coordination_prune_inventory.txt
+++ b/apps/backend/docs/coordination_prune_inventory.txt
@@ -1,0 +1,3 @@
+2 apps/backend/crates/orchestration/src/postgres.rs
+2 apps/backend/src/services/happy_route/repository.rs
+2 apps/backend/tests/happy_route.rs

--- a/apps/backend/docs/guardrails.md
+++ b/apps/backend/docs/guardrails.md
@@ -15,6 +15,8 @@ checks. It fails if backend source, backend crates, or migrations introduce:
 - floating-point money primitives;
 - direct external network client usage outside an explicit reviewed boundary;
 - raw `tokio_postgres` transaction surface drift from the reviewed inventory;
+- direct outbox / command-inbox hot-table prune/delete surface drift from the
+  reviewed inventory;
 - settlement/provider adapter surface drift from the reviewed inventory;
 - `WriterReadSource::ReadReplica` usage outside the orchestration rejection
   implementation and its tests;
@@ -30,6 +32,7 @@ representative forbidden fixtures and verifies that the sweep patterns detect:
 - word-boundary network clients such as `reqwest`;
 - namespace-style network clients such as `curl::`;
 - raw transaction inventory construction;
+- coordination hot-table prune/delete inventory construction;
 - provider adapter inventory construction;
 - `WriterReadSource::ReadReplica` outside its allowlist;
 - tracked `.codex` files and `.codex/` ignore-rule detection.
@@ -102,6 +105,13 @@ transaction usage must either remove an existing site or update that inventory
 deliberately after review. This is not a proof that existing transaction bodies
 are safe; it is a CI tripwire against silent surface growth.
 
+`apps/backend/docs/coordination_prune_inventory.txt` fixes the current direct
+`DELETE FROM outbox.events` and `DELETE FROM outbox.command_inbox` surface by
+file and matching-line count. New or moved hot-table pruning must update that
+inventory deliberately after review. This prevents silent growth of direct
+coordination pruning surfaces after archive-before-prune landed; it does not
+prove that each allowed site still archives before deleting.
+
 `apps/backend/docs/provider_adapter_inventory.txt` fixes the current
 settlement/provider adapter surface by file and matching-line count. It
 currently allows only the `SettlementBackend` seam and the sandbox Pi adapter in
@@ -166,6 +176,8 @@ Product and later domain flows must not describe this as complete anti-spoofing.
 The next meaningful upgrades would be:
 - add integration tests around real PostgreSQL writer/claim/persist flows as the happy route grows
 - add CI review hooks or linting that flag suspicious `Transaction` + remote client usage patterns
+- add a deeper archive-before-delete lint once the coordination lifecycle worker
+  shape is pinned
 - turn the provider adapter inventory into a richer boundary lint once production Pi networking is pinned
 
 ## Bottom line

--- a/apps/backend/scripts/guardrail_sweep.sh
+++ b/apps/backend/scripts/guardrail_sweep.sh
@@ -10,6 +10,8 @@ FLOAT_MONEY_PATTERN='\b(f32|f64)\b|double[[:space:]]+precision|\breal\b|\bfloat[
 NETWORK_CLIENT_PATTERN='\b(reqwest|ureq|surf|hyper::Client|awc::Client|TcpStream|tokio::net::TcpStream|isahc)\b|curl::'
 RAW_TRANSACTION_PATTERN="\\.transaction\\(|\\b(?:tokio_postgres::)?Transaction<'[A-Za-z_][A-Za-z0-9_]*>"
 RAW_TRANSACTION_INVENTORY_PATH='apps/backend/docs/raw_transaction_inventory.txt'
+COORDINATION_PRUNE_PATTERN='(?i)delete[[:space:]]+from[[:space:]]+outbox\.(events|command_inbox)\b'
+COORDINATION_PRUNE_INVENTORY_PATH='apps/backend/docs/coordination_prune_inventory.txt'
 PROVIDER_ADAPTER_PATTERN='\btrait[[:space:]]+SettlementBackend\b|\bimpl[[:space:]]+SettlementBackend[[:space:]]+for\b|\bstruct[[:space:]]+[A-Za-z0-9_]*(SettlementBackend|ProviderClient|ProviderConfig)\b|\b(derive_provider_idempotency_key|verify_receipt_impl|submit_action_impl|reconcile_submission_impl|normalize_callback_impl)\b'
 PROVIDER_ADAPTER_INVENTORY_PATH='apps/backend/docs/provider_adapter_inventory.txt'
 READ_REPLICA_TOKEN='WriterReadSource::ReadReplica'
@@ -91,6 +93,28 @@ raw_transaction_inventory() {
     sort -k2,2
 }
 
+coordination_prune_inventory() {
+  git ls-files -- \
+    apps/backend/src \
+    apps/backend/crates \
+    apps/backend/tests \
+    apps/backend/migrations |
+    while IFS= read -r path; do
+      local match_count
+      match_count="$(
+        COORDINATION_PRUNE_PATTERN="$COORDINATION_PRUNE_PATTERN" perl -0ne '
+          BEGIN { $pattern = qr/$ENV{COORDINATION_PRUNE_PATTERN}/; }
+          while (/$pattern/g) { $count++; }
+          END { print $count || 0; }
+        ' "$path"
+      )"
+      if [ "$match_count" -gt 0 ]; then
+        printf "%d %s\n" "$match_count" "$path"
+      fi
+    done |
+    sort -k2,2
+}
+
 provider_adapter_inventory() {
   local source_paths=(apps/backend/src apps/backend/crates/*/src)
 
@@ -117,6 +141,27 @@ check_raw_transaction_inventory() {
     echo "ok: raw transaction inventory matches the reviewed baseline"
   else
     report_failure "raw transaction inventory changed; review DB transaction surface before updating baseline"
+  fi
+
+  rm -f "$actual_path"
+}
+
+check_coordination_prune_inventory() {
+  local expected_path="$repo_root/$COORDINATION_PRUNE_INVENTORY_PATH"
+  local actual_path
+  actual_path="$(mktemp)"
+
+  if [ ! -f "$expected_path" ]; then
+    rm -f "$actual_path"
+    report_failure "coordination prune inventory file is missing"
+    return
+  fi
+
+  coordination_prune_inventory > "$actual_path"
+  if diff -u "$expected_path" "$actual_path"; then
+    echo "ok: coordination prune inventory matches the reviewed baseline"
+  else
+    report_failure "coordination hot-table prune/delete surface changed; review archive-before-prune behavior before updating baseline"
   fi
 
   rm -f "$actual_path"
@@ -188,6 +233,7 @@ run_sweep() {
     apps/backend/crates
 
   check_raw_transaction_inventory
+  check_coordination_prune_inventory
   check_provider_adapter_inventory
   check_read_replica_boundary
   check_codex_hygiene
@@ -221,6 +267,7 @@ run_self_test() {
     printf 'let client = reqwest::Client::new();\n' > apps/backend/src/reqwest_client.rs
     printf 'let client = curl::easy::Easy::new();\n' > apps/backend/src/curl_client.rs
     printf 'let tx = client.transaction().await?;\n' > apps/backend/src/raw_transaction.rs
+    printf 'delete FROM outbox.events WHERE retain_until < CURRENT_TIMESTAMP;\nDeLeTe\nfrom outbox.command_inbox WHERE retain_until < CURRENT_TIMESTAMP;\n' > apps/backend/src/coordination_prune.rs
     printf 'pub trait SettlementBackend { async fn submit_action_impl(&self); }\n' > apps/backend/crates/settlement-domain/src/backend.rs
     printf 'struct SandboxPiProviderClient;\nimpl SettlementBackend for PiSettlementBackend {}\n' > apps/backend/src/provider_adapter.rs
     printf "tx: &tokio_postgres::Transaction<'tx>,\n" > apps/backend/tests/raw_transaction_ref.rs
@@ -258,6 +305,13 @@ run_self_test() {
     else
       raw_transaction_inventory >&2
       report_failure "self-test builds the raw transaction inventory"
+    fi
+
+    if [ "$(coordination_prune_inventory)" = "$(printf '2 apps/backend/src/coordination_prune.rs')" ]; then
+      echo "ok: self-test builds the coordination prune inventory"
+    else
+      coordination_prune_inventory >&2
+      report_failure "self-test builds the coordination prune inventory"
     fi
 
     if [ "$(provider_adapter_inventory)" = "$(printf '1 apps/backend/crates/settlement-domain/src/backend.rs\n2 apps/backend/src/provider_adapter.rs')" ]; then


### PR DESCRIPTION
## Summary
- Add a deterministic coordination prune inventory to the backend guardrail sweep.
- Fix the current direct `DELETE FROM outbox.events` / `outbox.command_inbox` surface by reviewed file and matching-line count.
- Document the scope and limitation: this prevents silent hot-table prune/delete surface growth, but does not prove archive-before-delete sequencing inside allowed files.

## Validation
- `bash -n apps/backend/scripts/guardrail_sweep.sh`
- `make guardrail-sweep-self-test`
- `make guardrail-sweep`
- `git diff --check`