### PR TITLE
test: cover orchestration prune deterministic outcome ordering

### DIFF
--- a/apps/backend/crates/orchestration/tests/postgres_contract.rs
+++ b/apps/backend/crates/orchestration/tests/postgres_contract.rs
@@ -3016,6 +3016,544 @@ async fn postgres_prune_separates_mixed_retention_eligibility_rows() {
 }
 
 #[tokio::test]
+async fn postgres_prune_returns_deterministic_outcome_ordering() {
+    let Ok(database_url) = std::env::var("MUSUBI_TEST_DATABASE_URL") else {
+        return;
+    };
+
+    let (mut client, connection) = tokio_postgres::connect(&database_url, NoTls)
+        .await
+        .expect("failed to connect to MUSUBI_TEST_DATABASE_URL");
+    tokio::spawn(async move {
+        let _ = connection.await;
+    });
+
+    let tx = client
+        .transaction()
+        .await
+        .expect("failed to open transaction");
+    tx.batch_execute(include_str!(
+        "../../../migrations/0004_create_outbox_schema.sql"
+    ))
+    .await
+    .expect("failed to apply outbox schema");
+    tx.batch_execute(include_str!(
+        "../../../migrations/0006_orchestration_runtime_baseline.sql"
+    ))
+    .await
+    .expect("failed to apply orchestration baseline migration");
+
+    let late_event_id = Uuid::from_u128(0x760);
+    let first_event_id = Uuid::from_u128(0x761);
+    let middle_event_id = Uuid::from_u128(0x762);
+    let retained_event_id = Uuid::from_u128(0x763);
+    let nonterminal_event_id = Uuid::from_u128(0x764);
+
+    let outbox_cases: [(Uuid, Uuid, Uuid, &str, &str, i64, chrono::DateTime<Utc>); 5] = [
+        (
+            late_event_id,
+            Uuid::from_u128(0x765),
+            Uuid::from_u128(0x766),
+            "ordering-late",
+            "published",
+            30,
+            ts(100),
+        ),
+        (
+            first_event_id,
+            Uuid::from_u128(0x767),
+            Uuid::from_u128(0x768),
+            "ordering-first",
+            "published",
+            10,
+            ts(100),
+        ),
+        (
+            middle_event_id,
+            Uuid::from_u128(0x769),
+            Uuid::from_u128(0x76a),
+            "ordering-middle",
+            "published",
+            20,
+            ts(100),
+        ),
+        (
+            retained_event_id,
+            Uuid::from_u128(0x76b),
+            Uuid::from_u128(0x76c),
+            "ordering-retained",
+            "published",
+            5,
+            ts(300),
+        ),
+        (
+            nonterminal_event_id,
+            Uuid::from_u128(0x76d),
+            Uuid::from_u128(0x76e),
+            "ordering-nonterminal",
+            "pending",
+            15,
+            ts(100),
+        ),
+    ];
+
+    for (
+        event_id,
+        idempotency_key,
+        aggregate_id,
+        label,
+        delivery_status,
+        causal_order,
+        retain_until,
+    ) in outbox_cases
+    {
+        let message = NewOutboxMessage::new(NewOutboxMessageSpec {
+            event_id,
+            idempotency_key,
+            stream_key: format!("settlement_case:{label}"),
+            aggregate_type: "settlement_case".to_owned(),
+            aggregate_id,
+            event_type: "settlement.submit_action".to_owned(),
+            schema_version: 1,
+            payload_json: json!({
+                "intent_id": label,
+                "retention_probe": { "kind": "deterministic_outcome_ordering" }
+            }),
+            available_at: ts(0),
+            created_at: ts(0),
+        })
+        .unwrap();
+        let attempt_count = if delivery_status == "published" {
+            1_i32
+        } else {
+            0_i32
+        };
+        let published_at = if delivery_status == "published" {
+            Some(ts(10))
+        } else {
+            None
+        };
+        let external_key = if delivery_status == "published" {
+            Some(format!("provider-key-{label}"))
+        } else {
+            None
+        };
+
+        tx.execute(
+            "
+            INSERT INTO outbox.events (
+                event_id,
+                idempotency_key,
+                stream_key,
+                aggregate_type,
+                aggregate_id,
+                event_type,
+                schema_version,
+                payload_json,
+                payload_hash,
+                delivery_status,
+                attempt_count,
+                causal_order,
+                available_at,
+                created_at,
+                published_at,
+                last_attempt_at,
+                retain_until,
+                published_external_idempotency_key
+            )
+            OVERRIDING SYSTEM VALUE
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $15, $16, $17)
+            ",
+            &[
+                &message.event_id,
+                &message.idempotency_key,
+                &message.stream_key,
+                &message.aggregate_type,
+                &message.aggregate_id,
+                &message.event_type,
+                &message.schema_version,
+                &message.payload_json,
+                &message.payload_hash,
+                &delivery_status,
+                &attempt_count,
+                &causal_order,
+                &message.available_at,
+                &message.created_at,
+                &published_at,
+                &retain_until,
+                &external_key,
+            ],
+        )
+        .await
+        .expect("failed to insert deterministic ordering outbox event");
+
+        if delivery_status == "published" {
+            tx.execute(
+                "
+                INSERT INTO outbox.outbox_attempts (
+                    event_id,
+                    attempt_number,
+                    relay_name,
+                    claimed_at,
+                    claimed_until,
+                    finished_at,
+                    failure_class,
+                    failure_code,
+                    failure_detail,
+                    external_idempotency_key
+                )
+                VALUES ($1, $2, $3, $4, $5, $6, NULL, NULL, NULL, $7)
+                ",
+                &[
+                    &event_id,
+                    &1_i32,
+                    &"settlement-relay",
+                    &ts(0),
+                    &ts(300),
+                    &ts(10),
+                    &external_key,
+                ],
+            )
+            .await
+            .expect("failed to insert deterministic ordering outbox attempt");
+        }
+    }
+
+    let zeta_command_id = Uuid::from_u128(0x773);
+    let alpha_high_command_id = Uuid::from_u128(0x772);
+    let alpha_low_command_id = Uuid::from_u128(0x771);
+    let retained_command_id = Uuid::from_u128(0x774);
+    let nonterminal_command_id = Uuid::from_u128(0x775);
+
+    let command_cases: [(
+        &str,
+        Uuid,
+        Uuid,
+        &str,
+        &str,
+        chrono::DateTime<Utc>,
+        chrono::DateTime<Utc>,
+    ); 5] = [
+        (
+            "projection-zeta",
+            zeta_command_id,
+            late_event_id,
+            "ordering-zeta",
+            "completed",
+            ts(100),
+            ts(30),
+        ),
+        (
+            "projection-alpha",
+            alpha_high_command_id,
+            middle_event_id,
+            "ordering-alpha-high",
+            "completed",
+            ts(100),
+            ts(10),
+        ),
+        (
+            "projection-alpha",
+            alpha_low_command_id,
+            first_event_id,
+            "ordering-alpha-low",
+            "completed",
+            ts(100),
+            ts(20),
+        ),
+        (
+            "projection-alpha",
+            retained_command_id,
+            retained_event_id,
+            "ordering-retained-command",
+            "completed",
+            ts(300),
+            ts(0),
+        ),
+        (
+            "projection-alpha",
+            nonterminal_command_id,
+            nonterminal_event_id,
+            "ordering-nonterminal-command",
+            "processing",
+            ts(100),
+            ts(40),
+        ),
+    ];
+
+    for (consumer_name, command_id, source_event_id, label, status, retain_until, received_at) in
+        command_cases
+    {
+        let command = CommandEnvelope::new(
+            command_id,
+            source_event_id,
+            "projection.refresh",
+            1,
+            json!({ "settlement_case_id": label }),
+        )
+        .unwrap();
+
+        if status == "completed" {
+            let result_json = json!({ "projection_id": label });
+            tx.execute(
+                "
+                INSERT INTO outbox.command_inbox (
+                    inbox_entry_id,
+                    consumer_name,
+                    command_id,
+                    source_event_id,
+                    payload_checksum,
+                    received_at,
+                    status,
+                    available_at,
+                    attempt_count,
+                    command_type,
+                    schema_version,
+                    completed_at,
+                    result_type,
+                    result_json,
+                    retain_until
+                )
+                VALUES ($1, $2, $3, $4, $5, $6, 'completed', $6, 1, $7, $8, $9, $10, $11, $12)
+                ",
+                &[
+                    &Uuid::new_v4(),
+                    &consumer_name,
+                    &command.command_id,
+                    &command.source_event_id,
+                    &command.payload_hash,
+                    &received_at,
+                    &command.command_type,
+                    &command.schema_version,
+                    &ts(50),
+                    &"projected",
+                    &result_json,
+                    &retain_until,
+                ],
+            )
+            .await
+            .expect("failed to insert deterministic ordering completed command inbox row");
+        } else {
+            tx.execute(
+                "
+                INSERT INTO outbox.command_inbox (
+                    inbox_entry_id,
+                    consumer_name,
+                    command_id,
+                    source_event_id,
+                    payload_checksum,
+                    received_at,
+                    status,
+                    available_at,
+                    attempt_count,
+                    command_type,
+                    schema_version,
+                    claimed_by,
+                    claimed_until,
+                    retain_until
+                )
+                VALUES ($1, $2, $3, $4, $5, $6, 'processing', $6, 0, $7, $8, $9, $10, $11)
+                ",
+                &[
+                    &Uuid::new_v4(),
+                    &consumer_name,
+                    &command.command_id,
+                    &command.source_event_id,
+                    &command.payload_hash,
+                    &received_at,
+                    &command.command_type,
+                    &command.schema_version,
+                    &"projection-builder",
+                    &ts(300),
+                    &retain_until,
+                ],
+            )
+            .await
+            .expect("failed to insert deterministic ordering processing command inbox row");
+        }
+    }
+
+    let outcome = PostgresOrchestrationStore::prune_coordination(&tx, ts(200))
+        .await
+        .expect("failed to prune deterministic ordering coordination rows");
+
+    assert_eq!(
+        outcome.pruned_outbox_event_ids,
+        vec![first_event_id, middle_event_id, late_event_id]
+    );
+    assert_eq!(
+        outcome.pruned_command_keys,
+        vec![
+            CommandKey {
+                consumer_name: "projection-alpha".to_owned(),
+                command_id: alpha_low_command_id,
+            },
+            CommandKey {
+                consumer_name: "projection-alpha".to_owned(),
+                command_id: alpha_high_command_id,
+            },
+            CommandKey {
+                consumer_name: "projection-zeta".to_owned(),
+                command_id: zeta_command_id,
+            },
+        ]
+    );
+
+    let hot_eligible_outbox_count: i64 = tx
+        .query_one(
+            "
+            SELECT COUNT(*) AS count
+            FROM outbox.events
+            WHERE event_id IN ($1, $2, $3)
+            ",
+            &[&late_event_id, &first_event_id, &middle_event_id],
+        )
+        .await
+        .expect("failed to count deterministic ordering hot eligible outbox rows")
+        .get("count");
+    let archived_eligible_outbox_count: i64 = tx
+        .query_one(
+            "
+            SELECT COUNT(*) AS count
+            FROM outbox.outbox_event_archive
+            WHERE event_id IN ($1, $2, $3)
+            ",
+            &[&late_event_id, &first_event_id, &middle_event_id],
+        )
+        .await
+        .expect("failed to count deterministic ordering archived eligible outbox rows")
+        .get("count");
+    let hot_eligible_attempt_count: i64 = tx
+        .query_one(
+            "
+            SELECT COUNT(*) AS count
+            FROM outbox.outbox_attempts
+            WHERE event_id IN ($1, $2, $3)
+            ",
+            &[&late_event_id, &first_event_id, &middle_event_id],
+        )
+        .await
+        .expect("failed to count deterministic ordering hot eligible attempts")
+        .get("count");
+    let archived_eligible_attempt_count: i64 = tx
+        .query_one(
+            "
+            SELECT COUNT(*) AS count
+            FROM outbox.outbox_attempt_archive
+            WHERE event_id IN ($1, $2, $3)
+            ",
+            &[&late_event_id, &first_event_id, &middle_event_id],
+        )
+        .await
+        .expect("failed to count deterministic ordering archived eligible attempts")
+        .get("count");
+    let hot_eligible_command_count: i64 = tx
+        .query_one(
+            "
+            SELECT COUNT(*) AS count
+            FROM outbox.command_inbox
+            WHERE (consumer_name = $1 AND command_id IN ($2, $3))
+               OR (consumer_name = $4 AND command_id = $5)
+            ",
+            &[
+                &"projection-alpha",
+                &alpha_low_command_id,
+                &alpha_high_command_id,
+                &"projection-zeta",
+                &zeta_command_id,
+            ],
+        )
+        .await
+        .expect("failed to count deterministic ordering hot eligible command rows")
+        .get("count");
+    let archived_eligible_command_count: i64 = tx
+        .query_one(
+            "
+            SELECT COUNT(*) AS count
+            FROM outbox.command_inbox_archive
+            WHERE (consumer_name = $1 AND command_id IN ($2, $3))
+               OR (consumer_name = $4 AND command_id = $5)
+            ",
+            &[
+                &"projection-alpha",
+                &alpha_low_command_id,
+                &alpha_high_command_id,
+                &"projection-zeta",
+                &zeta_command_id,
+            ],
+        )
+        .await
+        .expect("failed to count deterministic ordering archived eligible command rows")
+        .get("count");
+    let retained_hot_outbox_count: i64 = tx
+        .query_one(
+            "SELECT COUNT(*) AS count FROM outbox.events WHERE event_id = $1",
+            &[&retained_event_id],
+        )
+        .await
+        .expect("failed to count deterministic ordering retained hot outbox row")
+        .get("count");
+    let retained_hot_attempt_count: i64 = tx
+        .query_one(
+            "SELECT COUNT(*) AS count FROM outbox.outbox_attempts WHERE event_id = $1",
+            &[&retained_event_id],
+        )
+        .await
+        .expect("failed to count deterministic ordering retained hot attempt")
+        .get("count");
+    let retained_hot_command_count: i64 = tx
+        .query_one(
+            "
+            SELECT COUNT(*) AS count
+            FROM outbox.command_inbox
+            WHERE consumer_name = $1
+              AND command_id = $2
+            ",
+            &[&"projection-alpha", &retained_command_id],
+        )
+        .await
+        .expect("failed to count deterministic ordering retained hot command row")
+        .get("count");
+    let nonterminal_hot_outbox_count: i64 = tx
+        .query_one(
+            "SELECT COUNT(*) AS count FROM outbox.events WHERE event_id = $1",
+            &[&nonterminal_event_id],
+        )
+        .await
+        .expect("failed to count deterministic ordering nonterminal hot outbox row")
+        .get("count");
+    let nonterminal_hot_command_count: i64 = tx
+        .query_one(
+            "
+            SELECT COUNT(*) AS count
+            FROM outbox.command_inbox
+            WHERE consumer_name = $1
+              AND command_id = $2
+            ",
+            &[&"projection-alpha", &nonterminal_command_id],
+        )
+        .await
+        .expect("failed to count deterministic ordering nonterminal hot command row")
+        .get("count");
+
+    assert_eq!(hot_eligible_outbox_count, 0);
+    assert_eq!(archived_eligible_outbox_count, 3);
+    assert_eq!(hot_eligible_attempt_count, 0);
+    assert_eq!(archived_eligible_attempt_count, 3);
+    assert_eq!(hot_eligible_command_count, 0);
+    assert_eq!(archived_eligible_command_count, 3);
+    assert_eq!(retained_hot_outbox_count, 1);
+    assert_eq!(retained_hot_attempt_count, 1);
+    assert_eq!(retained_hot_command_count, 1);
+    assert_eq!(nonterminal_hot_outbox_count, 1);
+    assert_eq!(nonterminal_hot_command_count, 1);
+
+    tx.rollback()
+        .await
+        .expect("rollback should clean up transactional test state");
+}
+
+#[tokio::test]
 async fn postgres_prune_preserves_nonterminal_coordination_rows() {
     let Ok(database_url) = std::env::var("MUSUBI_TEST_DATABASE_URL") else {
         return;

--- a/apps/backend/docs/guardrails.md
+++ b/apps/backend/docs/guardrails.md
@@ -134,6 +134,7 @@ Current executable tests:
 - `postgres_prune_is_idempotent_with_existing_archive_rows`
 - `postgres_prune_preserves_terminal_rows_before_retain_until`
 - `postgres_prune_separates_mixed_retention_eligibility_rows`
+- `postgres_prune_returns_deterministic_outcome_ordering`
 - `postgres_prune_preserves_nonterminal_coordination_rows`
 
 These prove terminal outbox and command-inbox coordination rows are archived
@@ -152,7 +153,10 @@ their `retain_until` is NULL or later than the prune timestamp. The mixed
 retention eligibility contract proves that one prune run archives and removes
 eligible terminal rows while retaining terminal rows whose `retain_until` is
 NULL or later than the prune timestamp, retaining their hot attempts, and
-preserving nonterminal coordination rows.
+preserving nonterminal coordination rows. The deterministic outcome ordering
+contract proves that a multi-row prune result reports outbox event ids in
+writer-owned replay order and command inbox keys in stable command-key order
+while still preserving retained terminal rows and nonterminal rows.
 
 ### 5. Drop-Tx-Before-Await at the runtime seam
 

--- a/apps/backend/docs/raw_transaction_inventory.txt
+++ b/apps/backend/docs/raw_transaction_inventory.txt
@@ -1,6 +1,6 @@
 1 apps/backend/crates/db-runtime/src/migrations.rs
 4 apps/backend/crates/orchestration/src/postgres.rs
-15 apps/backend/crates/orchestration/tests/postgres_contract.rs
+16 apps/backend/crates/orchestration/tests/postgres_contract.rs
 37 apps/backend/src/services/happy_route/repository.rs
 6 apps/backend/src/services/operator_review/repository.rs
 7 apps/backend/src/services/realm_bootstrap/repository.rs

--- a/docs/foundation_lock.md
+++ b/docs/foundation_lock.md
@@ -1,6 +1,6 @@
 # Foundation Lock
 
-Status: Draft; aligned to accepted foundation commit `52d20d0`
+Status: Draft; aligned to accepted foundation commit `985eb58`
 Applies to: `mt4110/pi-musubi-core`
 Purpose: Pin the constitutional and architectural source of truth that this implementation repository must follow.
 
@@ -26,14 +26,14 @@ Upstream repository:
 Pinned reference for implementation work:
 
 - Foundation reference type: `commit`
-- Foundation commit SHA: `52d20d010d71a006a07307fe9e4d8ff0bce57a84`
-- Foundation commit title: `docs: add orchestration prune mixed eligibility separation handoff gate`
-- Foundation PR title: `docs: add orchestration prune mixed eligibility separation handoff gate`
-- Foundation PR URL: `https://github.com/mt4110/musubi-foundation/pull/259`
+- Foundation commit SHA: `985eb58d99346bf1f62e90b47a2b2ea1752043dc`
+- Foundation commit title: `Merge pull request #265 from mt4110/feat/post-c2-orchestration-prune-deterministic-outcome-ordering-handoff`
+- Foundation PR title: `docs: evaluate post-C2 orchestration prune deterministic outcome ordering handoff`
+- Foundation PR URL: `https://github.com/mt4110/musubi-foundation/pull/265`
 - Date pinned: `2026-06-12`
 - Pinned by: `Masaki Takemura`
-- Pinned commit URL: `https://github.com/mt4110/musubi-foundation/commit/52d20d010d71a006a07307fe9e4d8ff0bce57a84`
-- Previous pinned reference: `a77f78e` / `Merge pull request #253 from mt4110/feat/post-c2-orchestration-terminal-prune-retention-eligibility-handoff`
+- Pinned commit URL: `https://github.com/mt4110/musubi-foundation/commit/985eb58d99346bf1f62e90b47a2b2ea1752043dc`
+- Previous pinned reference: `52d20d0` / `docs: add orchestration prune mixed eligibility separation handoff gate`
 - Post-C2 evidence source: `cfdba28` / `Merge pull request #114 from mt4110/feat/post-c2-runtime-handoff-evidence-package`
 - Alignment allowance source: `69b7aa4` / `Merge pull request #116 from mt4110/feat/evaluate-post-c2-runtime-handoff-gate`
 - Post-C2 implementation handoff evidence source: `ef23e88` / `Merge pull request #122 from mt4110/feat/post-c2-implementation-handoff-evidence-package`
@@ -109,6 +109,9 @@ Pinned reference for implementation work:
 - Post-C2 orchestration terminal prune retention eligibility implementation closeout source: `be7d8bb` / `docs: close orchestration terminal prune retention eligibility handoff`
 - Post-C2 orchestration prune mixed eligibility separation evidence source: `ab8f6f5` / `docs: define orchestration prune mixed eligibility separation evidence`
 - Post-C2 orchestration prune mixed eligibility separation handoff source: `52d20d0` / `docs: add orchestration prune mixed eligibility separation handoff gate`
+- Post-C2 orchestration prune mixed eligibility separation implementation closeout source: `7d732d9` / `docs: close orchestration prune mixed eligibility separation handoff`
+- Post-C2 orchestration prune deterministic outcome ordering evidence source: `4d95282` / `Merge pull request #263 from mt4110/feat/orchestration-prune-deterministic-outcome-ordering-evidence`
+- Post-C2 orchestration prune deterministic outcome ordering handoff source: `985eb58` / `Merge pull request #265 from mt4110/feat/post-c2-orchestration-prune-deterministic-outcome-ordering-handoff`
 
 No release tag is asserted for this alignment.
 Do not invent a foundation version label for this commit.
@@ -255,38 +258,41 @@ Before coding, read these upstream documents in order.
 126. `docs/readiness/post_c2_orchestration_terminal_prune_retention_eligibility_implementation_closeout_ledger.md`
 127. `docs/readiness/post_c2_orchestration_prune_mixed_eligibility_separation_evidence_package.md`
 128. `docs/readiness/post_c2_orchestration_prune_mixed_eligibility_separation_handoff_gate_decision.md`
+129. `docs/readiness/post_c2_orchestration_prune_mixed_eligibility_separation_implementation_closeout_ledger.md`
+130. `docs/readiness/post_c2_orchestration_prune_deterministic_outcome_ordering_evidence_package.md`
+131. `docs/readiness/post_c2_orchestration_prune_deterministic_outcome_ordering_handoff_gate_decision.md`
 
 ### Operations layer
-129. `docs/operations/readiness_routine.md`
-130. `docs/operations/runalways_readiness_orchestrator_design.md`
-131. `docs/operations/runalways_readiness_orchestrator_stage0.md`
-132. `docs/operations/runalways_lane_controller_v0_1.md`
+132. `docs/operations/readiness_routine.md`
+133. `docs/operations/runalways_readiness_orchestrator_design.md`
+134. `docs/operations/runalways_readiness_orchestrator_stage0.md`
+135. `docs/operations/runalways_lane_controller_v0_1.md`
 
 ### Detail layer
-133. `docs/detail/accountability_matrix.md`
-134. `docs/detail/critical_incident_and_loss.md`
-135. `docs/detail/automated_decisioning_and_human_appeal.md`
-136. `docs/detail/youth_safety_and_age_assurance.md`
-137. `docs/detail/off_platform_handoff_and_scam_prevention.md`
-138. `docs/detail/data_deletion_vs_legal_hold.md`
-139. `docs/detail/security_and_autonomy_hardening.md`
-140. `docs/detail/realm_model.md`
-141. `docs/detail/data_scope_model.md`
-142. `docs/detail/mobility_model.md`
-143. `docs/detail/settlement_model.md`
-144. `docs/detail/settlement_backend_trait.md`
-145. `docs/detail/proof_of_infrastructure.md`
-146. `docs/detail/protected_groups_and_translation_safety.md`
+136. `docs/detail/accountability_matrix.md`
+137. `docs/detail/critical_incident_and_loss.md`
+138. `docs/detail/automated_decisioning_and_human_appeal.md`
+139. `docs/detail/youth_safety_and_age_assurance.md`
+140. `docs/detail/off_platform_handoff_and_scam_prevention.md`
+141. `docs/detail/data_deletion_vs_legal_hold.md`
+142. `docs/detail/security_and_autonomy_hardening.md`
+143. `docs/detail/realm_model.md`
+144. `docs/detail/data_scope_model.md`
+145. `docs/detail/mobility_model.md`
+146. `docs/detail/settlement_model.md`
+147. `docs/detail/settlement_backend_trait.md`
+148. `docs/detail/proof_of_infrastructure.md`
+149. `docs/detail/protected_groups_and_translation_safety.md`
 
 ### Whitepaper layer (contextual, not higher than detail/ADR)
-147. `docs/whitepaper/01_executive_summary.md`
-148. `docs/whitepaper/02_realm_model.md`
-149. `docs/whitepaper/03_experience_model.md`
-150. `docs/whitepaper/04_dm_shield.md`
-151. `docs/whitepaper/05_trust_model.md`
-152. `docs/whitepaper/06_promise_protocol.md`
-153. `docs/whitepaper/07_realm_economy.md`
-154. `docs/whitepaper/08_unlock_engine.md`
+150. `docs/whitepaper/01_executive_summary.md`
+151. `docs/whitepaper/02_realm_model.md`
+152. `docs/whitepaper/03_experience_model.md`
+153. `docs/whitepaper/04_dm_shield.md`
+154. `docs/whitepaper/05_trust_model.md`
+155. `docs/whitepaper/06_promise_protocol.md`
+156. `docs/whitepaper/07_realm_economy.md`
+157. `docs/whitepaper/08_unlock_engine.md`
 
 If any of the above are unavailable or materially inconsistent, stop and escalate.
 
@@ -317,7 +323,7 @@ That one-use C2 implementation allowance was consumed by `mt4110/pi-musubi-core`
 No remaining work may inherit permission from foundation PR #108 or implementation PR #88.
 The broad runtime implementation gate result remains NO-GO.
 Broad runtime implementation remains blocked.
-The current narrow downstream allowance is one implementation-repo test-only PR for post-C2 orchestration prune mixed eligibility separation verification.
+The current narrow downstream allowance is one implementation-repo test-only PR for post-C2 orchestration prune deterministic outcome ordering verification.
 
 The C2 and post-C2 readiness and closeout chain is accepted for docs-only foundation semantic scope:
 
@@ -399,6 +405,9 @@ The C2 and post-C2 readiness and closeout chain is accepted for docs-only founda
 - `docs/readiness/post_c2_orchestration_terminal_prune_retention_eligibility_implementation_closeout_ledger.md`
 - `docs/readiness/post_c2_orchestration_prune_mixed_eligibility_separation_evidence_package.md`
 - `docs/readiness/post_c2_orchestration_prune_mixed_eligibility_separation_handoff_gate_decision.md`
+- `docs/readiness/post_c2_orchestration_prune_mixed_eligibility_separation_implementation_closeout_ledger.md`
+- `docs/readiness/post_c2_orchestration_prune_deterministic_outcome_ordering_evidence_package.md`
+- `docs/readiness/post_c2_orchestration_prune_deterministic_outcome_ordering_handoff_gate_decision.md`
 - `docs/operations/readiness_routine.md`
 - `docs/operations/runalways_readiness_orchestrator_design.md`
 - `docs/operations/runalways_readiness_orchestrator_stage0.md`
@@ -501,10 +510,13 @@ Foundation PR #251 accepted the exact candidate test-only slice as post-C2 orche
 Foundation PR #253 provided the prior narrow downstream test-only handoff authority for one later implementation-repo PR only.
 That allowance was consumed by `mt4110/pi-musubi-core` PR #147 and closed out by foundation PR #255.
 Foundation PR #257 accepted the exact candidate test-only slice as post-C2 orchestration prune mixed eligibility separation verification.
-Foundation PR #259 provides the current narrow downstream test-only handoff authority for one later implementation-repo PR only.
+Foundation PR #259 provided the prior narrow downstream test-only handoff authority for one later implementation-repo PR only.
+That allowance was consumed by `mt4110/pi-musubi-core` PR #148 and closed out by foundation PR #261.
+Foundation PR #263 accepted the exact candidate test-only slice as post-C2 orchestration prune deterministic outcome ordering verification.
+Foundation PR #265 provides the current narrow downstream test-only handoff authority for one later implementation-repo PR only.
 This update is the required lock pin for that one-use allowance.
 It authorizes only `docs/foundation_lock.md`, `apps/backend/crates/orchestration/tests/postgres_contract.rs`, `apps/backend/docs/guardrails.md`, and `apps/backend/docs/raw_transaction_inventory.txt`.
-It allows only deterministic PostgreSQL-backed contract verification that existing coordination pruning separates eligible and ineligible terminal coordination rows in the same prune run, proves eligible terminal outbox events and command inbox rows are archived and removed from hot state, proves eligible-row outbox attempts are archived and removed from hot state, proves retained terminal rows and their attempts remain hot, and proves pending, processing, or otherwise nonterminal rows remain protected, plus the required backend-local guardrail documentation and raw transaction inventory updates.
+It allows only deterministic PostgreSQL-backed contract verification that existing coordination pruning returns stable prune outcome ordering when multiple eligible terminal coordination rows are pruned in one run, proves outbox outcomes follow writer-owned replay order, proves command inbox outcomes follow stable command-key order, proves reported rows are archived and removed from hot state, proves retained terminal rows and nonterminal rows are not reported or removed, plus the required backend-local guardrail documentation and raw transaction inventory updates.
 It does not authorize broad runtime implementation, DDL, migrations, backend runtime code, public API changes, mobile UI, projection refresh, new runtime orchestration behavior, retry workers, queues, outbox changes, inbox changes, archive schema changes, retention policy changes, manual-review provider evidence pruning behavior, lifecycle runtime behavior, pruning runtime behavior, archive runtime behavior, deletion, Legal Hold runtime behavior, evidence access runtime behavior, key lifecycle behavior, choosing retention periods, provider callbacks, network I/O, external guarantees, scheduled workers, repository workflow changes, secrets, credentials, self-hosted runners, branch protection changes, discovery, recommendation, room, settlement, Promise runtime behavior, proof runtime behavior, Relationship Depth behavior, Social Trust scoring, public trust display, paid romantic advantage, DM unlock by payment, or any broader `pi-musubi-core` change.
 
 Implementation merge history, issue order, branch ancestry, and existing code are not foundation design proof.
@@ -726,11 +738,11 @@ When updating:
 - Review completed by:
 
 ### Current drift note
-- Updated from foundation SHA: `4f1faafe231faf6ae4ad8314a3650d5e6f781e37` -> `a77f78eb3ccbc04edd5b0741848b98a862a9b5b7`
-- Reason: Align implementation-repo lock with the accepted foundation state after PR #253 (`docs: evaluate post-C2 orchestration terminal prune retention eligibility handoff`).
-- New required docs: Post-C2 orchestration prune archive conflict idempotency implementation closeout ledger; Post-C2 orchestration terminal prune retention eligibility evidence package; Post-C2 orchestration terminal prune retention eligibility handoff gate decision.
+- Updated from foundation SHA: `52d20d010d71a006a07307fe9e4d8ff0bce57a84` -> `985eb58d99346bf1f62e90b47a2b2ea1752043dc`
+- Reason: Align implementation-repo lock with the accepted foundation state after PR #265 (`docs: evaluate post-C2 orchestration prune deterministic outcome ordering handoff`).
+- New required docs: Post-C2 orchestration prune mixed eligibility separation implementation closeout ledger; Post-C2 orchestration prune deterministic outcome ordering evidence package; Post-C2 orchestration prune deterministic outcome ordering handoff gate decision.
 - Removed docs: None.
-- Implementation impact: PR #253 authorizes one later implementation-repo test-only PR. This PR may update this foundation lock, add deterministic PostgreSQL-backed terminal prune retention eligibility verification to `apps/backend/crates/orchestration/tests/postgres_contract.rs`, and update only `apps/backend/docs/guardrails.md` plus `apps/backend/docs/raw_transaction_inventory.txt` for the new guardrail test surface. Broad runtime implementation, DDL, migrations, backend runtime code, public API changes, mobile UI, projection refresh, new runtime orchestration behavior, retry workers, queues, outbox changes, inbox changes, archive schema changes, retention policy changes, manual-review provider evidence pruning behavior, lifecycle runtime behavior, pruning runtime behavior, archive runtime behavior, deletion, Legal Hold runtime behavior, evidence access runtime behavior, key lifecycle behavior, choosing retention periods, Relationship Depth behavior, Social Trust scoring, public trust display, provider callbacks, network I/O, external guarantees, scheduled workers, repository workflow changes, secrets, credentials, self-hosted runners, branch protection changes, paid romantic advantage, and DM unlock by payment remain blocked.
+- Implementation impact: PR #265 authorizes one later implementation-repo test-only PR. This PR may update this foundation lock, add deterministic PostgreSQL-backed prune outcome ordering verification to `apps/backend/crates/orchestration/tests/postgres_contract.rs`, and update only `apps/backend/docs/guardrails.md` plus `apps/backend/docs/raw_transaction_inventory.txt` for the new guardrail test surface. Broad runtime implementation, runtime prune fixes, DDL, migrations, backend runtime code, public API changes, mobile UI, projection refresh, new runtime orchestration behavior, retry workers, queues, outbox changes, inbox changes, archive schema changes, retention policy changes, manual-review provider evidence pruning behavior, lifecycle runtime behavior, pruning runtime behavior, archive runtime behavior, deletion, Legal Hold runtime behavior, evidence access runtime behavior, key lifecycle behavior, choosing retention periods, Relationship Depth behavior, Social Trust scoring, public trust display, provider callbacks, network I/O, external guarantees, scheduled workers, repository workflow changes, secrets, credentials, self-hosted runners, branch protection changes, paid romantic advantage, and DM unlock by payment remain blocked.
 - Review completed by: Masaki Takemura
 
 ---


### PR DESCRIPTION
## Summary

- Pins docs/foundation_lock.md to musubi-foundation PR #265 / commit 985eb58d99346bf1f62e90b47a2b2ea1752043dc.
- Adds postgres_prune_returns_deterministic_outcome_ordering to prove existing prune outcomes are stable for multiple eligible rows.
- Updates backend guardrail docs and raw transaction inventory for the new PostgreSQL contract test surface.

## Foundation scope

Authorized by mt4110/musubi-foundation#265.

Allowed files only:

- docs/foundation_lock.md
- apps/backend/crates/orchestration/tests/postgres_contract.rs
- apps/backend/docs/guardrails.md
- apps/backend/docs/raw_transaction_inventory.txt

This PR is test-only plus required lock/docs inventory updates. It does not change runtime prune logic, DDL, migrations, backend runtime code, public API, mobile UI, projection refresh, workers, queues, outbox/inbox schema, retention policy, Legal Hold, provider evidence pruning, Social Trust, Relationship Depth, room, settlement, Promise, proof, discovery, or recommendation behavior.

## Validation

Using fresh local DB musubi_test_deterministic_ordering_validation:

- PASS: test -n MUSUBI_TEST_DATABASE_URL
- PASS: rustfmt --edition 2024 --check crates/orchestration/tests/postgres_contract.rs
- PASS: MUSUBI_TEST_DATABASE_URL=postgres://musubi:musubi_local_dev@127.0.0.1:55432/musubi_test_deterministic_ordering_validation cargo test -p musubi_orchestration --test postgres_contract postgres_prune_returns_deterministic_outcome_ordering -- --exact --nocapture
- PASS: MUSUBI_TEST_DATABASE_URL=postgres://musubi:musubi_local_dev@127.0.0.1:55432/musubi_test_deterministic_ordering_validation cargo test -p musubi_orchestration --test postgres_contract -- --nocapture
- PASS: MUSUBI_TEST_DATABASE_URL=postgres://musubi:musubi_local_dev@127.0.0.1:55432/musubi_test_deterministic_ordering_validation cargo test -p musubi_orchestration
- PASS: make guardrail-sweep
- PASS: git diff --check origin/main...HEAD

The fresh validation DB was dropped after local validation.
