### PR TITLE
test: cover orchestration terminal prune retention eligibility

### DIFF
--- a/apps/backend/crates/orchestration/tests/postgres_contract.rs
+++ b/apps/backend/crates/orchestration/tests/postgres_contract.rs
@@ -1954,6 +1954,460 @@ async fn postgres_prune_is_idempotent_with_existing_archive_rows() {
 }
 
 #[tokio::test]
+async fn postgres_prune_preserves_terminal_rows_before_retain_until() {
+    let Ok(database_url) = std::env::var("MUSUBI_TEST_DATABASE_URL") else {
+        return;
+    };
+
+    let (mut client, connection) = tokio_postgres::connect(&database_url, NoTls)
+        .await
+        .expect("failed to connect to MUSUBI_TEST_DATABASE_URL");
+    tokio::spawn(async move {
+        let _ = connection.await;
+    });
+
+    let tx = client
+        .transaction()
+        .await
+        .expect("failed to open transaction");
+    tx.batch_execute(include_str!(
+        "../../../migrations/0004_create_outbox_schema.sql"
+    ))
+    .await
+    .expect("failed to apply outbox schema");
+    tx.batch_execute(include_str!(
+        "../../../migrations/0006_orchestration_runtime_baseline.sql"
+    ))
+    .await
+    .expect("failed to apply orchestration baseline migration");
+
+    let published_null_event_id = Uuid::from_u128(0x72b);
+    let published_future_event_id = Uuid::from_u128(0x72c);
+    let quarantined_null_event_id = Uuid::from_u128(0x72d);
+    let quarantined_future_event_id = Uuid::from_u128(0x72e);
+    let completed_null_command_id = Uuid::from_u128(0x737);
+    let completed_future_command_id = Uuid::from_u128(0x738);
+    let quarantined_null_command_id = Uuid::from_u128(0x739);
+    let quarantined_future_command_id = Uuid::from_u128(0x73a);
+
+    let outbox_cases: [(Uuid, Uuid, Uuid, &str, &str, Option<chrono::DateTime<Utc>>); 4] = [
+        (
+            published_null_event_id,
+            Uuid::from_u128(0x72f),
+            Uuid::from_u128(0x733),
+            "published-retain-null",
+            "published",
+            None,
+        ),
+        (
+            published_future_event_id,
+            Uuid::from_u128(0x730),
+            Uuid::from_u128(0x734),
+            "published-retain-future",
+            "published",
+            Some(ts(300)),
+        ),
+        (
+            quarantined_null_event_id,
+            Uuid::from_u128(0x731),
+            Uuid::from_u128(0x735),
+            "quarantined-retain-null",
+            "quarantined",
+            None,
+        ),
+        (
+            quarantined_future_event_id,
+            Uuid::from_u128(0x732),
+            Uuid::from_u128(0x736),
+            "quarantined-retain-future",
+            "quarantined",
+            Some(ts(300)),
+        ),
+    ];
+
+    for (event_id, idempotency_key, aggregate_id, label, delivery_status, retain_until) in
+        outbox_cases
+    {
+        let message = NewOutboxMessage::new(NewOutboxMessageSpec {
+            event_id,
+            idempotency_key,
+            stream_key: format!("settlement_case:{label}"),
+            aggregate_type: "settlement_case".to_owned(),
+            aggregate_id,
+            event_type: "settlement.submit_action".to_owned(),
+            schema_version: 1,
+            payload_json: json!({
+                "intent_id": label,
+                "retention_probe": { "kind": "terminal_prune_retention_eligibility" }
+            }),
+            available_at: ts(0),
+            created_at: ts(0),
+        })
+        .unwrap();
+
+        PostgresOrchestrationStore::insert_outbox_message(&tx, &message)
+            .await
+            .expect("failed to insert retention eligibility outbox message");
+
+        if delivery_status == "published" {
+            let external_key = format!("provider-key-{label}");
+            tx.execute(
+                "
+                UPDATE outbox.events
+                SET delivery_status = 'published',
+                    attempt_count = 1,
+                    published_at = $2,
+                    last_attempt_at = $2,
+                    retain_until = $3,
+                    published_external_idempotency_key = $4
+                WHERE event_id = $1
+                ",
+                &[&event_id, &ts(10), &retain_until, &external_key],
+            )
+            .await
+            .expect("failed to mark retention eligibility outbox event published");
+            tx.execute(
+                "
+                INSERT INTO outbox.outbox_attempts (
+                    event_id,
+                    attempt_number,
+                    relay_name,
+                    claimed_at,
+                    claimed_until,
+                    finished_at,
+                    failure_class,
+                    failure_code,
+                    failure_detail,
+                    external_idempotency_key
+                )
+                VALUES ($1, $2, $3, $4, $5, $6, NULL, NULL, NULL, $7)
+                ",
+                &[
+                    &event_id,
+                    &1_i32,
+                    &"settlement-relay",
+                    &ts(0),
+                    &ts(300),
+                    &ts(10),
+                    &external_key,
+                ],
+            )
+            .await
+            .expect("failed to insert retention eligibility published attempt");
+        } else {
+            tx.execute(
+                "
+                UPDATE outbox.events
+                SET delivery_status = 'quarantined',
+                    attempt_count = 1,
+                    quarantined_at = $2,
+                    last_attempt_at = $2,
+                    last_error_class = $3,
+                    last_error_code = $4,
+                    last_error_detail = $5,
+                    quarantine_reason = $6,
+                    retain_until = $7
+                WHERE event_id = $1
+                ",
+                &[
+                    &event_id,
+                    &ts(10),
+                    &"permanent",
+                    &"provider_rejected",
+                    &"terminal retention eligibility quarantine detail",
+                    &"permanent_failure",
+                    &retain_until,
+                ],
+            )
+            .await
+            .expect("failed to mark retention eligibility outbox event quarantined");
+            tx.execute(
+                "
+                INSERT INTO outbox.outbox_attempts (
+                    event_id,
+                    attempt_number,
+                    relay_name,
+                    claimed_at,
+                    claimed_until,
+                    finished_at,
+                    failure_class,
+                    failure_code,
+                    failure_detail,
+                    external_idempotency_key
+                )
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NULL)
+                ",
+                &[
+                    &event_id,
+                    &1_i32,
+                    &"settlement-relay",
+                    &ts(0),
+                    &ts(300),
+                    &ts(10),
+                    &"permanent",
+                    &"provider_rejected",
+                    &"terminal retention eligibility attempt detail",
+                ],
+            )
+            .await
+            .expect("failed to insert retention eligibility quarantined attempt");
+        }
+    }
+
+    let command_cases: [(Uuid, Uuid, &str, &str, Option<chrono::DateTime<Utc>>); 4] = [
+        (
+            completed_null_command_id,
+            published_null_event_id,
+            "completed-retain-null",
+            "completed",
+            None,
+        ),
+        (
+            completed_future_command_id,
+            published_future_event_id,
+            "completed-retain-future",
+            "completed",
+            Some(ts(300)),
+        ),
+        (
+            quarantined_null_command_id,
+            quarantined_null_event_id,
+            "quarantined-retain-null",
+            "quarantined",
+            None,
+        ),
+        (
+            quarantined_future_command_id,
+            quarantined_future_event_id,
+            "quarantined-retain-future",
+            "quarantined",
+            Some(ts(300)),
+        ),
+    ];
+
+    for (command_id, source_event_id, label, status, retain_until) in command_cases {
+        let command = CommandEnvelope::new(
+            command_id,
+            source_event_id,
+            "projection.refresh",
+            1,
+            json!({ "settlement_case_id": label }),
+        )
+        .unwrap();
+
+        if status == "completed" {
+            let result_json = json!({ "projection_id": label });
+            tx.execute(
+                "
+                INSERT INTO outbox.command_inbox (
+                    inbox_entry_id,
+                    consumer_name,
+                    command_id,
+                    source_event_id,
+                    payload_checksum,
+                    received_at,
+                    status,
+                    available_at,
+                    attempt_count,
+                    command_type,
+                    schema_version,
+                    completed_at,
+                    result_type,
+                    result_json,
+                    retain_until
+                )
+                VALUES ($1, $2, $3, $4, $5, $6, 'completed', $6, 1, $7, $8, $9, $10, $11, $12)
+                ",
+                &[
+                    &Uuid::new_v4(),
+                    &"projection-builder",
+                    &command_id,
+                    &source_event_id,
+                    &command.payload_hash,
+                    &ts(20),
+                    &command.command_type,
+                    &command.schema_version,
+                    &ts(30),
+                    &"projected",
+                    &result_json,
+                    &retain_until,
+                ],
+            )
+            .await
+            .expect("failed to insert retention eligibility completed command inbox row");
+        } else {
+            tx.execute(
+                "
+                INSERT INTO outbox.command_inbox (
+                    inbox_entry_id,
+                    consumer_name,
+                    command_id,
+                    source_event_id,
+                    payload_checksum,
+                    received_at,
+                    status,
+                    available_at,
+                    attempt_count,
+                    command_type,
+                    schema_version,
+                    processed_at,
+                    last_error_class,
+                    last_error_code,
+                    last_error_detail,
+                    quarantine_reason,
+                    retain_until
+                )
+                VALUES ($1, $2, $3, $4, $5, $6, 'quarantined', $6, 1, $7, $8, $9, $10, $11, $12, $13, $14)
+                ",
+                &[
+                    &Uuid::new_v4(),
+                    &"projection-builder",
+                    &command_id,
+                    &source_event_id,
+                    &command.payload_hash,
+                    &ts(20),
+                    &command.command_type,
+                    &command.schema_version,
+                    &ts(30),
+                    &"permanent",
+                    &"projection_failed",
+                    &"terminal retention eligibility command detail",
+                    &"permanent_failure",
+                    &retain_until,
+                ],
+            )
+            .await
+            .expect("failed to insert retention eligibility quarantined command inbox row");
+        }
+    }
+
+    let outcome = PostgresOrchestrationStore::prune_coordination(&tx, ts(200))
+        .await
+        .expect("failed to prune retention eligibility coordination rows");
+
+    assert!(outcome.pruned_outbox_event_ids.is_empty());
+    assert!(outcome.pruned_command_keys.is_empty());
+
+    let hot_outbox_count: i64 = tx
+        .query_one(
+            "
+            SELECT COUNT(*) AS count
+            FROM outbox.events
+            WHERE event_id IN ($1, $2, $3, $4)
+            ",
+            &[
+                &published_null_event_id,
+                &published_future_event_id,
+                &quarantined_null_event_id,
+                &quarantined_future_event_id,
+            ],
+        )
+        .await
+        .expect("failed to count retention eligibility hot outbox rows")
+        .get("count");
+    let archived_outbox_count: i64 = tx
+        .query_one(
+            "
+            SELECT COUNT(*) AS count
+            FROM outbox.outbox_event_archive
+            WHERE event_id IN ($1, $2, $3, $4)
+            ",
+            &[
+                &published_null_event_id,
+                &published_future_event_id,
+                &quarantined_null_event_id,
+                &quarantined_future_event_id,
+            ],
+        )
+        .await
+        .expect("failed to count retention eligibility archived outbox rows")
+        .get("count");
+    let hot_attempt_count: i64 = tx
+        .query_one(
+            "
+            SELECT COUNT(*) AS count
+            FROM outbox.outbox_attempts
+            WHERE event_id IN ($1, $2, $3, $4)
+            ",
+            &[
+                &published_null_event_id,
+                &published_future_event_id,
+                &quarantined_null_event_id,
+                &quarantined_future_event_id,
+            ],
+        )
+        .await
+        .expect("failed to count retention eligibility hot attempt rows")
+        .get("count");
+    let archived_attempt_count: i64 = tx
+        .query_one(
+            "
+            SELECT COUNT(*) AS count
+            FROM outbox.outbox_attempt_archive
+            WHERE event_id IN ($1, $2, $3, $4)
+            ",
+            &[
+                &published_null_event_id,
+                &published_future_event_id,
+                &quarantined_null_event_id,
+                &quarantined_future_event_id,
+            ],
+        )
+        .await
+        .expect("failed to count retention eligibility archived attempt rows")
+        .get("count");
+    let hot_command_count: i64 = tx
+        .query_one(
+            "
+            SELECT COUNT(*) AS count
+            FROM outbox.command_inbox
+            WHERE consumer_name = $1
+              AND command_id IN ($2, $3, $4, $5)
+            ",
+            &[
+                &"projection-builder",
+                &completed_null_command_id,
+                &completed_future_command_id,
+                &quarantined_null_command_id,
+                &quarantined_future_command_id,
+            ],
+        )
+        .await
+        .expect("failed to count retention eligibility hot command inbox rows")
+        .get("count");
+    let archived_command_count: i64 = tx
+        .query_one(
+            "
+            SELECT COUNT(*) AS count
+            FROM outbox.command_inbox_archive
+            WHERE consumer_name = $1
+              AND command_id IN ($2, $3, $4, $5)
+            ",
+            &[
+                &"projection-builder",
+                &completed_null_command_id,
+                &completed_future_command_id,
+                &quarantined_null_command_id,
+                &quarantined_future_command_id,
+            ],
+        )
+        .await
+        .expect("failed to count retention eligibility archived command inbox rows")
+        .get("count");
+
+    assert_eq!(hot_outbox_count, 4);
+    assert_eq!(archived_outbox_count, 0);
+    assert_eq!(hot_attempt_count, 4);
+    assert_eq!(archived_attempt_count, 0);
+    assert_eq!(hot_command_count, 4);
+    assert_eq!(archived_command_count, 0);
+
+    tx.rollback()
+        .await
+        .expect("rollback should clean up transactional test state");
+}
+
+#[tokio::test]
 async fn postgres_prune_preserves_nonterminal_coordination_rows() {
     let Ok(database_url) = std::env::var("MUSUBI_TEST_DATABASE_URL") else {
         return;

--- a/apps/backend/docs/guardrails.md
+++ b/apps/backend/docs/guardrails.md
@@ -132,6 +132,7 @@ Current executable tests:
 - `postgres_prune_preserves_terminal_archive_payloads`
 - `postgres_prune_preserves_terminal_quarantine_archive_diagnostics`
 - `postgres_prune_is_idempotent_with_existing_archive_rows`
+- `postgres_prune_preserves_terminal_rows_before_retain_until`
 - `postgres_prune_preserves_nonterminal_coordination_rows`
 
 These prove terminal outbox and command-inbox coordination rows are archived
@@ -143,7 +144,10 @@ The archive conflict contract proves preexisting archive rows are not duplicated
 or overwritten while matching prune-ready hot rows are removed. The nonterminal
 preservation contract proves that pending and processing coordination rows are
 not archived or deleted by the same prune helper, even when their retention
-timestamp is already in the past.
+timestamp is already in the past. The terminal retention eligibility contract
+proves that terminal published/quarantined outbox rows, their hot attempt rows,
+and completed/quarantined command-inbox rows are not archived or deleted when
+their `retain_until` is NULL or later than the prune timestamp.
 
 ### 5. Drop-Tx-Before-Await at the runtime seam
 

--- a/apps/backend/docs/raw_transaction_inventory.txt
+++ b/apps/backend/docs/raw_transaction_inventory.txt
@@ -1,6 +1,6 @@
 1 apps/backend/crates/db-runtime/src/migrations.rs
 4 apps/backend/crates/orchestration/src/postgres.rs
-13 apps/backend/crates/orchestration/tests/postgres_contract.rs
+14 apps/backend/crates/orchestration/tests/postgres_contract.rs
 37 apps/backend/src/services/happy_route/repository.rs
 6 apps/backend/src/services/operator_review/repository.rs
 7 apps/backend/src/services/realm_bootstrap/repository.rs

--- a/docs/foundation_lock.md
+++ b/docs/foundation_lock.md
@@ -1,6 +1,6 @@
 # Foundation Lock
 
-Status: Draft; aligned to accepted foundation commit `4f1faaf`
+Status: Draft; aligned to accepted foundation commit `a77f78e`
 Applies to: `mt4110/pi-musubi-core`
 Purpose: Pin the constitutional and architectural source of truth that this implementation repository must follow.
 
@@ -26,14 +26,14 @@ Upstream repository:
 Pinned reference for implementation work:
 
 - Foundation reference type: `commit`
-- Foundation commit SHA: `4f1faafe231faf6ae4ad8314a3650d5e6f781e37`
-- Foundation commit title: `Merge pull request #247 from mt4110/feat/post-c2-orchestration-prune-archive-conflict-idempotency-handoff`
-- Foundation PR title: `docs: evaluate post-C2 orchestration prune archive conflict idempotency handoff`
-- Foundation PR URL: `https://github.com/mt4110/musubi-foundation/pull/247`
+- Foundation commit SHA: `a77f78eb3ccbc04edd5b0741848b98a862a9b5b7`
+- Foundation commit title: `Merge pull request #253 from mt4110/feat/post-c2-orchestration-terminal-prune-retention-eligibility-handoff`
+- Foundation PR title: `docs: evaluate post-C2 orchestration terminal prune retention eligibility handoff`
+- Foundation PR URL: `https://github.com/mt4110/musubi-foundation/pull/253`
 - Date pinned: `2026-06-11`
 - Pinned by: `Masaki Takemura`
-- Pinned commit URL: `https://github.com/mt4110/musubi-foundation/commit/4f1faafe231faf6ae4ad8314a3650d5e6f781e37`
-- Previous pinned reference: `5862e40` / `Merge pull request #241 from mt4110/feat/post-c2-orchestration-terminal-quarantine-archive-diagnostics-preservation-handoff`
+- Pinned commit URL: `https://github.com/mt4110/musubi-foundation/commit/a77f78eb3ccbc04edd5b0741848b98a862a9b5b7`
+- Previous pinned reference: `4f1faaf` / `Merge pull request #247 from mt4110/feat/post-c2-orchestration-prune-archive-conflict-idempotency-handoff`
 - Post-C2 evidence source: `cfdba28` / `Merge pull request #114 from mt4110/feat/post-c2-runtime-handoff-evidence-package`
 - Alignment allowance source: `69b7aa4` / `Merge pull request #116 from mt4110/feat/evaluate-post-c2-runtime-handoff-gate`
 - Post-C2 implementation handoff evidence source: `ef23e88` / `Merge pull request #122 from mt4110/feat/post-c2-implementation-handoff-evidence-package`
@@ -103,6 +103,9 @@ Pinned reference for implementation work:
 - Post-C2 orchestration terminal quarantine archive diagnostics preservation implementation closeout source: `6d72b8d` / `Merge pull request #243 from mt4110/feat/close-orchestration-terminal-quarantine-archive-diagnostics-handoff`
 - Post-C2 orchestration prune archive conflict idempotency evidence source: `57ee247` / `Merge pull request #245 from mt4110/feat/orchestration-prune-archive-conflict-idempotency-evidence`
 - Post-C2 orchestration prune archive conflict idempotency handoff source: `4f1faaf` / `Merge pull request #247 from mt4110/feat/post-c2-orchestration-prune-archive-conflict-idempotency-handoff`
+- Post-C2 orchestration prune archive conflict idempotency implementation closeout source: `0e2787d` / `Merge pull request #249 from mt4110/feat/close-orchestration-prune-archive-conflict-idempotency-handoff`
+- Post-C2 orchestration terminal prune retention eligibility evidence source: `62f367f` / `Merge pull request #251 from mt4110/feat/orchestration-terminal-prune-retention-eligibility-evidence`
+- Post-C2 orchestration terminal prune retention eligibility handoff source: `a77f78e` / `Merge pull request #253 from mt4110/feat/post-c2-orchestration-terminal-prune-retention-eligibility-handoff`
 
 No release tag is asserted for this alignment.
 Do not invent a foundation version label for this commit.
@@ -243,38 +246,41 @@ Before coding, read these upstream documents in order.
 120. `docs/readiness/post_c2_orchestration_terminal_quarantine_archive_diagnostics_preservation_implementation_closeout_ledger.md`
 121. `docs/readiness/post_c2_orchestration_prune_archive_conflict_idempotency_evidence_package.md`
 122. `docs/readiness/post_c2_orchestration_prune_archive_conflict_idempotency_handoff_gate_decision.md`
+123. `docs/readiness/post_c2_orchestration_prune_archive_conflict_idempotency_implementation_closeout_ledger.md`
+124. `docs/readiness/post_c2_orchestration_terminal_prune_retention_eligibility_evidence_package.md`
+125. `docs/readiness/post_c2_orchestration_terminal_prune_retention_eligibility_handoff_gate_decision.md`
 
 ### Operations layer
-123. `docs/operations/readiness_routine.md`
-124. `docs/operations/runalways_readiness_orchestrator_design.md`
-125. `docs/operations/runalways_readiness_orchestrator_stage0.md`
-126. `docs/operations/runalways_lane_controller_v0_1.md`
+126. `docs/operations/readiness_routine.md`
+127. `docs/operations/runalways_readiness_orchestrator_design.md`
+128. `docs/operations/runalways_readiness_orchestrator_stage0.md`
+129. `docs/operations/runalways_lane_controller_v0_1.md`
 
 ### Detail layer
-127. `docs/detail/accountability_matrix.md`
-128. `docs/detail/critical_incident_and_loss.md`
-129. `docs/detail/automated_decisioning_and_human_appeal.md`
-130. `docs/detail/youth_safety_and_age_assurance.md`
-131. `docs/detail/off_platform_handoff_and_scam_prevention.md`
-132. `docs/detail/data_deletion_vs_legal_hold.md`
-133. `docs/detail/security_and_autonomy_hardening.md`
-134. `docs/detail/realm_model.md`
-135. `docs/detail/data_scope_model.md`
-136. `docs/detail/mobility_model.md`
-137. `docs/detail/settlement_model.md`
-138. `docs/detail/settlement_backend_trait.md`
-139. `docs/detail/proof_of_infrastructure.md`
-140. `docs/detail/protected_groups_and_translation_safety.md`
+130. `docs/detail/accountability_matrix.md`
+131. `docs/detail/critical_incident_and_loss.md`
+132. `docs/detail/automated_decisioning_and_human_appeal.md`
+133. `docs/detail/youth_safety_and_age_assurance.md`
+134. `docs/detail/off_platform_handoff_and_scam_prevention.md`
+135. `docs/detail/data_deletion_vs_legal_hold.md`
+136. `docs/detail/security_and_autonomy_hardening.md`
+137. `docs/detail/realm_model.md`
+138. `docs/detail/data_scope_model.md`
+139. `docs/detail/mobility_model.md`
+140. `docs/detail/settlement_model.md`
+141. `docs/detail/settlement_backend_trait.md`
+142. `docs/detail/proof_of_infrastructure.md`
+143. `docs/detail/protected_groups_and_translation_safety.md`
 
 ### Whitepaper layer (contextual, not higher than detail/ADR)
-141. `docs/whitepaper/01_executive_summary.md`
-142. `docs/whitepaper/02_realm_model.md`
-143. `docs/whitepaper/03_experience_model.md`
-144. `docs/whitepaper/04_dm_shield.md`
-145. `docs/whitepaper/05_trust_model.md`
-146. `docs/whitepaper/06_promise_protocol.md`
-147. `docs/whitepaper/07_realm_economy.md`
-148. `docs/whitepaper/08_unlock_engine.md`
+144. `docs/whitepaper/01_executive_summary.md`
+145. `docs/whitepaper/02_realm_model.md`
+146. `docs/whitepaper/03_experience_model.md`
+147. `docs/whitepaper/04_dm_shield.md`
+148. `docs/whitepaper/05_trust_model.md`
+149. `docs/whitepaper/06_promise_protocol.md`
+150. `docs/whitepaper/07_realm_economy.md`
+151. `docs/whitepaper/08_unlock_engine.md`
 
 If any of the above are unavailable or materially inconsistent, stop and escalate.
 
@@ -305,7 +311,7 @@ That one-use C2 implementation allowance was consumed by `mt4110/pi-musubi-core`
 No remaining work may inherit permission from foundation PR #108 or implementation PR #88.
 The broad runtime implementation gate result remains NO-GO.
 Broad runtime implementation remains blocked.
-The current narrow downstream allowance is one implementation-repo test-only PR for post-C2 orchestration prune archive conflict idempotency verification.
+The current narrow downstream allowance is one implementation-repo test-only PR for post-C2 orchestration terminal prune retention eligibility verification.
 
 The C2 and post-C2 readiness and closeout chain is accepted for docs-only foundation semantic scope:
 
@@ -381,6 +387,9 @@ The C2 and post-C2 readiness and closeout chain is accepted for docs-only founda
 - `docs/readiness/post_c2_orchestration_terminal_quarantine_archive_diagnostics_preservation_implementation_closeout_ledger.md`
 - `docs/readiness/post_c2_orchestration_prune_archive_conflict_idempotency_evidence_package.md`
 - `docs/readiness/post_c2_orchestration_prune_archive_conflict_idempotency_handoff_gate_decision.md`
+- `docs/readiness/post_c2_orchestration_prune_archive_conflict_idempotency_implementation_closeout_ledger.md`
+- `docs/readiness/post_c2_orchestration_terminal_prune_retention_eligibility_evidence_package.md`
+- `docs/readiness/post_c2_orchestration_terminal_prune_retention_eligibility_handoff_gate_decision.md`
 - `docs/operations/readiness_routine.md`
 - `docs/operations/runalways_readiness_orchestrator_design.md`
 - `docs/operations/runalways_readiness_orchestrator_stage0.md`
@@ -477,11 +486,14 @@ It allowed only deterministic PostgreSQL-backed contract verification that exist
 It does not authorize broad runtime implementation, DDL, migrations, backend runtime code, public API changes, mobile UI, projection refresh, new runtime orchestration behavior, retry workers, queues, outbox changes, inbox changes, archive schema changes, manual-review provider evidence pruning behavior, lifecycle runtime behavior, pruning runtime behavior, archive runtime behavior, deletion, Legal Hold runtime behavior, evidence access runtime behavior, key lifecycle behavior, discovery, recommendation, room, settlement, Promise runtime behavior, proof runtime behavior, Relationship Depth behavior, Social Trust scoring, public trust display, or any broader `pi-musubi-core` change.
 That allowance was consumed by `mt4110/pi-musubi-core` PR #145 and closed out by foundation PR #243.
 Foundation PR #245 accepted the exact candidate test-only slice as post-C2 orchestration prune archive conflict idempotency verification.
-Foundation PR #247 provides the current narrow downstream test-only handoff authority for one later implementation-repo PR only.
+Foundation PR #247 provided the prior narrow downstream test-only handoff authority for one later implementation-repo PR only.
+That allowance was consumed by `mt4110/pi-musubi-core` PR #146 and closed out by foundation PR #249.
+Foundation PR #251 accepted the exact candidate test-only slice as post-C2 orchestration terminal prune retention eligibility verification.
+Foundation PR #253 provides the current narrow downstream test-only handoff authority for one later implementation-repo PR only.
 This update is the required lock pin for that one-use allowance.
 It authorizes only `docs/foundation_lock.md`, `apps/backend/crates/orchestration/tests/postgres_contract.rs`, `apps/backend/docs/guardrails.md`, and `apps/backend/docs/raw_transaction_inventory.txt`.
-It allows only deterministic PostgreSQL-backed contract verification that existing coordination pruning remains idempotent when matching coordination archive rows already exist before pruning terminal hot rows, plus the two named backend-local guardrail documentation updates.
-It does not authorize broad runtime implementation, DDL, migrations, backend runtime code, public API changes, mobile UI, projection refresh, new runtime orchestration behavior, retry workers, queues, outbox changes, inbox changes, archive schema changes, manual-review provider evidence pruning behavior, lifecycle runtime behavior, pruning runtime behavior, archive runtime behavior, deletion, Legal Hold runtime behavior, evidence access runtime behavior, key lifecycle behavior, concurrency tests that require timing assumptions or runner-specific scheduling behavior, provider callbacks, network I/O, external guarantees, scheduled workers, repository workflow changes, secrets, credentials, self-hosted runners, branch protection changes, discovery, recommendation, room, settlement, Promise runtime behavior, proof runtime behavior, Relationship Depth behavior, Social Trust scoring, public trust display, or any broader `pi-musubi-core` change.
+It allows only deterministic PostgreSQL-backed contract verification that existing coordination pruning preserves terminal published/quarantined outbox events, associated hot outbox attempt rows, and completed/quarantined command inbox rows whose `retain_until` is NULL or later than the prune timestamp, plus the two named backend-local guardrail documentation updates.
+It does not authorize broad runtime implementation, DDL, migrations, backend runtime code, public API changes, mobile UI, projection refresh, new runtime orchestration behavior, retry workers, queues, outbox changes, inbox changes, archive schema changes, retention policy changes, manual-review provider evidence pruning behavior, lifecycle runtime behavior, pruning runtime behavior, archive runtime behavior, deletion, Legal Hold runtime behavior, evidence access runtime behavior, key lifecycle behavior, choosing retention periods, provider callbacks, network I/O, external guarantees, scheduled workers, repository workflow changes, secrets, credentials, self-hosted runners, branch protection changes, discovery, recommendation, room, settlement, Promise runtime behavior, proof runtime behavior, Relationship Depth behavior, Social Trust scoring, public trust display, paid romantic advantage, DM unlock by payment, or any broader `pi-musubi-core` change.
 
 Implementation merge history, issue order, branch ancestry, and existing code are not foundation design proof.
 
@@ -702,11 +714,11 @@ When updating:
 - Review completed by:
 
 ### Current drift note
-- Updated from foundation SHA: `5862e402ce37a0ac77001d23b956a8ff9ac1c746` -> `4f1faafe231faf6ae4ad8314a3650d5e6f781e37`
-- Reason: Align implementation-repo lock with the accepted foundation state after PR #247 (`docs: evaluate post-C2 orchestration prune archive conflict idempotency handoff`).
-- New required docs: Post-C2 orchestration terminal quarantine archive diagnostics preservation implementation closeout ledger; Post-C2 orchestration prune archive conflict idempotency evidence package; Post-C2 orchestration prune archive conflict idempotency handoff gate decision.
+- Updated from foundation SHA: `4f1faafe231faf6ae4ad8314a3650d5e6f781e37` -> `a77f78eb3ccbc04edd5b0741848b98a862a9b5b7`
+- Reason: Align implementation-repo lock with the accepted foundation state after PR #253 (`docs: evaluate post-C2 orchestration terminal prune retention eligibility handoff`).
+- New required docs: Post-C2 orchestration prune archive conflict idempotency implementation closeout ledger; Post-C2 orchestration terminal prune retention eligibility evidence package; Post-C2 orchestration terminal prune retention eligibility handoff gate decision.
 - Removed docs: None.
-- Implementation impact: PR #247 authorizes one later implementation-repo test-only PR. This PR may update this foundation lock, add deterministic PostgreSQL-backed archive conflict idempotency verification to `apps/backend/crates/orchestration/tests/postgres_contract.rs`, and update only `apps/backend/docs/guardrails.md` plus `apps/backend/docs/raw_transaction_inventory.txt` for the new guardrail test surface. Broad runtime implementation, DDL, migrations, backend runtime code, public API changes, mobile UI, projection refresh, new runtime orchestration behavior, retry workers, queues, outbox changes, inbox changes, archive schema changes, manual-review provider evidence pruning behavior, lifecycle runtime behavior, pruning runtime behavior, archive runtime behavior, deletion, Legal Hold runtime behavior, evidence access runtime behavior, key lifecycle behavior, Relationship Depth behavior, Social Trust scoring, public trust display, concurrency tests that require timing assumptions or runner-specific scheduling behavior, provider callbacks, network I/O, external guarantees, scheduled workers, repository workflow changes, secrets, credentials, self-hosted runners, branch protection changes, and paid romantic advantage remain blocked.
+- Implementation impact: PR #253 authorizes one later implementation-repo test-only PR. This PR may update this foundation lock, add deterministic PostgreSQL-backed terminal prune retention eligibility verification to `apps/backend/crates/orchestration/tests/postgres_contract.rs`, and update only `apps/backend/docs/guardrails.md` plus `apps/backend/docs/raw_transaction_inventory.txt` for the new guardrail test surface. Broad runtime implementation, DDL, migrations, backend runtime code, public API changes, mobile UI, projection refresh, new runtime orchestration behavior, retry workers, queues, outbox changes, inbox changes, archive schema changes, retention policy changes, manual-review provider evidence pruning behavior, lifecycle runtime behavior, pruning runtime behavior, archive runtime behavior, deletion, Legal Hold runtime behavior, evidence access runtime behavior, key lifecycle behavior, choosing retention periods, Relationship Depth behavior, Social Trust scoring, public trust display, provider callbacks, network I/O, external guarantees, scheduled workers, repository workflow changes, secrets, credentials, self-hosted runners, branch protection changes, paid romantic advantage, and DM unlock by payment remain blocked.
 - Review completed by: Masaki Takemura
 
 ---


### PR DESCRIPTION
Foundation allowance:
- consumes the one-use test-only handoff from mt4110/musubi-foundation#253
- pins docs/foundation_lock.md to foundation commit a77f78eb3ccbc04edd5b0741848b98a862a9b5b7

Scope:
- add deterministic PostgreSQL contract coverage that prune_coordination preserves terminal published/quarantined outbox rows, associated hot attempt rows, and completed/quarantined command-inbox rows whose retain_until is NULL or later than the prune timestamp
- update backend guardrail docs and raw transaction inventory for the added test surface
- no DDL, migrations, runtime code, public API, mobile UI, projection, retention policy, pruning runtime, archive runtime, provider, workflow, secret, or runner changes

Validation:
- rustfmt --edition 2024 --check apps/backend/crates/orchestration/tests/postgres_contract.rs
- MUSUBI_TEST_DATABASE_URL=postgres://localhost:55432/musubi_core_test cargo test -p musubi_orchestration postgres_prune_preserves_terminal_rows_before_retain_until
- MUSUBI_TEST_DATABASE_URL=postgres://localhost:55432/musubi_core_test cargo test -p musubi_orchestration postgres_prune_
- MUSUBI_TEST_DATABASE_URL=postgres://localhost:55432/musubi_core_test cargo test -p musubi_orchestration
- make guardrail-sweep
- make guardrail-sweep-self-test
- git diff --check origin/main...HEAD