### PR TITLE
ci: guard route handler inventory

### DIFF
--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -283,8 +283,8 @@ make guardrail-sweep
 
 The sweep checks high-risk backend drift, including floating-point money
 primitives, direct network clients, raw transaction inventory drift, provider
-adapter inventory drift, provider callsite inventory drift, internal HTTP route
-and method surface drift, public HTTP route and method surface drift,
+adapter inventory drift, provider callsite inventory drift, internal HTTP
+route/method/handler surface drift, public HTTP route/method/handler surface drift,
 raw-string public/internal route literals, nested/split-prefix route
 composition, coordination hot-table prune/delete
 inventory drift, production archive-before-prune drift for coordination hot

--- a/apps/backend/docs/guardrails.md
+++ b/apps/backend/docs/guardrails.md
@@ -21,10 +21,10 @@ checks. It fails if backend source, backend crates, or migrations introduce:
   required archive inserts;
 - settlement/provider adapter surface drift from the reviewed inventory;
 - settlement/provider callsite surface drift from the reviewed inventory;
-- public HTTP route and method surface drift from the reviewed inventory;
+- public HTTP route, method, and handler surface drift from the reviewed inventory;
 - Rust raw-string public route literals that would bypass the ordinary-literal
   inventory scanner;
-- internal HTTP route and method surface drift from the reviewed inventory;
+- internal HTTP route, method, and handler surface drift from the reviewed inventory;
 - Rust raw-string `/api/internal/...` route literals that would bypass the
   ordinary-literal inventory scanner;
 - nested route/service or split `/api` route-prefix composition that would
@@ -50,11 +50,11 @@ representative forbidden fixtures and verifies that the sweep patterns detect:
   tables;
 - provider adapter inventory construction;
 - provider callsite inventory construction;
-- method-aware public HTTP route inventory construction;
+- method- and handler-aware public HTTP route inventory construction;
 - raw-string public route literal detection;
 - nested public route/service-prefix detection;
 - split public route-prefix detection;
-- method-aware internal HTTP route inventory construction;
+- method- and handler-aware internal HTTP route inventory construction;
 - raw-string internal route literal detection;
 - split internal route-prefix detection;
 - nested internal route-prefix detection;
@@ -169,30 +169,34 @@ it does not prove that an allowed callsite is outside a live database
 transaction.
 
 `apps/backend/docs/public_route_inventory.txt` fixes the current production
-public HTTP route surface by source file, route literal, and HTTP method for
-`/health` and non-internal `/api/...` routes. New, removed, moved, or
-method-expanded public routes must update that inventory deliberately after
-review. Because Axum `get(...)` also exposes `HEAD`, the inventory records
-implicit `HEAD` alongside `GET`. If the scanner cannot infer a method, it
-records `UNKNOWN_METHOD` instead of silently ignoring the route. This prevents
-silent growth of user-facing launch, auth, Promise, proof, projection, review,
-realm, payment, and health surfaces; it does not prove that an allowed public
-route has the right launch gate, consent gate, body limit, redaction behavior,
-or writer-truth semantics. The sweep also forbids production source from
-composing Rust raw-string public route literals or nested route/service and
-split `/api` route-prefix literals, so public routes must remain visible as
-ordinary full route literals in the inventory.
+public HTTP route surface by source file, route literal, HTTP method, and
+handler path for `/health` and non-internal `/api/...` routes. New, removed,
+moved, method-expanded, or handler-changed public routes must update that
+inventory deliberately after review. Because Axum `get(...)` also exposes
+`HEAD`, the inventory records implicit `HEAD` alongside `GET` with the same
+handler. If the scanner cannot infer a method, it records `UNKNOWN_METHOD`
+instead of silently ignoring the route. If it cannot infer a simple handler
+path, it records `UNKNOWN_HANDLER`. This prevents silent growth or same-surface
+handler replacement across user-facing launch, auth, Promise, proof,
+projection, review, realm, payment, and health surfaces; it does not prove that
+an allowed public route has the right launch gate, consent gate, body limit,
+redaction behavior, or writer-truth semantics. The sweep also forbids
+production source from composing Rust raw-string public route literals or
+nested route/service and split `/api` route-prefix literals, so public routes
+must remain visible as ordinary full route literals in the inventory.
 
 `apps/backend/docs/internal_route_inventory.txt` fixes the current production
