### PR TITLE
ci: guard provider callsite inventory

### DIFF
--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -283,9 +283,10 @@ make guardrail-sweep
 
 The sweep checks high-risk backend drift, including floating-point money
 primitives, direct network clients, raw transaction inventory drift, provider
-adapter inventory drift, coordination hot-table prune/delete inventory drift,
-production archive-before-prune drift for coordination hot tables,
-`ReadReplica` boundary leaks, and `.codex/` hygiene.
+adapter inventory drift, provider callsite inventory drift, coordination
+hot-table prune/delete inventory drift, production archive-before-prune drift
+for coordination hot tables, `ReadReplica` boundary leaks, and `.codex/`
+hygiene.
 
 To verify that the sweep catches representative forbidden fixtures, run:
 

--- a/apps/backend/docs/guardrails.md
+++ b/apps/backend/docs/guardrails.md
@@ -20,6 +20,7 @@ checks. It fails if backend source, backend crates, or migrations introduce:
 - production outbox / command-inbox hot-table pruning that deletes before the
   required archive inserts;
 - settlement/provider adapter surface drift from the reviewed inventory;
+- settlement/provider callsite surface drift from the reviewed inventory;
 - `WriterReadSource::ReadReplica` usage outside the orchestration rejection
   implementation and its tests;
 - tracked `.codex` files or a missing `.codex/` ignore rule.
@@ -38,6 +39,7 @@ representative forbidden fixtures and verifies that the sweep patterns detect:
 - production archive-before-prune detection for outbox and command-inbox hot
   tables;
 - provider adapter inventory construction;
+- provider callsite inventory construction;
 - `WriterReadSource::ReadReplica` outside its allowlist;
 - tracked `.codex` files and `.codex/` ignore-rule detection.
 
@@ -137,6 +139,17 @@ methods must update that inventory deliberately after review. This prevents
 silent provider-boundary growth; it does not prove adapter correctness or
 provider guarantee semantics.
 
+`apps/backend/docs/provider_callsite_inventory.txt` fixes the current
+production provider callsite surface by file and matching-call count for
+method-call and UFCS-style calls to `submit_action`, `verify_receipt`,
+`reconcile_submission`, and `normalize_callback`. Same-line calls count
+separately, and the UFCS matcher is method-name based so imported trait aliases
+do not silently bypass the inventory. New or moved provider callsites must
+update that inventory deliberately after review. This prevents silent growth of
+external-I/O-shaped provider calls outside the reviewed happy-route boundaries;
+it does not prove that an allowed callsite is outside a live database
+transaction.
+
 So the rule is still:
 - keep authoritative transaction code database-only
 - perform provider/network I/O only after that transaction is committed or dropped
@@ -195,7 +208,7 @@ The next meaningful upgrades would be:
 - add CI review hooks or linting that flag suspicious `Transaction` + remote client usage patterns
 - turn the archive-before-prune source tripwire into a syntax-aware lifecycle
   lint once coordination lifecycle shapes grow beyond the current SQL helpers
-- turn the provider adapter inventory into a richer boundary lint once production Pi networking is pinned
+- turn the provider adapter and callsite inventories into a richer boundary lint once production Pi networking is pinned
 
 ## Bottom line
 

--- a/apps/backend/docs/provider_callsite_inventory.txt
+++ b/apps/backend/docs/provider_callsite_inventory.txt
@@ -1,0 +1,2 @@
+2 apps/backend/src/services/happy_route/callback.rs
+1 apps/backend/src/services/happy_route/open_hold.rs

--- a/apps/backend/scripts/guardrail_sweep.sh
+++ b/apps/backend/scripts/guardrail_sweep.sh
@@ -15,6 +15,8 @@ COORDINATION_PRUNE_INVENTORY_PATH='apps/backend/docs/coordination_prune_inventor
 PRODUCTION_SOURCE_PATTERN='^apps/backend/(src/|crates/[^/]+/src/)'
 PROVIDER_ADAPTER_PATTERN='\btrait[[:space:]]+SettlementBackend\b|\bimpl[[:space:]]+SettlementBackend[[:space:]]+for\b|\bstruct[[:space:]]+[A-Za-z0-9_]*(SettlementBackend|ProviderClient|ProviderConfig)\b|\b(derive_provider_idempotency_key|verify_receipt_impl|submit_action_impl|reconcile_submission_impl|normalize_callback_impl)\b'
 PROVIDER_ADAPTER_INVENTORY_PATH='apps/backend/docs/provider_adapter_inventory.txt'
