### PR TITLE
fix: fail closed on archive conflict mismatch

### DIFF
--- a/apps/backend/crates/orchestration/src/postgres.rs
+++ b/apps/backend/crates/orchestration/src/postgres.rs
@@ -275,6 +275,48 @@ impl PostgresOrchestrationStore {
         .await
         .map_err(database_error)?;
 
+        let mismatched_outbox_event_archives: i64 = tx
+            .query_one(
+                "
+                SELECT COUNT(*) AS count
+                FROM outbox.events AS events
+                LEFT JOIN outbox.outbox_event_archive AS archive
+                  ON archive.event_id = events.event_id
+                WHERE events.delivery_status IN ('published', 'quarantined')
+                  AND events.retain_until IS NOT NULL
+                  AND events.retain_until <= $1
+                  AND (
+                    archive.event_id IS NULL
+                    OR archive.stream_key IS DISTINCT FROM events.stream_key
+                    OR archive.aggregate_type IS DISTINCT FROM events.aggregate_type
+                    OR archive.aggregate_id IS DISTINCT FROM events.aggregate_id
+                    OR archive.event_type IS DISTINCT FROM events.event_type
+                    OR archive.schema_version IS DISTINCT FROM events.schema_version
+                    OR archive.payload_json IS DISTINCT FROM events.payload_json
+                    OR archive.payload_hash IS DISTINCT FROM events.payload_hash
+                    OR archive.final_status IS DISTINCT FROM events.delivery_status
+                    OR archive.attempt_count IS DISTINCT FROM events.attempt_count
+                    OR archive.causal_order IS DISTINCT FROM events.causal_order
+                    OR archive.available_at IS DISTINCT FROM events.available_at
+                    OR archive.created_at IS DISTINCT FROM events.created_at
+                    OR archive.published_at IS DISTINCT FROM events.published_at
+                    OR archive.quarantined_at IS DISTINCT FROM events.quarantined_at
+                    OR archive.last_attempt_at IS DISTINCT FROM events.last_attempt_at
+                    OR archive.last_error_class IS DISTINCT FROM events.last_error_class
+                    OR archive.last_error_code IS DISTINCT FROM events.last_error_code
+                    OR archive.last_error_detail IS DISTINCT FROM events.last_error_detail
+                    OR archive.quarantine_reason IS DISTINCT FROM events.quarantine_reason
+                    OR archive.retain_until IS DISTINCT FROM events.retain_until
+                    OR archive.published_external_idempotency_key
+                        IS DISTINCT FROM events.published_external_idempotency_key
+                  )
+                ",
+                &[&now],
+            )
+            .await
+            .map_err(database_error)?
+            .get("count");
+
         tx.execute(
             "
             INSERT INTO outbox.outbox_attempt_archive (
@@ -315,17 +357,37 @@ impl PostgresOrchestrationStore {
         .await
         .map_err(database_error)?;
 
-        tx.execute(
-            "
-            DELETE FROM outbox.events
-            WHERE delivery_status IN ('published', 'quarantined')
-              AND retain_until IS NOT NULL
-              AND retain_until <= $1
-            ",
-            &[&now],
-        )
-        .await
-        .map_err(database_error)?;
+        let mismatched_outbox_attempt_archives: i64 = tx
+            .query_one(
+                "
+                SELECT COUNT(*) AS count
+                FROM outbox.outbox_attempts AS attempts
+                JOIN outbox.events AS events
+                  ON events.event_id = attempts.event_id
+                LEFT JOIN outbox.outbox_attempt_archive AS archive
+                  ON archive.event_id = attempts.event_id
+                 AND archive.attempt_number = attempts.attempt_number
+                WHERE events.delivery_status IN ('published', 'quarantined')
+                  AND events.retain_until IS NOT NULL
+                  AND events.retain_until <= $1
+                  AND (
+                    archive.event_id IS NULL
+                    OR archive.relay_name IS DISTINCT FROM attempts.relay_name
+                    OR archive.claimed_at IS DISTINCT FROM attempts.claimed_at
+                    OR archive.claimed_until IS DISTINCT FROM attempts.claimed_until
+                    OR archive.finished_at IS DISTINCT FROM attempts.finished_at
+                    OR archive.failure_class IS DISTINCT FROM attempts.failure_class
+                    OR archive.failure_code IS DISTINCT FROM attempts.failure_code
+                    OR archive.failure_detail IS DISTINCT FROM attempts.failure_detail
+                    OR archive.external_idempotency_key
+                        IS DISTINCT FROM attempts.external_idempotency_key
+                  )
+                ",
+                &[&now],
+            )
+            .await
+            .map_err(database_error)?
+            .get("count");
 
         let command_rows = tx
             .query(
@@ -390,6 +452,63 @@ impl PostgresOrchestrationStore {
               AND retain_until IS NOT NULL
               AND retain_until <= $1
             ON CONFLICT (consumer_name, command_id) DO NOTHING
+            ",
+            &[&now],
+        )
+        .await
+        .map_err(database_error)?;
+
+        let mismatched_command_inbox_archives: i64 = tx
+            .query_one(
+                "
+                SELECT COUNT(*) AS count
+                FROM outbox.command_inbox AS command
+                LEFT JOIN outbox.command_inbox_archive AS archive
+                  ON archive.consumer_name = command.consumer_name
+                 AND archive.command_id = command.command_id
+                WHERE command.status IN ('completed', 'quarantined')
+                  AND command.retain_until IS NOT NULL
+                  AND command.retain_until <= $1
+                  AND (
+                    archive.consumer_name IS NULL
+                    OR archive.source_event_id IS DISTINCT FROM command.source_event_id
+                    OR archive.command_type IS DISTINCT FROM command.command_type
+                    OR archive.schema_version IS DISTINCT FROM command.schema_version
+                    OR archive.status IS DISTINCT FROM command.status
+                    OR archive.attempt_count IS DISTINCT FROM command.attempt_count
+                    OR archive.payload_checksum IS DISTINCT FROM command.payload_checksum
+                    OR archive.received_at IS DISTINCT FROM command.received_at
+                    OR archive.processed_at IS DISTINCT FROM command.processed_at
+                    OR archive.completed_at IS DISTINCT FROM command.completed_at
+                    OR archive.last_error_class IS DISTINCT FROM command.last_error_class
+                    OR archive.last_error_code IS DISTINCT FROM command.last_error_code
+                    OR archive.last_error_detail IS DISTINCT FROM command.last_error_detail
+                    OR archive.quarantine_reason IS DISTINCT FROM command.quarantine_reason
+                    OR archive.result_type IS DISTINCT FROM command.result_type
+                    OR archive.result_json IS DISTINCT FROM command.result_json
+                    OR archive.retain_until IS DISTINCT FROM command.retain_until
+                  )
+                ",
+                &[&now],
+            )
+            .await
+            .map_err(database_error)?
+            .get("count");
+        if mismatched_outbox_event_archives > 0
+            || mismatched_outbox_attempt_archives > 0
+            || mismatched_command_inbox_archives > 0
+        {
+            return Err(OrchestrationError::Database(
+                "coordination archive evidence mismatch before prune".to_owned(),
+            ));
+        }
+
+        tx.execute(
+            "
+            DELETE FROM outbox.events
+            WHERE delivery_status IN ('published', 'quarantined')
+              AND retain_until IS NOT NULL
+              AND retain_until <= $1
             ",
             &[&now],
         )

--- a/apps/backend/crates/orchestration/tests/postgres_contract.rs
+++ b/apps/backend/crates/orchestration/tests/postgres_contract.rs
@@ -1954,6 +1954,498 @@ async fn postgres_prune_is_idempotent_with_existing_archive_rows() {
 }
 
 #[tokio::test]
+async fn postgres_prune_archive_conflict_mismatch_fails_closed() {
+    let Ok(database_url) = std::env::var("MUSUBI_TEST_DATABASE_URL") else {
+        return;
+    };
+
+    let (mut client, connection) = tokio_postgres::connect(&database_url, NoTls)
+        .await
+        .expect("failed to connect to MUSUBI_TEST_DATABASE_URL");
+    tokio::spawn(async move {
+        let _ = connection.await;
+    });
+
+    let tx = client
+        .transaction()
+        .await
+        .expect("failed to open transaction");
+    tx.batch_execute(include_str!(
+        "../../../migrations/0004_create_outbox_schema.sql"
+    ))
+    .await
+    .expect("failed to apply outbox schema");
+    tx.batch_execute(include_str!(
+        "../../../migrations/0006_orchestration_runtime_baseline.sql"
+    ))
+    .await
+    .expect("failed to apply orchestration baseline migration");
+
+    let aggregate_id = Uuid::from_u128(0x7b0);
+    let event_id = Uuid::from_u128(0x7b1);
+    let command_id = Uuid::from_u128(0x7b2);
+    let pending_event_id = Uuid::from_u128(0x7b3);
+    let pending_command_id = Uuid::from_u128(0x7b4);
+    let message = NewOutboxMessage::new(NewOutboxMessageSpec {
+        event_id,
+        idempotency_key: Uuid::from_u128(0x7b5),
+        stream_key: "settlement_case:archive-conflict-mismatch".to_owned(),
+        aggregate_type: "settlement_case".to_owned(),
+        aggregate_id,
+        event_type: "settlement.submit_action".to_owned(),
+        schema_version: 1,
+        payload_json: json!({
+            "intent_id": "intent-archive-conflict-mismatch",
+            "retention_probe": { "kind": "archive_conflict_mismatch" }
+        }),
+        available_at: ts(0),
+        created_at: ts(0),
+    })
+    .unwrap();
+    let pending_message = NewOutboxMessage::new(NewOutboxMessageSpec {
+        event_id: pending_event_id,
+        idempotency_key: Uuid::from_u128(0x7b6),
+        stream_key: "settlement_case:archive-conflict-mismatch-pending".to_owned(),
+        aggregate_type: "settlement_case".to_owned(),
+        aggregate_id: Uuid::from_u128(0x7b7),
+        event_type: "settlement.submit_action".to_owned(),
+        schema_version: 1,
+        payload_json: json!({
+            "intent_id": "intent-archive-conflict-mismatch-pending"
+        }),
+        available_at: ts(0),
+        created_at: ts(0),
+    })
+    .unwrap();
+
+    PostgresOrchestrationStore::insert_outbox_message(&tx, &message)
+        .await
+        .expect("failed to insert archive mismatch outbox message");
+    PostgresOrchestrationStore::insert_outbox_message(&tx, &pending_message)
+        .await
+        .expect("failed to insert pending archive mismatch outbox message");
+    tx.execute(
+        "
+        UPDATE outbox.events
+        SET delivery_status = 'published',
+            attempt_count = 1,
+            published_at = $2,
+            last_attempt_at = $2,
+            retain_until = $3,
+            published_external_idempotency_key = $4
+        WHERE event_id = $1
+        ",
+        &[
+            &event_id,
+            &ts(10),
+            &ts(100),
+            &"provider-key-archive-conflict-mismatch",
+        ],
+    )
+    .await
+    .expect("failed to mark archive mismatch outbox event terminal");
+    tx.execute(
+        "
+        UPDATE outbox.events
+        SET retain_until = $2
+        WHERE event_id = $1
+        ",
+        &[&pending_event_id, &ts(100)],
+    )
+    .await
+    .expect("failed to mark pending outbox retain_until");
+
+    let causal_order: i64 = tx
+        .query_one(
+            "SELECT causal_order FROM outbox.events WHERE event_id = $1",
+            &[&event_id],
+        )
+        .await
+        .expect("failed to read archive mismatch causal order")
+        .get("causal_order");
+    tx.execute(
+        "
+        INSERT INTO outbox.outbox_attempts (
+            event_id,
+            attempt_number,
+            relay_name,
+            claimed_at,
+            claimed_until,
+            finished_at,
+            failure_class,
+            failure_code,
+            failure_detail,
+            external_idempotency_key
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, NULL, NULL, NULL, $7)
+        ",
+        &[
+            &event_id,
+            &1_i32,
+            &"settlement-relay",
+            &ts(0),
+            &ts(300),
+            &ts(10),
+            &"provider-key-archive-conflict-mismatch",
+        ],
+    )
+    .await
+    .expect("failed to insert archive mismatch outbox attempt");
+
+    let command = CommandEnvelope::new(
+        command_id,
+        event_id,
+        "projection.refresh",
+        1,
+        json!({ "settlement_case_id": aggregate_id }),
+    )
+    .unwrap();
+    let result_json = json!({
+        "projection_id": "projection-archive-conflict-mismatch",
+        "archive_conflict_seen": true
+    });
+    tx.execute(
+        "
+        INSERT INTO outbox.command_inbox (
+            inbox_entry_id,
+            consumer_name,
+            command_id,
+            source_event_id,
+            payload_checksum,
+            received_at,
+            status,
+            available_at,
+            attempt_count,
+            command_type,
+            schema_version,
+            completed_at,
+            result_type,
+            result_json,
+            retain_until
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, 'completed', $6, 1, $7, $8, $9, $10, $11, $12)
+        ",
+        &[
+            &Uuid::from_u128(0x7b8),
+            &"projection-builder",
+            &command_id,
+            &event_id,
+            &command.payload_hash,
+            &ts(20),
+            &command.command_type,
+            &command.schema_version,
+            &ts(30),
+            &"projected",
+            &result_json,
+            &ts(100),
+        ],
+    )
+    .await
+    .expect("failed to insert archive mismatch command inbox row");
+    tx.execute(
+        "
+        INSERT INTO outbox.command_inbox (
+            inbox_entry_id,
+            consumer_name,
+            command_id,
+            source_event_id,
+            payload_checksum,
+            received_at,
+            status,
+            available_at,
+            attempt_count,
+            command_type,
+            schema_version,
+            retain_until
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, 'pending', $6, 0, $7, $8, $9)
+        ",
+        &[
+            &Uuid::from_u128(0x7b9),
+            &"projection-builder",
+            &pending_command_id,
+            &pending_event_id,
+            &"pending-command-checksum",
+            &ts(20),
+            &"projection.refresh",
+            &1_i32,
+            &ts(100),
+        ],
+    )
+    .await
+    .expect("failed to insert pending archive mismatch command inbox row");
+
+    tx.execute(
+        "
+        INSERT INTO outbox.outbox_event_archive (
+            event_id,
+            archived_at,
+            stream_key,
+            aggregate_type,
+            aggregate_id,
+            event_type,
+            schema_version,
+            payload_json,
+            payload_hash,
+            final_status,
+            attempt_count,
+            causal_order,
+            available_at,
+            created_at,
+            published_at,
+            quarantined_at,
+            last_attempt_at,
+            last_error_class,
+            last_error_code,
+            last_error_detail,
+            quarantine_reason,
+            retain_until,
+            published_external_idempotency_key
+        )
+        VALUES (
+            $1, $2, $3, $4, $5, $6, 1, $7, $8, 'published', 1, $9,
+            $10, $10, $11, NULL, $11, NULL, NULL, NULL, NULL, $12, $13
+        )
+        ",
+        &[
+            &event_id,
+            &ts(150),
+            &"settlement_case:mismatched-archive",
+            &message.aggregate_type,
+            &aggregate_id,
+            &message.event_type,
+            &json!({ "mismatched": "event-payload" }),
+            &"mismatched-event-payload-hash",
+            &causal_order,
+            &ts(0),
+            &ts(10),
+            &ts(100),
+            &"provider-key-archive-conflict-mismatch",
+        ],
+    )
+    .await
+    .expect("failed to seed mismatched outbox event archive row");
+    tx.execute(
+        "
+        INSERT INTO outbox.outbox_attempt_archive (
+            event_id,
+            attempt_number,
+            archived_at,
+            relay_name,
+            claimed_at,
+            claimed_until,
+            finished_at,
+            failure_class,
+            failure_code,
+            failure_detail,
+            external_idempotency_key
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, $7, NULL, NULL, NULL, $8)
+        ",
+        &[
+            &event_id,
+            &1_i32,
+            &ts(151),
+            &"unexpected-relay",
+            &ts(0),
+            &ts(300),
+            &ts(10),
+            &"mismatched-attempt-provider-key",
+        ],
+    )
+    .await
+    .expect("failed to seed mismatched outbox attempt archive row");
+    tx.execute(
+        "
+        INSERT INTO outbox.command_inbox_archive (
+            consumer_name,
+            command_id,
+            source_event_id,
+            archived_at,
+            command_type,
+            schema_version,
+            status,
+            attempt_count,
+            payload_checksum,
+            received_at,
+            processed_at,
+            completed_at,
+            last_error_class,
+            last_error_code,
+            last_error_detail,
+            quarantine_reason,
+            result_type,
+            result_json,
+            retain_until
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, 'completed', 1, $7, $8, NULL, $9, NULL, NULL, NULL, NULL, $10, $11, $12)
+        ",
+        &[
+            &"projection-builder",
+            &command_id,
+            &event_id,
+            &ts(152),
+            &"projection.unexpected",
+            &command.schema_version,
+            &"mismatched-command-checksum",
+            &ts(20),
+            &ts(30),
+            &"projected",
+            &result_json,
+            &ts(100),
+        ],
+    )
+    .await
+    .expect("failed to seed mismatched command inbox archive row");
+
+    let prune_error = PostgresOrchestrationStore::prune_coordination(&tx, ts(200))
+        .await
+        .expect_err("mismatched archive conflicts must fail closed before prune");
+    assert!(matches!(
+        prune_error,
+        OrchestrationError::Database(message)
+            if message == "coordination archive evidence mismatch before prune"
+    ));
+
+    let hot_outbox_count: i64 = tx
+        .query_one(
+            "SELECT COUNT(*) AS count FROM outbox.events WHERE event_id = $1",
+            &[&event_id],
+        )
+        .await
+        .expect("failed to count hot outbox event after mismatch prune")
+        .get("count");
+    let hot_attempt_count: i64 = tx
+        .query_one(
+            "SELECT COUNT(*) AS count FROM outbox.outbox_attempts WHERE event_id = $1",
+            &[&event_id],
+        )
+        .await
+        .expect("failed to count hot outbox attempt after mismatch prune")
+        .get("count");
+    let hot_command_count: i64 = tx
+        .query_one(
+            "
+            SELECT COUNT(*) AS count
+            FROM outbox.command_inbox
+            WHERE consumer_name = $1
+              AND command_id = $2
+            ",
+            &[&"projection-builder", &command_id],
+        )
+        .await
+        .expect("failed to count hot command after mismatch prune")
+        .get("count");
+    let pending_event_count: i64 = tx
+        .query_one(
+            "SELECT COUNT(*) AS count FROM outbox.events WHERE event_id = $1",
+            &[&pending_event_id],
+        )
+        .await
+        .expect("failed to count pending event after mismatch prune")
+        .get("count");
+    let pending_command_count: i64 = tx
+        .query_one(
+            "
+            SELECT COUNT(*) AS count
+            FROM outbox.command_inbox
+            WHERE consumer_name = $1
+              AND command_id = $2
+            ",
+            &[&"projection-builder", &pending_command_id],
+        )
+        .await
+        .expect("failed to count pending command after mismatch prune")
+        .get("count");
+
+    assert_eq!(hot_outbox_count, 1);
+    assert_eq!(hot_attempt_count, 1);
+    assert_eq!(hot_command_count, 1);
+    assert_eq!(pending_event_count, 1);
+    assert_eq!(pending_command_count, 1);
+
+    let archived_event = tx
+        .query_one(
+            "
+            SELECT COUNT(*) AS count, MIN(stream_key) AS stream_key, MIN(payload_hash) AS payload_hash
+            FROM outbox.outbox_event_archive
+            WHERE event_id = $1
+            ",
+            &[&event_id],
+        )
+        .await
+        .expect("failed to read mismatched event archive row");
+    let archived_attempt = tx
+        .query_one(
+            "
+            SELECT COUNT(*) AS count, MIN(relay_name) AS relay_name, MIN(external_idempotency_key) AS external_idempotency_key
+            FROM outbox.outbox_attempt_archive
+            WHERE event_id = $1
+              AND attempt_number = $2
+            ",
+            &[&event_id, &1_i32],
+        )
+        .await
+        .expect("failed to read mismatched attempt archive row");
+    let archived_command = tx
+        .query_one(
+            "
+            SELECT COUNT(*) AS count, MIN(command_type) AS command_type, MIN(payload_checksum) AS payload_checksum
+            FROM outbox.command_inbox_archive
+            WHERE consumer_name = $1
+              AND command_id = $2
+            ",
+            &[&"projection-builder", &command_id],
+        )
+        .await
+        .expect("failed to read mismatched command archive row");
+
+    assert_eq!(archived_event.get::<_, i64>("count"), 1);
+    assert_eq!(
+        archived_event
+            .get::<_, Option<String>>("stream_key")
+            .as_deref(),
+        Some("settlement_case:mismatched-archive")
+    );
+    assert_eq!(
+        archived_event
+            .get::<_, Option<String>>("payload_hash")
+            .as_deref(),
+        Some("mismatched-event-payload-hash")
+    );
+    assert_eq!(archived_attempt.get::<_, i64>("count"), 1);
+    assert_eq!(
+        archived_attempt
+            .get::<_, Option<String>>("relay_name")
+            .as_deref(),
+        Some("unexpected-relay")
+    );
+    assert_eq!(
+        archived_attempt
+            .get::<_, Option<String>>("external_idempotency_key")
+            .as_deref(),
+        Some("mismatched-attempt-provider-key")
+    );
+    assert_eq!(archived_command.get::<_, i64>("count"), 1);
+    assert_eq!(
+        archived_command
+            .get::<_, Option<String>>("command_type")
+            .as_deref(),
+        Some("projection.unexpected")
+    );
+    assert_eq!(
+        archived_command
+            .get::<_, Option<String>>("payload_checksum")
+            .as_deref(),
+        Some("mismatched-command-checksum")
+    );
+
+    tx.rollback()
+        .await
+        .expect("rollback should clean up transactional test state");
+}
+
+#[tokio::test]
 async fn postgres_prune_preserves_terminal_rows_before_retain_until() {
     let Ok(database_url) = std::env::var("MUSUBI_TEST_DATABASE_URL") else {
         return;

--- a/apps/backend/docs/guardrails.md
+++ b/apps/backend/docs/guardrails.md
@@ -132,6 +132,7 @@ Current executable tests:
 - `postgres_prune_preserves_terminal_archive_payloads`
 - `postgres_prune_preserves_terminal_quarantine_archive_diagnostics`
 - `postgres_prune_is_idempotent_with_existing_archive_rows`
+- `postgres_prune_archive_conflict_mismatch_fails_closed`
 - `postgres_prune_preserves_terminal_rows_before_retain_until`
 - `postgres_prune_separates_mixed_retention_eligibility_rows`
 - `postgres_prune_returns_deterministic_outcome_ordering`
@@ -148,24 +149,28 @@ The archive conflict contract proves preexisting archive rows are not duplicated
 or overwritten while matching prune-ready hot rows are removed. The nonterminal
 preservation contract proves that pending and processing coordination rows are
 not archived or deleted by the same prune helper, even when their retention
-timestamp is already in the past. The terminal retention eligibility contract
-proves that terminal published/quarantined outbox rows, their hot attempt rows,
-and completed/quarantined command-inbox rows are not archived or deleted when
-their `retain_until` is NULL or later than the prune timestamp. The mixed
-retention eligibility contract proves that one prune run archives and removes
-eligible terminal rows while retaining terminal rows whose `retain_until` is
-NULL or later than the prune timestamp, retaining their hot attempts, and
-preserving nonterminal coordination rows. The deterministic outcome ordering
-contract proves that a multi-row prune result reports outbox event ids in
-writer-owned replay order and command inbox keys in stable command-key order
-while still preserving retained terminal rows and nonterminal rows. The outbox
-attempt archive completeness contract proves that every hot outbox attempt row
-for one eligible terminal outbox event is copied into the attempt archive before
-hot rows are removed, while the prune outcome still reports the outbox event
-only once. The command inbox archive completeness contract proves that all
-eligible terminal command inbox rows for one source event are copied into the
-command archive before hot rows are removed, while terminal rows with future
-retention and nonterminal rows sharing that source event remain hot-row owned.
+timestamp is already in the past. The archive conflict mismatch contract proves
+that key-only preexisting archive conflicts with mismatched event, attempt, or
+command evidence fail closed before hot rows are removed or reported as pruned,
+without overwriting or duplicating the preexisting archive rows. The terminal
+retention eligibility contract proves that terminal published/quarantined
+outbox rows, their hot attempt rows, and completed/quarantined command-inbox
+rows are not archived or deleted when their `retain_until` is NULL or later
+than the prune timestamp. The mixed retention eligibility contract proves that
+one prune run archives and removes eligible terminal rows while retaining
+terminal rows whose `retain_until` is NULL or later than the prune timestamp,
+retaining their hot attempts, and preserving nonterminal coordination rows. The
+deterministic outcome ordering contract proves that a multi-row prune result
+reports outbox event ids in writer-owned replay order and command inbox keys in
+stable command-key order while still preserving retained terminal rows and
+nonterminal rows. The outbox attempt archive completeness contract proves that
+every hot outbox attempt row for one eligible terminal outbox event is copied
+into the attempt archive before hot rows are removed, while the prune outcome
+still reports the outbox event only once. The command inbox archive completeness
+contract proves that all eligible terminal command inbox rows for one source
+event are copied into the command archive before hot rows are removed, while
+terminal rows with future retention and nonterminal rows sharing that source
+event remain hot-row owned.
 
 ### 5. Drop-Tx-Before-Await at the runtime seam
 

--- a/apps/backend/docs/raw_transaction_inventory.txt
+++ b/apps/backend/docs/raw_transaction_inventory.txt
@@ -1,6 +1,6 @@
 1 apps/backend/crates/db-runtime/src/migrations.rs
 4 apps/backend/crates/orchestration/src/postgres.rs
-18 apps/backend/crates/orchestration/tests/postgres_contract.rs
+19 apps/backend/crates/orchestration/tests/postgres_contract.rs
 37 apps/backend/src/services/happy_route/repository.rs
 6 apps/backend/src/services/operator_review/repository.rs
 7 apps/backend/src/services/realm_bootstrap/repository.rs

--- a/docs/foundation_lock.md
+++ b/docs/foundation_lock.md
@@ -1,6 +1,6 @@
 # Foundation Lock
 
-Status: Draft; aligned to accepted foundation commit `17ee7d9`
+Status: Draft; aligned to accepted foundation commit `5ceba0d`
 Applies to: `mt4110/pi-musubi-core`
 Purpose: Pin the constitutional and architectural source of truth that this implementation repository must follow.
 
@@ -26,14 +26,14 @@ Upstream repository:
 Pinned reference for implementation work:
 
 - Foundation reference type: `commit`
-- Foundation commit SHA: `17ee7d95833d8e60b369b83bbf9c2e9f90c876ec`
-- Foundation commit title: `Merge pull request #283 from mt4110/feat/post-c2-orchestration-prune-command-inbox-formatting-compliance-handoff`
-- Foundation PR title: `docs: add command inbox archive formatting compliance handoff`
-- Foundation PR URL: `https://github.com/mt4110/musubi-foundation/pull/283`
-- Date pinned: `2026-06-12`
+- Foundation commit SHA: `5ceba0dd77031feda2f0dc385b6b101dc54d4dfa`
+- Foundation commit title: `Merge pull request #293 from mt4110/feat/post-c2-orchestration-prune-archive-conflict-mismatch-corrective-handoff`
+- Foundation PR title: `docs: evaluate post-C2 orchestration prune archive conflict mismatch corrective handoff`
+- Foundation PR URL: `https://github.com/mt4110/musubi-foundation/pull/293`
+- Date pinned: `2026-06-13`
 - Pinned by: `Masaki Takemura`
-- Pinned commit URL: `https://github.com/mt4110/musubi-foundation/commit/17ee7d95833d8e60b369b83bbf9c2e9f90c876ec`
-- Previous pinned reference: `c2729ce` / `Merge pull request #277 from mt4110/feat/post-c2-orchestration-prune-command-inbox-archive-completeness-handoff`
+- Pinned commit URL: `https://github.com/mt4110/musubi-foundation/commit/5ceba0dd77031feda2f0dc385b6b101dc54d4dfa`
+- Previous pinned reference: `17ee7d9` / `Merge pull request #283 from mt4110/feat/post-c2-orchestration-prune-command-inbox-formatting-compliance-handoff`
 - Post-C2 evidence source: `cfdba28` / `Merge pull request #114 from mt4110/feat/post-c2-runtime-handoff-evidence-package`
 - Alignment allowance source: `69b7aa4` / `Merge pull request #116 from mt4110/feat/evaluate-post-c2-runtime-handoff-gate`
 - Post-C2 implementation handoff evidence source: `ef23e88` / `Merge pull request #122 from mt4110/feat/post-c2-implementation-handoff-evidence-package`
@@ -121,6 +121,11 @@ Pinned reference for implementation work:
 - Post-C2 orchestration prune command inbox archive completeness implementation closeout source: `5ea1143` / `Merge pull request #279 from mt4110/feat/close-orchestration-prune-command-inbox-archive-completeness-handoff`
 - Post-C2 orchestration prune command inbox archive completeness formatting compliance evidence source: `daf0cab` / `Merge pull request #281 from mt4110/feat/orchestration-prune-command-inbox-formatting-compliance-evidence`
 - Post-C2 orchestration prune command inbox archive completeness formatting compliance handoff source: `17ee7d9` / `Merge pull request #283 from mt4110/feat/post-c2-orchestration-prune-command-inbox-formatting-compliance-handoff`
+- Post-C2 orchestration prune command inbox archive completeness formatting compliance implementation closeout source: `6a20749` / `Merge pull request #285 from mt4110/feat/close-command-inbox-archive-formatting-compliance-handoff`
+- Post-C2 orchestration prune archive conflict mismatch fail-closed evidence source: `19a9d2a` / `Merge pull request #287 from mt4110/feat/orchestration-prune-archive-conflict-mismatch-evidence`
+- Post-C2 orchestration prune archive conflict mismatch fail-closed handoff source: `6de5734` / `Merge pull request #289 from mt4110/feat/post-c2-orchestration-prune-archive-conflict-mismatch-fail-closed-handoff`
+- Post-C2 orchestration prune archive conflict mismatch corrective evidence source: `59ed92b` / `Merge pull request #291 from mt4110/feat/orchestration-prune-archive-conflict-mismatch-corrective-evidence`
+- Post-C2 orchestration prune archive conflict mismatch corrective handoff source: `5ceba0d` / `Merge pull request #293 from mt4110/feat/post-c2-orchestration-prune-archive-conflict-mismatch-corrective-handoff`
 
 No release tag is asserted for this alignment.
 Do not invent a foundation version label for this commit.
@@ -279,38 +284,43 @@ Before coding, read these upstream documents in order.
 138. `docs/readiness/post_c2_orchestration_prune_command_inbox_archive_completeness_implementation_closeout_ledger.md`
 139. `docs/readiness/post_c2_orchestration_prune_command_inbox_archive_completeness_formatting_compliance_evidence_package.md`
 140. `docs/readiness/post_c2_orchestration_prune_command_inbox_archive_completeness_formatting_compliance_handoff_gate_decision.md`
+141. `docs/readiness/post_c2_orchestration_prune_command_inbox_archive_completeness_formatting_compliance_implementation_closeout_ledger.md`
+142. `docs/readiness/post_c2_orchestration_prune_archive_conflict_mismatch_fail_closed_evidence_package.md`
+143. `docs/readiness/post_c2_orchestration_prune_archive_conflict_mismatch_fail_closed_handoff_gate_decision.md`
+144. `docs/readiness/post_c2_orchestration_prune_archive_conflict_mismatch_corrective_evidence_package.md`
+145. `docs/readiness/post_c2_orchestration_prune_archive_conflict_mismatch_corrective_handoff_gate_decision.md`
 
 ### Operations layer
-141. `docs/operations/readiness_routine.md`
-142. `docs/operations/runalways_readiness_orchestrator_design.md`
-143. `docs/operations/runalways_readiness_orchestrator_stage0.md`
-144. `docs/operations/runalways_lane_controller_v0_1.md`
+146. `docs/operations/readiness_routine.md`
+147. `docs/operations/runalways_readiness_orchestrator_design.md`
+148. `docs/operations/runalways_readiness_orchestrator_stage0.md`
+149. `docs/operations/runalways_lane_controller_v0_1.md`
 
 ### Detail layer
-145. `docs/detail/accountability_matrix.md`
-146. `docs/detail/critical_incident_and_loss.md`
-147. `docs/detail/automated_decisioning_and_human_appeal.md`
-148. `docs/detail/youth_safety_and_age_assurance.md`
-149. `docs/detail/off_platform_handoff_and_scam_prevention.md`
-150. `docs/detail/data_deletion_vs_legal_hold.md`
-151. `docs/detail/security_and_autonomy_hardening.md`
-152. `docs/detail/realm_model.md`
-153. `docs/detail/data_scope_model.md`
-154. `docs/detail/mobility_model.md`
-155. `docs/detail/settlement_model.md`
-156. `docs/detail/settlement_backend_trait.md`
-157. `docs/detail/proof_of_infrastructure.md`
-158. `docs/detail/protected_groups_and_translation_safety.md`
+150. `docs/detail/accountability_matrix.md`
+151. `docs/detail/critical_incident_and_loss.md`
+152. `docs/detail/automated_decisioning_and_human_appeal.md`
+153. `docs/detail/youth_safety_and_age_assurance.md`
+154. `docs/detail/off_platform_handoff_and_scam_prevention.md`
+155. `docs/detail/data_deletion_vs_legal_hold.md`
+156. `docs/detail/security_and_autonomy_hardening.md`
+157. `docs/detail/realm_model.md`
+158. `docs/detail/data_scope_model.md`
+159. `docs/detail/mobility_model.md`
+160. `docs/detail/settlement_model.md`
+161. `docs/detail/settlement_backend_trait.md`
+162. `docs/detail/proof_of_infrastructure.md`
+163. `docs/detail/protected_groups_and_translation_safety.md`
 
 ### Whitepaper layer (contextual, not higher than detail/ADR)
-159. `docs/whitepaper/01_executive_summary.md`
-160. `docs/whitepaper/02_realm_model.md`
-161. `docs/whitepaper/03_experience_model.md`
-162. `docs/whitepaper/04_dm_shield.md`
-163. `docs/whitepaper/05_trust_model.md`
-164. `docs/whitepaper/06_promise_protocol.md`
-165. `docs/whitepaper/07_realm_economy.md`
-166. `docs/whitepaper/08_unlock_engine.md`
+164. `docs/whitepaper/01_executive_summary.md`
+165. `docs/whitepaper/02_realm_model.md`
+166. `docs/whitepaper/03_experience_model.md`
+167. `docs/whitepaper/04_dm_shield.md`
+168. `docs/whitepaper/05_trust_model.md`
+169. `docs/whitepaper/06_promise_protocol.md`
+170. `docs/whitepaper/07_realm_economy.md`
+171. `docs/whitepaper/08_unlock_engine.md`
 
 If any of the above are unavailable or materially inconsistent, stop and escalate.
 
@@ -341,7 +351,7 @@ That one-use C2 implementation allowance was consumed by `mt4110/pi-musubi-core`
 No remaining work may inherit permission from foundation PR #108 or implementation PR #88.
 The broad runtime implementation gate result remains NO-GO.
 Broad runtime implementation remains blocked.
-The current narrow downstream allowance is one implementation-repo formatting-only PR for post-C2 orchestration prune command inbox archive completeness formatting compliance correction.
+The current narrow downstream allowance is one implementation-repo corrective runtime PR for post-C2 orchestration prune archive conflict mismatch corrective runtime fix.
 
 The C2 and post-C2 readiness and closeout chain is accepted for docs-only foundation semantic scope:
 
@@ -435,6 +445,11 @@ The C2 and post-C2 readiness and closeout chain is accepted for docs-only founda
 - `docs/readiness/post_c2_orchestration_prune_command_inbox_archive_completeness_implementation_closeout_ledger.md`
 - `docs/readiness/post_c2_orchestration_prune_command_inbox_archive_completeness_formatting_compliance_evidence_package.md`
 - `docs/readiness/post_c2_orchestration_prune_command_inbox_archive_completeness_formatting_compliance_handoff_gate_decision.md`
+- `docs/readiness/post_c2_orchestration_prune_command_inbox_archive_completeness_formatting_compliance_implementation_closeout_ledger.md`
+- `docs/readiness/post_c2_orchestration_prune_archive_conflict_mismatch_fail_closed_evidence_package.md`
+- `docs/readiness/post_c2_orchestration_prune_archive_conflict_mismatch_fail_closed_handoff_gate_decision.md`
+- `docs/readiness/post_c2_orchestration_prune_archive_conflict_mismatch_corrective_evidence_package.md`
+- `docs/readiness/post_c2_orchestration_prune_archive_conflict_mismatch_corrective_handoff_gate_decision.md`
 - `docs/operations/readiness_routine.md`
 - `docs/operations/runalways_readiness_orchestrator_design.md`
 - `docs/operations/runalways_readiness_orchestrator_stage0.md`
@@ -549,11 +564,17 @@ Foundation PR #275 accepted the exact candidate test-only slice as post-C2 orche
 Foundation PR #277 provided the prior narrow downstream test-only handoff authority for one later implementation-repo PR only.
 That allowance was consumed by `mt4110/pi-musubi-core` PR #151 and closed out by foundation PR #279 with a formatting validation gap recorded.
 Foundation PR #281 accepted the exact candidate corrective slice as post-C2 orchestration prune command inbox archive completeness formatting compliance correction.
-Foundation PR #283 provides the current narrow downstream formatting-only handoff authority for one later implementation-repo PR only.
+Foundation PR #283 provided the prior narrow downstream formatting-only handoff authority for one later implementation-repo PR only.
+That allowance was consumed by `mt4110/pi-musubi-core` PR #152 and closed out by foundation PR #285.
+Foundation PR #287 accepted the exact candidate test-only slice as post-C2 orchestration prune archive conflict mismatch fail-closed verification.
+Foundation PR #289 provided the prior narrow downstream test-only handoff authority for one later implementation-repo PR only, or a local proof attempt that would stop and return to foundation if the deterministic test failed before PR creation.
+That one-use test-only allowance was consumed locally, failed before PR creation, and returned to foundation without opening an implementation-repo PR or patching runtime code.
+Foundation PR #291 accepted the corrective evidence package recording that failing proof.
+Foundation PR #293 provides the current narrow downstream corrective runtime handoff authority for one later implementation-repo PR only.
 This update is the required lock pin for that one-use allowance.
-It authorizes only `docs/foundation_lock.md` and `apps/backend/crates/orchestration/tests/postgres_contract.rs`.
-It allows only updating this foundation lock to pin PR #283 and applying the minimal `rustfmt --edition 2024` formatting output to the already-merged `postgres_prune_archives_all_eligible_command_inbox_rows_for_source_event` test while preserving the existing test name, proof semantics, and raw transaction inventory count.
-It does not authorize broad runtime implementation, runtime prune fixes, DDL, migrations, backend runtime code, public API changes, mobile UI, projection refresh, new runtime orchestration behavior, retry workers, queues, outbox changes, inbox changes, archive schema changes, retention policy changes, manual-review provider evidence pruning, lifecycle runtime behavior, pruning runtime behavior, archive runtime behavior, deletion, Legal Hold runtime behavior, evidence access, key lifecycle, choosing retention periods, provider callbacks, network I/O, external guarantees, scheduled workers, repository workflow changes, secrets, credentials, self-hosted runners, branch protection, discovery, recommendation, room, settlement, Promise runtime, proof runtime, Relationship Depth, Social Trust scoring/display, new tests, test behavior changes, paid romantic advantage, DM unlock by payment, or broader `pi-musubi-core` changes.
+It authorizes only `docs/foundation_lock.md`, `apps/backend/crates/orchestration/src/postgres.rs`, `apps/backend/crates/orchestration/tests/postgres_contract.rs`, `apps/backend/docs/guardrails.md`, and `apps/backend/docs/raw_transaction_inventory.txt`.
+It allows only updating this foundation lock to pin PR #293, adding exactly one deterministic PostgreSQL contract test named `postgres_prune_archive_conflict_mismatch_fails_closed`, correcting the existing PostgreSQL prune path so preexisting archive rows under the same keys must be evidence-equivalent before corresponding terminal hot coordination rows are deleted or reported as pruned, preserving the accepted matching archive conflict idempotency behavior, and updating the named backend-local guardrail documents.
+It does not authorize broad runtime implementation, DDL, migrations, backend runtime code outside `apps/backend/crates/orchestration/src/postgres.rs`, service source code, public API changes, mobile UI, projection refresh, new runtime orchestration behavior outside the exact prune correction, retry workers, queues, outbox schema changes, command inbox schema changes, archive schema changes, constraint changes, index changes, retention policy changes, manual-review provider evidence pruning, lifecycle runtime behavior, pruning runtime behavior outside the exact corrective scope, archive runtime behavior outside the exact corrective scope, deletion behavior outside the exact corrective scope, Legal Hold runtime behavior, evidence access, key lifecycle, provider callbacks, network I/O, external guarantees, scheduled workers, repository workflow changes, secrets, credentials, self-hosted runners, branch protection, discovery, recommendation, room, settlement, Promise runtime, proof runtime, Relationship Depth, Social Trust scoring/display, paid romantic advantage, DM unlock by payment, or broader `pi-musubi-core` changes.
 
 Implementation merge history, issue order, branch ancestry, and existing code are not foundation design proof.
 
@@ -774,11 +795,11 @@ When updating:
 - Review completed by:
 
 ### Current drift note
-- Updated from foundation SHA: `c2729ce7a2df2aa66e4ee0f438fb97cafab8aee4` -> `17ee7d95833d8e60b369b83bbf9c2e9f90c876ec`
-- Reason: Align implementation-repo lock with the accepted foundation state after PR #283 (`docs: add command inbox archive formatting compliance handoff`).
-- New required docs: Post-C2 orchestration prune command inbox archive completeness implementation closeout ledger; Post-C2 orchestration prune command inbox archive completeness formatting compliance evidence package; Post-C2 orchestration prune command inbox archive completeness formatting compliance handoff gate decision.
+- Updated from foundation SHA: `17ee7d95833d8e60b369b83bbf9c2e9f90c876ec` -> `5ceba0dd77031feda2f0dc385b6b101dc54d4dfa`
+- Reason: Align implementation-repo lock with the accepted foundation state after PR #293 (`docs: evaluate post-C2 orchestration prune archive conflict mismatch corrective handoff`).
+- New required docs: Post-C2 orchestration prune command inbox archive completeness formatting compliance implementation closeout ledger; Post-C2 orchestration prune archive conflict mismatch fail-closed evidence package; Post-C2 orchestration prune archive conflict mismatch fail-closed handoff gate decision; Post-C2 orchestration prune archive conflict mismatch corrective evidence package; Post-C2 orchestration prune archive conflict mismatch corrective handoff gate decision.
 - Removed docs: None.
-- Implementation impact: PR #283 authorizes one later implementation-repo formatting-only PR. This PR may update this foundation lock and apply minimal `rustfmt --edition 2024` formatting to the existing `postgres_prune_archives_all_eligible_command_inbox_rows_for_source_event` test in `apps/backend/crates/orchestration/tests/postgres_contract.rs`. Broad runtime implementation, runtime prune fixes, DDL, migrations, backend runtime code, public API changes, mobile UI, projection refresh, new runtime orchestration behavior, retry workers, queues, outbox changes, inbox changes, archive schema changes, retention policy changes, manual-review provider evidence pruning behavior, lifecycle runtime behavior, pruning runtime behavior, archive runtime behavior, deletion, Legal Hold runtime behavior, evidence access runtime behavior, key lifecycle behavior, choosing retention periods, Relationship Depth behavior, Social Trust scoring/display, provider callbacks, network I/O, external guarantees, scheduled workers, repository workflow changes, secrets, credentials, self-hosted runners, branch protection changes, new tests, test behavior changes, paid romantic advantage, and DM unlock by payment remain blocked.
+- Implementation impact: PR #293 authorizes one later implementation-repo corrective runtime PR. This PR may update this foundation lock, add exactly one deterministic PostgreSQL contract test named `postgres_prune_archive_conflict_mismatch_fails_closed`, correct the existing PostgreSQL prune path in `apps/backend/crates/orchestration/src/postgres.rs` so preexisting archive rows under the same keys must be evidence-equivalent before corresponding terminal hot coordination rows are deleted or reported as pruned, preserve matching archive conflict idempotency, and update `apps/backend/docs/guardrails.md` and `apps/backend/docs/raw_transaction_inventory.txt`. Broad runtime implementation, DDL, migrations, backend runtime code outside `apps/backend/crates/orchestration/src/postgres.rs`, service source code, public API changes, mobile UI, projection refresh, new runtime orchestration behavior outside the exact prune correction, retry workers, queues, outbox schema changes, command inbox schema changes, archive schema changes, constraints, indexes, retention policy changes, manual-review provider evidence pruning behavior, lifecycle runtime behavior, broad pruning runtime behavior, broad archive runtime behavior, Legal Hold runtime behavior, evidence access runtime behavior, key lifecycle behavior, provider callbacks, network I/O, external guarantees, scheduled workers, repository workflow changes, secrets, credentials, self-hosted runners, branch protection changes, Relationship Depth behavior, Social Trust scoring/display, paid romantic advantage, and DM unlock by payment remain blocked.
 - Review completed by: Masaki Takemura
 
 ---


### PR DESCRIPTION
## Summary

- consumes foundation PR #293's one-use corrective runtime handoff
- pins the foundation lock to 5ceba0d and records the new corrective scope
- makes PostgreSQL prune fail closed when preexisting archive rows under matching keys do not preserve event, attempt, or command evidence
- adds postgres_prune_archive_conflict_mismatch_fails_closed and updates backend guardrail docs/inventory

## Scope

Allowed files only: docs/foundation_lock.md, apps/backend/crates/orchestration/src/postgres.rs, apps/backend/crates/orchestration/tests/postgres_contract.rs, apps/backend/docs/guardrails.md, apps/backend/docs/raw_transaction_inventory.txt.

## Validation

- test -n "${MUSUBI_TEST_DATABASE_URL:?MUSUBI_TEST_DATABASE_URL is required for PostgreSQL contract validation}"
- rustfmt --edition 2024 --check apps/backend/crates/orchestration/src/postgres.rs apps/backend/crates/orchestration/tests/postgres_contract.rs
- MUSUBI_TEST_DATABASE_URL=... cargo test --manifest-path apps/backend/Cargo.toml -p musubi_orchestration --test postgres_contract postgres_prune_archive_conflict_mismatch_fails_closed -- --exact --nocapture
- MUSUBI_TEST_DATABASE_URL=... cargo test --manifest-path apps/backend/Cargo.toml -p musubi_orchestration --test postgres_contract postgres_prune_is_idempotent_with_existing_archive_rows -- --exact --nocapture
- MUSUBI_TEST_DATABASE_URL=... cargo test --manifest-path apps/backend/Cargo.toml -p musubi_orchestration --test postgres_contract -- --nocapture
- make guardrail-sweep
- git diff --check origin/main...HEAD