-`/api/internal/...` HTTP route surface by source file, route literal, and HTTP
-method. New, removed, moved, or method-expanded internal routes must update
-that inventory deliberately after review. Because Axum `get(...)` also exposes
-`HEAD`, the inventory records implicit `HEAD` alongside `GET`. If the scanner
-cannot infer a method, it records `UNKNOWN_METHOD` instead of silently ignoring
-the route. This prevents silent growth of operator, repair, drain, rebuild, and
-observability surfaces; it does not prove that an allowed internal route has the
-right auth gate, release gate, body limit, redaction behavior, or writer-truth
-semantics.
+`/api/internal/...` HTTP route surface by source file, route literal, HTTP
+method, and handler path. New, removed, moved, method-expanded, or
+handler-changed internal routes must update that inventory deliberately after
+review. Because Axum `get(...)` also exposes `HEAD`, the inventory records
+implicit `HEAD` alongside `GET` with the same handler. If the scanner cannot
+infer a method, it records `UNKNOWN_METHOD` instead of silently ignoring the
+route. If it cannot infer a simple handler path, it records `UNKNOWN_HANDLER`.
+This prevents silent growth or same-surface handler replacement across
+operator, repair, drain, rebuild, and observability surfaces; it does not prove
+that an allowed internal route has the right auth gate, release gate, body
+limit, redaction behavior, or writer-truth semantics.
 The sweep also forbids production source from composing Rust raw-string internal
 route literals, an exact `"/api/internal"` nest prefix, or nested route/service
 and split `/api` route-prefix literals, so internal routes must remain visible