+PROVIDER_CALLSITE_PATTERN='(?:\.[[:space:]]*|(?:(?:::)?(?:[A-Za-z_][A-Za-z0-9_]*::)*[A-Za-z_][A-Za-z0-9_]*(?:::[[:space:]]*<[^;{}]*>)?|<[^;{}]*[[:space:]]+as[[:space:]]+(?:::)?(?:[A-Za-z_][A-Za-z0-9_]*::)*[A-Za-z_][A-Za-z0-9_]*>)[[:space:]]*::[[:space:]]*)(submit_action|verify_receipt|reconcile_submission|normalize_callback)[[:space:]]*\('
+PROVIDER_CALLSITE_INVENTORY_PATH='apps/backend/docs/provider_callsite_inventory.txt'
 READ_REPLICA_TOKEN='WriterReadSource::ReadReplica'
 
 report_failure() {
@@ -161,6 +163,25 @@ provider_adapter_inventory() {
     sort -k2,2
 }
 
+provider_callsite_inventory() {
+  git ls-files -- apps/backend/src apps/backend/crates |
+    awk -v pattern="$PRODUCTION_SOURCE_PATTERN" '$0 ~ pattern { print }' |
+    while IFS= read -r path; do
+      local match_count
+      match_count="$(
+        PROVIDER_CALLSITE_PATTERN="$PROVIDER_CALLSITE_PATTERN" perl -0ne '
+          BEGIN { $pattern = qr/$ENV{PROVIDER_CALLSITE_PATTERN}/; }
+          while (/$pattern/g) { $count++; }
+          END { print $count || 0; }
+        ' "$path"
+      )"
+      if [ "$match_count" -gt 0 ]; then
+        printf "%d %s\n" "$match_count" "$path"
+      fi
+    done |
+    sort -k2,2
+}
+
 check_raw_transaction_inventory() {
   local expected_path="$repo_root/$RAW_TRANSACTION_INVENTORY_PATH"
   local actual_path
@@ -235,6 +256,27 @@ check_provider_adapter_inventory() {
   rm -f "$actual_path"
 }
 
+check_provider_callsite_inventory() {
+  local expected_path="$repo_root/$PROVIDER_CALLSITE_INVENTORY_PATH"
+  local actual_path
+  actual_path="$(mktemp)"
+
+  if [ ! -f "$expected_path" ]; then
+    rm -f "$actual_path"
+    report_failure "provider callsite inventory file is missing"
+    return
+  fi
+
+  provider_callsite_inventory > "$actual_path"
+  if diff -u "$expected_path" "$actual_path"; then
+    echo "ok: provider callsite inventory matches the reviewed baseline"
+  else
+    report_failure "provider callsite inventory changed; review provider I/O boundary and no-Tx-across-await shape before updating baseline"
+  fi
+
+  rm -f "$actual_path"
+}
+
 read_replica_boundary_matches() {
   git grep -n "$READ_REPLICA_TOKEN" -- \
     apps/backend/src \
@@ -283,6 +325,7 @@ run_sweep() {
   check_coordination_prune_inventory
   check_archive_before_prune
   check_provider_adapter_inventory
+  check_provider_callsite_inventory
   check_read_replica_boundary
   check_codex_hygiene
 }
@@ -319,6 +362,7 @@ run_self_test() {
     printf 'delete FROM outbox.events WHERE retain_until < CURRENT_TIMESTAMP;\nDeLeTe\nfrom outbox.command_inbox WHERE retain_until < CURRENT_TIMESTAMP;\n' > apps/backend/src/coordination_prune_without_archive.rs
     printf 'pub trait SettlementBackend { async fn submit_action_impl(&self); }\n' > apps/backend/crates/settlement-domain/src/backend.rs
     printf 'struct SandboxPiProviderClient;\nimpl SettlementBackend for PiSettlementBackend {}\n' > apps/backend/src/provider_adapter.rs
+    printf 'backend.submit_action(cmd).await?; backend.verify_receipt(receipt).await?;\nbackend\n    .normalize_callback(callback)\n    .await?;\nSettlementBackend::submit_action(&backend, cmd).await?;\n<PiSettlementBackend as SettlementBackend>::normalize_callback(&backend, callback).await?;\nsettlement_domain::SettlementBackend::submit_action(&backend, cmd).await?;\n<PiSettlementBackend as settlement_domain::SettlementBackend>::normalize_callback(&backend, callback).await?;\nProviderBackend::verify_receipt(&backend, receipt).await?;\n<PiSettlementBackend as ProviderBackend>::reconcile_submission(&backend, submission).await?;\n' > apps/backend/src/provider_callsite.rs
     printf "tx: &tokio_postgres::Transaction<'tx>,\n" > apps/backend/tests/raw_transaction_ref.rs
     printf "tx: &Transaction<'txn>,\n" > apps/backend/tests/raw_transaction_imported_ref.rs
     printf 'let source = WriterReadSource::ReadReplica;\n' > apps/backend/crates/orchestration/src/replica_leak.rs
@@ -375,6 +419,13 @@ run_self_test() {
     else
       provider_adapter_inventory >&2
       report_failure "self-test builds the provider adapter inventory"
+    fi
+
+    if [ "$(provider_callsite_inventory)" = "$(printf '9 apps/backend/src/provider_callsite.rs')" ]; then
+      echo "ok: self-test builds the provider callsite inventory"
+    else
+      provider_callsite_inventory >&2
+      report_failure "self-test builds the provider callsite inventory"
     fi
 
     if [ -n "$(read_replica_boundary_matches)" ]; then


### PR DESCRIPTION
## Summary
- Add a deterministic provider callsite inventory to the backend guardrail sweep.
- Fix the current production provider call surface by reviewed file and matching-call count.
- Detect method-call and UFCS-style provider method callsites, including imported trait aliases and same-line calls, while documenting that no-Tx-across-await semantics still require review at allowed sites.

## Validation
- `bash -n apps/backend/scripts/guardrail_sweep.sh`
- `make guardrail-sweep-self-test`
- `make guardrail-sweep`
- `git diff --check`