### PR TITLE
ci: enforce archive-before-prune guardrail

### DIFF
--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -284,6 +284,7 @@ make guardrail-sweep
 The sweep checks high-risk backend drift, including floating-point money
 primitives, direct network clients, raw transaction inventory drift, provider
 adapter inventory drift, coordination hot-table prune/delete inventory drift,
+production archive-before-prune drift for coordination hot tables,
 `ReadReplica` boundary leaks, and `.codex/` hygiene.
 
 To verify that the sweep catches representative forbidden fixtures, run:

--- a/apps/backend/docs/guardrails.md
+++ b/apps/backend/docs/guardrails.md
@@ -17,6 +17,8 @@ checks. It fails if backend source, backend crates, or migrations introduce:
 - raw `tokio_postgres` transaction surface drift from the reviewed inventory;
 - direct outbox / command-inbox hot-table prune/delete surface drift from the
   reviewed inventory;
+- production outbox / command-inbox hot-table pruning that deletes before the
+  required archive inserts;
 - settlement/provider adapter surface drift from the reviewed inventory;
 - `WriterReadSource::ReadReplica` usage outside the orchestration rejection
   implementation and its tests;
@@ -33,6 +35,8 @@ representative forbidden fixtures and verifies that the sweep patterns detect:
 - namespace-style network clients such as `curl::`;
 - raw transaction inventory construction;
 - coordination hot-table prune/delete inventory construction;
+- production archive-before-prune detection for outbox and command-inbox hot
+  tables;
 - provider adapter inventory construction;
 - `WriterReadSource::ReadReplica` outside its allowlist;
 - tracked `.codex` files and `.codex/` ignore-rule detection.
@@ -109,8 +113,21 @@ are safe; it is a CI tripwire against silent surface growth.
 `DELETE FROM outbox.events` and `DELETE FROM outbox.command_inbox` surface by
 file and matching-line count. New or moved hot-table pruning must update that
 inventory deliberately after review. This prevents silent growth of direct
-coordination pruning surfaces after archive-before-prune landed; it does not
-prove that each allowed site still archives before deleting.
+coordination pruning surfaces after archive-before-prune landed.
+
+The sweep also checks production source under `apps/backend/src` and
+`apps/backend/crates/*/src` for archive-before-prune sequencing on those hot
+tables. A production `DELETE FROM outbox.events` must be preceded by inserts
+into both `outbox.outbox_event_archive` and `outbox.outbox_attempt_archive`
+since the previous event hot-table delete in that file. A production
+`DELETE FROM outbox.command_inbox` must be preceded by an insert into
+`outbox.command_inbox_archive` since the previous command-inbox hot-table delete
+in that file.
+
+This is still a source tripwire, not a SQL parser or proof of semantic
+equivalence. Intentional test fixtures that delete outbox rows to simulate PITR
+gaps remain covered by the inventory baseline but are not subject to the
+production archive-before-prune sequencing check.
 
 `apps/backend/docs/provider_adapter_inventory.txt` fixes the current
 settlement/provider adapter surface by file and matching-line count. It
@@ -176,8 +193,8 @@ Product and later domain flows must not describe this as complete anti-spoofing.
 The next meaningful upgrades would be:
 - add integration tests around real PostgreSQL writer/claim/persist flows as the happy route grows
 - add CI review hooks or linting that flag suspicious `Transaction` + remote client usage patterns
-- add a deeper archive-before-delete lint once the coordination lifecycle worker
-  shape is pinned
+- turn the archive-before-prune source tripwire into a syntax-aware lifecycle
+  lint once coordination lifecycle shapes grow beyond the current SQL helpers
 - turn the provider adapter inventory into a richer boundary lint once production Pi networking is pinned
 
 ## Bottom line