--- a/apps/backend/docs/internal_route_inventory.txt
+++ b/apps/backend/docs/internal_route_inventory.txt
@@ -1,35 +1,35 @@
-apps/backend/src/lib.rs /api/internal/launch/posture GET
-apps/backend/src/lib.rs /api/internal/launch/posture HEAD
-apps/backend/src/lib.rs /api/internal/operator/realms/requests GET
-apps/backend/src/lib.rs /api/internal/operator/realms/requests HEAD
-apps/backend/src/lib.rs /api/internal/operator/realms/requests/{realm_request_id} GET
-apps/backend/src/lib.rs /api/internal/operator/realms/requests/{realm_request_id} HEAD
-apps/backend/src/lib.rs /api/internal/operator/realms/requests/{realm_request_id}/approve POST
-apps/backend/src/lib.rs /api/internal/operator/realms/requests/{realm_request_id}/reject POST
-apps/backend/src/lib.rs /api/internal/operator/realms/{realm_id}/review-summary GET
-apps/backend/src/lib.rs /api/internal/operator/realms/{realm_id}/review-summary HEAD
-apps/backend/src/lib.rs /api/internal/operator/review-cases GET
-apps/backend/src/lib.rs /api/internal/operator/review-cases HEAD
-apps/backend/src/lib.rs /api/internal/operator/review-cases POST
-apps/backend/src/lib.rs /api/internal/operator/review-cases/{review_case_id} GET
-apps/backend/src/lib.rs /api/internal/operator/review-cases/{review_case_id} HEAD
-apps/backend/src/lib.rs /api/internal/operator/review-cases/{review_case_id}/decisions POST
-apps/backend/src/lib.rs /api/internal/operator/review-cases/{review_case_id}/evidence-access-grants POST
-apps/backend/src/lib.rs /api/internal/operator/review-cases/{review_case_id}/evidence-bundles POST
-apps/backend/src/lib.rs /api/internal/ops/health GET
-apps/backend/src/lib.rs /api/internal/ops/health HEAD
-apps/backend/src/lib.rs /api/internal/ops/observability/slo GET
-apps/backend/src/lib.rs /api/internal/ops/observability/slo HEAD
-apps/backend/src/lib.rs /api/internal/ops/observability/snapshot GET
-apps/backend/src/lib.rs /api/internal/ops/observability/snapshot HEAD
-apps/backend/src/lib.rs /api/internal/ops/readiness GET
-apps/backend/src/lib.rs /api/internal/ops/readiness HEAD
-apps/backend/src/lib.rs /api/internal/orchestration/drain POST
-apps/backend/src/lib.rs /api/internal/orchestration/repair POST
-apps/backend/src/lib.rs /api/internal/projection/realms/rebuild POST
-apps/backend/src/lib.rs /api/internal/projection/rebuild POST
-apps/backend/src/lib.rs /api/internal/projection/room-progressions/rebuild POST
-apps/backend/src/lib.rs /api/internal/realms/{realm_id}/admissions POST
-apps/backend/src/lib.rs /api/internal/realms/{realm_id}/sponsor-records POST
-apps/backend/src/lib.rs /api/internal/room-progressions POST
-apps/backend/src/lib.rs /api/internal/room-progressions/{room_progression_id}/facts POST
+apps/backend/src/lib.rs /api/internal/launch/posture GET handlers::launch_posture::get_internal_launch_posture
+apps/backend/src/lib.rs /api/internal/launch/posture HEAD handlers::launch_posture::get_internal_launch_posture
+apps/backend/src/lib.rs /api/internal/operator/realms/requests GET handlers::realm_bootstrap::list_realm_requests
+apps/backend/src/lib.rs /api/internal/operator/realms/requests HEAD handlers::realm_bootstrap::list_realm_requests
+apps/backend/src/lib.rs /api/internal/operator/realms/requests/{realm_request_id} GET handlers::realm_bootstrap::read_realm_request
+apps/backend/src/lib.rs /api/internal/operator/realms/requests/{realm_request_id} HEAD handlers::realm_bootstrap::read_realm_request
+apps/backend/src/lib.rs /api/internal/operator/realms/requests/{realm_request_id}/approve POST handlers::realm_bootstrap::approve_realm_request
+apps/backend/src/lib.rs /api/internal/operator/realms/requests/{realm_request_id}/reject POST handlers::realm_bootstrap::reject_realm_request
+apps/backend/src/lib.rs /api/internal/operator/realms/{realm_id}/review-summary GET handlers::realm_bootstrap::get_review_summary
+apps/backend/src/lib.rs /api/internal/operator/realms/{realm_id}/review-summary HEAD handlers::realm_bootstrap::get_review_summary
+apps/backend/src/lib.rs /api/internal/operator/review-cases GET handlers::operator_review::list_review_cases
+apps/backend/src/lib.rs /api/internal/operator/review-cases HEAD handlers::operator_review::list_review_cases
+apps/backend/src/lib.rs /api/internal/operator/review-cases POST handlers::operator_review::create_review_case
+apps/backend/src/lib.rs /api/internal/operator/review-cases/{review_case_id} GET handlers::operator_review::read_review_case
+apps/backend/src/lib.rs /api/internal/operator/review-cases/{review_case_id} HEAD handlers::operator_review::read_review_case
+apps/backend/src/lib.rs /api/internal/operator/review-cases/{review_case_id}/decisions POST handlers::operator_review::record_operator_decision
+apps/backend/src/lib.rs /api/internal/operator/review-cases/{review_case_id}/evidence-access-grants POST handlers::operator_review::grant_evidence_access
+apps/backend/src/lib.rs /api/internal/operator/review-cases/{review_case_id}/evidence-bundles POST handlers::operator_review::attach_evidence_bundle
+apps/backend/src/lib.rs /api/internal/ops/health GET handlers::ops_observability::get_ops_health
+apps/backend/src/lib.rs /api/internal/ops/health HEAD handlers::ops_observability::get_ops_health
+apps/backend/src/lib.rs /api/internal/ops/observability/slo GET handlers::ops_observability::get_ops_slo
+apps/backend/src/lib.rs /api/internal/ops/observability/slo HEAD handlers::ops_observability::get_ops_slo
+apps/backend/src/lib.rs /api/internal/ops/observability/snapshot GET handlers::ops_observability::get_ops_snapshot
+apps/backend/src/lib.rs /api/internal/ops/observability/snapshot HEAD handlers::ops_observability::get_ops_snapshot
+apps/backend/src/lib.rs /api/internal/ops/readiness GET handlers::ops_observability::get_ops_readiness
+apps/backend/src/lib.rs /api/internal/ops/readiness HEAD handlers::ops_observability::get_ops_readiness
+apps/backend/src/lib.rs /api/internal/orchestration/drain POST handlers::orchestration::drain_outbox
+apps/backend/src/lib.rs /api/internal/orchestration/repair POST handlers::orchestration::repair_orchestration
+apps/backend/src/lib.rs /api/internal/projection/realms/rebuild POST handlers::realm_bootstrap::rebuild_realm_bootstrap_views
+apps/backend/src/lib.rs /api/internal/projection/rebuild POST handlers::projection::rebuild_projection_read_models
+apps/backend/src/lib.rs /api/internal/projection/room-progressions/rebuild POST handlers::room_progression::rebuild_room_progression_views
+apps/backend/src/lib.rs /api/internal/realms/{realm_id}/admissions POST handlers::realm_bootstrap::create_realm_admission
+apps/backend/src/lib.rs /api/internal/realms/{realm_id}/sponsor-records POST handlers::realm_bootstrap::create_realm_sponsor_record
+apps/backend/src/lib.rs /api/internal/room-progressions POST handlers::room_progression::create_room_progression
+apps/backend/src/lib.rs /api/internal/room-progressions/{room_progression_id}/facts POST handlers::room_progression::append_room_progression_fact

