### PR TITLE
test: cover command lease reclaim

### DIFF
--- a/apps/backend/crates/orchestration/tests/postgres_contract.rs
+++ b/apps/backend/crates/orchestration/tests/postgres_contract.rs
@@ -711,6 +711,102 @@ async fn postgres_prune_archives_terminal_coordination_rows() {
 }
 
 #[tokio::test]
+async fn postgres_begin_command_reclaims_expired_processing_lease() {
+    let Ok(database_url) = std::env::var("MUSUBI_TEST_DATABASE_URL") else {
+        return;
+    };
+
+    let (mut client, connection) = tokio_postgres::connect(&database_url, NoTls)
+        .await
+        .expect("failed to connect to MUSUBI_TEST_DATABASE_URL");
+    tokio::spawn(async move {
+        let _ = connection.await;
+    });
+
+    let tx = client
+        .transaction()
+        .await
+        .expect("failed to open transaction");
+    tx.batch_execute(include_str!(
+        "../../../migrations/0004_create_outbox_schema.sql"
+    ))
+    .await
+    .expect("failed to apply outbox schema");
+    tx.batch_execute(include_str!(
+        "../../../migrations/0006_orchestration_runtime_baseline.sql"
+    ))
+    .await
+    .expect("failed to apply orchestration baseline migration");
+
+    let command_id = Uuid::from_u128(0x715);
+    let source_event_id = Uuid::from_u128(0x716);
+    let command = CommandEnvelope::new(
+        command_id,
+        source_event_id,
+        "projection.refresh",
+        1,
+        json!({ "settlement_case_id": "expired-lease" }),
+    )
+    .unwrap();
+
+    let first = PostgresOrchestrationStore::begin_command(
+        &tx,
+        "projection-builder",
+        &command,
+        ts(10),
+        ts(310),
+    )
+    .await
+    .expect("first command begin should insert processing lease");
+    assert!(matches!(
+        first,
+        CommandBeginOutcome::FirstSeen(entry)
+            if entry.status == musubi_orchestration::CommandInboxStatus::Processing
+                && entry.claimed_until == Some(ts(310))
+    ));
+
+    let reclaimed = PostgresOrchestrationStore::begin_command(
+        &tx,
+        "projection-builder",
+        &command,
+        ts(311),
+        ts(611),
+    )
+    .await
+    .expect("expired processing lease should be ready for retry");
+    assert!(matches!(
+        reclaimed,
+        CommandBeginOutcome::ReadyForRetry(entry)
+            if entry.status == musubi_orchestration::CommandInboxStatus::Processing
+                && entry.claimed_until == Some(ts(611))
+    ));
+
+    let row = tx
+        .query_one(
+            "
+            SELECT status, claimed_by, claimed_until
+            FROM outbox.command_inbox
+            WHERE consumer_name = $1
+              AND command_id = $2
+            ",
+            &[&"projection-builder", &command_id],
+        )
+        .await
+        .expect("failed to read reclaimed command inbox row");
+    let status: String = row.get("status");
+    let claimed_by: Option<String> = row.get("claimed_by");
+    let claimed_until: Option<chrono::DateTime<Utc>> = row.get("claimed_until");
+
+    assert_eq!(status, "processing");
+    assert_eq!(claimed_by.as_deref(), Some("projection-builder"));
+    assert_eq!(claimed_until, Some(ts(611)));
+
+    tx.rollback()
+        .await
+        .expect("rollback should clean up transactional test state");
+}
+
+#[tokio::test]
 async fn legacy_command_rows_without_payload_checksum_fail_gracefully() {
     let Ok(database_url) = std::env::var("MUSUBI_TEST_DATABASE_URL") else {
         return;

--- a/apps/backend/docs/guardrails.md
+++ b/apps/backend/docs/guardrails.md
@@ -87,6 +87,7 @@ Current executable guards:
   - `begin_command(...)`
 - `OrchestrationRuntime` does not expose a replica option for those progression paths. It always uses `WriterReadSource::PrimaryWriter`.
 - `apps/backend/crates/orchestration/tests/runtime_contract.rs` includes `authoritative_progression_rejects_read_replica_sources`.
+- `apps/backend/crates/orchestration/tests/postgres_contract.rs` includes `postgres_begin_command_reclaims_expired_processing_lease`.
 
 Why this matters:
 - settlement progression

--- a/apps/backend/docs/guardrails.md
+++ b/apps/backend/docs/guardrails.md
@@ -87,7 +87,6 @@ Current executable guards:
   - `begin_command(...)`
 - `OrchestrationRuntime` does not expose a replica option for those progression paths. It always uses `WriterReadSource::PrimaryWriter`.
 - `apps/backend/crates/orchestration/tests/runtime_contract.rs` includes `authoritative_progression_rejects_read_replica_sources`.
-- `apps/backend/crates/orchestration/tests/postgres_contract.rs` includes `postgres_begin_command_reclaims_expired_processing_lease`.
 
 Why this matters:
 - settlement progression
@@ -96,7 +95,17 @@ Why this matters:
 
 These are the places where replica lag would create duplicate execution or stale settlement truth.
 
-### 2. Idempotency behavior
+### 2. Command inbox lease reclaim
+
+Current executable tests:
+- `active_processing_lease_is_deferred_until_claim_expiry`
+- `postgres_begin_command_reclaims_expired_processing_lease`
+
+These prove active command processing leases defer duplicate delivery, while
+expired leases can be reclaimed and persisted as a new processing claim on the
+real PostgreSQL command inbox schema.
+
+### 3. Idempotency behavior
 
 Current executable guards:
 - producer-side duplicate outbox idempotency keys are rejected before a second authoritative change is recorded
@@ -115,7 +124,7 @@ The `backend-db-smoke` CI workflow runs the `musubi_orchestration` package tests
 after DB bootstrap and migrations, so those PostgreSQL-backed contracts are
 covered before the HTTP smoke suite.
 
-### 3. Coordination retention / pruning
+### 4. Coordination retention / pruning
 
 Current executable tests:
 - `pruning_archives_terminal_coordination_rows`
@@ -126,7 +135,7 @@ before hot-table pruning removes them. The PostgreSQL-backed contract covers
 event archive, attempt archive, command-inbox archive, and the returned prune
 outcome on the real schema.
 
-### 4. Drop-Tx-Before-Await at the runtime seam
+### 5. Drop-Tx-Before-Await at the runtime seam
 
 Current executable guards:
 - `OrchestrationRuntime::deliver_ready_outbox(...)` claims work first, then awaits publish, then records the result in a fresh store call

--- a/apps/backend/docs/raw_transaction_inventory.txt
+++ b/apps/backend/docs/raw_transaction_inventory.txt
@@ -1,6 +1,6 @@
 1 apps/backend/crates/db-runtime/src/migrations.rs
 4 apps/backend/crates/orchestration/src/postgres.rs
-8 apps/backend/crates/orchestration/tests/postgres_contract.rs
+9 apps/backend/crates/orchestration/tests/postgres_contract.rs
 37 apps/backend/src/services/happy_route/repository.rs
 6 apps/backend/src/services/operator_review/repository.rs
 7 apps/backend/src/services/realm_bootstrap/repository.rs


### PR DESCRIPTION
## Summary
- add a PostgreSQL contract for reclaiming expired command inbox processing leases
- verify begin_command returns ReadyForRetry and persists the new claimed_until on the real schema
- update guardrail docs and the reviewed raw transaction inventory for the new test surface

## Verification
- cargo test -p musubi_orchestration postgres_begin_command_reclaims_expired_processing_lease
- cargo test -p musubi_orchestration
- make guardrail-sweep
- rustfmt --edition 2024 --check apps/backend/crates/orchestration/tests/postgres_contract.rs
- git diff --check