### PR TITLE
test: cover orchestration prune archive conflict idempotency

### DIFF
--- a/apps/backend/crates/orchestration/tests/postgres_contract.rs
+++ b/apps/backend/crates/orchestration/tests/postgres_contract.rs
@@ -1561,6 +1561,399 @@ async fn postgres_prune_preserves_terminal_quarantine_archive_diagnostics() {
 }
 
 #[tokio::test]
+async fn postgres_prune_is_idempotent_with_existing_archive_rows() {
+    let Ok(database_url) = std::env::var("MUSUBI_TEST_DATABASE_URL") else {
+        return;
+    };
+
+    let (mut client, connection) = tokio_postgres::connect(&database_url, NoTls)
+        .await
+        .expect("failed to connect to MUSUBI_TEST_DATABASE_URL");
+    tokio::spawn(async move {
+        let _ = connection.await;
+    });
+
+    let tx = client
+        .transaction()
+        .await
+        .expect("failed to open transaction");
+    tx.batch_execute(include_str!(
+        "../../../migrations/0004_create_outbox_schema.sql"
+    ))
+    .await
+    .expect("failed to apply outbox schema");
+    tx.batch_execute(include_str!(
+        "../../../migrations/0006_orchestration_runtime_baseline.sql"
+    ))
+    .await
+    .expect("failed to apply orchestration baseline migration");
+
+    let aggregate_id = Uuid::from_u128(0x727);
+    let event_id = Uuid::from_u128(0x728);
+    let command_id = Uuid::from_u128(0x729);
+    let message = NewOutboxMessage::new(NewOutboxMessageSpec {
+        event_id,
+        idempotency_key: Uuid::from_u128(0x72a),
+        stream_key: "settlement_case:archive-conflict".to_owned(),
+        aggregate_type: "settlement_case".to_owned(),
+        aggregate_id,
+        event_type: "settlement.submit_action".to_owned(),
+        schema_version: 1,
+        payload_json: json!({
+            "intent_id": "intent-archive-conflict",
+            "retention_probe": { "kind": "archive_conflict_idempotency" }
+        }),
+        available_at: ts(0),
+        created_at: ts(0),
+    })
+    .unwrap();
+
+    PostgresOrchestrationStore::insert_outbox_message(&tx, &message)
+        .await
+        .expect("failed to insert archive conflict outbox message");
+    tx.execute(
+        "
+        UPDATE outbox.events
+        SET delivery_status = 'published',
+            attempt_count = 1,
+            published_at = $2,
+            last_attempt_at = $2,
+            retain_until = $3,
+            published_external_idempotency_key = $4
+        WHERE event_id = $1
+        ",
+        &[
+            &event_id,
+            &ts(10),
+            &ts(100),
+            &"provider-key-archive-conflict",
+        ],
+    )
+    .await
+    .expect("failed to mark archive conflict outbox event terminal");
+    let causal_order: i64 = tx
+        .query_one(
+            "SELECT causal_order FROM outbox.events WHERE event_id = $1",
+            &[&event_id],
+        )
+        .await
+        .expect("failed to read archive conflict causal order")
+        .get("causal_order");
+    tx.execute(
+        "
+        INSERT INTO outbox.outbox_attempts (
+            event_id,
+            attempt_number,
+            relay_name,
+            claimed_at,
+            claimed_until,
+            finished_at,
+            failure_class,
+            failure_code,
+            failure_detail,
+            external_idempotency_key
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, NULL, NULL, NULL, $7)
+        ",
+        &[
+            &event_id,
+            &1_i32,
+            &"settlement-relay",
+            &ts(0),
+            &ts(300),
+            &ts(10),
+            &"provider-key-archive-conflict",
+        ],
+    )
+    .await
+    .expect("failed to insert archive conflict outbox attempt");
+
+    let command = CommandEnvelope::new(
+        command_id,
+        event_id,
+        "projection.refresh",
+        1,
+        json!({ "settlement_case_id": aggregate_id }),
+    )
+    .unwrap();
+    let result_json = json!({
+        "projection_id": "projection-archive-conflict",
+        "archive_conflict_seen": true
+    });
+    tx.execute(
+        "
+        INSERT INTO outbox.command_inbox (
+            inbox_entry_id,
+            consumer_name,
+            command_id,
+            source_event_id,
+            payload_checksum,
+            received_at,
+            status,
+            available_at,
+            attempt_count,
+            command_type,
+            schema_version,
+            completed_at,
+            result_type,
+            result_json,
+            retain_until
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, 'completed', $6, 1, $7, $8, $9, $10, $11, $12)
+        ",
+        &[
+            &Uuid::new_v4(),
+            &"projection-builder",
+            &command_id,
+            &event_id,
+            &command.payload_hash,
+            &ts(20),
+            &command.command_type,
+            &command.schema_version,
+            &ts(30),
+            &"projected",
+            &result_json,
+            &ts(100),
+        ],
+    )
+    .await
+    .expect("failed to insert archive conflict command inbox row");
+
+    tx.execute(
+        "
+        INSERT INTO outbox.outbox_event_archive (
+            event_id,
+            archived_at,
+            stream_key,
+            aggregate_type,
+            aggregate_id,
+            event_type,
+            schema_version,
+            payload_json,
+            payload_hash,
+            final_status,
+            attempt_count,
+            causal_order,
+            available_at,
+            created_at,
+            published_at,
+            quarantined_at,
+            last_attempt_at,
+            last_error_class,
+            last_error_code,
+            last_error_detail,
+            quarantine_reason,
+            retain_until,
+            published_external_idempotency_key
+        )
+        VALUES (
+            $1, $2, $3, $4, $5, $6, 1, $7, $8, 'published', 1, $9,
+            $10, $10, $11, NULL, $11, NULL, NULL, NULL, NULL, $12, $13
+        )
+        ",
+        &[
+            &event_id,
+            &ts(150),
+            &message.stream_key,
+            &message.aggregate_type,
+            &aggregate_id,
+            &message.event_type,
+            &message.payload_json,
+            &message.payload_hash,
+            &causal_order,
+            &ts(0),
+            &ts(10),
+            &ts(100),
+            &"provider-key-archive-conflict",
+        ],
+    )
+    .await
+    .expect("failed to seed existing outbox event archive row");
+    tx.execute(
+        "
+        INSERT INTO outbox.outbox_attempt_archive (
+            event_id,
+            attempt_number,
+            archived_at,
+            relay_name,
+            claimed_at,
+            claimed_until,
+            finished_at,
+            failure_class,
+            failure_code,
+            failure_detail,
+            external_idempotency_key
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, $7, NULL, NULL, NULL, $8)
+        ",
+        &[
+            &event_id,
+            &1_i32,
+            &ts(151),
+            &"settlement-relay",
+            &ts(0),
+            &ts(300),
+            &ts(10),
+            &"provider-key-archive-conflict",
+        ],
+    )
+    .await
+    .expect("failed to seed existing outbox attempt archive row");
+    tx.execute(
+        "
+        INSERT INTO outbox.command_inbox_archive (
+            consumer_name,
+            command_id,
+            source_event_id,
+            archived_at,
+            command_type,
+            schema_version,
+            status,
+            attempt_count,
+            payload_checksum,
+            received_at,
+            processed_at,
+            completed_at,
+            last_error_class,
+            last_error_code,
+            last_error_detail,
+            quarantine_reason,
+            result_type,
+            result_json,
+            retain_until
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, 'completed', 1, $7, $8, NULL, $9, NULL, NULL, NULL, NULL, $10, $11, $12)
+        ",
+        &[
+            &"projection-builder",
+            &command_id,
+            &event_id,
+            &ts(152),
+            &command.command_type,
+            &command.schema_version,
+            &command.payload_hash,
+            &ts(20),
+            &ts(30),
+            &"projected",
+            &result_json,
+            &ts(100),
+        ],
+    )
+    .await
+    .expect("failed to seed existing command inbox archive row");
+
+    let first = PostgresOrchestrationStore::prune_coordination(&tx, ts(200))
+        .await
+        .expect("failed to prune archive conflict coordination rows");
+
+    assert_eq!(first.pruned_outbox_event_ids, vec![event_id]);
+    assert_eq!(
+        first.pruned_command_keys,
+        vec![CommandKey {
+            consumer_name: "projection-builder".to_owned(),
+            command_id,
+        }]
+    );
+
+    let second = PostgresOrchestrationStore::prune_coordination(&tx, ts(201))
+        .await
+        .expect("second archive conflict prune should be idempotent");
+
+    assert!(second.pruned_outbox_event_ids.is_empty());
+    assert!(second.pruned_command_keys.is_empty());
+
+    let archived_event = tx
+        .query_one(
+            "
+            SELECT COUNT(*) AS count, MIN(archived_at) AS archived_at
+            FROM outbox.outbox_event_archive
+            WHERE event_id = $1
+            ",
+            &[&event_id],
+        )
+        .await
+        .expect("failed to read archive conflict outbox archive state");
+    let archived_attempt = tx
+        .query_one(
+            "
+            SELECT COUNT(*) AS count, MIN(archived_at) AS archived_at
+            FROM outbox.outbox_attempt_archive
+            WHERE event_id = $1
+              AND attempt_number = $2
+            ",
+            &[&event_id, &1_i32],
+        )
+        .await
+        .expect("failed to read archive conflict attempt archive state");
+    let archived_command = tx
+        .query_one(
+            "
+            SELECT COUNT(*) AS count, MIN(archived_at) AS archived_at
+            FROM outbox.command_inbox_archive
+            WHERE consumer_name = $1
+              AND command_id = $2
+            ",
+            &[&"projection-builder", &command_id],
+        )
+        .await
+        .expect("failed to read archive conflict command archive state");
+
+    assert_eq!(archived_event.get::<_, i64>("count"), 1);
+    assert_eq!(
+        archived_event.get::<_, chrono::DateTime<Utc>>("archived_at"),
+        ts(150)
+    );
+    assert_eq!(archived_attempt.get::<_, i64>("count"), 1);
+    assert_eq!(
+        archived_attempt.get::<_, chrono::DateTime<Utc>>("archived_at"),
+        ts(151)
+    );
+    assert_eq!(archived_command.get::<_, i64>("count"), 1);
+    assert_eq!(
+        archived_command.get::<_, chrono::DateTime<Utc>>("archived_at"),
+        ts(152)
+    );
+
+    let hot_outbox_count: i64 = tx
+        .query_one(
+            "SELECT COUNT(*) AS count FROM outbox.events WHERE event_id = $1",
+            &[&event_id],
+        )
+        .await
+        .expect("failed to count hot outbox events after archive conflict prune")
+        .get("count");
+    let hot_attempt_count: i64 = tx
+        .query_one(
+            "SELECT COUNT(*) AS count FROM outbox.outbox_attempts WHERE event_id = $1",
+            &[&event_id],
+        )
+        .await
+        .expect("failed to count hot outbox attempts after archive conflict prune")
+        .get("count");
+    let hot_command_count: i64 = tx
+        .query_one(
+            "
+            SELECT COUNT(*) AS count
+            FROM outbox.command_inbox
+            WHERE consumer_name = $1
+              AND command_id = $2
+            ",
+            &[&"projection-builder", &command_id],
+        )
+        .await
+        .expect("failed to count hot command rows after archive conflict prune")
+        .get("count");
+
+    assert_eq!(hot_outbox_count, 0);
+    assert_eq!(hot_attempt_count, 0);
+    assert_eq!(hot_command_count, 0);
+
+    tx.rollback()
+        .await
+        .expect("rollback should clean up transactional test state");
+}
+
+#[tokio::test]
 async fn postgres_prune_preserves_nonterminal_coordination_rows() {
     let Ok(database_url) = std::env::var("MUSUBI_TEST_DATABASE_URL") else {
         return;

--- a/apps/backend/docs/guardrails.md
+++ b/apps/backend/docs/guardrails.md
@@ -131,16 +131,19 @@ Current executable tests:
 - `postgres_prune_archives_terminal_coordination_rows`
 - `postgres_prune_preserves_terminal_archive_payloads`
 - `postgres_prune_preserves_terminal_quarantine_archive_diagnostics`
+- `postgres_prune_is_idempotent_with_existing_archive_rows`
 - `postgres_prune_preserves_nonterminal_coordination_rows`
 
 These prove terminal outbox and command-inbox coordination rows are archived
 before hot-table pruning removes them. The PostgreSQL-backed contract covers
 event archive, attempt archive, command-inbox archive, archive payload and
 correlation evidence preservation, terminal quarantine diagnostic preservation,
-and the returned prune outcome on the real schema. The nonterminal preservation
-contract proves that pending and processing coordination rows are not archived
-or deleted by the same prune helper, even when their retention timestamp is
-already in the past.
+archive conflict idempotency, and the returned prune outcome on the real schema.
+The archive conflict contract proves preexisting archive rows are not duplicated
+or overwritten while matching prune-ready hot rows are removed. The nonterminal
+preservation contract proves that pending and processing coordination rows are
+not archived or deleted by the same prune helper, even when their retention
+timestamp is already in the past.
 
 ### 5. Drop-Tx-Before-Await at the runtime seam
 

--- a/apps/backend/docs/raw_transaction_inventory.txt
+++ b/apps/backend/docs/raw_transaction_inventory.txt
@@ -1,6 +1,6 @@
 1 apps/backend/crates/db-runtime/src/migrations.rs
 4 apps/backend/crates/orchestration/src/postgres.rs
-12 apps/backend/crates/orchestration/tests/postgres_contract.rs
+13 apps/backend/crates/orchestration/tests/postgres_contract.rs
 37 apps/backend/src/services/happy_route/repository.rs
 6 apps/backend/src/services/operator_review/repository.rs
 7 apps/backend/src/services/realm_bootstrap/repository.rs

--- a/docs/foundation_lock.md
+++ b/docs/foundation_lock.md
@@ -1,6 +1,6 @@
 # Foundation Lock
 
-Status: Draft; aligned to accepted foundation commit `5862e40`
+Status: Draft; aligned to accepted foundation commit `4f1faaf`
 Applies to: `mt4110/pi-musubi-core`
 Purpose: Pin the constitutional and architectural source of truth that this implementation repository must follow.
 
@@ -26,14 +26,14 @@ Upstream repository:
 Pinned reference for implementation work:
 
 - Foundation reference type: `commit`
-- Foundation commit SHA: `5862e402ce37a0ac77001d23b956a8ff9ac1c746`
-- Foundation commit title: `Merge pull request #241 from mt4110/feat/post-c2-orchestration-terminal-quarantine-archive-diagnostics-preservation-handoff`
-- Foundation PR title: `docs: evaluate post-C2 orchestration terminal quarantine archive diagnostics preservation handoff`
-- Foundation PR URL: `https://github.com/mt4110/musubi-foundation/pull/241`
+- Foundation commit SHA: `4f1faafe231faf6ae4ad8314a3650d5e6f781e37`
+- Foundation commit title: `Merge pull request #247 from mt4110/feat/post-c2-orchestration-prune-archive-conflict-idempotency-handoff`
+- Foundation PR title: `docs: evaluate post-C2 orchestration prune archive conflict idempotency handoff`
+- Foundation PR URL: `https://github.com/mt4110/musubi-foundation/pull/247`
 - Date pinned: `2026-06-11`
 - Pinned by: `Masaki Takemura`
-- Pinned commit URL: `https://github.com/mt4110/musubi-foundation/commit/5862e402ce37a0ac77001d23b956a8ff9ac1c746`
-- Previous pinned reference: `b3e8c9b` / `Merge pull request #235 from mt4110/feat/post-c2-orchestration-terminal-archive-payload-preservation-handoff`
+- Pinned commit URL: `https://github.com/mt4110/musubi-foundation/commit/4f1faafe231faf6ae4ad8314a3650d5e6f781e37`
+- Previous pinned reference: `5862e40` / `Merge pull request #241 from mt4110/feat/post-c2-orchestration-terminal-quarantine-archive-diagnostics-preservation-handoff`
 - Post-C2 evidence source: `cfdba28` / `Merge pull request #114 from mt4110/feat/post-c2-runtime-handoff-evidence-package`
 - Alignment allowance source: `69b7aa4` / `Merge pull request #116 from mt4110/feat/evaluate-post-c2-runtime-handoff-gate`
 - Post-C2 implementation handoff evidence source: `ef23e88` / `Merge pull request #122 from mt4110/feat/post-c2-implementation-handoff-evidence-package`
@@ -100,6 +100,9 @@ Pinned reference for implementation work:
 - Post-C2 orchestration terminal archive payload preservation implementation closeout source: `ebccabd` / `Merge pull request #237 from mt4110/feat/close-orchestration-terminal-archive-payload-handoff`
 - Post-C2 orchestration terminal quarantine archive diagnostics preservation evidence source: `393f370` / `Merge pull request #239 from mt4110/feat/orchestration-terminal-quarantine-archive-diagnostics-evidence`
 - Post-C2 orchestration terminal quarantine archive diagnostics preservation handoff source: `5862e40` / `Merge pull request #241 from mt4110/feat/post-c2-orchestration-terminal-quarantine-archive-diagnostics-preservation-handoff`
+- Post-C2 orchestration terminal quarantine archive diagnostics preservation implementation closeout source: `6d72b8d` / `Merge pull request #243 from mt4110/feat/close-orchestration-terminal-quarantine-archive-diagnostics-handoff`
+- Post-C2 orchestration prune archive conflict idempotency evidence source: `57ee247` / `Merge pull request #245 from mt4110/feat/orchestration-prune-archive-conflict-idempotency-evidence`
+- Post-C2 orchestration prune archive conflict idempotency handoff source: `4f1faaf` / `Merge pull request #247 from mt4110/feat/post-c2-orchestration-prune-archive-conflict-idempotency-handoff`
 
 No release tag is asserted for this alignment.
 Do not invent a foundation version label for this commit.
@@ -237,38 +240,41 @@ Before coding, read these upstream documents in order.
 117. `docs/readiness/post_c2_orchestration_terminal_archive_payload_preservation_implementation_closeout_ledger.md`
 118. `docs/readiness/post_c2_orchestration_terminal_quarantine_archive_diagnostics_preservation_evidence_package.md`
 119. `docs/readiness/post_c2_orchestration_terminal_quarantine_archive_diagnostics_preservation_handoff_gate_decision.md`
+120. `docs/readiness/post_c2_orchestration_terminal_quarantine_archive_diagnostics_preservation_implementation_closeout_ledger.md`
+121. `docs/readiness/post_c2_orchestration_prune_archive_conflict_idempotency_evidence_package.md`
+122. `docs/readiness/post_c2_orchestration_prune_archive_conflict_idempotency_handoff_gate_decision.md`
 
 ### Operations layer
-120. `docs/operations/readiness_routine.md`
-121. `docs/operations/runalways_readiness_orchestrator_design.md`
-122. `docs/operations/runalways_readiness_orchestrator_stage0.md`
-123. `docs/operations/runalways_lane_controller_v0_1.md`
+123. `docs/operations/readiness_routine.md`
+124. `docs/operations/runalways_readiness_orchestrator_design.md`
+125. `docs/operations/runalways_readiness_orchestrator_stage0.md`
+126. `docs/operations/runalways_lane_controller_v0_1.md`
 
 ### Detail layer
-124. `docs/detail/accountability_matrix.md`
-125. `docs/detail/critical_incident_and_loss.md`
-126. `docs/detail/automated_decisioning_and_human_appeal.md`
-127. `docs/detail/youth_safety_and_age_assurance.md`
-128. `docs/detail/off_platform_handoff_and_scam_prevention.md`
-129. `docs/detail/data_deletion_vs_legal_hold.md`
-130. `docs/detail/security_and_autonomy_hardening.md`
-131. `docs/detail/realm_model.md`
-132. `docs/detail/data_scope_model.md`
-133. `docs/detail/mobility_model.md`
-134. `docs/detail/settlement_model.md`
-135. `docs/detail/settlement_backend_trait.md`
-136. `docs/detail/proof_of_infrastructure.md`
-137. `docs/detail/protected_groups_and_translation_safety.md`
+127. `docs/detail/accountability_matrix.md`
+128. `docs/detail/critical_incident_and_loss.md`
+129. `docs/detail/automated_decisioning_and_human_appeal.md`
+130. `docs/detail/youth_safety_and_age_assurance.md`
+131. `docs/detail/off_platform_handoff_and_scam_prevention.md`
+132. `docs/detail/data_deletion_vs_legal_hold.md`
+133. `docs/detail/security_and_autonomy_hardening.md`
+134. `docs/detail/realm_model.md`
+135. `docs/detail/data_scope_model.md`
+136. `docs/detail/mobility_model.md`
+137. `docs/detail/settlement_model.md`
+138. `docs/detail/settlement_backend_trait.md`
+139. `docs/detail/proof_of_infrastructure.md`
+140. `docs/detail/protected_groups_and_translation_safety.md`
 
 ### Whitepaper layer (contextual, not higher than detail/ADR)
-138. `docs/whitepaper/01_executive_summary.md`
-139. `docs/whitepaper/02_realm_model.md`
-140. `docs/whitepaper/03_experience_model.md`
-141. `docs/whitepaper/04_dm_shield.md`
-142. `docs/whitepaper/05_trust_model.md`
-143. `docs/whitepaper/06_promise_protocol.md`
-144. `docs/whitepaper/07_realm_economy.md`
-145. `docs/whitepaper/08_unlock_engine.md`
+141. `docs/whitepaper/01_executive_summary.md`
+142. `docs/whitepaper/02_realm_model.md`
+143. `docs/whitepaper/03_experience_model.md`
+144. `docs/whitepaper/04_dm_shield.md`
+145. `docs/whitepaper/05_trust_model.md`
+146. `docs/whitepaper/06_promise_protocol.md`
+147. `docs/whitepaper/07_realm_economy.md`
+148. `docs/whitepaper/08_unlock_engine.md`
 
 If any of the above are unavailable or materially inconsistent, stop and escalate.
 
@@ -299,7 +305,7 @@ That one-use C2 implementation allowance was consumed by `mt4110/pi-musubi-core`
 No remaining work may inherit permission from foundation PR #108 or implementation PR #88.
 The broad runtime implementation gate result remains NO-GO.
 Broad runtime implementation remains blocked.
-The current narrow downstream allowance is one implementation-repo test-only PR for post-C2 orchestration terminal quarantine archive diagnostics preservation verification.
+The current narrow downstream allowance is one implementation-repo test-only PR for post-C2 orchestration prune archive conflict idempotency verification.
 
 The C2 and post-C2 readiness and closeout chain is accepted for docs-only foundation semantic scope:
 
@@ -372,6 +378,9 @@ The C2 and post-C2 readiness and closeout chain is accepted for docs-only founda
 - `docs/readiness/post_c2_orchestration_terminal_archive_payload_preservation_implementation_closeout_ledger.md`
 - `docs/readiness/post_c2_orchestration_terminal_quarantine_archive_diagnostics_preservation_evidence_package.md`
 - `docs/readiness/post_c2_orchestration_terminal_quarantine_archive_diagnostics_preservation_handoff_gate_decision.md`
+- `docs/readiness/post_c2_orchestration_terminal_quarantine_archive_diagnostics_preservation_implementation_closeout_ledger.md`
+- `docs/readiness/post_c2_orchestration_prune_archive_conflict_idempotency_evidence_package.md`
+- `docs/readiness/post_c2_orchestration_prune_archive_conflict_idempotency_handoff_gate_decision.md`
 - `docs/operations/readiness_routine.md`
 - `docs/operations/runalways_readiness_orchestrator_design.md`
 - `docs/operations/runalways_readiness_orchestrator_stage0.md`
@@ -462,11 +471,17 @@ It allowed only deterministic PostgreSQL-backed contract verification that exist
 It did not authorize broad runtime implementation, DDL, migrations, backend runtime code, public API changes, mobile UI, projection refresh, new runtime orchestration behavior, retry workers, queues, outbox changes, inbox changes, archive schema changes, manual-review provider evidence pruning behavior, lifecycle runtime behavior, pruning runtime behavior, archive runtime behavior, deletion, Legal Hold runtime behavior, evidence access runtime behavior, key lifecycle behavior, discovery, recommendation, room, settlement, Promise runtime behavior, proof runtime behavior, Relationship Depth behavior, Social Trust scoring, public trust display, or any broader `pi-musubi-core` change.
 That allowance was consumed by `mt4110/pi-musubi-core` PR #144 and closed out by foundation PR #237.
 Foundation PR #239 accepted the exact candidate test-only slice as post-C2 orchestration terminal quarantine archive diagnostics preservation verification.
-Foundation PR #241 provides the current narrow downstream test-only handoff authority for one later implementation-repo PR only.
+Foundation PR #241 provided the prior narrow downstream test-only handoff authority for one later implementation-repo PR only.
+That consumed lock update authorized only `docs/foundation_lock.md`, `apps/backend/crates/orchestration/tests/postgres_contract.rs`, `apps/backend/docs/guardrails.md`, and `apps/backend/docs/raw_transaction_inventory.txt`.
+It allowed only deterministic PostgreSQL-backed contract verification that existing coordination pruning preserves terminal quarantine and failure diagnostics when existing hot-table coordination rows are moved to archive tables before pruning, plus the two named backend-local guardrail documentation updates.
+It does not authorize broad runtime implementation, DDL, migrations, backend runtime code, public API changes, mobile UI, projection refresh, new runtime orchestration behavior, retry workers, queues, outbox changes, inbox changes, archive schema changes, manual-review provider evidence pruning behavior, lifecycle runtime behavior, pruning runtime behavior, archive runtime behavior, deletion, Legal Hold runtime behavior, evidence access runtime behavior, key lifecycle behavior, discovery, recommendation, room, settlement, Promise runtime behavior, proof runtime behavior, Relationship Depth behavior, Social Trust scoring, public trust display, or any broader `pi-musubi-core` change.
+That allowance was consumed by `mt4110/pi-musubi-core` PR #145 and closed out by foundation PR #243.
+Foundation PR #245 accepted the exact candidate test-only slice as post-C2 orchestration prune archive conflict idempotency verification.
+Foundation PR #247 provides the current narrow downstream test-only handoff authority for one later implementation-repo PR only.
 This update is the required lock pin for that one-use allowance.
 It authorizes only `docs/foundation_lock.md`, `apps/backend/crates/orchestration/tests/postgres_contract.rs`, `apps/backend/docs/guardrails.md`, and `apps/backend/docs/raw_transaction_inventory.txt`.
-It allows only deterministic PostgreSQL-backed contract verification that existing coordination pruning preserves terminal quarantine and failure diagnostics when existing hot-table coordination rows are moved to archive tables before pruning, plus the two named backend-local guardrail documentation updates.
-It does not authorize broad runtime implementation, DDL, migrations, backend runtime code, public API changes, mobile UI, projection refresh, new runtime orchestration behavior, retry workers, queues, outbox changes, inbox changes, archive schema changes, manual-review provider evidence pruning behavior, lifecycle runtime behavior, pruning runtime behavior, archive runtime behavior, deletion, Legal Hold runtime behavior, evidence access runtime behavior, key lifecycle behavior, discovery, recommendation, room, settlement, Promise runtime behavior, proof runtime behavior, Relationship Depth behavior, Social Trust scoring, public trust display, or any broader `pi-musubi-core` change.
+It allows only deterministic PostgreSQL-backed contract verification that existing coordination pruning remains idempotent when matching coordination archive rows already exist before pruning terminal hot rows, plus the two named backend-local guardrail documentation updates.
+It does not authorize broad runtime implementation, DDL, migrations, backend runtime code, public API changes, mobile UI, projection refresh, new runtime orchestration behavior, retry workers, queues, outbox changes, inbox changes, archive schema changes, manual-review provider evidence pruning behavior, lifecycle runtime behavior, pruning runtime behavior, archive runtime behavior, deletion, Legal Hold runtime behavior, evidence access runtime behavior, key lifecycle behavior, concurrency tests that require timing assumptions or runner-specific scheduling behavior, provider callbacks, network I/O, external guarantees, scheduled workers, repository workflow changes, secrets, credentials, self-hosted runners, branch protection changes, discovery, recommendation, room, settlement, Promise runtime behavior, proof runtime behavior, Relationship Depth behavior, Social Trust scoring, public trust display, or any broader `pi-musubi-core` change.
 
 Implementation merge history, issue order, branch ancestry, and existing code are not foundation design proof.
 
@@ -687,11 +702,11 @@ When updating:
 - Review completed by:
 
 ### Current drift note
-- Updated from foundation SHA: `b3e8c9b370b320f86f39fc04e1fe0ca0feedf337` -> `5862e402ce37a0ac77001d23b956a8ff9ac1c746`
-- Reason: Align implementation-repo lock with the accepted foundation state after PR #241 (`docs: evaluate post-C2 orchestration terminal quarantine archive diagnostics preservation handoff`).
-- New required docs: Post-C2 orchestration terminal archive payload preservation implementation closeout ledger; Post-C2 orchestration terminal quarantine archive diagnostics preservation evidence package; Post-C2 orchestration terminal quarantine archive diagnostics preservation handoff gate decision.
+- Updated from foundation SHA: `5862e402ce37a0ac77001d23b956a8ff9ac1c746` -> `4f1faafe231faf6ae4ad8314a3650d5e6f781e37`
+- Reason: Align implementation-repo lock with the accepted foundation state after PR #247 (`docs: evaluate post-C2 orchestration prune archive conflict idempotency handoff`).
+- New required docs: Post-C2 orchestration terminal quarantine archive diagnostics preservation implementation closeout ledger; Post-C2 orchestration prune archive conflict idempotency evidence package; Post-C2 orchestration prune archive conflict idempotency handoff gate decision.
 - Removed docs: None.
-- Implementation impact: PR #241 authorizes one later implementation-repo test-only PR. This PR may update this foundation lock, add deterministic PostgreSQL-backed terminal quarantine archive diagnostics preservation verification to `apps/backend/crates/orchestration/tests/postgres_contract.rs`, and update only `apps/backend/docs/guardrails.md` plus `apps/backend/docs/raw_transaction_inventory.txt` for the new guardrail test surface. Broad runtime implementation, DDL, migrations, backend runtime code, public API changes, mobile UI, projection refresh, new runtime orchestration behavior, retry workers, queues, outbox changes, inbox changes, archive schema changes, manual-review provider evidence pruning behavior, lifecycle runtime behavior, pruning runtime behavior, archive runtime behavior, deletion, Legal Hold runtime behavior, evidence access runtime behavior, key lifecycle behavior, Relationship Depth behavior, Social Trust scoring, public trust display, and paid romantic advantage remain blocked.
+- Implementation impact: PR #247 authorizes one later implementation-repo test-only PR. This PR may update this foundation lock, add deterministic PostgreSQL-backed archive conflict idempotency verification to `apps/backend/crates/orchestration/tests/postgres_contract.rs`, and update only `apps/backend/docs/guardrails.md` plus `apps/backend/docs/raw_transaction_inventory.txt` for the new guardrail test surface. Broad runtime implementation, DDL, migrations, backend runtime code, public API changes, mobile UI, projection refresh, new runtime orchestration behavior, retry workers, queues, outbox changes, inbox changes, archive schema changes, manual-review provider evidence pruning behavior, lifecycle runtime behavior, pruning runtime behavior, archive runtime behavior, deletion, Legal Hold runtime behavior, evidence access runtime behavior, key lifecycle behavior, Relationship Depth behavior, Social Trust scoring, public trust display, concurrency tests that require timing assumptions or runner-specific scheduling behavior, provider callbacks, network I/O, external guarantees, scheduled workers, repository workflow changes, secrets, credentials, self-hosted runners, branch protection changes, and paid romantic advantage remain blocked.
 - Review completed by: Masaki Takemura
 
 ---


### PR DESCRIPTION
## Scope
- Pin `docs/foundation_lock.md` to the accepted foundation handoff in mt4110/musubi-foundation#247.
- Add a deterministic PostgreSQL contract test proving prune/archive conflict idempotency with preexisting archive rows.
- Update backend guardrail docs and raw transaction inventory for the new test surface.

## Validation
- `rustfmt --edition 2024 --check apps/backend/crates/orchestration/tests/postgres_contract.rs`
- `MUSUBI_TEST_DATABASE_URL=postgres://localhost:55432/musubi_core_test cargo test -p musubi_orchestration postgres_prune_is_idempotent_with_existing_archive_rows`
- `MUSUBI_TEST_DATABASE_URL=postgres://localhost:55432/musubi_core_test cargo test -p musubi_orchestration postgres_prune_`
- `MUSUBI_TEST_DATABASE_URL=postgres://localhost:55432/musubi_core_test cargo test -p musubi_orchestration`
- `make guardrail-sweep`
- `make guardrail-sweep-self-test`
- `git diff --check origin/main...HEAD`