### PR TITLE
ci: guard tx provider colocation

### DIFF
--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -283,10 +283,11 @@ make guardrail-sweep
 
 The sweep checks high-risk backend drift, including floating-point money
 primitives, direct network clients, raw transaction inventory drift, provider
-adapter inventory drift, provider callsite inventory drift, internal HTTP
-route/method/handler surface drift, public HTTP route/method/handler surface drift,
-HTTP route release-gate drift, explicit route body limit drift, state-changing
-route body-limit gap drift, raw-string public/internal route literals,
+adapter inventory drift, provider callsite inventory drift, production
+transaction/provider callsite co-location, internal HTTP route/method/handler
+surface drift, public HTTP route/method/handler surface drift, HTTP route
+release-gate drift, explicit route body limit drift, state-changing route
+body-limit gap drift, raw-string public/internal route literals,
 nested/split-prefix route composition, coordination hot-table prune/delete
 inventory drift, production archive-before-prune drift for coordination hot
 tables, `ReadReplica` boundary leaks, and `.codex/` hygiene.

--- a/apps/backend/docs/guardrails.md
+++ b/apps/backend/docs/guardrails.md
@@ -21,6 +21,8 @@ checks. It fails if backend source, backend crates, or migrations introduce:
   required archive inserts;
 - settlement/provider adapter surface drift from the reviewed inventory;
 - settlement/provider callsite surface drift from the reviewed inventory;
+- production files that co-locate raw DB transaction surface with
+  settlement/provider callsites;
 - public HTTP route, method, and handler surface drift from the reviewed inventory;
 - Rust raw-string public route literals that would bypass the ordinary-literal
   inventory scanner;
@@ -53,6 +55,7 @@ representative forbidden fixtures and verifies that the sweep patterns detect:
   tables;
 - provider adapter inventory construction;
 - provider callsite inventory construction;
+- transaction/provider callsite co-location detection;
 - method- and handler-aware public HTTP route inventory construction;
 - raw-string public route literal detection;
 - nested public route/service-prefix detection;
@@ -173,6 +176,14 @@ update that inventory deliberately after review. This prevents silent growth of
 external-I/O-shaped provider calls outside the reviewed happy-route boundaries;
 it does not prove that an allowed callsite is outside a live database
 transaction.
+
+The sweep also checks production source for files that contain both raw DB
+transaction surface and settlement/provider callsites. Today those surfaces are
+file-separated: transaction-heavy repository code owns PostgreSQL truth, while
+provider I/O-shaped calls live in the happy-route service boundary. If a future
+file contains both surfaces, CI fails so reviewers can inspect no-transaction-
+across-provider-await shape before the code lands. This is a deliberately coarse
+file-level tripwire, not a function-level async analysis.
 
 `apps/backend/docs/public_route_inventory.txt` fixes the current production
 public HTTP route surface by source file, route literal, HTTP method, and
@@ -297,7 +308,8 @@ Product and later domain flows must not describe this as complete anti-spoofing.
 
 The next meaningful upgrades would be:
 - add integration tests around real PostgreSQL writer/claim/persist flows as the happy route grows
-- add CI review hooks or linting that flag suspicious `Transaction` + remote client usage patterns
+- broaden the transaction/provider co-location tripwire into syntax-aware
+  linting that understands function-level await ordering
 - turn the archive-before-prune source tripwire into a syntax-aware lifecycle
   lint once coordination lifecycle shapes grow beyond the current SQL helpers
 - turn the internal route inventory into route-metadata linting once gate/auth

--- a/apps/backend/scripts/guardrail_sweep.sh
+++ b/apps/backend/scripts/guardrail_sweep.sh
@@ -192,6 +192,37 @@ provider_callsite_inventory() {
     sort -k2,2
 }
 
