### PR TITLE
test: cover orchestration prune mixed eligibility separation

### DIFF
--- a/apps/backend/crates/orchestration/tests/postgres_contract.rs
+++ b/apps/backend/crates/orchestration/tests/postgres_contract.rs
@@ -2408,6 +2408,614 @@ async fn postgres_prune_preserves_terminal_rows_before_retain_until() {
 }
 
 #[tokio::test]
+async fn postgres_prune_separates_mixed_retention_eligibility_rows() {
+    let Ok(database_url) = std::env::var("MUSUBI_TEST_DATABASE_URL") else {
+        return;
+    };
+
+    let (mut client, connection) = tokio_postgres::connect(&database_url, NoTls)
+        .await
+        .expect("failed to connect to MUSUBI_TEST_DATABASE_URL");
+    tokio::spawn(async move {
+        let _ = connection.await;
+    });
+
+    let tx = client
+        .transaction()
+        .await
+        .expect("failed to open transaction");
+    tx.batch_execute(include_str!(
+        "../../../migrations/0004_create_outbox_schema.sql"
+    ))
+    .await
+    .expect("failed to apply outbox schema");
+    tx.batch_execute(include_str!(
+        "../../../migrations/0006_orchestration_runtime_baseline.sql"
+    ))
+    .await
+    .expect("failed to apply orchestration baseline migration");
+
+    let eligible_event_id = Uuid::from_u128(0x73b);
+    let retained_null_event_id = Uuid::from_u128(0x73c);
+    let retained_future_event_id = Uuid::from_u128(0x73d);
+    let nonterminal_event_id = Uuid::from_u128(0x73e);
+    let eligible_command_id = Uuid::from_u128(0x747);
+    let retained_null_command_id = Uuid::from_u128(0x748);
+    let retained_future_command_id = Uuid::from_u128(0x749);
+    let nonterminal_command_id = Uuid::from_u128(0x74a);
+
+    let outbox_cases: [(Uuid, Uuid, Uuid, &str, &str, Option<chrono::DateTime<Utc>>); 3] = [
+        (
+            eligible_event_id,
+            Uuid::from_u128(0x73f),
+            Uuid::from_u128(0x742),
+            "mixed-eligible-published",
+            "published",
+            Some(ts(100)),
+        ),
+        (
+            retained_null_event_id,
+            Uuid::from_u128(0x740),
+            Uuid::from_u128(0x743),
+            "mixed-retained-null",
+            "published",
+            None,
+        ),
+        (
+            retained_future_event_id,
+            Uuid::from_u128(0x741),
+            Uuid::from_u128(0x744),
+            "mixed-retained-future",
+            "quarantined",
+            Some(ts(300)),
+        ),
+    ];
+
+    for (event_id, idempotency_key, aggregate_id, label, delivery_status, retain_until) in
+        outbox_cases
+    {
+        let message = NewOutboxMessage::new(NewOutboxMessageSpec {
+            event_id,
+            idempotency_key,
+            stream_key: format!("settlement_case:{label}"),
+            aggregate_type: "settlement_case".to_owned(),
+            aggregate_id,
+            event_type: "settlement.submit_action".to_owned(),
+            schema_version: 1,
+            payload_json: json!({
+                "intent_id": label,
+                "retention_probe": { "kind": "mixed_retention_eligibility" }
+            }),
+            available_at: ts(0),
+            created_at: ts(0),
+        })
+        .unwrap();
+
+        PostgresOrchestrationStore::insert_outbox_message(&tx, &message)
+            .await
+            .expect("failed to insert mixed eligibility outbox message");
+
+        if delivery_status == "published" {
+            let external_key = format!("provider-key-{label}");
+            tx.execute(
+                "
+                UPDATE outbox.events
+                SET delivery_status = 'published',
+                    attempt_count = 1,
+                    published_at = $2,
+                    last_attempt_at = $2,
+                    retain_until = $3,
+                    published_external_idempotency_key = $4
+                WHERE event_id = $1
+                ",
+                &[&event_id, &ts(10), &retain_until, &external_key],
+            )
+            .await
+            .expect("failed to mark mixed eligibility outbox event published");
+            tx.execute(
+                "
+                INSERT INTO outbox.outbox_attempts (
+                    event_id,
+                    attempt_number,
+                    relay_name,
+                    claimed_at,
+                    claimed_until,
+                    finished_at,
+                    failure_class,
+                    failure_code,
+                    failure_detail,
+                    external_idempotency_key
+                )
+                VALUES ($1, $2, $3, $4, $5, $6, NULL, NULL, NULL, $7)
+                ",
+                &[
+                    &event_id,
+                    &1_i32,
+                    &"settlement-relay",
+                    &ts(0),
+                    &ts(300),
+                    &ts(10),
+                    &external_key,
+                ],
+            )
+            .await
+            .expect("failed to insert mixed eligibility published attempt");
+        } else {
+            tx.execute(
+                "
+                UPDATE outbox.events
+                SET delivery_status = 'quarantined',
+                    attempt_count = 1,
+                    quarantined_at = $2,
+                    last_attempt_at = $2,
+                    last_error_class = $3,
+                    last_error_code = $4,
+                    last_error_detail = $5,
+                    quarantine_reason = $6,
+                    retain_until = $7
+                WHERE event_id = $1
+                ",
+                &[
+                    &event_id,
+                    &ts(10),
+                    &"permanent",
+                    &"provider_rejected",
+                    &"mixed eligibility quarantine detail",
+                    &"permanent_failure",
+                    &retain_until,
+                ],
+            )
+            .await
+            .expect("failed to mark mixed eligibility outbox event quarantined");
+            tx.execute(
+                "
+                INSERT INTO outbox.outbox_attempts (
+                    event_id,
+                    attempt_number,
+                    relay_name,
+                    claimed_at,
+                    claimed_until,
+                    finished_at,
+                    failure_class,
+                    failure_code,
+                    failure_detail,
+                    external_idempotency_key
+                )
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NULL)
+                ",
+                &[
+                    &event_id,
+                    &1_i32,
+                    &"settlement-relay",
+                    &ts(0),
+                    &ts(300),
+                    &ts(10),
+                    &"permanent",
+                    &"provider_rejected",
+                    &"mixed eligibility attempt detail",
+                ],
+            )
+            .await
+            .expect("failed to insert mixed eligibility quarantined attempt");
+        }
+    }
+
+    let nonterminal_message = NewOutboxMessage::new(NewOutboxMessageSpec {
+        event_id: nonterminal_event_id,
+        idempotency_key: Uuid::from_u128(0x745),
+        stream_key: "settlement_case:mixed-nonterminal".to_owned(),
+        aggregate_type: "settlement_case".to_owned(),
+        aggregate_id: Uuid::from_u128(0x746),
+        event_type: "settlement.submit_action".to_owned(),
+        schema_version: 1,
+        payload_json: json!({
+            "intent_id": "mixed-nonterminal",
+            "retention_probe": { "kind": "mixed_retention_eligibility_nonterminal" }
+        }),
+        available_at: ts(0),
+        created_at: ts(0),
+    })
+    .unwrap();
+    PostgresOrchestrationStore::insert_outbox_message(&tx, &nonterminal_message)
+        .await
+        .expect("failed to insert mixed eligibility nonterminal outbox message");
+    tx.execute(
+        "
+        UPDATE outbox.events
+        SET retain_until = $2
+        WHERE event_id = $1
+        ",
+        &[&nonterminal_event_id, &ts(100)],
+    )
+    .await
+    .expect("failed to mark mixed eligibility nonterminal outbox retain_until");
+
+    let command_cases: [(Uuid, Uuid, &str, &str, Option<chrono::DateTime<Utc>>); 3] = [
+        (
+            eligible_command_id,
+            eligible_event_id,
+            "mixed-eligible-command",
+            "completed",
+            Some(ts(100)),
+        ),
+        (
+            retained_null_command_id,
+            retained_null_event_id,
+            "mixed-retained-null-command",
+            "completed",
+            None,
+        ),
+        (
+            retained_future_command_id,
+            retained_future_event_id,
+            "mixed-retained-future-command",
+            "quarantined",
+            Some(ts(300)),
+        ),
+    ];
+
+    for (command_id, source_event_id, label, status, retain_until) in command_cases {
+        let command = CommandEnvelope::new(
+            command_id,
+            source_event_id,
+            "projection.refresh",
+            1,
+            json!({ "settlement_case_id": label }),
+        )
+        .unwrap();
+
+        if status == "completed" {
+            let result_json = json!({ "projection_id": label });
+            tx.execute(
+                "
+                INSERT INTO outbox.command_inbox (
+                    inbox_entry_id,
+                    consumer_name,
+                    command_id,
+                    source_event_id,
+                    payload_checksum,
+                    received_at,
+                    status,
+                    available_at,
+                    attempt_count,
+                    command_type,
+                    schema_version,
+                    completed_at,
+                    result_type,
+                    result_json,
+                    retain_until
+                )
+                VALUES ($1, $2, $3, $4, $5, $6, 'completed', $6, 1, $7, $8, $9, $10, $11, $12)
+                ",
+                &[
+                    &Uuid::new_v4(),
+                    &"projection-builder",
+                    &command_id,
+                    &source_event_id,
+                    &command.payload_hash,
+                    &ts(20),
+                    &command.command_type,
+                    &command.schema_version,
+                    &ts(30),
+                    &"projected",
+                    &result_json,
+                    &retain_until,
+                ],
+            )
+            .await
+            .expect("failed to insert mixed eligibility completed command inbox row");
+        } else {
+            tx.execute(
+                "
+                INSERT INTO outbox.command_inbox (
+                    inbox_entry_id,
+                    consumer_name,
+                    command_id,
+                    source_event_id,
+                    payload_checksum,
+                    received_at,
+                    status,
+                    available_at,
+                    attempt_count,
+                    command_type,
+                    schema_version,
+                    processed_at,
+                    last_error_class,
+                    last_error_code,
+                    last_error_detail,
+                    quarantine_reason,
+                    retain_until
+                )
+                VALUES ($1, $2, $3, $4, $5, $6, 'quarantined', $6, 1, $7, $8, $9, $10, $11, $12, $13, $14)
+                ",
+                &[
+                    &Uuid::new_v4(),
+                    &"projection-builder",
+                    &command_id,
+                    &source_event_id,
+                    &command.payload_hash,
+                    &ts(20),
+                    &command.command_type,
+                    &command.schema_version,
+                    &ts(30),
+                    &"permanent",
+                    &"projection_failed",
+                    &"mixed eligibility command detail",
+                    &"permanent_failure",
+                    &retain_until,
+                ],
+            )
+            .await
+            .expect("failed to insert mixed eligibility quarantined command inbox row");
+        }
+    }
+
+    let nonterminal_command = CommandEnvelope::new(
+        nonterminal_command_id,
+        nonterminal_event_id,
+        "projection.refresh",
+        1,
+        json!({ "settlement_case_id": "mixed-nonterminal" }),
+    )
+    .unwrap();
+    tx.execute(
+        "
+        INSERT INTO outbox.command_inbox (
+            inbox_entry_id,
+            consumer_name,
+            command_id,
+            source_event_id,
+            payload_checksum,
+            received_at,
+            status,
+            available_at,
+            attempt_count,
+            command_type,
+            schema_version,
+            claimed_by,
+            claimed_until,
+            retain_until
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, 'processing', $6, 0, $7, $8, $9, $10, $11)
+        ",
+        &[
+            &Uuid::new_v4(),
+            &"projection-builder",
+            &nonterminal_command.command_id,
+            &nonterminal_command.source_event_id,
+            &nonterminal_command.payload_hash,
+            &ts(0),
+            &nonterminal_command.command_type,
+            &nonterminal_command.schema_version,
+            &"projection-builder",
+            &ts(300),
+            &ts(100),
+        ],
+    )
+    .await
+    .expect("failed to insert mixed eligibility nonterminal command inbox row");
+
+    let outcome = PostgresOrchestrationStore::prune_coordination(&tx, ts(200))
+        .await
+        .expect("failed to prune mixed eligibility coordination rows");
+
+    assert_eq!(outcome.pruned_outbox_event_ids, vec![eligible_event_id]);
+    assert_eq!(
+        outcome.pruned_command_keys,
+        vec![CommandKey {
+            consumer_name: "projection-builder".to_owned(),
+            command_id: eligible_command_id,
+        }]
+    );
+
+    let hot_eligible_outbox_count: i64 = tx
+        .query_one(
+            "SELECT COUNT(*) AS count FROM outbox.events WHERE event_id = $1",
+            &[&eligible_event_id],
+        )
+        .await
+        .expect("failed to count mixed eligibility hot eligible outbox row")
+        .get("count");
+    let archived_eligible_outbox_count: i64 = tx
+        .query_one(
+            "SELECT COUNT(*) AS count FROM outbox.outbox_event_archive WHERE event_id = $1",
+            &[&eligible_event_id],
+        )
+        .await
+        .expect("failed to count mixed eligibility archived eligible outbox row")
+        .get("count");
+    let hot_eligible_attempt_count: i64 = tx
+        .query_one(
+            "SELECT COUNT(*) AS count FROM outbox.outbox_attempts WHERE event_id = $1",
+            &[&eligible_event_id],
+        )
+        .await
+        .expect("failed to count mixed eligibility hot eligible attempt row")
+        .get("count");
+    let archived_eligible_attempt_count: i64 = tx
+        .query_one(
+            "SELECT COUNT(*) AS count FROM outbox.outbox_attempt_archive WHERE event_id = $1",
+            &[&eligible_event_id],
+        )
+        .await
+        .expect("failed to count mixed eligibility archived eligible attempt row")
+        .get("count");
+    let hot_eligible_command_count: i64 = tx
+        .query_one(
+            "
+            SELECT COUNT(*) AS count
+            FROM outbox.command_inbox
+            WHERE consumer_name = $1
+              AND command_id = $2
+            ",
+            &[&"projection-builder", &eligible_command_id],
+        )
+        .await
+        .expect("failed to count mixed eligibility hot eligible command row")
+        .get("count");
+    let archived_eligible_command_count: i64 = tx
+        .query_one(
+            "
+            SELECT COUNT(*) AS count
+            FROM outbox.command_inbox_archive
+            WHERE consumer_name = $1
+              AND command_id = $2
+            ",
+            &[&"projection-builder", &eligible_command_id],
+        )
+        .await
+        .expect("failed to count mixed eligibility archived eligible command row")
+        .get("count");
+
+    let hot_retained_outbox_count: i64 = tx
+        .query_one(
+            "
+            SELECT COUNT(*) AS count
+            FROM outbox.events
+            WHERE event_id IN ($1, $2)
+            ",
+            &[&retained_null_event_id, &retained_future_event_id],
+        )
+        .await
+        .expect("failed to count mixed eligibility retained hot outbox rows")
+        .get("count");
+    let archived_retained_outbox_count: i64 = tx
+        .query_one(
+            "
+            SELECT COUNT(*) AS count
+            FROM outbox.outbox_event_archive
+            WHERE event_id IN ($1, $2)
+            ",
+            &[&retained_null_event_id, &retained_future_event_id],
+        )
+        .await
+        .expect("failed to count mixed eligibility retained archived outbox rows")
+        .get("count");
+    let hot_retained_attempt_count: i64 = tx
+        .query_one(
+            "
+            SELECT COUNT(*) AS count
+            FROM outbox.outbox_attempts
+            WHERE event_id IN ($1, $2)
+            ",
+            &[&retained_null_event_id, &retained_future_event_id],
+        )
+        .await
+        .expect("failed to count mixed eligibility retained hot attempt rows")
+        .get("count");
+    let archived_retained_attempt_count: i64 = tx
+        .query_one(
+            "
+            SELECT COUNT(*) AS count
+            FROM outbox.outbox_attempt_archive
+            WHERE event_id IN ($1, $2)
+            ",
+            &[&retained_null_event_id, &retained_future_event_id],
+        )
+        .await
+        .expect("failed to count mixed eligibility retained archived attempt rows")
+        .get("count");
+    let hot_retained_command_count: i64 = tx
+        .query_one(
+            "
+            SELECT COUNT(*) AS count
+            FROM outbox.command_inbox
+            WHERE consumer_name = $1
+              AND command_id IN ($2, $3)
+            ",
+            &[
+                &"projection-builder",
+                &retained_null_command_id,
+                &retained_future_command_id,
+            ],
+        )
+        .await
+        .expect("failed to count mixed eligibility retained hot command rows")
+        .get("count");
+    let archived_retained_command_count: i64 = tx
+        .query_one(
+            "
+            SELECT COUNT(*) AS count
+            FROM outbox.command_inbox_archive
+            WHERE consumer_name = $1
+              AND command_id IN ($2, $3)
+            ",
+            &[
+                &"projection-builder",
+                &retained_null_command_id,
+                &retained_future_command_id,
+            ],
+        )
+        .await
+        .expect("failed to count mixed eligibility retained archived command rows")
+        .get("count");
+
+    let hot_nonterminal_outbox_count: i64 = tx
+        .query_one(
+            "SELECT COUNT(*) AS count FROM outbox.events WHERE event_id = $1",
+            &[&nonterminal_event_id],
+        )
+        .await
+        .expect("failed to count mixed eligibility nonterminal hot outbox row")
+        .get("count");
+    let archived_nonterminal_outbox_count: i64 = tx
+        .query_one(
+            "SELECT COUNT(*) AS count FROM outbox.outbox_event_archive WHERE event_id = $1",
+            &[&nonterminal_event_id],
+        )
+        .await
+        .expect("failed to count mixed eligibility nonterminal archived outbox row")
+        .get("count");
+    let hot_nonterminal_command_count: i64 = tx
+        .query_one(
+            "
+            SELECT COUNT(*) AS count
+            FROM outbox.command_inbox
+            WHERE consumer_name = $1
+              AND command_id = $2
+            ",
+            &[&"projection-builder", &nonterminal_command_id],
+        )
+        .await
+        .expect("failed to count mixed eligibility nonterminal hot command row")
+        .get("count");
+    let archived_nonterminal_command_count: i64 = tx
+        .query_one(
+            "
+            SELECT COUNT(*) AS count
+            FROM outbox.command_inbox_archive
+            WHERE consumer_name = $1
+              AND command_id = $2
+            ",
+            &[&"projection-builder", &nonterminal_command_id],
+        )
+        .await
+        .expect("failed to count mixed eligibility nonterminal archived command row")
+        .get("count");
+
+    assert_eq!(hot_eligible_outbox_count, 0);
+    assert_eq!(archived_eligible_outbox_count, 1);
+    assert_eq!(hot_eligible_attempt_count, 0);
+    assert_eq!(archived_eligible_attempt_count, 1);
+    assert_eq!(hot_eligible_command_count, 0);
+    assert_eq!(archived_eligible_command_count, 1);
+    assert_eq!(hot_retained_outbox_count, 2);
+    assert_eq!(archived_retained_outbox_count, 0);
+    assert_eq!(hot_retained_attempt_count, 2);
+    assert_eq!(archived_retained_attempt_count, 0);
+    assert_eq!(hot_retained_command_count, 2);
+    assert_eq!(archived_retained_command_count, 0);
+    assert_eq!(hot_nonterminal_outbox_count, 1);
+    assert_eq!(archived_nonterminal_outbox_count, 0);
+    assert_eq!(hot_nonterminal_command_count, 1);
+    assert_eq!(archived_nonterminal_command_count, 0);
+
+    tx.rollback()
+        .await
+        .expect("rollback should clean up transactional test state");
+}
+
+#[tokio::test]
 async fn postgres_prune_preserves_nonterminal_coordination_rows() {
     let Ok(database_url) = std::env::var("MUSUBI_TEST_DATABASE_URL") else {
         return;

--- a/apps/backend/docs/guardrails.md
+++ b/apps/backend/docs/guardrails.md
@@ -133,6 +133,7 @@ Current executable tests:
 - `postgres_prune_preserves_terminal_quarantine_archive_diagnostics`
 - `postgres_prune_is_idempotent_with_existing_archive_rows`
 - `postgres_prune_preserves_terminal_rows_before_retain_until`
+- `postgres_prune_separates_mixed_retention_eligibility_rows`
 - `postgres_prune_preserves_nonterminal_coordination_rows`
 
 These prove terminal outbox and command-inbox coordination rows are archived
@@ -147,7 +148,11 @@ not archived or deleted by the same prune helper, even when their retention
 timestamp is already in the past. The terminal retention eligibility contract
 proves that terminal published/quarantined outbox rows, their hot attempt rows,
 and completed/quarantined command-inbox rows are not archived or deleted when
-their `retain_until` is NULL or later than the prune timestamp.
+their `retain_until` is NULL or later than the prune timestamp. The mixed
+retention eligibility contract proves that one prune run archives and removes
+eligible terminal rows while retaining terminal rows whose `retain_until` is
+NULL or later than the prune timestamp, retaining their hot attempts, and
+preserving nonterminal coordination rows.
 
 ### 5. Drop-Tx-Before-Await at the runtime seam
 

--- a/apps/backend/docs/raw_transaction_inventory.txt
+++ b/apps/backend/docs/raw_transaction_inventory.txt
@@ -1,6 +1,6 @@
 1 apps/backend/crates/db-runtime/src/migrations.rs
 4 apps/backend/crates/orchestration/src/postgres.rs
-14 apps/backend/crates/orchestration/tests/postgres_contract.rs
+15 apps/backend/crates/orchestration/tests/postgres_contract.rs
 37 apps/backend/src/services/happy_route/repository.rs
 6 apps/backend/src/services/operator_review/repository.rs
 7 apps/backend/src/services/realm_bootstrap/repository.rs

--- a/docs/foundation_lock.md
+++ b/docs/foundation_lock.md
@@ -1,6 +1,6 @@
 # Foundation Lock
 
-Status: Draft; aligned to accepted foundation commit `a77f78e`
+Status: Draft; aligned to accepted foundation commit `52d20d0`
 Applies to: `mt4110/pi-musubi-core`
 Purpose: Pin the constitutional and architectural source of truth that this implementation repository must follow.
 
@@ -26,14 +26,14 @@ Upstream repository:
 Pinned reference for implementation work:
 
 - Foundation reference type: `commit`
-- Foundation commit SHA: `a77f78eb3ccbc04edd5b0741848b98a862a9b5b7`
-- Foundation commit title: `Merge pull request #253 from mt4110/feat/post-c2-orchestration-terminal-prune-retention-eligibility-handoff`
-- Foundation PR title: `docs: evaluate post-C2 orchestration terminal prune retention eligibility handoff`
-- Foundation PR URL: `https://github.com/mt4110/musubi-foundation/pull/253`
-- Date pinned: `2026-06-11`
+- Foundation commit SHA: `52d20d010d71a006a07307fe9e4d8ff0bce57a84`
+- Foundation commit title: `docs: add orchestration prune mixed eligibility separation handoff gate`
+- Foundation PR title: `docs: add orchestration prune mixed eligibility separation handoff gate`
+- Foundation PR URL: `https://github.com/mt4110/musubi-foundation/pull/259`
+- Date pinned: `2026-06-12`
 - Pinned by: `Masaki Takemura`
-- Pinned commit URL: `https://github.com/mt4110/musubi-foundation/commit/a77f78eb3ccbc04edd5b0741848b98a862a9b5b7`
-- Previous pinned reference: `4f1faaf` / `Merge pull request #247 from mt4110/feat/post-c2-orchestration-prune-archive-conflict-idempotency-handoff`
+- Pinned commit URL: `https://github.com/mt4110/musubi-foundation/commit/52d20d010d71a006a07307fe9e4d8ff0bce57a84`
+- Previous pinned reference: `a77f78e` / `Merge pull request #253 from mt4110/feat/post-c2-orchestration-terminal-prune-retention-eligibility-handoff`
 - Post-C2 evidence source: `cfdba28` / `Merge pull request #114 from mt4110/feat/post-c2-runtime-handoff-evidence-package`
 - Alignment allowance source: `69b7aa4` / `Merge pull request #116 from mt4110/feat/evaluate-post-c2-runtime-handoff-gate`
 - Post-C2 implementation handoff evidence source: `ef23e88` / `Merge pull request #122 from mt4110/feat/post-c2-implementation-handoff-evidence-package`
@@ -106,6 +106,9 @@ Pinned reference for implementation work:
 - Post-C2 orchestration prune archive conflict idempotency implementation closeout source: `0e2787d` / `Merge pull request #249 from mt4110/feat/close-orchestration-prune-archive-conflict-idempotency-handoff`
 - Post-C2 orchestration terminal prune retention eligibility evidence source: `62f367f` / `Merge pull request #251 from mt4110/feat/orchestration-terminal-prune-retention-eligibility-evidence`
 - Post-C2 orchestration terminal prune retention eligibility handoff source: `a77f78e` / `Merge pull request #253 from mt4110/feat/post-c2-orchestration-terminal-prune-retention-eligibility-handoff`
+- Post-C2 orchestration terminal prune retention eligibility implementation closeout source: `be7d8bb` / `docs: close orchestration terminal prune retention eligibility handoff`
+- Post-C2 orchestration prune mixed eligibility separation evidence source: `ab8f6f5` / `docs: define orchestration prune mixed eligibility separation evidence`
+- Post-C2 orchestration prune mixed eligibility separation handoff source: `52d20d0` / `docs: add orchestration prune mixed eligibility separation handoff gate`
 
 No release tag is asserted for this alignment.
 Do not invent a foundation version label for this commit.
@@ -249,38 +252,41 @@ Before coding, read these upstream documents in order.
 123. `docs/readiness/post_c2_orchestration_prune_archive_conflict_idempotency_implementation_closeout_ledger.md`
 124. `docs/readiness/post_c2_orchestration_terminal_prune_retention_eligibility_evidence_package.md`
 125. `docs/readiness/post_c2_orchestration_terminal_prune_retention_eligibility_handoff_gate_decision.md`
+126. `docs/readiness/post_c2_orchestration_terminal_prune_retention_eligibility_implementation_closeout_ledger.md`
+127. `docs/readiness/post_c2_orchestration_prune_mixed_eligibility_separation_evidence_package.md`
+128. `docs/readiness/post_c2_orchestration_prune_mixed_eligibility_separation_handoff_gate_decision.md`
 
 ### Operations layer
-126. `docs/operations/readiness_routine.md`
-127. `docs/operations/runalways_readiness_orchestrator_design.md`
-128. `docs/operations/runalways_readiness_orchestrator_stage0.md`
-129. `docs/operations/runalways_lane_controller_v0_1.md`
+129. `docs/operations/readiness_routine.md`
+130. `docs/operations/runalways_readiness_orchestrator_design.md`
+131. `docs/operations/runalways_readiness_orchestrator_stage0.md`
+132. `docs/operations/runalways_lane_controller_v0_1.md`
 
 ### Detail layer
-130. `docs/detail/accountability_matrix.md`
-131. `docs/detail/critical_incident_and_loss.md`
-132. `docs/detail/automated_decisioning_and_human_appeal.md`
-133. `docs/detail/youth_safety_and_age_assurance.md`
-134. `docs/detail/off_platform_handoff_and_scam_prevention.md`
-135. `docs/detail/data_deletion_vs_legal_hold.md`
-136. `docs/detail/security_and_autonomy_hardening.md`
-137. `docs/detail/realm_model.md`
-138. `docs/detail/data_scope_model.md`
-139. `docs/detail/mobility_model.md`
-140. `docs/detail/settlement_model.md`
-141. `docs/detail/settlement_backend_trait.md`
-142. `docs/detail/proof_of_infrastructure.md`
-143. `docs/detail/protected_groups_and_translation_safety.md`
+133. `docs/detail/accountability_matrix.md`
+134. `docs/detail/critical_incident_and_loss.md`
+135. `docs/detail/automated_decisioning_and_human_appeal.md`
+136. `docs/detail/youth_safety_and_age_assurance.md`
+137. `docs/detail/off_platform_handoff_and_scam_prevention.md`
+138. `docs/detail/data_deletion_vs_legal_hold.md`
+139. `docs/detail/security_and_autonomy_hardening.md`
+140. `docs/detail/realm_model.md`
+141. `docs/detail/data_scope_model.md`
+142. `docs/detail/mobility_model.md`
+143. `docs/detail/settlement_model.md`
+144. `docs/detail/settlement_backend_trait.md`
+145. `docs/detail/proof_of_infrastructure.md`
+146. `docs/detail/protected_groups_and_translation_safety.md`
 
 ### Whitepaper layer (contextual, not higher than detail/ADR)
-144. `docs/whitepaper/01_executive_summary.md`
-145. `docs/whitepaper/02_realm_model.md`
-146. `docs/whitepaper/03_experience_model.md`
-147. `docs/whitepaper/04_dm_shield.md`
-148. `docs/whitepaper/05_trust_model.md`
-149. `docs/whitepaper/06_promise_protocol.md`
-150. `docs/whitepaper/07_realm_economy.md`
-151. `docs/whitepaper/08_unlock_engine.md`
+147. `docs/whitepaper/01_executive_summary.md`
+148. `docs/whitepaper/02_realm_model.md`
+149. `docs/whitepaper/03_experience_model.md`
+150. `docs/whitepaper/04_dm_shield.md`
+151. `docs/whitepaper/05_trust_model.md`
+152. `docs/whitepaper/06_promise_protocol.md`
+153. `docs/whitepaper/07_realm_economy.md`
+154. `docs/whitepaper/08_unlock_engine.md`
 
 If any of the above are unavailable or materially inconsistent, stop and escalate.
 
@@ -311,7 +317,7 @@ That one-use C2 implementation allowance was consumed by `mt4110/pi-musubi-core`
 No remaining work may inherit permission from foundation PR #108 or implementation PR #88.
 The broad runtime implementation gate result remains NO-GO.
 Broad runtime implementation remains blocked.
-The current narrow downstream allowance is one implementation-repo test-only PR for post-C2 orchestration terminal prune retention eligibility verification.
+The current narrow downstream allowance is one implementation-repo test-only PR for post-C2 orchestration prune mixed eligibility separation verification.
 
 The C2 and post-C2 readiness and closeout chain is accepted for docs-only foundation semantic scope:
 
@@ -390,6 +396,9 @@ The C2 and post-C2 readiness and closeout chain is accepted for docs-only founda
 - `docs/readiness/post_c2_orchestration_prune_archive_conflict_idempotency_implementation_closeout_ledger.md`
 - `docs/readiness/post_c2_orchestration_terminal_prune_retention_eligibility_evidence_package.md`
 - `docs/readiness/post_c2_orchestration_terminal_prune_retention_eligibility_handoff_gate_decision.md`
+- `docs/readiness/post_c2_orchestration_terminal_prune_retention_eligibility_implementation_closeout_ledger.md`
+- `docs/readiness/post_c2_orchestration_prune_mixed_eligibility_separation_evidence_package.md`
+- `docs/readiness/post_c2_orchestration_prune_mixed_eligibility_separation_handoff_gate_decision.md`
 - `docs/operations/readiness_routine.md`
 - `docs/operations/runalways_readiness_orchestrator_design.md`
 - `docs/operations/runalways_readiness_orchestrator_stage0.md`
@@ -489,10 +498,13 @@ Foundation PR #245 accepted the exact candidate test-only slice as post-C2 orche
 Foundation PR #247 provided the prior narrow downstream test-only handoff authority for one later implementation-repo PR only.
 That allowance was consumed by `mt4110/pi-musubi-core` PR #146 and closed out by foundation PR #249.
 Foundation PR #251 accepted the exact candidate test-only slice as post-C2 orchestration terminal prune retention eligibility verification.
-Foundation PR #253 provides the current narrow downstream test-only handoff authority for one later implementation-repo PR only.
+Foundation PR #253 provided the prior narrow downstream test-only handoff authority for one later implementation-repo PR only.
+That allowance was consumed by `mt4110/pi-musubi-core` PR #147 and closed out by foundation PR #255.
+Foundation PR #257 accepted the exact candidate test-only slice as post-C2 orchestration prune mixed eligibility separation verification.
+Foundation PR #259 provides the current narrow downstream test-only handoff authority for one later implementation-repo PR only.
 This update is the required lock pin for that one-use allowance.
 It authorizes only `docs/foundation_lock.md`, `apps/backend/crates/orchestration/tests/postgres_contract.rs`, `apps/backend/docs/guardrails.md`, and `apps/backend/docs/raw_transaction_inventory.txt`.
-It allows only deterministic PostgreSQL-backed contract verification that existing coordination pruning preserves terminal published/quarantined outbox events, associated hot outbox attempt rows, and completed/quarantined command inbox rows whose `retain_until` is NULL or later than the prune timestamp, plus the two named backend-local guardrail documentation updates.
+It allows only deterministic PostgreSQL-backed contract verification that existing coordination pruning separates eligible and ineligible terminal coordination rows in the same prune run, proves eligible terminal outbox events and command inbox rows are archived and removed from hot state, proves eligible-row outbox attempts are archived and removed from hot state, proves retained terminal rows and their attempts remain hot, and proves pending, processing, or otherwise nonterminal rows remain protected, plus the required backend-local guardrail documentation and raw transaction inventory updates.
 It does not authorize broad runtime implementation, DDL, migrations, backend runtime code, public API changes, mobile UI, projection refresh, new runtime orchestration behavior, retry workers, queues, outbox changes, inbox changes, archive schema changes, retention policy changes, manual-review provider evidence pruning behavior, lifecycle runtime behavior, pruning runtime behavior, archive runtime behavior, deletion, Legal Hold runtime behavior, evidence access runtime behavior, key lifecycle behavior, choosing retention periods, provider callbacks, network I/O, external guarantees, scheduled workers, repository workflow changes, secrets, credentials, self-hosted runners, branch protection changes, discovery, recommendation, room, settlement, Promise runtime behavior, proof runtime behavior, Relationship Depth behavior, Social Trust scoring, public trust display, paid romantic advantage, DM unlock by payment, or any broader `pi-musubi-core` change.
 
 Implementation merge history, issue order, branch ancestry, and existing code are not foundation design proof.


### PR DESCRIPTION
## Scope
- Pin `docs/foundation_lock.md` to the merged foundation handoff gate from mt4110/musubi-foundation#259.
- Add the one authorized PostgreSQL contract test: `postgres_prune_separates_mixed_retention_eligibility_rows`.
- Update backend guardrails and raw transaction inventory for the added test surface.

## Boundaries
- Test-only downstream allowance from foundation PR #259.
- No runtime prune fix.
- No DDL or migrations.
- No backend runtime code, public API, mobile UI, worker, scheduler, queue, retention policy, Legal Hold, provider evidence pruning, PII segregation, Social Trust, Relationship Depth, discovery, recommendation, room, settlement, Promise runtime, or proof runtime changes.

## Validation
From `apps/backend`, using fresh PostgreSQL database `musubi_test_mixed_eligibility_validation` with `MUSUBI_TEST_DATABASE_URL` explicitly set:

- `test -n "${MUSUBI_TEST_DATABASE_URL:?MUSUBI_TEST_DATABASE_URL is required for PostgreSQL contract validation}"`
- `rustfmt --edition 2024 --check crates/orchestration/tests/postgres_contract.rs`
- `cargo test -p musubi_orchestration --test postgres_contract postgres_prune_separates_mixed_retention_eligibility_rows -- --exact --nocapture`
- `cargo test -p musubi_orchestration --test postgres_contract -- --nocapture`
- `cargo test -p musubi_orchestration`
- `git diff --check origin/main...HEAD`
- `make guardrail-sweep`

Note: the existing default local `musubi_test` database contained leftover outbox rows and made an unrelated pre-existing count assertion fail in the full `postgres_contract` suite. Re-running the required suite on a fresh test database passed.
