### PR TITLE
test: cover orchestration terminal archive payload preservation

### DIFF
--- a/apps/backend/crates/orchestration/tests/postgres_contract.rs
+++ b/apps/backend/crates/orchestration/tests/postgres_contract.rs
@@ -711,6 +711,433 @@ async fn postgres_prune_archives_terminal_coordination_rows() {
 }
 
 #[tokio::test]
+async fn postgres_prune_preserves_terminal_archive_payloads() {
+    let Ok(database_url) = std::env::var("MUSUBI_TEST_DATABASE_URL") else {
+        return;
+    };
+
+    let (mut client, connection) = tokio_postgres::connect(&database_url, NoTls)
+        .await
+        .expect("failed to connect to MUSUBI_TEST_DATABASE_URL");
+    tokio::spawn(async move {
+        let _ = connection.await;
+    });
+
+    let tx = client
+        .transaction()
+        .await
+        .expect("failed to open transaction");
+    tx.batch_execute(include_str!(
+        "../../../migrations/0004_create_outbox_schema.sql"
+    ))
+    .await
+    .expect("failed to apply outbox schema");
+    tx.batch_execute(include_str!(
+        "../../../migrations/0006_orchestration_runtime_baseline.sql"
+    ))
+    .await
+    .expect("failed to apply orchestration baseline migration");
+
+    let aggregate_id = Uuid::from_u128(0x71f);
+    let event_id = Uuid::from_u128(0x720);
+    let command_id = Uuid::from_u128(0x721);
+    let message = NewOutboxMessage::new(NewOutboxMessageSpec {
+        event_id,
+        idempotency_key: Uuid::from_u128(0x722),
+        stream_key: "settlement_case:archive-payload".to_owned(),
+        aggregate_type: "settlement_case".to_owned(),
+        aggregate_id,
+        event_type: "settlement.submit_action".to_owned(),
+        schema_version: 1,
+        payload_json: json!({
+            "intent_id": "intent-archive-payload",
+            "retention_probe": { "kind": "terminal_archive_payload" }
+        }),
+        available_at: ts(0),
+        created_at: ts(0),
+    })
+    .unwrap();
+
+    PostgresOrchestrationStore::insert_outbox_message(&tx, &message)
+        .await
+        .expect("failed to insert archive payload outbox message");
+    tx.execute(
+        "
+        UPDATE outbox.events
+        SET delivery_status = 'published',
+            attempt_count = 1,
+            published_at = $2,
+            last_attempt_at = $2,
+            retain_until = $3,
+            published_external_idempotency_key = $4
+        WHERE event_id = $1
+        ",
+        &[
+            &event_id,
+            &ts(10),
+            &ts(100),
+            &"provider-key-archive-payload",
+        ],
+    )
+    .await
+    .expect("failed to mark archive payload outbox event terminal");
+    let causal_order: i64 = tx
+        .query_one(
+            "SELECT causal_order FROM outbox.events WHERE event_id = $1",
+            &[&event_id],
+        )
+        .await
+        .expect("failed to read source outbox causal order")
+        .get("causal_order");
+    tx.execute(
+        "
+        INSERT INTO outbox.outbox_attempts (
+            event_id,
+            attempt_number,
+            relay_name,
+            claimed_at,
+            claimed_until,
+            finished_at,
+            failure_class,
+            failure_code,
+            failure_detail,
+            external_idempotency_key
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, NULL, NULL, NULL, $7)
+        ",
+        &[
+            &event_id,
+            &1_i32,
+            &"settlement-relay",
+            &ts(0),
+            &ts(300),
+            &ts(10),
+            &"provider-key-archive-payload",
+        ],
+    )
+    .await
+    .expect("failed to insert archive payload outbox attempt");
+
+    let command = CommandEnvelope::new(
+        command_id,
+        event_id,
+        "projection.refresh",
+        1,
+        json!({ "settlement_case_id": aggregate_id }),
+    )
+    .unwrap();
+    let result_json = json!({
+        "projection_id": "projection-archive-payload",
+        "archived_payload_seen": true
+    });
+    tx.execute(
+        "
+        INSERT INTO outbox.command_inbox (
+            inbox_entry_id,
+            consumer_name,
+            command_id,
+            source_event_id,
+            payload_checksum,
+            received_at,
+            status,
+            available_at,
+            attempt_count,
+            command_type,
+            schema_version,
+            completed_at,
+            result_type,
+            result_json,
+            retain_until
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, 'completed', $6, 1, $7, $8, $9, $10, $11, $12)
+        ",
+        &[
+            &Uuid::new_v4(),
+            &"projection-builder",
+            &command_id,
+            &event_id,
+            &command.payload_hash,
+            &ts(20),
+            &command.command_type,
+            &command.schema_version,
+            &ts(30),
+            &"projected",
+            &result_json,
+            &ts(100),
+        ],
+    )
+    .await
+    .expect("failed to insert archive payload command inbox row");
+
+    let outcome = PostgresOrchestrationStore::prune_coordination(&tx, ts(200))
+        .await
+        .expect("failed to prune archive payload coordination rows");
+
+    assert_eq!(outcome.pruned_outbox_event_ids, vec![event_id]);
+    assert_eq!(
+        outcome.pruned_command_keys,
+        vec![CommandKey {
+            consumer_name: "projection-builder".to_owned(),
+            command_id,
+        }]
+    );
+
+    let archived_event = tx
+        .query_one(
+            "
+            SELECT
+                archived_at,
+                stream_key,
+                aggregate_type,
+                aggregate_id,
+                event_type,
+                schema_version,
+                payload_json,
+                payload_hash,
+                final_status,
+                attempt_count,
+                causal_order,
+                available_at,
+                created_at,
+                published_at,
+                last_attempt_at,
+                retain_until,
+                published_external_idempotency_key
+            FROM outbox.outbox_event_archive
+            WHERE event_id = $1
+            ",
+            &[&event_id],
+        )
+        .await
+        .expect("failed to read archived outbox event");
+    assert_eq!(
+        archived_event.get::<_, chrono::DateTime<Utc>>("archived_at"),
+        ts(200)
+    );
+    assert_eq!(
+        archived_event
+            .get::<_, Option<String>>("stream_key")
+            .as_deref(),
+        Some(message.stream_key.as_str())
+    );
+    assert_eq!(
+        archived_event.get::<_, String>("aggregate_type"),
+        message.aggregate_type.as_str()
+    );
+    assert_eq!(archived_event.get::<_, Uuid>("aggregate_id"), aggregate_id);
+    assert_eq!(
+        archived_event.get::<_, String>("event_type"),
+        message.event_type.as_str()
+    );
+    assert_eq!(archived_event.get::<_, i32>("schema_version"), 1);
+    assert_eq!(
+        archived_event.get::<_, serde_json::Value>("payload_json"),
+        message.payload_json.clone()
+    );
+    assert_eq!(
+        archived_event
+            .get::<_, Option<String>>("payload_hash")
+            .as_deref(),
+        Some(message.payload_hash.as_str())
+    );
+    assert_eq!(archived_event.get::<_, String>("final_status"), "published");
+    assert_eq!(archived_event.get::<_, i32>("attempt_count"), 1);
+    assert_eq!(archived_event.get::<_, i64>("causal_order"), causal_order);
+    assert_eq!(
+        archived_event.get::<_, chrono::DateTime<Utc>>("available_at"),
+        ts(0)
+    );
+    assert_eq!(
+        archived_event.get::<_, chrono::DateTime<Utc>>("created_at"),
+        ts(0)
+    );
+    assert_eq!(
+        archived_event.get::<_, Option<chrono::DateTime<Utc>>>("published_at"),
+        Some(ts(10))
+    );
+    assert_eq!(
+        archived_event.get::<_, Option<chrono::DateTime<Utc>>>("last_attempt_at"),
+        Some(ts(10))
+    );
+    assert_eq!(
+        archived_event.get::<_, Option<chrono::DateTime<Utc>>>("retain_until"),
+        Some(ts(100))
+    );
+    assert_eq!(
+        archived_event
+            .get::<_, Option<String>>("published_external_idempotency_key")
+            .as_deref(),
+        Some("provider-key-archive-payload")
+    );
+
+    let archived_attempt = tx
+        .query_one(
+            "
+            SELECT
+                archived_at,
+                relay_name,
+                claimed_at,
+                claimed_until,
+                finished_at,
+                failure_class,
+                failure_code,
+                failure_detail,
+                external_idempotency_key
+            FROM outbox.outbox_attempt_archive
+            WHERE event_id = $1
+              AND attempt_number = $2
+            ",
+            &[&event_id, &1_i32],
+        )
+        .await
+        .expect("failed to read archived outbox attempt");
+    assert_eq!(
+        archived_attempt.get::<_, chrono::DateTime<Utc>>("archived_at"),
+        ts(200)
+    );
+    assert_eq!(
+        archived_attempt.get::<_, String>("relay_name"),
+        "settlement-relay"
+    );
+    assert_eq!(
+        archived_attempt.get::<_, chrono::DateTime<Utc>>("claimed_at"),
+        ts(0)
+    );
+    assert_eq!(
+        archived_attempt.get::<_, chrono::DateTime<Utc>>("claimed_until"),
+        ts(300)
+    );
+    assert_eq!(
+        archived_attempt.get::<_, chrono::DateTime<Utc>>("finished_at"),
+        ts(10)
+    );
+    assert_eq!(
+        archived_attempt.get::<_, Option<String>>("failure_class"),
+        None
+    );
+    assert_eq!(
+        archived_attempt.get::<_, Option<String>>("failure_code"),
+        None
+    );
+    assert_eq!(
+        archived_attempt.get::<_, Option<String>>("failure_detail"),
+        None
+    );
+    assert_eq!(
+        archived_attempt
+            .get::<_, Option<String>>("external_idempotency_key")
+            .as_deref(),
+        Some("provider-key-archive-payload")
+    );
+
+    let archived_command = tx
+        .query_one(
+            "
+            SELECT
+                source_event_id,
+                archived_at,
+                command_type,
+                schema_version,
+                status,
+                attempt_count,
+                payload_checksum,
+                received_at,
+                completed_at,
+                result_type,
+                result_json,
+                retain_until
+            FROM outbox.command_inbox_archive
+            WHERE consumer_name = $1
+              AND command_id = $2
+            ",
+            &[&"projection-builder", &command_id],
+        )
+        .await
+        .expect("failed to read archived command inbox row");
+    assert_eq!(archived_command.get::<_, Uuid>("source_event_id"), event_id);
+    assert_eq!(
+        archived_command.get::<_, chrono::DateTime<Utc>>("archived_at"),
+        ts(200)
+    );
+    assert_eq!(
+        archived_command.get::<_, String>("command_type"),
+        command.command_type.as_str()
+    );
+    assert_eq!(
+        archived_command.get::<_, i32>("schema_version"),
+        command.schema_version
+    );
+    assert_eq!(archived_command.get::<_, String>("status"), "completed");
+    assert_eq!(archived_command.get::<_, i32>("attempt_count"), 1);
+    assert_eq!(
+        archived_command
+            .get::<_, Option<String>>("payload_checksum")
+            .as_deref(),
+        Some(command.payload_hash.as_str())
+    );
+    assert_eq!(
+        archived_command.get::<_, chrono::DateTime<Utc>>("received_at"),
+        ts(20)
+    );
+    assert_eq!(
+        archived_command.get::<_, Option<chrono::DateTime<Utc>>>("completed_at"),
+        Some(ts(30))
+    );
+    assert_eq!(
+        archived_command
+            .get::<_, Option<String>>("result_type")
+            .as_deref(),
+        Some("projected")
+    );
+    assert_eq!(
+        archived_command.get::<_, Option<serde_json::Value>>("result_json"),
+        Some(result_json)
+    );
+    assert_eq!(
+        archived_command.get::<_, Option<chrono::DateTime<Utc>>>("retain_until"),
+        Some(ts(100))
+    );
+
+    let hot_outbox_count: i64 = tx
+        .query_one(
+            "SELECT COUNT(*) AS count FROM outbox.events WHERE event_id = $1",
+            &[&event_id],
+        )
+        .await
+        .expect("failed to count hot outbox events after archive payload prune")
+        .get("count");
+    let hot_attempt_count: i64 = tx
+        .query_one(
+            "SELECT COUNT(*) AS count FROM outbox.outbox_attempts WHERE event_id = $1",
+            &[&event_id],
+        )
+        .await
+        .expect("failed to count hot outbox attempts after archive payload prune")
+        .get("count");
+    let hot_command_count: i64 = tx
+        .query_one(
+            "
+            SELECT COUNT(*) AS count
+            FROM outbox.command_inbox
+            WHERE consumer_name = $1
+              AND command_id = $2
+            ",
+            &[&"projection-builder", &command_id],
+        )
+        .await
+        .expect("failed to count hot command rows after archive payload prune")
+        .get("count");
+
+    assert_eq!(hot_outbox_count, 0);
+    assert_eq!(hot_attempt_count, 0);
+    assert_eq!(hot_command_count, 0);
+
+    tx.rollback()
+        .await
+        .expect("rollback should clean up transactional test state");
+}
+
+#[tokio::test]
 async fn postgres_prune_preserves_nonterminal_coordination_rows() {
     let Ok(database_url) = std::env::var("MUSUBI_TEST_DATABASE_URL") else {
         return;

--- a/apps/backend/docs/guardrails.md
+++ b/apps/backend/docs/guardrails.md
@@ -129,14 +129,16 @@ covered before the HTTP smoke suite.
 Current executable tests:
 - `pruning_archives_terminal_coordination_rows`
 - `postgres_prune_archives_terminal_coordination_rows`
+- `postgres_prune_preserves_terminal_archive_payloads`
 - `postgres_prune_preserves_nonterminal_coordination_rows`
 
 These prove terminal outbox and command-inbox coordination rows are archived
 before hot-table pruning removes them. The PostgreSQL-backed contract covers
-event archive, attempt archive, command-inbox archive, and the returned prune
-outcome on the real schema. The nonterminal preservation contract proves that
-pending and processing coordination rows are not archived or deleted by the
-same prune helper, even when their retention timestamp is already in the past.
+event archive, attempt archive, command-inbox archive, archive payload and
+correlation evidence preservation, and the returned prune outcome on the real
+schema. The nonterminal preservation contract proves that pending and
+processing coordination rows are not archived or deleted by the same prune
+helper, even when their retention timestamp is already in the past.
 
 ### 5. Drop-Tx-Before-Await at the runtime seam
 

--- a/apps/backend/docs/raw_transaction_inventory.txt
+++ b/apps/backend/docs/raw_transaction_inventory.txt
@@ -1,6 +1,6 @@
 1 apps/backend/crates/db-runtime/src/migrations.rs
 4 apps/backend/crates/orchestration/src/postgres.rs
-10 apps/backend/crates/orchestration/tests/postgres_contract.rs
+11 apps/backend/crates/orchestration/tests/postgres_contract.rs
 37 apps/backend/src/services/happy_route/repository.rs
 6 apps/backend/src/services/operator_review/repository.rs
 7 apps/backend/src/services/realm_bootstrap/repository.rs

--- a/docs/foundation_lock.md
+++ b/docs/foundation_lock.md
@@ -1,6 +1,6 @@
 # Foundation Lock
 
-Status: Draft; aligned to accepted foundation commit `e619312`
+Status: Draft; aligned to accepted foundation commit `b3e8c9b`
 Applies to: `mt4110/pi-musubi-core`
 Purpose: Pin the constitutional and architectural source of truth that this implementation repository must follow.
 
@@ -26,14 +26,14 @@ Upstream repository:
 Pinned reference for implementation work:
 
 - Foundation reference type: `commit`
-- Foundation commit SHA: `e619312e3963c0769d242602c595b2e752fc4766`
-- Foundation commit title: `Merge pull request #229 from mt4110/feat/post-c2-orchestration-prune-nonterminal-preservation-handoff`
-- Foundation PR title: `docs: evaluate post-C2 orchestration prune nonterminal preservation handoff`
-- Foundation PR URL: `https://github.com/mt4110/musubi-foundation/pull/229`
+- Foundation commit SHA: `b3e8c9b370b320f86f39fc04e1fe0ca0feedf337`
+- Foundation commit title: `Merge pull request #235 from mt4110/feat/post-c2-orchestration-terminal-archive-payload-preservation-handoff`
+- Foundation PR title: `docs: evaluate post-C2 orchestration terminal archive payload preservation handoff`
+- Foundation PR URL: `https://github.com/mt4110/musubi-foundation/pull/235`
 - Date pinned: `2026-06-11`
 - Pinned by: `Masaki Takemura`
-- Pinned commit URL: `https://github.com/mt4110/musubi-foundation/commit/e619312e3963c0769d242602c595b2e752fc4766`
-- Previous pinned reference: `575b60c` / `Merge pull request #221 from mt4110/feat/orchestration-command-lease-reclaim-handoff`
+- Pinned commit URL: `https://github.com/mt4110/musubi-foundation/commit/b3e8c9b370b320f86f39fc04e1fe0ca0feedf337`
+- Previous pinned reference: `e619312` / `Merge pull request #229 from mt4110/feat/post-c2-orchestration-prune-nonterminal-preservation-handoff`
 - Post-C2 evidence source: `cfdba28` / `Merge pull request #114 from mt4110/feat/post-c2-runtime-handoff-evidence-package`
 - Alignment allowance source: `69b7aa4` / `Merge pull request #116 from mt4110/feat/evaluate-post-c2-runtime-handoff-gate`
 - Post-C2 implementation handoff evidence source: `ef23e88` / `Merge pull request #122 from mt4110/feat/post-c2-implementation-handoff-evidence-package`
@@ -89,10 +89,14 @@ Pinned reference for implementation work:
 - Post-C2 legal privacy consumer-contract quantitative gate evidence source: `7f83d33` / `Merge pull request #216 from mt4110/feat/master-submaster-active-authority-fact-shape`
 - Post-C2 Master / Submaster active authority writer fact shape handoff source: `0aa667b` / `Merge pull request #217 from mt4110/feat/master-submaster-active-authority-handoff-gate`
 - Post-C2 legal privacy consumer-contract quantitative gate handoff source: `6dbf34b` / `Merge pull request #218 from mt4110/feat/legal-privacy-quantitative-gate-handoff`
+- RunAlways Lane Controller v0.1 operations protocol source: `9dffc01` / `Merge pull request #225 from mt4110/feat/runalways-lane-controller-v0`
 - Post-C2 orchestration command lease reclaim test handoff source: `575b60c` / `Merge pull request #221 from mt4110/feat/orchestration-command-lease-reclaim-handoff`
 - Post-C2 orchestration command lease reclaim test implementation closeout source: `2821fc1` / `Merge pull request #223 from mt4110/feat/close-orchestration-command-lease-reclaim-handoff`
 - Post-C2 orchestration prune nonterminal preservation evidence source: `23cecc1` / `Merge pull request #227 from mt4110/feat/orchestration-prune-nonterminal-evidence`
 - Post-C2 orchestration prune nonterminal preservation handoff source: `e619312` / `Merge pull request #229 from mt4110/feat/post-c2-orchestration-prune-nonterminal-preservation-handoff`
+- Post-C2 orchestration prune nonterminal preservation implementation closeout source: `7713770` / `Merge pull request #231 from mt4110/feat/close-orchestration-prune-nonterminal-preservation-handoff`
+- Post-C2 orchestration terminal archive payload preservation evidence source: `b8ee362` / `Merge pull request #233 from mt4110/feat/orchestration-terminal-archive-payload-evidence`
+- Post-C2 orchestration terminal archive payload preservation handoff source: `b3e8c9b` / `Merge pull request #235 from mt4110/feat/post-c2-orchestration-terminal-archive-payload-preservation-handoff`
 
 No release tag is asserted for this alignment.
 Do not invent a foundation version label for this commit.
@@ -224,37 +228,41 @@ Before coding, read these upstream documents in order.
 111. `docs/readiness/post_c2_orchestration_command_lease_reclaim_test_implementation_closeout_ledger.md`
 112. `docs/readiness/post_c2_orchestration_prune_nonterminal_preservation_evidence_package.md`
 113. `docs/readiness/post_c2_orchestration_prune_nonterminal_preservation_handoff_gate_decision.md`
+114. `docs/readiness/post_c2_orchestration_prune_nonterminal_preservation_implementation_closeout_ledger.md`
+115. `docs/readiness/post_c2_orchestration_terminal_archive_payload_preservation_evidence_package.md`
+116. `docs/readiness/post_c2_orchestration_terminal_archive_payload_preservation_handoff_gate_decision.md`
 
 ### Operations layer
-114. `docs/operations/readiness_routine.md`
-115. `docs/operations/runalways_readiness_orchestrator_design.md`
-116. `docs/operations/runalways_readiness_orchestrator_stage0.md`
+117. `docs/operations/readiness_routine.md`
+118. `docs/operations/runalways_readiness_orchestrator_design.md`
+119. `docs/operations/runalways_readiness_orchestrator_stage0.md`
+120. `docs/operations/runalways_lane_controller_v0_1.md`
 
 ### Detail layer
-117. `docs/detail/accountability_matrix.md`
-118. `docs/detail/critical_incident_and_loss.md`
-119. `docs/detail/automated_decisioning_and_human_appeal.md`
-120. `docs/detail/youth_safety_and_age_assurance.md`
-121. `docs/detail/off_platform_handoff_and_scam_prevention.md`
-122. `docs/detail/data_deletion_vs_legal_hold.md`
-123. `docs/detail/security_and_autonomy_hardening.md`
-124. `docs/detail/realm_model.md`
-125. `docs/detail/data_scope_model.md`
-126. `docs/detail/mobility_model.md`
-127. `docs/detail/settlement_model.md`
-128. `docs/detail/settlement_backend_trait.md`
-129. `docs/detail/proof_of_infrastructure.md`
-130. `docs/detail/protected_groups_and_translation_safety.md`
+121. `docs/detail/accountability_matrix.md`
+122. `docs/detail/critical_incident_and_loss.md`
+123. `docs/detail/automated_decisioning_and_human_appeal.md`
+124. `docs/detail/youth_safety_and_age_assurance.md`
+125. `docs/detail/off_platform_handoff_and_scam_prevention.md`
+126. `docs/detail/data_deletion_vs_legal_hold.md`
+127. `docs/detail/security_and_autonomy_hardening.md`
+128. `docs/detail/realm_model.md`
+129. `docs/detail/data_scope_model.md`
+130. `docs/detail/mobility_model.md`
+131. `docs/detail/settlement_model.md`
+132. `docs/detail/settlement_backend_trait.md`
+133. `docs/detail/proof_of_infrastructure.md`
+134. `docs/detail/protected_groups_and_translation_safety.md`
 
 ### Whitepaper layer (contextual, not higher than detail/ADR)
-131. `docs/whitepaper/01_executive_summary.md`
-132. `docs/whitepaper/02_realm_model.md`
-133. `docs/whitepaper/03_experience_model.md`
-134. `docs/whitepaper/04_dm_shield.md`
-135. `docs/whitepaper/05_trust_model.md`
-136. `docs/whitepaper/06_promise_protocol.md`
-137. `docs/whitepaper/07_realm_economy.md`
-138. `docs/whitepaper/08_unlock_engine.md`
+135. `docs/whitepaper/01_executive_summary.md`
+136. `docs/whitepaper/02_realm_model.md`
+137. `docs/whitepaper/03_experience_model.md`
+138. `docs/whitepaper/04_dm_shield.md`
+139. `docs/whitepaper/05_trust_model.md`
+140. `docs/whitepaper/06_promise_protocol.md`
+141. `docs/whitepaper/07_realm_economy.md`
+142. `docs/whitepaper/08_unlock_engine.md`
 
 If any of the above are unavailable or materially inconsistent, stop and escalate.
 
@@ -285,7 +293,7 @@ That one-use C2 implementation allowance was consumed by `mt4110/pi-musubi-core`
 No remaining work may inherit permission from foundation PR #108 or implementation PR #88.
 The broad runtime implementation gate result remains NO-GO.
 Broad runtime implementation remains blocked.
-The current narrow downstream allowance is one implementation-repo test-only PR for post-C2 orchestration coordination prune nonterminal preservation verification.
+The current narrow downstream allowance is one implementation-repo test-only PR for post-C2 orchestration terminal archive payload preservation verification.
 
 The C2 and post-C2 readiness and closeout chain is accepted for docs-only foundation semantic scope:
 
@@ -352,9 +360,13 @@ The C2 and post-C2 readiness and closeout chain is accepted for docs-only founda
 - `docs/readiness/post_c2_orchestration_command_lease_reclaim_test_implementation_closeout_ledger.md`
 - `docs/readiness/post_c2_orchestration_prune_nonterminal_preservation_evidence_package.md`
 - `docs/readiness/post_c2_orchestration_prune_nonterminal_preservation_handoff_gate_decision.md`
+- `docs/readiness/post_c2_orchestration_prune_nonterminal_preservation_implementation_closeout_ledger.md`
+- `docs/readiness/post_c2_orchestration_terminal_archive_payload_preservation_evidence_package.md`
+- `docs/readiness/post_c2_orchestration_terminal_archive_payload_preservation_handoff_gate_decision.md`
 - `docs/operations/readiness_routine.md`
 - `docs/operations/runalways_readiness_orchestrator_design.md`
 - `docs/operations/runalways_readiness_orchestrator_stage0.md`
+- `docs/operations/runalways_lane_controller_v0_1.md`
 
 The accepted C2 gate records `bounded_promise_reliability` as the only positive Social Trust source-family candidate and accepts exact source facts and exact Social Trust mutation facts only as foundation semantic labels.
 Those labels are not runtime schema names, enum values, API names, migration names, module names, or test names.
@@ -429,11 +441,18 @@ It did not authorize runtime implementation, DDL, migrations, runtime tests, gat
 Foundation PR #221 provided the prior narrow downstream test-only handoff authority for one later implementation-repo PR only.
 That allowance was consumed by `mt4110/pi-musubi-core` PR #142 and closed out by foundation PR #223.
 Foundation PR #227 accepted the exact candidate test-only slice as post-C2 orchestration coordination prune nonterminal preservation verification.
-Foundation PR #229 provides the current narrow downstream test-only handoff authority for one later implementation-repo PR only.
+Foundation PR #229 provided the prior narrow downstream test-only handoff authority for one later implementation-repo PR only.
 This update is the required lock pin for that one-use allowance.
 It authorizes only `docs/foundation_lock.md`, `apps/backend/crates/orchestration/tests/postgres_contract.rs`, `apps/backend/docs/guardrails.md`, and `apps/backend/docs/raw_transaction_inventory.txt`.
 It allows only deterministic PostgreSQL-backed contract verification that existing coordination pruning preserves pending and processing outbox / command inbox coordination rows and does not archive or delete them as terminal coordination rows, plus the two named backend-local guardrail documentation updates.
 It does not authorize broad runtime implementation, DDL, migrations, backend runtime code, public API changes, mobile UI, projection refresh, new runtime orchestration behavior, retry workers, queues, outbox changes, inbox changes, lifecycle runtime behavior, pruning runtime behavior, archive runtime behavior, deletion, Legal Hold runtime behavior, evidence access runtime behavior, key lifecycle behavior, discovery, recommendation, room, settlement, Promise runtime behavior, proof runtime behavior, Relationship Depth behavior, Social Trust scoring, public trust display, or any broader `pi-musubi-core` change.
+That allowance was consumed by `mt4110/pi-musubi-core` PR #143 and closed out by foundation PR #231.
+Foundation PR #233 accepted the exact candidate test-only slice as post-C2 orchestration terminal archive payload preservation verification.
+Foundation PR #235 provides the current narrow downstream test-only handoff authority for one later implementation-repo PR only.
+This update is the required lock pin for that one-use allowance.
+It authorizes only `docs/foundation_lock.md`, `apps/backend/crates/orchestration/tests/postgres_contract.rs`, `apps/backend/docs/guardrails.md`, and `apps/backend/docs/raw_transaction_inventory.txt`.
+It allows only deterministic PostgreSQL-backed contract verification that existing coordination pruning preserves terminal coordination archive payload and correlation evidence when existing hot-table coordination rows are moved to archive tables before pruning, plus the two named backend-local guardrail documentation updates.
+It does not authorize broad runtime implementation, DDL, migrations, backend runtime code, public API changes, mobile UI, projection refresh, new runtime orchestration behavior, retry workers, queues, outbox changes, inbox changes, archive schema changes, manual-review provider evidence pruning behavior, lifecycle runtime behavior, pruning runtime behavior, archive runtime behavior, deletion, Legal Hold runtime behavior, evidence access runtime behavior, key lifecycle behavior, discovery, recommendation, room, settlement, Promise runtime behavior, proof runtime behavior, Relationship Depth behavior, Social Trust scoring, public trust display, or any broader `pi-musubi-core` change.
 
 Implementation merge history, issue order, branch ancestry, and existing code are not foundation design proof.
 
@@ -654,11 +673,11 @@ When updating:
 - Review completed by:
 
 ### Current drift note
-- Updated from foundation SHA: `575b60c7b7bcff3f64fbac87343f391478217583` -> `e619312e3963c0769d242602c595b2e752fc4766`
-- Reason: Align implementation-repo lock with the accepted foundation state after PR #229 (`docs: evaluate post-C2 orchestration prune nonterminal preservation handoff`).
-- New required docs: Post-C2 orchestration command lease reclaim test implementation closeout ledger; Post-C2 orchestration prune nonterminal preservation evidence package; Post-C2 orchestration prune nonterminal preservation handoff gate decision.
+- Updated from foundation SHA: `e619312e3963c0769d242602c595b2e752fc4766` -> `b3e8c9b370b320f86f39fc04e1fe0ca0feedf337`
+- Reason: Align implementation-repo lock with the accepted foundation state after PR #235 (`docs: evaluate post-C2 orchestration terminal archive payload preservation handoff`).
+- New required docs: Post-C2 orchestration prune nonterminal preservation implementation closeout ledger; Post-C2 orchestration terminal archive payload preservation evidence package; Post-C2 orchestration terminal archive payload preservation handoff gate decision; RunAlways Lane Controller v0.1 operations protocol.
 - Removed docs: None.
-- Implementation impact: PR #229 authorizes one later implementation-repo test-only PR. This PR may update this foundation lock, add deterministic PostgreSQL-backed coordination prune nonterminal preservation verification to `apps/backend/crates/orchestration/tests/postgres_contract.rs`, and update only `apps/backend/docs/guardrails.md` plus `apps/backend/docs/raw_transaction_inventory.txt` for the new guardrail test surface. Broad runtime implementation, DDL, migrations, backend runtime code, public API changes, mobile UI, projection refresh, new runtime orchestration behavior, retry workers, queues, outbox changes, inbox changes, lifecycle runtime behavior, pruning runtime behavior, archive runtime behavior, deletion, Legal Hold runtime behavior, evidence access runtime behavior, key lifecycle behavior, Relationship Depth behavior, Social Trust scoring, public trust display, and paid romantic advantage remain blocked.
+- Implementation impact: PR #235 authorizes one later implementation-repo test-only PR. This PR may update this foundation lock, add deterministic PostgreSQL-backed terminal coordination archive payload preservation verification to `apps/backend/crates/orchestration/tests/postgres_contract.rs`, and update only `apps/backend/docs/guardrails.md` plus `apps/backend/docs/raw_transaction_inventory.txt` for the new guardrail test surface. Broad runtime implementation, DDL, migrations, backend runtime code, public API changes, mobile UI, projection refresh, new runtime orchestration behavior, retry workers, queues, outbox changes, inbox changes, archive schema changes, manual-review provider evidence pruning behavior, lifecycle runtime behavior, pruning runtime behavior, archive runtime behavior, deletion, Legal Hold runtime behavior, evidence access runtime behavior, key lifecycle behavior, Relationship Depth behavior, Social Trust scoring, public trust display, and paid romantic advantage remain blocked.
 - Review completed by: Masaki Takemura
 
 ---


### PR DESCRIPTION
## Summary
- Pin `docs/foundation_lock.md` to foundation PR #235 and add the required evidence / handoff reading order.
- Add a PostgreSQL contract test proving terminal coordination pruning preserves archive payload and correlation evidence.
- Update backend guardrail docs and raw transaction inventory for the new test surface.

## Foundation authority
- Authorized by https://github.com/mt4110/musubi-foundation/pull/235.
- Exact downstream files only: `docs/foundation_lock.md`, `apps/backend/crates/orchestration/tests/postgres_contract.rs`, `apps/backend/docs/guardrails.md`, `apps/backend/docs/raw_transaction_inventory.txt`.
- No runtime code, DDL, migration, API, UI, queue, retry, archive schema, or manual-review provider evidence pruning behavior changes.

## Verification
- `rustfmt --edition 2024 --check apps/backend/crates/orchestration/tests/postgres_contract.rs`
- `git diff --check`
- `MUSUBI_TEST_DATABASE_URL=<postgres test database> cargo test -p musubi_orchestration postgres_prune_preserves_terminal_archive_payloads`
- `MUSUBI_TEST_DATABASE_URL=<postgres test database> cargo test -p musubi_orchestration postgres_prune_`
- `MUSUBI_TEST_DATABASE_URL=<temporary clean postgres database> cargo test -p musubi_orchestration`
- `make guardrail-sweep`
- `make guardrail-sweep-self-test`
