### PR TITLE
ci: run orchestration contract tests

### DIFF
--- a/.github/workflows/backend-db-smoke.yml
+++ b/.github/workflows/backend-db-smoke.yml
@@ -45,10 +45,11 @@ jobs:
           cargo run -p musubi-ops -- db bootstrap
           cargo run -p musubi-ops -- db migrate
           cargo run -p musubi-ops -- db status
-      - name: Runtime and backend checks
+      - name: Runtime, orchestration, and backend checks
         working-directory: apps/backend
         run: |
           cargo test -p musubi_db_runtime
+          cargo test -p musubi_orchestration
           cargo test -p musubi_backend
       - name: HTTP Day 1 smoke
         working-directory: apps/backend

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -144,6 +144,10 @@ set +a
 cargo test -p musubi_orchestration
 ```
 
+The `backend-db-smoke` CI workflow also runs this package after DB bootstrap
+and migrations, so the PostgreSQL-backed orchestration contract stays covered
+before the HTTP smoke suite.
+
 ### Run the backend checks
 
 For the full local backend verification path, including local Postgres/Redis,

--- a/apps/backend/docs/guardrails.md
+++ b/apps/backend/docs/guardrails.md
@@ -108,6 +108,9 @@ Current executable tests:
 - `postgres_helpers_keep_truth_and_outbox_in_same_transaction`
 
 This is intentionally database-shaped logic, not in-memory optimism.
+The `backend-db-smoke` CI workflow runs the `musubi_orchestration` package tests
+after DB bootstrap and migrations, so those PostgreSQL-backed contracts are
+covered before the HTTP smoke suite.
 
 ### 3. Drop-Tx-Before-Await at the runtime seam
 
@@ -318,7 +321,8 @@ Product and later domain flows must not describe this as complete anti-spoofing.
 ## Expected next improvements
 
 The next meaningful upgrades would be:
-- add integration tests around real PostgreSQL writer/claim/persist flows as the happy route grows
+- broaden integration tests around real PostgreSQL writer/claim/persist flows
+  as the happy route grows beyond the current orchestration contracts
 - broaden the transaction/provider co-location tripwire into syntax-aware
   linting that understands function-level await ordering
 - turn the archive-before-prune source tripwire into a syntax-aware lifecycle


### PR DESCRIPTION
## Summary
- Run `cargo test -p musubi_orchestration` in the backend DB smoke workflow after DB bootstrap and migrations.
- Document that CI now covers the PostgreSQL-backed orchestration contract before the HTTP smoke suite.
- Narrow the guardrails next-improvement note to broader writer/claim/persist coverage beyond the current orchestration contracts.

## Validation
- `cargo test -p musubi_orchestration`
- `make guardrail-sweep`
- `git diff --check`