+transaction_provider_colocation_matches() {
+  git ls-files -- apps/backend/src apps/backend/crates |
+    awk -v pattern="$PRODUCTION_SOURCE_PATTERN" '$0 ~ pattern { print }' |
+    while IFS= read -r path; do
+      local raw_transaction_count
+      raw_transaction_count="$(
+        RAW_TRANSACTION_PATTERN="$RAW_TRANSACTION_PATTERN" perl -0ne '
+          BEGIN { $pattern = qr/$ENV{RAW_TRANSACTION_PATTERN}/; }
+          while (/$pattern/g) { $count++; }
+          END { print $count || 0; }
+        ' "$path"
+      )"
+
+      local provider_callsite_count
+      provider_callsite_count="$(
+        PROVIDER_CALLSITE_PATTERN="$PROVIDER_CALLSITE_PATTERN" perl -0ne '
+          BEGIN { $pattern = qr/$ENV{PROVIDER_CALLSITE_PATTERN}/; }
+          while (/$pattern/g) { $count++; }
+          END { print $count || 0; }
+        ' "$path"
+      )"
+
+      if [ "$raw_transaction_count" -gt 0 ] && [ "$provider_callsite_count" -gt 0 ]; then
+        printf "%s:1: raw transaction surface (%s) and provider callsite surface (%s) are co-located\n" \
+          "$path" \
+          "$raw_transaction_count" \
+          "$provider_callsite_count"
+      fi
+    done
+}
+
 route_prefix_composition_violations() {
   git ls-files -- apps/backend/src apps/backend/crates |
     awk -v pattern="$PRODUCTION_SOURCE_PATTERN" '$0 ~ pattern { print }' |
@@ -510,6 +541,17 @@ check_provider_callsite_inventory() {
   rm -f "$actual_path"
 }
 
+check_transaction_provider_colocation() {
+  local matches
+  matches="$(transaction_provider_colocation_matches)"
+  if [ -n "$matches" ]; then
+    echo "$matches" >&2
+    report_failure "production files must not co-locate raw DB transaction surface with provider callsites"
+  else
+    echo "ok: production transaction and provider callsite surfaces stay separated by file"
+  fi
+}
+
 check_route_prefix_composition() {
   local matches
   matches="$(route_prefix_composition_violations)"
@@ -675,6 +717,7 @@ run_sweep() {
   check_archive_before_prune
   check_provider_adapter_inventory
   check_provider_callsite_inventory
+  check_transaction_provider_colocation
   check_no_matches \
     "production public routes must use ordinary string literals, not Rust raw strings" \
     "$PUBLIC_ROUTE_RAW_STRING_PATTERN" \
@@ -815,6 +858,16 @@ run_self_test() {
     else
       provider_callsite_inventory >&2
       report_failure "self-test builds the provider callsite inventory"
+    fi
+
+    printf 'let tx = client.transaction().await?;\nbackend.submit_action(cmd).await?;\n' > apps/backend/src/transaction_provider_colocation.rs
+    git add apps/backend/src/transaction_provider_colocation.rs
+
+    if [ "$(transaction_provider_colocation_matches)" = "$(printf 'apps/backend/src/transaction_provider_colocation.rs:1: raw transaction surface (1) and provider callsite surface (1) are co-located')" ]; then
+      echo "ok: self-test catches transaction and provider callsite co-location"
+    else
+      transaction_provider_colocation_matches >&2
+      report_failure "self-test catches transaction and provider callsite co-location"
     fi
 
     assert_matches \


### PR DESCRIPTION
## Summary
- Add a backend guardrail that fails when production source co-locates raw DB transaction surface with settlement/provider callsites.
- Extend the guardrail self-test with a representative raw transaction plus provider callsite fixture.
- Document the new tripwire as a coarse CI review hook for no-transaction-across-provider-await shape, not a syntax-aware proof.

## Validation
- `bash -n apps/backend/scripts/guardrail_sweep.sh`
- `make guardrail-sweep-self-test`
- `make guardrail-sweep`
- `git diff --check`