--- a/apps/backend/docs/public_route_inventory.txt
+++ b/apps/backend/docs/public_route_inventory.txt
@@ -1,31 +1,31 @@
-apps/backend/src/lib.rs /api/auth/pi POST
-apps/backend/src/lib.rs /api/launch/posture GET
-apps/backend/src/lib.rs /api/launch/posture HEAD
-apps/backend/src/lib.rs /api/payment/callback POST
-apps/backend/src/lib.rs /api/projection/promise-views/{promise_intent_id} GET
-apps/backend/src/lib.rs /api/projection/promise-views/{promise_intent_id} HEAD
-apps/backend/src/lib.rs /api/projection/realm-trust-snapshots/{realm_id}/{account_id} GET
-apps/backend/src/lib.rs /api/projection/realm-trust-snapshots/{realm_id}/{account_id} HEAD
-apps/backend/src/lib.rs /api/projection/realms/{realm_id}/bootstrap-summary GET
-apps/backend/src/lib.rs /api/projection/realms/{realm_id}/bootstrap-summary HEAD
-apps/backend/src/lib.rs /api/projection/room-progression-views/{room_progression_id} GET
-apps/backend/src/lib.rs /api/projection/room-progression-views/{room_progression_id} HEAD
-apps/backend/src/lib.rs /api/projection/settlement-views/{settlement_case_id} GET
-apps/backend/src/lib.rs /api/projection/settlement-views/{settlement_case_id} HEAD
-apps/backend/src/lib.rs /api/projection/settlement-views/{settlement_case_id}/expanded GET
-apps/backend/src/lib.rs /api/projection/settlement-views/{settlement_case_id}/expanded HEAD
-apps/backend/src/lib.rs /api/projection/trust-snapshots/{account_id} GET
-apps/backend/src/lib.rs /api/projection/trust-snapshots/{account_id} HEAD
-apps/backend/src/lib.rs /api/promise/intents POST
-apps/backend/src/lib.rs /api/proof/challenges POST
-apps/backend/src/lib.rs /api/proof/submissions POST
-apps/backend/src/lib.rs /api/realms/requests POST
-apps/backend/src/lib.rs /api/realms/requests/{realm_request_id} GET
-apps/backend/src/lib.rs /api/realms/requests/{realm_request_id} HEAD
-apps/backend/src/lib.rs /api/review-cases/{review_case_id}/appeals GET
-apps/backend/src/lib.rs /api/review-cases/{review_case_id}/appeals HEAD
-apps/backend/src/lib.rs /api/review-cases/{review_case_id}/appeals POST
-apps/backend/src/lib.rs /api/review-cases/{review_case_id}/status GET
-apps/backend/src/lib.rs /api/review-cases/{review_case_id}/status HEAD
-apps/backend/src/lib.rs /health GET
-apps/backend/src/lib.rs /health HEAD
+apps/backend/src/lib.rs /api/auth/pi POST handlers::auth::authenticate_pi
+apps/backend/src/lib.rs /api/launch/posture GET handlers::launch_posture::get_public_launch_posture
+apps/backend/src/lib.rs /api/launch/posture HEAD handlers::launch_posture::get_public_launch_posture
+apps/backend/src/lib.rs /api/payment/callback POST handlers::payments::payment_callback
+apps/backend/src/lib.rs /api/projection/promise-views/{promise_intent_id} GET handlers::projection::get_promise_projection
+apps/backend/src/lib.rs /api/projection/promise-views/{promise_intent_id} HEAD handlers::projection::get_promise_projection
+apps/backend/src/lib.rs /api/projection/realm-trust-snapshots/{realm_id}/{account_id} GET handlers::projection::get_realm_trust_snapshot
+apps/backend/src/lib.rs /api/projection/realm-trust-snapshots/{realm_id}/{account_id} HEAD handlers::projection::get_realm_trust_snapshot
+apps/backend/src/lib.rs /api/projection/realms/{realm_id}/bootstrap-summary GET handlers::realm_bootstrap::get_bootstrap_summary
+apps/backend/src/lib.rs /api/projection/realms/{realm_id}/bootstrap-summary HEAD handlers::realm_bootstrap::get_bootstrap_summary
+apps/backend/src/lib.rs /api/projection/room-progression-views/{room_progression_id} GET handlers::room_progression::get_room_progression_view
+apps/backend/src/lib.rs /api/projection/room-progression-views/{room_progression_id} HEAD handlers::room_progression::get_room_progression_view
+apps/backend/src/lib.rs /api/projection/settlement-views/{settlement_case_id} GET handlers::projection::get_settlement_view
+apps/backend/src/lib.rs /api/projection/settlement-views/{settlement_case_id} HEAD handlers::projection::get_settlement_view
+apps/backend/src/lib.rs /api/projection/settlement-views/{settlement_case_id}/expanded GET handlers::projection::get_expanded_settlement_view
+apps/backend/src/lib.rs /api/projection/settlement-views/{settlement_case_id}/expanded HEAD handlers::projection::get_expanded_settlement_view
+apps/backend/src/lib.rs /api/projection/trust-snapshots/{account_id} GET handlers::projection::get_trust_snapshot
+apps/backend/src/lib.rs /api/projection/trust-snapshots/{account_id} HEAD handlers::projection::get_trust_snapshot
+apps/backend/src/lib.rs /api/promise/intents POST handlers::promise_intents::create_promise_intent
+apps/backend/src/lib.rs /api/proof/challenges POST handlers::proof::start_proof_challenge
+apps/backend/src/lib.rs /api/proof/submissions POST handlers::proof::submit_proof_envelope
+apps/backend/src/lib.rs /api/realms/requests POST handlers::realm_bootstrap::create_realm_request
+apps/backend/src/lib.rs /api/realms/requests/{realm_request_id} GET handlers::realm_bootstrap::get_realm_request
+apps/backend/src/lib.rs /api/realms/requests/{realm_request_id} HEAD handlers::realm_bootstrap::get_realm_request
+apps/backend/src/lib.rs /api/review-cases/{review_case_id}/appeals GET handlers::operator_review::list_appeal_cases
+apps/backend/src/lib.rs /api/review-cases/{review_case_id}/appeals HEAD handlers::operator_review::list_appeal_cases
+apps/backend/src/lib.rs /api/review-cases/{review_case_id}/appeals POST handlers::operator_review::create_appeal_case
+apps/backend/src/lib.rs /api/review-cases/{review_case_id}/status GET handlers::operator_review::get_review_status
+apps/backend/src/lib.rs /api/review-cases/{review_case_id}/status HEAD handlers::operator_review::get_review_status
+apps/backend/src/lib.rs /health GET health
+apps/backend/src/lib.rs /health HEAD health

