### PR TITLE
ci: guard tx provider adapter colocation

### DIFF
--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -283,11 +283,12 @@ make guardrail-sweep
 
 The sweep checks high-risk backend drift, including floating-point money
 primitives, direct network clients, raw transaction inventory drift, provider
-adapter inventory drift, provider callsite inventory drift, production
-transaction/provider callsite co-location, internal HTTP route/method/handler
-surface drift, public HTTP route/method/handler surface drift, HTTP route
-release-gate drift, explicit route body limit drift, state-changing route
-body-limit gap drift, raw-string public/internal route literals,
+adapter inventory drift, production transaction/provider adapter co-location,
+provider callsite inventory drift, production transaction/provider callsite
+co-location, internal HTTP route/method/handler surface drift, public HTTP
+route/method/handler surface drift, HTTP route release-gate drift, explicit
+route body limit drift, state-changing route body-limit gap drift,
+raw-string public/internal route literals,
 nested/split-prefix route composition, coordination hot-table prune/delete
 inventory drift, production archive-before-prune drift for coordination hot
 tables, `ReadReplica` boundary leaks, and `.codex/` hygiene.

--- a/apps/backend/docs/guardrails.md
+++ b/apps/backend/docs/guardrails.md
@@ -20,6 +20,8 @@ checks. It fails if backend source, backend crates, or migrations introduce:
 - production outbox / command-inbox hot-table pruning that deletes before the
   required archive inserts;
 - settlement/provider adapter surface drift from the reviewed inventory;
+- production files that co-locate raw DB transaction surface with
+  settlement/provider adapter surface;
 - settlement/provider callsite surface drift from the reviewed inventory;
 - production files that co-locate raw DB transaction surface with
   settlement/provider callsites;
@@ -54,6 +56,7 @@ representative forbidden fixtures and verifies that the sweep patterns detect:
 - production archive-before-prune detection for outbox and command-inbox hot
   tables;
 - provider adapter inventory construction;
+- transaction/provider adapter co-location detection;
 - provider callsite inventory construction;
 - transaction/provider callsite co-location detection;
 - method- and handler-aware public HTTP route inventory construction;
@@ -165,6 +168,14 @@ the happy-route service. New provider adapter types, implementations, or hook
 methods must update that inventory deliberately after review. This prevents
 silent provider-boundary growth; it does not prove adapter correctness or
 provider guarantee semantics.
+
+The sweep also checks production source for files that contain both raw DB
+transaction surface and settlement/provider adapter surface. Today adapter
+surface stays file-separated from transaction-heavy repository code. If a
+future file contains both surfaces, CI fails so reviewers can inspect the
+provider boundary before adapter logic is allowed to share a raw transaction
+surface. This is a coarse file-level tripwire, not a proof that every adapter
+method is side-effect free or correctly sequenced.
 
 `apps/backend/docs/provider_callsite_inventory.txt` fixes the current
 production provider callsite surface by file and matching-call count for
@@ -314,7 +325,8 @@ The next meaningful upgrades would be:
   lint once coordination lifecycle shapes grow beyond the current SQL helpers
 - turn the internal route inventory into route-metadata linting once gate/auth
   declarations are centralized
-- turn the provider adapter and callsite inventories into a richer boundary lint once production Pi networking is pinned
+- turn the provider adapter and callsite inventories plus co-location
+  tripwires into a richer boundary lint once production Pi networking is pinned
 
 ## Bottom line
 

--- a/apps/backend/scripts/guardrail_sweep.sh
+++ b/apps/backend/scripts/guardrail_sweep.sh
@@ -192,6 +192,37 @@ provider_callsite_inventory() {
     sort -k2,2
 }
 
