### PR TITLE
test: cover orchestration prune command inbox archive completeness

### DIFF
--- a/apps/backend/crates/orchestration/tests/postgres_contract.rs
+++ b/apps/backend/crates/orchestration/tests/postgres_contract.rs
@@ -3918,6 +3918,788 @@ async fn postgres_prune_archives_all_attempts_for_eligible_terminal_outbox_event
 }
 
 #[tokio::test]
+async fn postgres_prune_archives_all_eligible_command_inbox_rows_for_source_event() {
+    let Ok(database_url) = std::env::var("MUSUBI_TEST_DATABASE_URL") else {
+        return;
+    };
+
+    let (mut client, connection) = tokio_postgres::connect(&database_url, NoTls)
+        .await
+        .expect("failed to connect to MUSUBI_TEST_DATABASE_URL");
+    tokio::spawn(async move {
+        let _ = connection.await;
+    });
+
+    let tx = client
+        .transaction()
+        .await
+        .expect("failed to open transaction");
+    tx.batch_execute(include_str!(
+        "../../../migrations/0004_create_outbox_schema.sql"
+    ))
+    .await
+    .expect("failed to apply outbox schema");
+    tx.batch_execute(include_str!(
+        "../../../migrations/0006_orchestration_runtime_baseline.sql"
+    ))
+    .await
+    .expect("failed to apply orchestration baseline migration");
+
+    let aggregate_id = Uuid::from_u128(0x790);
+    let event_id = Uuid::from_u128(0x791);
+    let completed_projection_command_id = Uuid::from_u128(0x792);
+    let completed_audit_command_id = Uuid::from_u128(0x793);
+    let quarantined_command_id = Uuid::from_u128(0x794);
+    let retained_terminal_command_id = Uuid::from_u128(0x795);
+    let nonterminal_command_id = Uuid::from_u128(0x796);
+    let message = NewOutboxMessage::new(NewOutboxMessageSpec {
+        event_id,
+        idempotency_key: Uuid::from_u128(0x797),
+        stream_key: "settlement_case:command-inbox-archive-completeness".to_owned(),
+        aggregate_type: "settlement_case".to_owned(),
+        aggregate_id,
+        event_type: "settlement.submit_action".to_owned(),
+        schema_version: 1,
+        payload_json: json!({
+            "intent_id": "intent-command-inbox-archive-completeness",
+            "retention_probe": { "kind": "command_inbox_archive_completeness" }
+        }),
+        available_at: ts(0),
+        created_at: ts(0),
+    })
+    .unwrap();
+
+    PostgresOrchestrationStore::insert_outbox_message(&tx, &message)
+        .await
+        .expect("failed to insert command inbox archive completeness outbox message");
+    tx.execute(
+        "
+        UPDATE outbox.events
+        SET delivery_status = 'published',
+            attempt_count = 1,
+            published_at = $2,
+            last_attempt_at = $3,
+            retain_until = $4,
+            published_external_idempotency_key = $5
+        WHERE event_id = $1
+        ",
+        &[
+            &event_id,
+            &ts(30),
+            &ts(30),
+            &ts(100),
+            &"provider-key-command-inbox-completeness",
+        ],
+    )
+    .await
+    .expect("failed to mark command inbox archive completeness outbox event terminal");
+    tx.execute(
+        "
+        INSERT INTO outbox.outbox_attempts (
+            event_id,
+            attempt_number,
+            relay_name,
+            claimed_at,
+            claimed_until,
+            finished_at,
+            failure_class,
+            failure_code,
+            failure_detail,
+            external_idempotency_key
+        )
+        VALUES ($1, 1, $2, $3, $4, $5, NULL, NULL, NULL, $6)
+        ",
+        &[
+            &event_id,
+            &"settlement-relay",
+            &ts(0),
+            &ts(300),
+            &ts(30),
+            &"provider-key-command-inbox-completeness",
+        ],
+    )
+    .await
+    .expect("failed to insert command inbox archive completeness outbox attempt");
+
+    let completed_projection_command = CommandEnvelope::new(
+        completed_projection_command_id,
+        event_id,
+        "projection.refresh",
+        1,
+        json!({
+            "settlement_case_id": aggregate_id,
+            "command_label": "projection-completed"
+        }),
+    )
+    .unwrap();
+    let completed_audit_command = CommandEnvelope::new(
+        completed_audit_command_id,
+        event_id,
+        "projection.audit",
+        1,
+        json!({
+            "settlement_case_id": aggregate_id,
+            "command_label": "audit-completed"
+        }),
+    )
+    .unwrap();
+    let quarantined_command = CommandEnvelope::new(
+        quarantined_command_id,
+        event_id,
+        "projection.refresh",
+        1,
+        json!({
+            "settlement_case_id": aggregate_id,
+            "command_label": "search-quarantined"
+        }),
+    )
+    .unwrap();
+    let retained_terminal_command = CommandEnvelope::new(
+        retained_terminal_command_id,
+        event_id,
+        "projection.refresh",
+        1,
+        json!({
+            "settlement_case_id": aggregate_id,
+            "command_label": "future-retained"
+        }),
+    )
+    .unwrap();
+    let nonterminal_command = CommandEnvelope::new(
+        nonterminal_command_id,
+        event_id,
+        "projection.audit",
+        1,
+        json!({
+            "settlement_case_id": aggregate_id,
+            "command_label": "processing-retained"
+        }),
+    )
+    .unwrap();
+
+    let completed_projection_result = json!({
+        "projection_id": "projection-command-inbox-completeness"
+    });
+    tx.execute(
+        "
+        INSERT INTO outbox.command_inbox (
+            inbox_entry_id,
+            consumer_name,
+            command_id,
+            source_event_id,
+            payload_checksum,
+            received_at,
+            status,
+            available_at,
+            attempt_count,
+            command_type,
+            schema_version,
+            completed_at,
+            result_type,
+            result_json,
+            retain_until
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, 'completed', $6, 1, $7, $8, $9, $10, $11, $12)
+        ",
+        &[
+            &Uuid::new_v4(),
+            &"projection-builder",
+            &completed_projection_command.command_id,
+            &completed_projection_command.source_event_id,
+            &completed_projection_command.payload_hash,
+            &ts(40),
+            &completed_projection_command.command_type,
+            &completed_projection_command.schema_version,
+            &ts(50),
+            &"projected",
+            &completed_projection_result,
+            &ts(100),
+        ],
+    )
+    .await
+    .expect("failed to insert eligible completed projection command inbox row");
+
+    let completed_audit_result = json!({
+        "audit_id": "audit-command-inbox-completeness"
+    });
+    tx.execute(
+        "
+        INSERT INTO outbox.command_inbox (
+            inbox_entry_id,
+            consumer_name,
+            command_id,
+            source_event_id,
+            payload_checksum,
+            received_at,
+            status,
+            available_at,
+            attempt_count,
+            command_type,
+            schema_version,
+            completed_at,
+            result_type,
+            result_json,
+            retain_until
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, 'completed', $6, 1, $7, $8, $9, $10, $11, $12)
+        ",
+        &[
+            &Uuid::new_v4(),
+            &"audit-projector",
+            &completed_audit_command.command_id,
+            &completed_audit_command.source_event_id,
+            &completed_audit_command.payload_hash,
+            &ts(42),
+            &completed_audit_command.command_type,
+            &completed_audit_command.schema_version,
+            &ts(52),
+            &"audited",
+            &completed_audit_result,
+            &ts(100),
+        ],
+    )
+    .await
+    .expect("failed to insert eligible completed audit command inbox row");
+
+    tx.execute(
+        "
+        INSERT INTO outbox.command_inbox (
+            inbox_entry_id,
+            consumer_name,
+            command_id,
+            source_event_id,
+            payload_checksum,
+            received_at,
+            status,
+            available_at,
+            attempt_count,
+            command_type,
+            schema_version,
+            last_error_class,
+            last_error_code,
+            last_error_detail,
+            quarantine_reason,
+            retain_until
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, 'quarantined', $6, 2, $7, $8, $9, $10, $11, $12, $13)
+        ",
+        &[
+            &Uuid::new_v4(),
+            &"search-indexer",
+            &quarantined_command.command_id,
+            &quarantined_command.source_event_id,
+            &quarantined_command.payload_hash,
+            &ts(44),
+            &quarantined_command.command_type,
+            &quarantined_command.schema_version,
+            &"permanent",
+            &"poison_command",
+            &"command payload rejected by projection worker",
+            &"poison_pill",
+            &ts(100),
+        ],
+    )
+    .await
+    .expect("failed to insert eligible quarantined command inbox row");
+
+    let retained_terminal_result = json!({
+        "projection_id": "future-retained-command-inbox-completeness"
+    });
+    tx.execute(
+        "
+        INSERT INTO outbox.command_inbox (
+            inbox_entry_id,
+            consumer_name,
+            command_id,
+            source_event_id,
+            payload_checksum,
+            received_at,
+            status,
+            available_at,
+            attempt_count,
+            command_type,
+            schema_version,
+            completed_at,
+            result_type,
+            result_json,
+            retain_until
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, 'completed', $6, 1, $7, $8, $9, $10, $11, $12)
+        ",
+        &[
+            &Uuid::new_v4(),
+            &"projection-builder",
+            &retained_terminal_command.command_id,
+            &retained_terminal_command.source_event_id,
+            &retained_terminal_command.payload_hash,
+            &ts(46),
+            &retained_terminal_command.command_type,
+            &retained_terminal_command.schema_version,
+            &ts(56),
+            &"projected",
+            &retained_terminal_result,
+            &ts(300),
+        ],
+    )
+    .await
+    .expect("failed to insert retained terminal command inbox row");
+
+    tx.execute(
+        "
+        INSERT INTO outbox.command_inbox (
+            inbox_entry_id,
+            consumer_name,
+            command_id,
+            source_event_id,
+            payload_checksum,
+            received_at,
+            status,
+            available_at,
+            attempt_count,
+            command_type,
+            schema_version,
+            claimed_by,
+            claimed_until,
+            retain_until
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, 'processing', $6, 0, $7, $8, $9, $10, $11)
+        ",
+        &[
+            &Uuid::new_v4(),
+            &"audit-projector",
+            &nonterminal_command.command_id,
+            &nonterminal_command.source_event_id,
+            &nonterminal_command.payload_hash,
+            &ts(48),
+            &nonterminal_command.command_type,
+            &nonterminal_command.schema_version,
+            &"audit-projector",
+            &ts(360),
+            &ts(100),
+        ],
+    )
+    .await
+    .expect("failed to insert retained nonterminal command inbox row");
+
+    let hot_command_count_before: i64 = tx
+        .query_one(
+            "
+            SELECT COUNT(*) AS count
+            FROM outbox.command_inbox
+            WHERE source_event_id = $1
+            ",
+            &[&event_id],
+        )
+        .await
+        .expect("failed to count hot command inbox rows before prune")
+        .get("count");
+    assert_eq!(hot_command_count_before, 5);
+
+    let outcome = PostgresOrchestrationStore::prune_coordination(&tx, ts(200))
+        .await
+        .expect("failed to prune command inbox archive completeness coordination rows");
+
+    assert_eq!(outcome.pruned_outbox_event_ids, vec![event_id]);
+    assert_eq!(
+        outcome.pruned_command_keys,
+        vec![
+            CommandKey {
+                consumer_name: "audit-projector".to_owned(),
+                command_id: completed_audit_command_id,
+            },
+            CommandKey {
+                consumer_name: "projection-builder".to_owned(),
+                command_id: completed_projection_command_id,
+            },
+            CommandKey {
+                consumer_name: "search-indexer".to_owned(),
+                command_id: quarantined_command_id,
+            },
+        ]
+    );
+
+    let archived_commands = tx
+        .query(
+            "
+            SELECT
+                consumer_name,
+                command_id,
+                source_event_id,
+                archived_at,
+                command_type,
+                schema_version,
+                status,
+                attempt_count,
+                payload_checksum,
+                received_at,
+                completed_at,
+                last_error_class,
+                last_error_code,
+                last_error_detail,
+                quarantine_reason,
+                result_type,
+                result_json,
+                retain_until
+            FROM outbox.command_inbox_archive
+            WHERE source_event_id = $1
+            ORDER BY consumer_name, command_id
+            ",
+            &[&event_id],
+        )
+        .await
+        .expect("failed to read command inbox archive completeness rows");
+    assert_eq!(archived_commands.len(), 3);
+
+    let archived_audit_command = &archived_commands[0];
+    assert_eq!(
+        archived_audit_command.get::<_, String>("consumer_name"),
+        "audit-projector"
+    );
+    assert_eq!(
+        archived_audit_command.get::<_, Uuid>("command_id"),
+        completed_audit_command_id
+    );
+    assert_eq!(
+        archived_audit_command.get::<_, Uuid>("source_event_id"),
+        event_id
+    );
+    assert_eq!(
+        archived_audit_command.get::<_, chrono::DateTime<Utc>>("archived_at"),
+        ts(200)
+    );
+    assert_eq!(
+        archived_audit_command.get::<_, String>("command_type"),
+        completed_audit_command.command_type.as_str()
+    );
+    assert_eq!(
+        archived_audit_command.get::<_, i32>("schema_version"),
+        completed_audit_command.schema_version
+    );
+    assert_eq!(
+        archived_audit_command.get::<_, String>("status"),
+        "completed"
+    );
+    assert_eq!(archived_audit_command.get::<_, i32>("attempt_count"), 1);
+    assert_eq!(
+        archived_audit_command
+            .get::<_, Option<String>>("payload_checksum")
+            .as_deref(),
+        Some(completed_audit_command.payload_hash.as_str())
+    );
+    assert_eq!(
+        archived_audit_command.get::<_, chrono::DateTime<Utc>>("received_at"),
+        ts(42)
+    );
+    assert_eq!(
+        archived_audit_command.get::<_, Option<chrono::DateTime<Utc>>>("completed_at"),
+        Some(ts(52))
+    );
+    assert_eq!(
+        archived_audit_command
+            .get::<_, Option<String>>("result_type")
+            .as_deref(),
+        Some("audited")
+    );
+    assert_eq!(
+        archived_audit_command.get::<_, Option<serde_json::Value>>("result_json"),
+        Some(completed_audit_result)
+    );
+    assert_eq!(
+        archived_audit_command.get::<_, Option<chrono::DateTime<Utc>>>("retain_until"),
+        Some(ts(100))
+    );
+    assert_eq!(
+        archived_audit_command
+            .get::<_, Option<String>>("last_error_class"),
+        None
+    );
+
+    let archived_projection_command = &archived_commands[1];
+    assert_eq!(
+        archived_projection_command.get::<_, String>("consumer_name"),
+        "projection-builder"
+    );
+    assert_eq!(
+        archived_projection_command.get::<_, Uuid>("command_id"),
+        completed_projection_command_id
+    );
+    assert_eq!(
+        archived_projection_command.get::<_, Uuid>("source_event_id"),
+        event_id
+    );
+    assert_eq!(
+        archived_projection_command.get::<_, chrono::DateTime<Utc>>("archived_at"),
+        ts(200)
+    );
+    assert_eq!(
+        archived_projection_command.get::<_, String>("command_type"),
+        completed_projection_command.command_type.as_str()
+    );
+    assert_eq!(
+        archived_projection_command.get::<_, i32>("schema_version"),
+        completed_projection_command.schema_version
+    );
+    assert_eq!(
+        archived_projection_command.get::<_, String>("status"),
+        "completed"
+    );
+    assert_eq!(
+        archived_projection_command.get::<_, i32>("attempt_count"),
+        1
+    );
+    assert_eq!(
+        archived_projection_command
+            .get::<_, Option<String>>("payload_checksum")
+            .as_deref(),
+        Some(completed_projection_command.payload_hash.as_str())
+    );
+    assert_eq!(
+        archived_projection_command.get::<_, chrono::DateTime<Utc>>("received_at"),
+        ts(40)
+    );
+    assert_eq!(
+        archived_projection_command.get::<_, Option<chrono::DateTime<Utc>>>("completed_at"),
+        Some(ts(50))
+    );
+    assert_eq!(
+        archived_projection_command
+            .get::<_, Option<String>>("result_type")
+            .as_deref(),
+        Some("projected")
+    );
+    assert_eq!(
+        archived_projection_command.get::<_, Option<serde_json::Value>>("result_json"),
+        Some(completed_projection_result)
+    );
+    assert_eq!(
+        archived_projection_command.get::<_, Option<chrono::DateTime<Utc>>>("retain_until"),
+        Some(ts(100))
+    );
+    assert_eq!(
+        archived_projection_command
+            .get::<_, Option<String>>("last_error_code"),
+        None
+    );
+
+    let archived_quarantined_command = &archived_commands[2];
+    assert_eq!(
+        archived_quarantined_command.get::<_, String>("consumer_name"),
+        "search-indexer"
+    );
+    assert_eq!(
+        archived_quarantined_command.get::<_, Uuid>("command_id"),
+        quarantined_command_id
+    );
+    assert_eq!(
+        archived_quarantined_command.get::<_, Uuid>("source_event_id"),
+        event_id
+    );
+    assert_eq!(
+        archived_quarantined_command.get::<_, chrono::DateTime<Utc>>("archived_at"),
+        ts(200)
+    );
+    assert_eq!(
+        archived_quarantined_command.get::<_, String>("command_type"),
+        quarantined_command.command_type.as_str()
+    );
+    assert_eq!(
+        archived_quarantined_command.get::<_, i32>("schema_version"),
+        quarantined_command.schema_version
+    );
+    assert_eq!(
+        archived_quarantined_command.get::<_, String>("status"),
+        "quarantined"
+    );
+    assert_eq!(
+        archived_quarantined_command.get::<_, i32>("attempt_count"),
+        2
+    );
+    assert_eq!(
+        archived_quarantined_command
+            .get::<_, Option<String>>("payload_checksum")
+            .as_deref(),
+        Some(quarantined_command.payload_hash.as_str())
+    );
+    assert_eq!(
+        archived_quarantined_command.get::<_, chrono::DateTime<Utc>>("received_at"),
+        ts(44)
+    );
+    assert_eq!(
+        archived_quarantined_command.get::<_, Option<chrono::DateTime<Utc>>>("completed_at"),
+        None
+    );
+    assert_eq!(
+        archived_quarantined_command
+            .get::<_, Option<String>>("last_error_class")
+            .as_deref(),
+        Some("permanent")
+    );
+    assert_eq!(
+        archived_quarantined_command
+            .get::<_, Option<String>>("last_error_code")
+            .as_deref(),
+        Some("poison_command")
+    );
+    assert_eq!(
+        archived_quarantined_command
+            .get::<_, Option<String>>("last_error_detail")
+            .as_deref(),
+        Some("command payload rejected by projection worker")
+    );
+    assert_eq!(
+        archived_quarantined_command
+            .get::<_, Option<String>>("quarantine_reason")
+            .as_deref(),
+        Some("poison_pill")
+    );
+    assert_eq!(
+        archived_quarantined_command
+            .get::<_, Option<String>>("result_type"),
+        None
+    );
+    assert_eq!(
+        archived_quarantined_command.get::<_, Option<serde_json::Value>>("result_json"),
+        None
+    );
+    assert_eq!(
+        archived_quarantined_command.get::<_, Option<chrono::DateTime<Utc>>>("retain_until"),
+        Some(ts(100))
+    );
+
+    let hot_eligible_command_count: i64 = tx
+        .query_one(
+            "
+            SELECT COUNT(*) AS count
+            FROM outbox.command_inbox
+            WHERE (consumer_name = $1 AND command_id = $2)
+               OR (consumer_name = $3 AND command_id = $4)
+               OR (consumer_name = $5 AND command_id = $6)
+            ",
+            &[
+                &"audit-projector",
+                &completed_audit_command_id,
+                &"projection-builder",
+                &completed_projection_command_id,
+                &"search-indexer",
+                &quarantined_command_id,
+            ],
+        )
+        .await
+        .expect("failed to count hot eligible command inbox rows after prune")
+        .get("count");
+    let archived_eligible_command_count: i64 = tx
+        .query_one(
+            "
+            SELECT COUNT(*) AS count
+            FROM outbox.command_inbox_archive
+            WHERE (consumer_name = $1 AND command_id = $2)
+               OR (consumer_name = $3 AND command_id = $4)
+               OR (consumer_name = $5 AND command_id = $6)
+            ",
+            &[
+                &"audit-projector",
+                &completed_audit_command_id,
+                &"projection-builder",
+                &completed_projection_command_id,
+                &"search-indexer",
+                &quarantined_command_id,
+            ],
+        )
+        .await
+        .expect("failed to count archived eligible command inbox rows after prune")
+        .get("count");
+    let retained_terminal_hot_count: i64 = tx
+        .query_one(
+            "
+            SELECT COUNT(*) AS count
+            FROM outbox.command_inbox
+            WHERE consumer_name = $1
+              AND command_id = $2
+              AND status = 'completed'
+              AND retain_until = $3
+            ",
+            &[
+                &"projection-builder",
+                &retained_terminal_command_id,
+                &ts(300),
+            ],
+        )
+        .await
+        .expect("failed to count retained terminal command inbox row after prune")
+        .get("count");
+    let retained_terminal_archive_count: i64 = tx
+        .query_one(
+            "
+            SELECT COUNT(*) AS count
+            FROM outbox.command_inbox_archive
+            WHERE consumer_name = $1
+              AND command_id = $2
+            ",
+            &[&"projection-builder", &retained_terminal_command_id],
+        )
+        .await
+        .expect("failed to count retained terminal command archive row after prune")
+        .get("count");
+    let nonterminal_hot_count: i64 = tx
+        .query_one(
+            "
+            SELECT COUNT(*) AS count
+            FROM outbox.command_inbox
+            WHERE consumer_name = $1
+              AND command_id = $2
+              AND status = 'processing'
+              AND retain_until = $3
+            ",
+            &[&"audit-projector", &nonterminal_command_id, &ts(100)],
+        )
+        .await
+        .expect("failed to count retained nonterminal command inbox row after prune")
+        .get("count");
+    let nonterminal_archive_count: i64 = tx
+        .query_one(
+            "
+            SELECT COUNT(*) AS count
+            FROM outbox.command_inbox_archive
+            WHERE consumer_name = $1
+              AND command_id = $2
+            ",
+            &[&"audit-projector", &nonterminal_command_id],
+        )
+        .await
+        .expect("failed to count retained nonterminal command archive row after prune")
+        .get("count");
+    let hot_outbox_count: i64 = tx
+        .query_one(
+            "SELECT COUNT(*) AS count FROM outbox.events WHERE event_id = $1",
+            &[&event_id],
+        )
+        .await
+        .expect("failed to count hot outbox event after command inbox completeness prune")
+        .get("count");
+    let archived_outbox_count: i64 = tx
+        .query_one(
+            "SELECT COUNT(*) AS count FROM outbox.outbox_event_archive WHERE event_id = $1",
+            &[&event_id],
+        )
+        .await
+        .expect("failed to count archived outbox event after command inbox completeness prune")
+        .get("count");
+
+    assert_eq!(hot_eligible_command_count, 0);
+    assert_eq!(archived_eligible_command_count, 3);
+    assert_eq!(retained_terminal_hot_count, 1);
+    assert_eq!(retained_terminal_archive_count, 0);
+    assert_eq!(nonterminal_hot_count, 1);
+    assert_eq!(nonterminal_archive_count, 0);
+    assert_eq!(hot_outbox_count, 0);
+    assert_eq!(archived_outbox_count, 1);
+
+    tx.rollback()
+        .await
+        .expect("rollback should clean up transactional test state");
+}
+
+#[tokio::test]
 async fn postgres_prune_preserves_nonterminal_coordination_rows() {
     let Ok(database_url) = std::env::var("MUSUBI_TEST_DATABASE_URL") else {
         return;

--- a/apps/backend/docs/guardrails.md
+++ b/apps/backend/docs/guardrails.md
@@ -136,6 +136,7 @@ Current executable tests:
 - `postgres_prune_separates_mixed_retention_eligibility_rows`
 - `postgres_prune_returns_deterministic_outcome_ordering`
 - `postgres_prune_archives_all_attempts_for_eligible_terminal_outbox_event`
+- `postgres_prune_archives_all_eligible_command_inbox_rows_for_source_event`
 - `postgres_prune_preserves_nonterminal_coordination_rows`
 
 These prove terminal outbox and command-inbox coordination rows are archived
@@ -161,7 +162,10 @@ while still preserving retained terminal rows and nonterminal rows. The outbox
 attempt archive completeness contract proves that every hot outbox attempt row
 for one eligible terminal outbox event is copied into the attempt archive before
 hot rows are removed, while the prune outcome still reports the outbox event
-only once.
+only once. The command inbox archive completeness contract proves that all
+eligible terminal command inbox rows for one source event are copied into the
+command archive before hot rows are removed, while terminal rows with future
+retention and nonterminal rows sharing that source event remain hot-row owned.
 
 ### 5. Drop-Tx-Before-Await at the runtime seam
 

--- a/apps/backend/docs/raw_transaction_inventory.txt
+++ b/apps/backend/docs/raw_transaction_inventory.txt
@@ -1,6 +1,6 @@
 1 apps/backend/crates/db-runtime/src/migrations.rs
 4 apps/backend/crates/orchestration/src/postgres.rs
-17 apps/backend/crates/orchestration/tests/postgres_contract.rs
+18 apps/backend/crates/orchestration/tests/postgres_contract.rs
 37 apps/backend/src/services/happy_route/repository.rs
 6 apps/backend/src/services/operator_review/repository.rs
 7 apps/backend/src/services/realm_bootstrap/repository.rs

--- a/docs/foundation_lock.md
+++ b/docs/foundation_lock.md
@@ -1,6 +1,6 @@
 # Foundation Lock
 
-Status: Draft; aligned to accepted foundation commit `c9b6e37`
+Status: Draft; aligned to accepted foundation commit `c2729ce`
 Applies to: `mt4110/pi-musubi-core`
 Purpose: Pin the constitutional and architectural source of truth that this implementation repository must follow.
 
@@ -26,14 +26,14 @@ Upstream repository:
 Pinned reference for implementation work:
 
 - Foundation reference type: `commit`
-- Foundation commit SHA: `c9b6e378959fc386bd545d6b5fa844354725ae01`
-- Foundation commit title: `Merge pull request #271 from mt4110/feat/post-c2-orchestration-prune-outbox-attempt-archive-completeness-handoff`
-- Foundation PR title: `docs: evaluate post-C2 orchestration prune outbox attempt archive completeness handoff`
-- Foundation PR URL: `https://github.com/mt4110/musubi-foundation/pull/271`
+- Foundation commit SHA: `c2729ce7a2df2aa66e4ee0f438fb97cafab8aee4`
+- Foundation commit title: `Merge pull request #277 from mt4110/feat/post-c2-orchestration-prune-command-inbox-archive-completeness-handoff`
+- Foundation PR title: `docs: evaluate post-C2 orchestration prune command inbox archive completeness handoff`
+- Foundation PR URL: `https://github.com/mt4110/musubi-foundation/pull/277`
 - Date pinned: `2026-06-12`
 - Pinned by: `Masaki Takemura`
-- Pinned commit URL: `https://github.com/mt4110/musubi-foundation/commit/c9b6e378959fc386bd545d6b5fa844354725ae01`
-- Previous pinned reference: `985eb58` / `Merge pull request #265 from mt4110/feat/post-c2-orchestration-prune-deterministic-outcome-ordering-handoff`
+- Pinned commit URL: `https://github.com/mt4110/musubi-foundation/commit/c2729ce7a2df2aa66e4ee0f438fb97cafab8aee4`
+- Previous pinned reference: `c9b6e37` / `Merge pull request #271 from mt4110/feat/post-c2-orchestration-prune-outbox-attempt-archive-completeness-handoff`
 - Post-C2 evidence source: `cfdba28` / `Merge pull request #114 from mt4110/feat/post-c2-runtime-handoff-evidence-package`
 - Alignment allowance source: `69b7aa4` / `Merge pull request #116 from mt4110/feat/evaluate-post-c2-runtime-handoff-gate`
 - Post-C2 implementation handoff evidence source: `ef23e88` / `Merge pull request #122 from mt4110/feat/post-c2-implementation-handoff-evidence-package`
@@ -115,6 +115,9 @@ Pinned reference for implementation work:
 - Post-C2 orchestration prune deterministic outcome ordering implementation closeout source: `b98fc53` / `Merge pull request #267 from mt4110/feat/close-orchestration-prune-deterministic-outcome-ordering-handoff`
 - Post-C2 orchestration prune outbox attempt archive completeness evidence source: `97aa9e0` / `Merge pull request #269 from mt4110/feat/orchestration-prune-outbox-attempt-archive-completeness-evidence`
 - Post-C2 orchestration prune outbox attempt archive completeness handoff source: `c9b6e37` / `Merge pull request #271 from mt4110/feat/post-c2-orchestration-prune-outbox-attempt-archive-completeness-handoff`
+- Post-C2 orchestration prune outbox attempt archive completeness implementation closeout source: `f314d55` / `Merge pull request #273 from mt4110/feat/close-orchestration-prune-outbox-attempt-archive-completeness-handoff`
+- Post-C2 orchestration prune command inbox archive completeness evidence source: `963f0e6` / `Merge pull request #275 from mt4110/feat/orchestration-prune-command-inbox-archive-completeness-evidence`
+- Post-C2 orchestration prune command inbox archive completeness handoff source: `c2729ce` / `Merge pull request #277 from mt4110/feat/post-c2-orchestration-prune-command-inbox-archive-completeness-handoff`
 
 No release tag is asserted for this alignment.
 Do not invent a foundation version label for this commit.
@@ -267,38 +270,41 @@ Before coding, read these upstream documents in order.
 132. `docs/readiness/post_c2_orchestration_prune_deterministic_outcome_ordering_implementation_closeout_ledger.md`
 133. `docs/readiness/post_c2_orchestration_prune_outbox_attempt_archive_completeness_evidence_package.md`
 134. `docs/readiness/post_c2_orchestration_prune_outbox_attempt_archive_completeness_handoff_gate_decision.md`
+135. `docs/readiness/post_c2_orchestration_prune_outbox_attempt_archive_completeness_implementation_closeout_ledger.md`
+136. `docs/readiness/post_c2_orchestration_prune_command_inbox_archive_completeness_evidence_package.md`
+137. `docs/readiness/post_c2_orchestration_prune_command_inbox_archive_completeness_handoff_gate_decision.md`
 
 ### Operations layer
-135. `docs/operations/readiness_routine.md`
-136. `docs/operations/runalways_readiness_orchestrator_design.md`
-137. `docs/operations/runalways_readiness_orchestrator_stage0.md`
-138. `docs/operations/runalways_lane_controller_v0_1.md`
+138. `docs/operations/readiness_routine.md`
+139. `docs/operations/runalways_readiness_orchestrator_design.md`
+140. `docs/operations/runalways_readiness_orchestrator_stage0.md`
+141. `docs/operations/runalways_lane_controller_v0_1.md`
 
 ### Detail layer
-139. `docs/detail/accountability_matrix.md`
-140. `docs/detail/critical_incident_and_loss.md`
-141. `docs/detail/automated_decisioning_and_human_appeal.md`
-142. `docs/detail/youth_safety_and_age_assurance.md`
-143. `docs/detail/off_platform_handoff_and_scam_prevention.md`
-144. `docs/detail/data_deletion_vs_legal_hold.md`
-145. `docs/detail/security_and_autonomy_hardening.md`
-146. `docs/detail/realm_model.md`
-147. `docs/detail/data_scope_model.md`
-148. `docs/detail/mobility_model.md`
-149. `docs/detail/settlement_model.md`
-150. `docs/detail/settlement_backend_trait.md`
-151. `docs/detail/proof_of_infrastructure.md`
-152. `docs/detail/protected_groups_and_translation_safety.md`
+142. `docs/detail/accountability_matrix.md`
+143. `docs/detail/critical_incident_and_loss.md`
+144. `docs/detail/automated_decisioning_and_human_appeal.md`
+145. `docs/detail/youth_safety_and_age_assurance.md`
+146. `docs/detail/off_platform_handoff_and_scam_prevention.md`
+147. `docs/detail/data_deletion_vs_legal_hold.md`
+148. `docs/detail/security_and_autonomy_hardening.md`
+149. `docs/detail/realm_model.md`
+150. `docs/detail/data_scope_model.md`
+151. `docs/detail/mobility_model.md`
+152. `docs/detail/settlement_model.md`
+153. `docs/detail/settlement_backend_trait.md`
+154. `docs/detail/proof_of_infrastructure.md`
+155. `docs/detail/protected_groups_and_translation_safety.md`
 
 ### Whitepaper layer (contextual, not higher than detail/ADR)
-153. `docs/whitepaper/01_executive_summary.md`
-154. `docs/whitepaper/02_realm_model.md`
-155. `docs/whitepaper/03_experience_model.md`
-156. `docs/whitepaper/04_dm_shield.md`
-157. `docs/whitepaper/05_trust_model.md`
-158. `docs/whitepaper/06_promise_protocol.md`
-159. `docs/whitepaper/07_realm_economy.md`
-160. `docs/whitepaper/08_unlock_engine.md`
+156. `docs/whitepaper/01_executive_summary.md`
+157. `docs/whitepaper/02_realm_model.md`
+158. `docs/whitepaper/03_experience_model.md`
+159. `docs/whitepaper/04_dm_shield.md`
+160. `docs/whitepaper/05_trust_model.md`
+161. `docs/whitepaper/06_promise_protocol.md`
+162. `docs/whitepaper/07_realm_economy.md`
+163. `docs/whitepaper/08_unlock_engine.md`
 
 If any of the above are unavailable or materially inconsistent, stop and escalate.
 
@@ -329,7 +335,7 @@ That one-use C2 implementation allowance was consumed by `mt4110/pi-musubi-core`
 No remaining work may inherit permission from foundation PR #108 or implementation PR #88.
 The broad runtime implementation gate result remains NO-GO.
 Broad runtime implementation remains blocked.
-The current narrow downstream allowance is one implementation-repo test-only PR for post-C2 orchestration prune outbox attempt archive completeness verification.
+The current narrow downstream allowance is one implementation-repo test-only PR for post-C2 orchestration prune command inbox archive completeness verification.
 
 The C2 and post-C2 readiness and closeout chain is accepted for docs-only foundation semantic scope:
 
@@ -417,6 +423,9 @@ The C2 and post-C2 readiness and closeout chain is accepted for docs-only founda
 - `docs/readiness/post_c2_orchestration_prune_deterministic_outcome_ordering_implementation_closeout_ledger.md`
 - `docs/readiness/post_c2_orchestration_prune_outbox_attempt_archive_completeness_evidence_package.md`
 - `docs/readiness/post_c2_orchestration_prune_outbox_attempt_archive_completeness_handoff_gate_decision.md`
+- `docs/readiness/post_c2_orchestration_prune_outbox_attempt_archive_completeness_implementation_closeout_ledger.md`
+- `docs/readiness/post_c2_orchestration_prune_command_inbox_archive_completeness_evidence_package.md`
+- `docs/readiness/post_c2_orchestration_prune_command_inbox_archive_completeness_handoff_gate_decision.md`
 - `docs/operations/readiness_routine.md`
 - `docs/operations/runalways_readiness_orchestrator_design.md`
 - `docs/operations/runalways_readiness_orchestrator_stage0.md`
@@ -525,11 +534,14 @@ Foundation PR #263 accepted the exact candidate test-only slice as post-C2 orche
 Foundation PR #265 provided the prior narrow downstream test-only handoff authority for one later implementation-repo PR only.
 That allowance was consumed by `mt4110/pi-musubi-core` PR #149 and closed out by foundation PR #267.
 Foundation PR #269 accepted the exact candidate test-only slice as post-C2 orchestration prune outbox attempt archive completeness verification.
-Foundation PR #271 provides the current narrow downstream test-only handoff authority for one later implementation-repo PR only.
+Foundation PR #271 provided the prior narrow downstream test-only handoff authority for one later implementation-repo PR only.
+That allowance was consumed by `mt4110/pi-musubi-core` PR #150 and closed out by foundation PR #273.
+Foundation PR #275 accepted the exact candidate test-only slice as post-C2 orchestration prune command inbox archive completeness verification.
+Foundation PR #277 provides the current narrow downstream test-only handoff authority for one later implementation-repo PR only.
 This update is the required lock pin for that one-use allowance.
 It authorizes only `docs/foundation_lock.md`, `apps/backend/crates/orchestration/tests/postgres_contract.rs`, `apps/backend/docs/guardrails.md`, and `apps/backend/docs/raw_transaction_inventory.txt`.
-It allows only deterministic PostgreSQL-backed contract verification that existing coordination pruning archives every hot outbox attempt row belonging to one pruned eligible terminal outbox event, preserves attempt number identity and copied attempt evidence, reports the outbox event once rather than once per attempt, plus the required backend-local guardrail documentation and raw transaction inventory updates.
-It does not authorize broad runtime implementation, DDL, migrations, backend runtime code, public API changes, mobile UI, projection refresh, new runtime orchestration behavior, retry workers, queues, outbox changes, inbox changes, archive schema changes, retention policy changes, manual-review provider evidence pruning behavior, lifecycle runtime behavior, pruning runtime behavior, archive runtime behavior, deletion, Legal Hold runtime behavior, evidence access runtime behavior, key lifecycle behavior, choosing retention periods, provider callbacks, network I/O, external guarantees, scheduled workers, repository workflow changes, secrets, credentials, self-hosted runners, branch protection changes, discovery, recommendation, room, settlement, Promise runtime behavior, proof runtime behavior, Relationship Depth behavior, Social Trust scoring, public trust display, paid romantic advantage, DM unlock by payment, or any broader `pi-musubi-core` change.
+It allows only deterministic PostgreSQL-backed contract verification that existing coordination pruning archives every eligible terminal command inbox row for a shared source event, preserves command archive source event, envelope, terminal status, completion result, quarantine diagnostic, and retention evidence, removes eligible hot command inbox rows, retains terminal rows not retention-eligible and nonterminal rows, and proves command inbox eligibility is row-owned by terminal status plus `retain_until` rather than `source_event_id` alone, plus the required backend-local guardrail documentation and raw transaction inventory updates.
+It does not authorize broad runtime implementation, runtime prune fixes, DDL, migrations, backend runtime code, public API changes, mobile UI, projection refresh, new runtime orchestration behavior, retry workers, queues, outbox changes, inbox changes, archive schema changes, retention policy changes, manual-review provider evidence pruning, lifecycle runtime behavior, pruning runtime behavior, archive runtime behavior, deletion, Legal Hold runtime behavior, evidence access, key lifecycle, choosing retention periods, provider callbacks, network I/O, external guarantees, scheduled workers, repository workflow changes, secrets, credentials, self-hosted runners, branch protection, discovery, recommendation, room, settlement, Promise runtime, proof runtime, Relationship Depth, Social Trust scoring/display, paid romantic advantage, DM unlock by payment, or broader `pi-musubi-core` changes.
 
 Implementation merge history, issue order, branch ancestry, and existing code are not foundation design proof.
 
@@ -750,11 +762,11 @@ When updating:
 - Review completed by:
 
 ### Current drift note
-- Updated from foundation SHA: `985eb58d99346bf1f62e90b47a2b2ea1752043dc` -> `c9b6e378959fc386bd545d6b5fa844354725ae01`
-- Reason: Align implementation-repo lock with the accepted foundation state after PR #271 (`docs: evaluate post-C2 orchestration prune outbox attempt archive completeness handoff`).
-- New required docs: Post-C2 orchestration prune deterministic outcome ordering implementation closeout ledger; Post-C2 orchestration prune outbox attempt archive completeness evidence package; Post-C2 orchestration prune outbox attempt archive completeness handoff gate decision.
+- Updated from foundation SHA: `c9b6e378959fc386bd545d6b5fa844354725ae01` -> `c2729ce7a2df2aa66e4ee0f438fb97cafab8aee4`
+- Reason: Align implementation-repo lock with the accepted foundation state after PR #277 (`docs: evaluate post-C2 orchestration prune command inbox archive completeness handoff`).
+- New required docs: Post-C2 orchestration prune outbox attempt archive completeness implementation closeout ledger; Post-C2 orchestration prune command inbox archive completeness evidence package; Post-C2 orchestration prune command inbox archive completeness handoff gate decision.
 - Removed docs: None.
-- Implementation impact: PR #271 authorizes one later implementation-repo test-only PR. This PR may update this foundation lock, add deterministic PostgreSQL-backed outbox attempt archive completeness verification to `apps/backend/crates/orchestration/tests/postgres_contract.rs`, and update only `apps/backend/docs/guardrails.md` plus `apps/backend/docs/raw_transaction_inventory.txt` for the new guardrail test surface. Broad runtime implementation, runtime prune fixes, DDL, migrations, backend runtime code, public API changes, mobile UI, projection refresh, new runtime orchestration behavior, retry workers, queues, outbox changes, inbox changes, archive schema changes, retention policy changes, manual-review provider evidence pruning behavior, lifecycle runtime behavior, pruning runtime behavior, archive runtime behavior, deletion, Legal Hold runtime behavior, evidence access runtime behavior, key lifecycle behavior, choosing retention periods, Relationship Depth behavior, Social Trust scoring, public trust display, provider callbacks, network I/O, external guarantees, scheduled workers, repository workflow changes, secrets, credentials, self-hosted runners, branch protection changes, paid romantic advantage, and DM unlock by payment remain blocked.
+- Implementation impact: PR #277 authorizes one later implementation-repo test-only PR. This PR may update this foundation lock, add deterministic PostgreSQL-backed command inbox archive completeness verification to `apps/backend/crates/orchestration/tests/postgres_contract.rs`, and update only `apps/backend/docs/guardrails.md` plus `apps/backend/docs/raw_transaction_inventory.txt` for the new guardrail test surface. Broad runtime implementation, runtime prune fixes, DDL, migrations, backend runtime code, public API changes, mobile UI, projection refresh, new runtime orchestration behavior, retry workers, queues, outbox changes, inbox changes, archive schema changes, retention policy changes, manual-review provider evidence pruning behavior, lifecycle runtime behavior, pruning runtime behavior, archive runtime behavior, deletion, Legal Hold runtime behavior, evidence access runtime behavior, key lifecycle behavior, choosing retention periods, Relationship Depth behavior, Social Trust scoring/display, provider callbacks, network I/O, external guarantees, scheduled workers, repository workflow changes, secrets, credentials, self-hosted runners, branch protection changes, paid romantic advantage, and DM unlock by payment remain blocked.
 - Review completed by: Masaki Takemura
 
 ---


### PR DESCRIPTION
## Summary
- pin `docs/foundation_lock.md` to foundation PR #277 / commit `c2729ce`
- add the PostgreSQL contract `postgres_prune_archives_all_eligible_command_inbox_rows_for_source_event`
- document the new guardrail surface and update the raw transaction inventory count

## Scope
This stays within the PR #277 narrow test-only allowance: foundation lock, one orchestration PostgreSQL contract test, guardrail docs, and raw transaction inventory only. No runtime code, DDL, migration, API, UI, worker, queue, schema, retention policy, provider guarantee, Social Trust, Relationship Depth, settlement, Promise runtime, or proof runtime changes are included.

## Validation
- `MUSUBI_TEST_DATABASE_URL=postgres://musubi:musubi_local_dev@127.0.0.1:55432/musubi_test cargo test --manifest-path apps/backend/Cargo.toml -p musubi_orchestration postgres_prune_archives_all_eligible_command_inbox_rows_for_source_event`
- `MUSUBI_TEST_DATABASE_URL=postgres://musubi:musubi_local_dev@127.0.0.1:55432/musubi_test_command_inbox_archive_completeness_20260612 cargo test --manifest-path apps/backend/Cargo.toml -p musubi_orchestration`
- `make guardrail-sweep`
- `make guardrail-sweep-self-test`
- `git diff --check`