--- a/apps/backend/scripts/guardrail_sweep.sh
+++ b/apps/backend/scripts/guardrail_sweep.sh
@@ -214,23 +214,30 @@ public_route_inventory() {
           if ($segment =~ /(?:^|[\n\r;]|\.)\s*route\s*\(/) {
             $segment = substr($segment, 0, $-[0]);
           }
-          my %seen_methods;
-          while ($segment =~ /\b(get|post|put|patch|delete|head|options|trace|any)\s*\(/g) {
-            $seen_methods{uc($1)} = 1;
+          my %seen_handlers;
+          while ($segment =~ /\b(get|post|put|patch|delete|head|options|trace|any)\s*\(\s*([^,\)\s]+)/g) {
+            my $method = uc($1);
+            my $handler = $2;
+            if ($handler !~ /^[A-Za-z_][A-Za-z0-9_:]*$/ || $handler =~ /^(async|move)$/) {
+              $handler = "UNKNOWN_HANDLER";
+            }
+            $seen_handlers{$method}{$handler} = 1;
+            if ($method eq "GET") {
+              $seen_handlers{HEAD}{$handler} = 1;
+            }
           }
-          if ($seen_methods{GET}) {
-            $seen_methods{HEAD} = 1;
+          if (!%seen_handlers) {
+            $seen_handlers{UNKNOWN_METHOD}{UNKNOWN_HANDLER} = 1;
           }
-          if (!%seen_methods) {
-            $seen_methods{UNKNOWN_METHOD} = 1;
-          }
-          for my $method (sort keys %seen_methods) {
-            print "$ENV{PUBLIC_ROUTE_SOURCE_PATH} $route $method\n";
+          for my $method (sort keys %seen_handlers) {
+            for my $handler (sort keys %{ $seen_handlers{$method} }) {
+              print "$ENV{PUBLIC_ROUTE_SOURCE_PATH} $route $method $handler\n";
+            }
           }
         }
       ' "$path"
     done |
-    sort -k1,1 -k2,2 -k3,3
+    sort -k1,1 -k2,2 -k3,3 -k4,4
 }
 
 internal_route_inventory() {
@@ -244,23 +251,30 @@ internal_route_inventory() {
           if ($segment =~ /(?:^|[\n\r;]|\.)\s*route\s*\(/) {
             $segment = substr($segment, 0, $-[0]);
           }
-          my %seen_methods;
-          while ($segment =~ /\b(get|post|put|patch|delete|head|options|trace|any)\s*\(/g) {
-            $seen_methods{uc($1)} = 1;
+          my %seen_handlers;
+          while ($segment =~ /\b(get|post|put|patch|delete|head|options|trace|any)\s*\(\s*([^,\)\s]+)/g) {
+            my $method = uc($1);
+            my $handler = $2;
+            if ($handler !~ /^[A-Za-z_][A-Za-z0-9_:]*$/ || $handler =~ /^(async|move)$/) {
+              $handler = "UNKNOWN_HANDLER";
+            }
+            $seen_handlers{$method}{$handler} = 1;
+            if ($method eq "GET") {
+              $seen_handlers{HEAD}{$handler} = 1;
+            }
           }
-          if ($seen_methods{GET}) {
-            $seen_methods{HEAD} = 1;
+          if (!%seen_handlers) {
+            $seen_handlers{UNKNOWN_METHOD}{UNKNOWN_HANDLER} = 1;
           }
-          if (!%seen_methods) {
-            $seen_methods{UNKNOWN_METHOD} = 1;
-          }
-          for my $method (sort keys %seen_methods) {
-            print "$ENV{INTERNAL_ROUTE_SOURCE_PATH} $route $method\n";
+          for my $method (sort keys %seen_handlers) {
+            for my $handler (sort keys %{ $seen_handlers{$method} }) {
+              print "$ENV{INTERNAL_ROUTE_SOURCE_PATH} $route $method $handler\n";
+            }
           }
         }
       ' "$path"
     done |
-    sort -k1,1 -k2,2 -k3,3
+    sort -k1,1 -k2,2 -k3,3 -k4,4
 }
 
 check_raw_transaction_inventory() {
@@ -384,7 +398,7 @@ check_public_route_inventory() {
   if diff -u "$expected_path" "$actual_path"; then
     echo "ok: public route inventory matches the reviewed baseline"
   else
-    report_failure "public HTTP route surface changed; review launch, consent, body limits, and user-facing exposure before updating baseline"
+    report_failure "public HTTP route/method/handler surface changed; review launch, consent, body limits, and user-facing exposure before updating baseline"
   fi
 
   rm -f "$actual_path"
@@ -405,7 +419,7 @@ check_internal_route_inventory() {
   if diff -u "$expected_path" "$actual_path"; then
     echo "ok: internal route inventory matches the reviewed baseline"
   else
-    report_failure "internal HTTP route surface changed; review gate, auth, and operator-only semantics before updating baseline"
+    report_failure "internal HTTP route/method/handler surface changed; review gate, auth, and operator-only semantics before updating baseline"
   fi
 
   rm -f "$actual_path"
@@ -604,7 +618,7 @@ run_self_test() {
       "$PUBLIC_ROUTE_RAW_STRING_PATTERN" \
       apps/backend/src/public_route_raw.rs
 
-    if [ "$(public_route_inventory)" = "$(printf 'apps/backend/src/public_routes.rs /api/auth/pi POST\napps/backend/src/public_routes.rs /api/payment/callback UNKNOWN_METHOD\napps/backend/src/public_routes.rs /api/review-cases/{review_case_id}/appeals GET\napps/backend/src/public_routes.rs /api/review-cases/{review_case_id}/appeals HEAD\napps/backend/src/public_routes.rs /api/review-cases/{review_case_id}/appeals POST\napps/backend/src/public_routes.rs /health GET\napps/backend/src/public_routes.rs /health HEAD')" ]; then
+    if [ "$(public_route_inventory)" = "$(printf 'apps/backend/src/public_routes.rs /api/auth/pi POST auth\napps/backend/src/public_routes.rs /api/payment/callback UNKNOWN_METHOD UNKNOWN_HANDLER\napps/backend/src/public_routes.rs /api/review-cases/{review_case_id}/appeals GET list\napps/backend/src/public_routes.rs /api/review-cases/{review_case_id}/appeals HEAD list\napps/backend/src/public_routes.rs /api/review-cases/{review_case_id}/appeals POST create\napps/backend/src/public_routes.rs /health GET health\napps/backend/src/public_routes.rs /health HEAD health')" ]; then
       echo "ok: self-test builds the public route inventory"
     else
       public_route_inventory >&2
@@ -651,7 +665,7 @@ run_self_test() {
       "$ROUTE_SPLIT_RAW_STRING_PATTERN" \
       apps/backend/src/internal_route_split_raw.rs
 
-    if [ "$(internal_route_inventory)" = "$(printf 'apps/backend/src/internal_routes.rs /api/internal/operator/review-cases/{review_case_id} GET\napps/backend/src/internal_routes.rs /api/internal/operator/review-cases/{review_case_id} HEAD\napps/backend/src/internal_routes.rs /api/internal/operator/review-cases/{review_case_id} POST\napps/backend/src/internal_routes.rs /api/internal/ops/unknown-method UNKNOWN_METHOD\napps/backend/src/internal_routes.rs /api/internal/orchestration/drain POST')" ]; then
+    if [ "$(internal_route_inventory)" = "$(printf 'apps/backend/src/internal_routes.rs /api/internal/operator/review-cases/{review_case_id} GET read\napps/backend/src/internal_routes.rs /api/internal/operator/review-cases/{review_case_id} HEAD read\napps/backend/src/internal_routes.rs /api/internal/operator/review-cases/{review_case_id} POST write\napps/backend/src/internal_routes.rs /api/internal/ops/unknown-method UNKNOWN_METHOD UNKNOWN_HANDLER\napps/backend/src/internal_routes.rs /api/internal/orchestration/drain POST handler')" ]; then
       echo "ok: self-test builds the internal route inventory"
     else
       internal_route_inventory >&2


### PR DESCRIPTION
## Summary
- Extend public and internal HTTP route inventories to record handler paths alongside source file, route path, and HTTP method.
- Keep Axum implicit `HEAD` exposure paired with the same handler as `GET`.
- Update guardrail docs and self-tests so same-path/same-method handler swaps require baseline review.

## Validation
- `bash -n apps/backend/scripts/guardrail_sweep.sh`
- `make guardrail-sweep-self-test`
- `make guardrail-sweep`
- `git diff --check`