+transaction_provider_adapter_colocation_matches() {
+  git ls-files -- apps/backend/src apps/backend/crates |
+    awk -v pattern="$PRODUCTION_SOURCE_PATTERN" '$0 ~ pattern { print }' |
+    while IFS= read -r path; do
+      local raw_transaction_count
+      raw_transaction_count="$(
+        RAW_TRANSACTION_PATTERN="$RAW_TRANSACTION_PATTERN" perl -0ne '
+          BEGIN { $pattern = qr/$ENV{RAW_TRANSACTION_PATTERN}/; }
+          while (/$pattern/g) { $count++; }
+          END { print $count || 0; }
+        ' "$path"
+      )"
+
+      local provider_adapter_count
+      provider_adapter_count="$(
+        PROVIDER_ADAPTER_PATTERN="$PROVIDER_ADAPTER_PATTERN" perl -0ne '
+          BEGIN { $pattern = qr/$ENV{PROVIDER_ADAPTER_PATTERN}/; }
+          while (/$pattern/g) { $count++; }
+          END { print $count || 0; }
+        ' "$path"
+      )"
+
+      if [ "$raw_transaction_count" -gt 0 ] && [ "$provider_adapter_count" -gt 0 ]; then
+        printf "%s:1: raw transaction surface (%s) and provider adapter surface (%s) are co-located\n" \
+          "$path" \
+          "$raw_transaction_count" \
+          "$provider_adapter_count"
+      fi
+    done
+}
+
 transaction_provider_colocation_matches() {
   git ls-files -- apps/backend/src apps/backend/crates |
     awk -v pattern="$PRODUCTION_SOURCE_PATTERN" '$0 ~ pattern { print }' |
@@ -541,6 +572,17 @@ check_provider_callsite_inventory() {
   rm -f "$actual_path"
 }
 
+check_transaction_provider_adapter_colocation() {
+  local matches
+  matches="$(transaction_provider_adapter_colocation_matches)"
+  if [ -n "$matches" ]; then
+    echo "$matches" >&2
+    report_failure "production files must not co-locate raw DB transaction surface with provider adapter surface"
+  else
+    echo "ok: production transaction and provider adapter surfaces stay separated by file"
+  fi
+}
+
 check_transaction_provider_colocation() {
   local matches
   matches="$(transaction_provider_colocation_matches)"
@@ -716,6 +758,7 @@ run_sweep() {
   check_coordination_prune_inventory
   check_archive_before_prune
   check_provider_adapter_inventory
+  check_transaction_provider_adapter_colocation
   check_provider_callsite_inventory
   check_transaction_provider_colocation
   check_no_matches \
@@ -851,6 +894,16 @@ run_self_test() {
     else
       provider_adapter_inventory >&2
       report_failure "self-test builds the provider adapter inventory"
+    fi
+
+    printf 'let tx = client.transaction().await?;\nstruct InlineSettlementBackend;\nimpl SettlementBackend for InlineSettlementBackend {}\n' > apps/backend/src/transaction_provider_adapter_colocation.rs
+    git add apps/backend/src/transaction_provider_adapter_colocation.rs
+
+    if [ "$(transaction_provider_adapter_colocation_matches)" = "$(printf 'apps/backend/src/transaction_provider_adapter_colocation.rs:1: raw transaction surface (1) and provider adapter surface (2) are co-located')" ]; then
+      echo "ok: self-test catches transaction and provider adapter co-location"
+    else
+      transaction_provider_adapter_colocation_matches >&2
+      report_failure "self-test catches transaction and provider adapter co-location"
     fi
 
     if [ "$(provider_callsite_inventory)" = "$(printf '9 apps/backend/src/provider_callsite.rs')" ]; then

--- a/apps/backend/scripts/guardrail_sweep.sh
+++ b/apps/backend/scripts/guardrail_sweep.sh
@@ -204,6 +204,9 @@ transaction_provider_adapter_colocation_matches() {
           END { print $count || 0; }
         ' "$path"
       )"
+      if [ "$raw_transaction_count" -eq 0 ]; then
+        continue
+      fi
 
       local provider_adapter_count
       provider_adapter_count="$(
@@ -235,6 +238,9 @@ transaction_provider_colocation_matches() {
           END { print $count || 0; }
         ' "$path"
       )"
+      if [ "$raw_transaction_count" -eq 0 ]; then
+        continue
+      fi
 
       local provider_callsite_count
       provider_callsite_count="$(


### PR DESCRIPTION
## Summary
- Add a backend guardrail that fails when production source co-locates raw DB transaction surface with settlement/provider adapter surface.
- Extend the guardrail self-test with a representative raw transaction plus provider adapter fixture.
- Document the new adapter-side tripwire as a coarse CI review hook that complements the existing provider callsite co-location guard.

## Validation
- `bash -n apps/backend/scripts/guardrail_sweep.sh`
- `make guardrail-sweep-self-test`
- `make guardrail-sweep`
- `git diff --check`