--- a/apps/backend/scripts/guardrail_sweep.sh
+++ b/apps/backend/scripts/guardrail_sweep.sh
@@ -12,6 +12,7 @@ RAW_TRANSACTION_PATTERN="\\.transaction\\(|\\b(?:tokio_postgres::)?Transaction<'
 RAW_TRANSACTION_INVENTORY_PATH='apps/backend/docs/raw_transaction_inventory.txt'
 COORDINATION_PRUNE_PATTERN='(?i)delete[[:space:]]+from[[:space:]]+outbox\.(events|command_inbox)\b'
 COORDINATION_PRUNE_INVENTORY_PATH='apps/backend/docs/coordination_prune_inventory.txt'
+PRODUCTION_SOURCE_PATTERN='^apps/backend/(src/|crates/[^/]+/src/)'
 PROVIDER_ADAPTER_PATTERN='\btrait[[:space:]]+SettlementBackend\b|\bimpl[[:space:]]+SettlementBackend[[:space:]]+for\b|\bstruct[[:space:]]+[A-Za-z0-9_]*(SettlementBackend|ProviderClient|ProviderConfig)\b|\b(derive_provider_idempotency_key|verify_receipt_impl|submit_action_impl|reconcile_submission_impl|normalize_callback_impl)\b'
 PROVIDER_ADAPTER_INVENTORY_PATH='apps/backend/docs/provider_adapter_inventory.txt'
 READ_REPLICA_TOKEN='WriterReadSource::ReadReplica'
@@ -115,6 +116,41 @@ coordination_prune_inventory() {
     sort -k2,2
 }
 
