### PR TITLE
test: apply command inbox archive formatting compliance

### DIFF
--- a/apps/backend/crates/orchestration/tests/postgres_contract.rs
+++ b/apps/backend/crates/orchestration/tests/postgres_contract.rs
@@ -4409,8 +4409,7 @@ async fn postgres_prune_archives_all_eligible_command_inbox_rows_for_source_even
         Some(ts(100))
     );
     assert_eq!(
-        archived_audit_command
-            .get::<_, Option<String>>("last_error_class"),
+        archived_audit_command.get::<_, Option<String>>("last_error_class"),
         None
     );
 
@@ -4476,8 +4475,7 @@ async fn postgres_prune_archives_all_eligible_command_inbox_rows_for_source_even
         Some(ts(100))
     );
     assert_eq!(
-        archived_projection_command
-            .get::<_, Option<String>>("last_error_code"),
+        archived_projection_command.get::<_, Option<String>>("last_error_code"),
         None
     );
 
@@ -4553,8 +4551,7 @@ async fn postgres_prune_archives_all_eligible_command_inbox_rows_for_source_even
         Some("poison_pill")
     );
     assert_eq!(
-        archived_quarantined_command
-            .get::<_, Option<String>>("result_type"),
+        archived_quarantined_command.get::<_, Option<String>>("result_type"),
         None
     );
     assert_eq!(

--- a/docs/foundation_lock.md
+++ b/docs/foundation_lock.md
@@ -1,6 +1,6 @@
 # Foundation Lock
 
-Status: Draft; aligned to accepted foundation commit `c2729ce`
+Status: Draft; aligned to accepted foundation commit `17ee7d9`
 Applies to: `mt4110/pi-musubi-core`
 Purpose: Pin the constitutional and architectural source of truth that this implementation repository must follow.
 
@@ -26,14 +26,14 @@ Upstream repository:
 Pinned reference for implementation work:
 
 - Foundation reference type: `commit`
-- Foundation commit SHA: `c2729ce7a2df2aa66e4ee0f438fb97cafab8aee4`
-- Foundation commit title: `Merge pull request #277 from mt4110/feat/post-c2-orchestration-prune-command-inbox-archive-completeness-handoff`
-- Foundation PR title: `docs: evaluate post-C2 orchestration prune command inbox archive completeness handoff`
-- Foundation PR URL: `https://github.com/mt4110/musubi-foundation/pull/277`
+- Foundation commit SHA: `17ee7d95833d8e60b369b83bbf9c2e9f90c876ec`
+- Foundation commit title: `Merge pull request #283 from mt4110/feat/post-c2-orchestration-prune-command-inbox-formatting-compliance-handoff`
+- Foundation PR title: `docs: add command inbox archive formatting compliance handoff`
+- Foundation PR URL: `https://github.com/mt4110/musubi-foundation/pull/283`
 - Date pinned: `2026-06-12`
 - Pinned by: `Masaki Takemura`
-- Pinned commit URL: `https://github.com/mt4110/musubi-foundation/commit/c2729ce7a2df2aa66e4ee0f438fb97cafab8aee4`
-- Previous pinned reference: `c9b6e37` / `Merge pull request #271 from mt4110/feat/post-c2-orchestration-prune-outbox-attempt-archive-completeness-handoff`
+- Pinned commit URL: `https://github.com/mt4110/musubi-foundation/commit/17ee7d95833d8e60b369b83bbf9c2e9f90c876ec`
+- Previous pinned reference: `c2729ce` / `Merge pull request #277 from mt4110/feat/post-c2-orchestration-prune-command-inbox-archive-completeness-handoff`
 - Post-C2 evidence source: `cfdba28` / `Merge pull request #114 from mt4110/feat/post-c2-runtime-handoff-evidence-package`
 - Alignment allowance source: `69b7aa4` / `Merge pull request #116 from mt4110/feat/evaluate-post-c2-runtime-handoff-gate`
 - Post-C2 implementation handoff evidence source: `ef23e88` / `Merge pull request #122 from mt4110/feat/post-c2-implementation-handoff-evidence-package`
@@ -118,6 +118,9 @@ Pinned reference for implementation work:
 - Post-C2 orchestration prune outbox attempt archive completeness implementation closeout source: `f314d55` / `Merge pull request #273 from mt4110/feat/close-orchestration-prune-outbox-attempt-archive-completeness-handoff`
 - Post-C2 orchestration prune command inbox archive completeness evidence source: `963f0e6` / `Merge pull request #275 from mt4110/feat/orchestration-prune-command-inbox-archive-completeness-evidence`
 - Post-C2 orchestration prune command inbox archive completeness handoff source: `c2729ce` / `Merge pull request #277 from mt4110/feat/post-c2-orchestration-prune-command-inbox-archive-completeness-handoff`
+- Post-C2 orchestration prune command inbox archive completeness implementation closeout source: `5ea1143` / `Merge pull request #279 from mt4110/feat/close-orchestration-prune-command-inbox-archive-completeness-handoff`
+- Post-C2 orchestration prune command inbox archive completeness formatting compliance evidence source: `daf0cab` / `Merge pull request #281 from mt4110/feat/orchestration-prune-command-inbox-formatting-compliance-evidence`
+- Post-C2 orchestration prune command inbox archive completeness formatting compliance handoff source: `17ee7d9` / `Merge pull request #283 from mt4110/feat/post-c2-orchestration-prune-command-inbox-formatting-compliance-handoff`
 
 No release tag is asserted for this alignment.
 Do not invent a foundation version label for this commit.
@@ -273,38 +276,41 @@ Before coding, read these upstream documents in order.
 135. `docs/readiness/post_c2_orchestration_prune_outbox_attempt_archive_completeness_implementation_closeout_ledger.md`
 136. `docs/readiness/post_c2_orchestration_prune_command_inbox_archive_completeness_evidence_package.md`
 137. `docs/readiness/post_c2_orchestration_prune_command_inbox_archive_completeness_handoff_gate_decision.md`
+138. `docs/readiness/post_c2_orchestration_prune_command_inbox_archive_completeness_implementation_closeout_ledger.md`
+139. `docs/readiness/post_c2_orchestration_prune_command_inbox_archive_completeness_formatting_compliance_evidence_package.md`
+140. `docs/readiness/post_c2_orchestration_prune_command_inbox_archive_completeness_formatting_compliance_handoff_gate_decision.md`
 
 ### Operations layer
-138. `docs/operations/readiness_routine.md`
-139. `docs/operations/runalways_readiness_orchestrator_design.md`
-140. `docs/operations/runalways_readiness_orchestrator_stage0.md`
-141. `docs/operations/runalways_lane_controller_v0_1.md`
+141. `docs/operations/readiness_routine.md`
+142. `docs/operations/runalways_readiness_orchestrator_design.md`
+143. `docs/operations/runalways_readiness_orchestrator_stage0.md`
+144. `docs/operations/runalways_lane_controller_v0_1.md`
 
 ### Detail layer
-142. `docs/detail/accountability_matrix.md`
-143. `docs/detail/critical_incident_and_loss.md`
-144. `docs/detail/automated_decisioning_and_human_appeal.md`
-145. `docs/detail/youth_safety_and_age_assurance.md`
-146. `docs/detail/off_platform_handoff_and_scam_prevention.md`
-147. `docs/detail/data_deletion_vs_legal_hold.md`
-148. `docs/detail/security_and_autonomy_hardening.md`
-149. `docs/detail/realm_model.md`
-150. `docs/detail/data_scope_model.md`
-151. `docs/detail/mobility_model.md`
-152. `docs/detail/settlement_model.md`
-153. `docs/detail/settlement_backend_trait.md`
-154. `docs/detail/proof_of_infrastructure.md`
-155. `docs/detail/protected_groups_and_translation_safety.md`
+145. `docs/detail/accountability_matrix.md`
+146. `docs/detail/critical_incident_and_loss.md`
+147. `docs/detail/automated_decisioning_and_human_appeal.md`
+148. `docs/detail/youth_safety_and_age_assurance.md`
+149. `docs/detail/off_platform_handoff_and_scam_prevention.md`
+150. `docs/detail/data_deletion_vs_legal_hold.md`
+151. `docs/detail/security_and_autonomy_hardening.md`
+152. `docs/detail/realm_model.md`
+153. `docs/detail/data_scope_model.md`
+154. `docs/detail/mobility_model.md`
+155. `docs/detail/settlement_model.md`
+156. `docs/detail/settlement_backend_trait.md`
+157. `docs/detail/proof_of_infrastructure.md`
+158. `docs/detail/protected_groups_and_translation_safety.md`
 
 ### Whitepaper layer (contextual, not higher than detail/ADR)
-156. `docs/whitepaper/01_executive_summary.md`
-157. `docs/whitepaper/02_realm_model.md`
-158. `docs/whitepaper/03_experience_model.md`
-159. `docs/whitepaper/04_dm_shield.md`
-160. `docs/whitepaper/05_trust_model.md`
-161. `docs/whitepaper/06_promise_protocol.md`
-162. `docs/whitepaper/07_realm_economy.md`
-163. `docs/whitepaper/08_unlock_engine.md`
+159. `docs/whitepaper/01_executive_summary.md`
+160. `docs/whitepaper/02_realm_model.md`
+161. `docs/whitepaper/03_experience_model.md`
+162. `docs/whitepaper/04_dm_shield.md`
+163. `docs/whitepaper/05_trust_model.md`
+164. `docs/whitepaper/06_promise_protocol.md`
+165. `docs/whitepaper/07_realm_economy.md`
+166. `docs/whitepaper/08_unlock_engine.md`
 
 If any of the above are unavailable or materially inconsistent, stop and escalate.
 
@@ -335,7 +341,7 @@ That one-use C2 implementation allowance was consumed by `mt4110/pi-musubi-core`
 No remaining work may inherit permission from foundation PR #108 or implementation PR #88.
 The broad runtime implementation gate result remains NO-GO.
 Broad runtime implementation remains blocked.
-The current narrow downstream allowance is one implementation-repo test-only PR for post-C2 orchestration prune command inbox archive completeness verification.
+The current narrow downstream allowance is one implementation-repo formatting-only PR for post-C2 orchestration prune command inbox archive completeness formatting compliance correction.
 
 The C2 and post-C2 readiness and closeout chain is accepted for docs-only foundation semantic scope:
 
@@ -426,6 +432,9 @@ The C2 and post-C2 readiness and closeout chain is accepted for docs-only founda
 - `docs/readiness/post_c2_orchestration_prune_outbox_attempt_archive_completeness_implementation_closeout_ledger.md`
 - `docs/readiness/post_c2_orchestration_prune_command_inbox_archive_completeness_evidence_package.md`
 - `docs/readiness/post_c2_orchestration_prune_command_inbox_archive_completeness_handoff_gate_decision.md`
+- `docs/readiness/post_c2_orchestration_prune_command_inbox_archive_completeness_implementation_closeout_ledger.md`
+- `docs/readiness/post_c2_orchestration_prune_command_inbox_archive_completeness_formatting_compliance_evidence_package.md`
+- `docs/readiness/post_c2_orchestration_prune_command_inbox_archive_completeness_formatting_compliance_handoff_gate_decision.md`
 - `docs/operations/readiness_routine.md`
 - `docs/operations/runalways_readiness_orchestrator_design.md`
 - `docs/operations/runalways_readiness_orchestrator_stage0.md`
@@ -537,11 +546,14 @@ Foundation PR #269 accepted the exact candidate test-only slice as post-C2 orche
 Foundation PR #271 provided the prior narrow downstream test-only handoff authority for one later implementation-repo PR only.
 That allowance was consumed by `mt4110/pi-musubi-core` PR #150 and closed out by foundation PR #273.
 Foundation PR #275 accepted the exact candidate test-only slice as post-C2 orchestration prune command inbox archive completeness verification.
-Foundation PR #277 provides the current narrow downstream test-only handoff authority for one later implementation-repo PR only.
+Foundation PR #277 provided the prior narrow downstream test-only handoff authority for one later implementation-repo PR only.
+That allowance was consumed by `mt4110/pi-musubi-core` PR #151 and closed out by foundation PR #279 with a formatting validation gap recorded.
+Foundation PR #281 accepted the exact candidate corrective slice as post-C2 orchestration prune command inbox archive completeness formatting compliance correction.
+Foundation PR #283 provides the current narrow downstream formatting-only handoff authority for one later implementation-repo PR only.
 This update is the required lock pin for that one-use allowance.
-It authorizes only `docs/foundation_lock.md`, `apps/backend/crates/orchestration/tests/postgres_contract.rs`, `apps/backend/docs/guardrails.md`, and `apps/backend/docs/raw_transaction_inventory.txt`.
-It allows only deterministic PostgreSQL-backed contract verification that existing coordination pruning archives every eligible terminal command inbox row for a shared source event, preserves command archive source event, envelope, terminal status, completion result, quarantine diagnostic, and retention evidence, removes eligible hot command inbox rows, retains terminal rows not retention-eligible and nonterminal rows, and proves command inbox eligibility is row-owned by terminal status plus `retain_until` rather than `source_event_id` alone, plus the required backend-local guardrail documentation and raw transaction inventory updates.
-It does not authorize broad runtime implementation, runtime prune fixes, DDL, migrations, backend runtime code, public API changes, mobile UI, projection refresh, new runtime orchestration behavior, retry workers, queues, outbox changes, inbox changes, archive schema changes, retention policy changes, manual-review provider evidence pruning, lifecycle runtime behavior, pruning runtime behavior, archive runtime behavior, deletion, Legal Hold runtime behavior, evidence access, key lifecycle, choosing retention periods, provider callbacks, network I/O, external guarantees, scheduled workers, repository workflow changes, secrets, credentials, self-hosted runners, branch protection, discovery, recommendation, room, settlement, Promise runtime, proof runtime, Relationship Depth, Social Trust scoring/display, paid romantic advantage, DM unlock by payment, or broader `pi-musubi-core` changes.
+It authorizes only `docs/foundation_lock.md` and `apps/backend/crates/orchestration/tests/postgres_contract.rs`.
+It allows only updating this foundation lock to pin PR #283 and applying the minimal `rustfmt --edition 2024` formatting output to the already-merged `postgres_prune_archives_all_eligible_command_inbox_rows_for_source_event` test while preserving the existing test name, proof semantics, and raw transaction inventory count.
+It does not authorize broad runtime implementation, runtime prune fixes, DDL, migrations, backend runtime code, public API changes, mobile UI, projection refresh, new runtime orchestration behavior, retry workers, queues, outbox changes, inbox changes, archive schema changes, retention policy changes, manual-review provider evidence pruning, lifecycle runtime behavior, pruning runtime behavior, archive runtime behavior, deletion, Legal Hold runtime behavior, evidence access, key lifecycle, choosing retention periods, provider callbacks, network I/O, external guarantees, scheduled workers, repository workflow changes, secrets, credentials, self-hosted runners, branch protection, discovery, recommendation, room, settlement, Promise runtime, proof runtime, Relationship Depth, Social Trust scoring/display, new tests, test behavior changes, paid romantic advantage, DM unlock by payment, or broader `pi-musubi-core` changes.
 
 Implementation merge history, issue order, branch ancestry, and existing code are not foundation design proof.
 
@@ -762,11 +774,11 @@ When updating:
 - Review completed by:
 
 ### Current drift note
-- Updated from foundation SHA: `c9b6e378959fc386bd545d6b5fa844354725ae01` -> `c2729ce7a2df2aa66e4ee0f438fb97cafab8aee4`
-- Reason: Align implementation-repo lock with the accepted foundation state after PR #277 (`docs: evaluate post-C2 orchestration prune command inbox archive completeness handoff`).
-- New required docs: Post-C2 orchestration prune outbox attempt archive completeness implementation closeout ledger; Post-C2 orchestration prune command inbox archive completeness evidence package; Post-C2 orchestration prune command inbox archive completeness handoff gate decision.
+- Updated from foundation SHA: `c2729ce7a2df2aa66e4ee0f438fb97cafab8aee4` -> `17ee7d95833d8e60b369b83bbf9c2e9f90c876ec`
+- Reason: Align implementation-repo lock with the accepted foundation state after PR #283 (`docs: add command inbox archive formatting compliance handoff`).
+- New required docs: Post-C2 orchestration prune command inbox archive completeness implementation closeout ledger; Post-C2 orchestration prune command inbox archive completeness formatting compliance evidence package; Post-C2 orchestration prune command inbox archive completeness formatting compliance handoff gate decision.
 - Removed docs: None.
-- Implementation impact: PR #277 authorizes one later implementation-repo test-only PR. This PR may update this foundation lock, add deterministic PostgreSQL-backed command inbox archive completeness verification to `apps/backend/crates/orchestration/tests/postgres_contract.rs`, and update only `apps/backend/docs/guardrails.md` plus `apps/backend/docs/raw_transaction_inventory.txt` for the new guardrail test surface. Broad runtime implementation, runtime prune fixes, DDL, migrations, backend runtime code, public API changes, mobile UI, projection refresh, new runtime orchestration behavior, retry workers, queues, outbox changes, inbox changes, archive schema changes, retention policy changes, manual-review provider evidence pruning behavior, lifecycle runtime behavior, pruning runtime behavior, archive runtime behavior, deletion, Legal Hold runtime behavior, evidence access runtime behavior, key lifecycle behavior, choosing retention periods, Relationship Depth behavior, Social Trust scoring/display, provider callbacks, network I/O, external guarantees, scheduled workers, repository workflow changes, secrets, credentials, self-hosted runners, branch protection changes, paid romantic advantage, and DM unlock by payment remain blocked.
+- Implementation impact: PR #283 authorizes one later implementation-repo formatting-only PR. This PR may update this foundation lock and apply minimal `rustfmt --edition 2024` formatting to the existing `postgres_prune_archives_all_eligible_command_inbox_rows_for_source_event` test in `apps/backend/crates/orchestration/tests/postgres_contract.rs`. Broad runtime implementation, runtime prune fixes, DDL, migrations, backend runtime code, public API changes, mobile UI, projection refresh, new runtime orchestration behavior, retry workers, queues, outbox changes, inbox changes, archive schema changes, retention policy changes, manual-review provider evidence pruning behavior, lifecycle runtime behavior, pruning runtime behavior, archive runtime behavior, deletion, Legal Hold runtime behavior, evidence access runtime behavior, key lifecycle behavior, choosing retention periods, Relationship Depth behavior, Social Trust scoring/display, provider callbacks, network I/O, external guarantees, scheduled workers, repository workflow changes, secrets, credentials, self-hosted runners, branch protection changes, new tests, test behavior changes, paid romantic advantage, and DM unlock by payment remain blocked.
 - Review completed by: Masaki Takemura
 
 ---


### PR DESCRIPTION
## Summary
- pin `docs/foundation_lock.md` to foundation PR #283 / commit `17ee7d9`
- apply the minimal `rustfmt --edition 2024` formatting output to the existing `postgres_prune_archives_all_eligible_command_inbox_rows_for_source_event` test

## Scope
This stays within the PR #283 formatting-only allowance: `docs/foundation_lock.md` and `apps/backend/crates/orchestration/tests/postgres_contract.rs` only. No new tests, test behavior changes, runtime code, DDL, migrations, API, UI, provider guarantee, Social Trust, Relationship Depth, settlement, Promise runtime, or proof runtime changes are included.

## Validation
- `test -n "$MUSUBI_TEST_DATABASE_URL"` with explicit local PostgreSQL URL
- `rustfmt --edition 2024 --check apps/backend/crates/orchestration/tests/postgres_contract.rs`
- `MUSUBI_TEST_DATABASE_URL=postgres://musubi:musubi_local_dev@127.0.0.1:55432/musubi_test_command_inbox_formatting_compliance cargo test --manifest-path apps/backend/Cargo.toml -p musubi_orchestration --test postgres_contract postgres_prune_archives_all_eligible_command_inbox_rows_for_source_event -- --exact --nocapture`
- `git diff --check origin/main...HEAD`
- `MUSUBI_TEST_DATABASE_URL=postgres://musubi:musubi_local_dev@127.0.0.1:55432/musubi_test_command_inbox_formatting_compliance cargo test --manifest-path apps/backend/Cargo.toml -p musubi_orchestration --test postgres_contract -- --nocapture`
- `make guardrail-sweep`