+archive_before_prune_violations() {
+  git ls-files -- apps/backend/src apps/backend/crates |
+    awk -v pattern="$PRODUCTION_SOURCE_PATTERN" '$0 ~ pattern { print }' |
+    while IFS= read -r path; do
+      ARCHIVE_BEFORE_PRUNE_PATH="$path" perl -0ne '
+        my $path = $ENV{ARCHIVE_BEFORE_PRUNE_PATH};
+        while (/(?i)delete[[:space:]]+from[[:space:]]+outbox\.(events|command_inbox)\b/g) {
+          my $table = lc($1);
+          my $delete_start = $-[0];
+          my $line = 1 + (() = substr($_, 0, $delete_start) =~ /\n/g);
+
+          my $prefix = substr($_, 0, $delete_start);
+          my $last_same_delete_end = 0;
+          my $same_delete_pattern = qr/(?i)delete[[:space:]]+from[[:space:]]+outbox\.\Q$table\E\b/;
+          while ($prefix =~ /$same_delete_pattern/g) {
+            $last_same_delete_end = $+[0];
+          }
+
+          my $segment = substr($prefix, $last_same_delete_end);
+          my @required_archives =
+            $table eq "events"
+              ? ("outbox.outbox_event_archive", "outbox.outbox_attempt_archive")
+              : ("outbox.command_inbox_archive");
+
+          for my $archive (@required_archives) {
+            my $archive_pattern = qr/(?i)insert[[:space:]]+into[[:space:]]+\Q$archive\E\b/;
+            if ($segment !~ /$archive_pattern/) {
+              print "$path:$line: DELETE FROM outbox.$table must be preceded by INSERT INTO $archive before pruning\n";
+            }
+          }
+        }
+      ' "$path"
+    done
+}
+
 provider_adapter_inventory() {
   local source_paths=(apps/backend/src apps/backend/crates/*/src)
 
@@ -165,6 +201,17 @@ check_coordination_prune_inventory() {
   fi
 
   rm -f "$actual_path"
+}
+
+check_archive_before_prune() {
+  local matches
+  matches="$(archive_before_prune_violations)"
+  if [ -n "$matches" ]; then
+    echo "$matches" >&2
+    report_failure "production coordination hot-table pruning must archive before deleting"
+  else
+    echo "ok: production coordination hot-table pruning archives before deleting"
+  fi
 }
 
 check_provider_adapter_inventory() {
@@ -234,6 +281,7 @@ run_sweep() {
 
   check_raw_transaction_inventory
   check_coordination_prune_inventory
+  check_archive_before_prune
   check_provider_adapter_inventory
   check_read_replica_boundary
   check_codex_hygiene
@@ -267,7 +315,8 @@ run_self_test() {
     printf 'let client = reqwest::Client::new();\n' > apps/backend/src/reqwest_client.rs
     printf 'let client = curl::easy::Easy::new();\n' > apps/backend/src/curl_client.rs
     printf 'let tx = client.transaction().await?;\n' > apps/backend/src/raw_transaction.rs
-    printf 'delete FROM outbox.events WHERE retain_until < CURRENT_TIMESTAMP;\nDeLeTe\nfrom outbox.command_inbox WHERE retain_until < CURRENT_TIMESTAMP;\n' > apps/backend/src/coordination_prune.rs
+    printf 'INSERT INTO outbox.outbox_event_archive SELECT event_id FROM outbox.events;\nINSERT INTO outbox.outbox_attempt_archive SELECT event_id FROM outbox.outbox_attempts;\ndelete FROM outbox.events WHERE retain_until < CURRENT_TIMESTAMP;\nINSERT INTO outbox.command_inbox_archive SELECT command_id FROM outbox.command_inbox;\nDeLeTe\nfrom outbox.command_inbox WHERE retain_until < CURRENT_TIMESTAMP;\n' > apps/backend/src/coordination_prune.rs
+    printf 'delete FROM outbox.events WHERE retain_until < CURRENT_TIMESTAMP;\nDeLeTe\nfrom outbox.command_inbox WHERE retain_until < CURRENT_TIMESTAMP;\n' > apps/backend/src/coordination_prune_without_archive.rs
     printf 'pub trait SettlementBackend { async fn submit_action_impl(&self); }\n' > apps/backend/crates/settlement-domain/src/backend.rs
     printf 'struct SandboxPiProviderClient;\nimpl SettlementBackend for PiSettlementBackend {}\n' > apps/backend/src/provider_adapter.rs
     printf "tx: &tokio_postgres::Transaction<'tx>,\n" > apps/backend/tests/raw_transaction_ref.rs
@@ -307,11 +356,18 @@ run_self_test() {
       report_failure "self-test builds the raw transaction inventory"
     fi
 
-    if [ "$(coordination_prune_inventory)" = "$(printf '2 apps/backend/src/coordination_prune.rs')" ]; then
+    if [ "$(coordination_prune_inventory)" = "$(printf '2 apps/backend/src/coordination_prune.rs\n2 apps/backend/src/coordination_prune_without_archive.rs')" ]; then
       echo "ok: self-test builds the coordination prune inventory"
     else
       coordination_prune_inventory >&2
       report_failure "self-test builds the coordination prune inventory"
+    fi
+
+    if [ "$(archive_before_prune_violations)" = "$(printf 'apps/backend/src/coordination_prune_without_archive.rs:1: DELETE FROM outbox.events must be preceded by INSERT INTO outbox.outbox_event_archive before pruning\napps/backend/src/coordination_prune_without_archive.rs:1: DELETE FROM outbox.events must be preceded by INSERT INTO outbox.outbox_attempt_archive before pruning\napps/backend/src/coordination_prune_without_archive.rs:2: DELETE FROM outbox.command_inbox must be preceded by INSERT INTO outbox.command_inbox_archive before pruning')" ]; then
+      echo "ok: self-test catches production pruning without archives"
+    else
+      archive_before_prune_violations >&2
+      report_failure "self-test catches production pruning without archives"
     fi
 
     if [ "$(provider_adapter_inventory)" = "$(printf '1 apps/backend/crates/settlement-domain/src/backend.rs\n2 apps/backend/src/provider_adapter.rs')" ]; then


### PR DESCRIPTION
## Summary
- Add a production-source archive-before-prune check to the backend guardrail sweep.
- Require production `DELETE FROM outbox.events` to be preceded by inserts into `outbox.outbox_event_archive` and `outbox.outbox_attempt_archive`.
- Require production `DELETE FROM outbox.command_inbox` to be preceded by an insert into `outbox.command_inbox_archive`.
- Document that PITR-gap test fixtures remain inventory-tracked but outside the production sequencing check.

## Validation
- `bash -n apps/backend/scripts/guardrail_sweep.sh`
- `make guardrail-sweep-self-test`
- `make guardrail-sweep`
- `git diff --check`