### PR TITLE
fix: contain archive conflict mismatch prune side effects

### DIFF
--- a/apps/backend/crates/orchestration/src/postgres.rs
+++ b/apps/backend/crates/orchestration/src/postgres.rs
@@ -213,6 +213,123 @@ impl PostgresOrchestrationStore {
             .map(|row| row.get::<_, Uuid>("event_id"))
             .collect::<Vec<_>>();
 
+        let preexisting_mismatched_outbox_event_archives: i64 = tx
+            .query_one(
+                "
+                SELECT COUNT(*) AS count
+                FROM outbox.events AS events
+                JOIN outbox.outbox_event_archive AS archive
+                  ON archive.event_id = events.event_id
+                WHERE events.delivery_status IN ('published', 'quarantined')
+                  AND events.retain_until IS NOT NULL
+                  AND events.retain_until <= $1
+                  AND (
+                    archive.stream_key IS DISTINCT FROM events.stream_key
+                    OR archive.aggregate_type IS DISTINCT FROM events.aggregate_type
+                    OR archive.aggregate_id IS DISTINCT FROM events.aggregate_id
+                    OR archive.event_type IS DISTINCT FROM events.event_type
+                    OR archive.schema_version IS DISTINCT FROM events.schema_version
+                    OR archive.payload_json IS DISTINCT FROM events.payload_json
+                    OR archive.payload_hash IS DISTINCT FROM events.payload_hash
+                    OR archive.final_status IS DISTINCT FROM events.delivery_status
+                    OR archive.attempt_count IS DISTINCT FROM events.attempt_count
+                    OR archive.causal_order IS DISTINCT FROM events.causal_order
+                    OR archive.available_at IS DISTINCT FROM events.available_at
+                    OR archive.created_at IS DISTINCT FROM events.created_at
+                    OR archive.published_at IS DISTINCT FROM events.published_at
+                    OR archive.quarantined_at IS DISTINCT FROM events.quarantined_at
+                    OR archive.last_attempt_at IS DISTINCT FROM events.last_attempt_at
+                    OR archive.last_error_class IS DISTINCT FROM events.last_error_class
+                    OR archive.last_error_code IS DISTINCT FROM events.last_error_code
+                    OR archive.last_error_detail IS DISTINCT FROM events.last_error_detail
+                    OR archive.quarantine_reason IS DISTINCT FROM events.quarantine_reason
+                    OR archive.retain_until IS DISTINCT FROM events.retain_until
+                    OR archive.published_external_idempotency_key
+                        IS DISTINCT FROM events.published_external_idempotency_key
+                  )
+                ",
+                &[&now],
+            )
+            .await
+            .map_err(database_error)?
+            .get("count");
+
+        let preexisting_mismatched_outbox_attempt_archives: i64 = tx
+            .query_one(
+                "
+                SELECT COUNT(*) AS count
+                FROM outbox.outbox_attempts AS attempts
+                JOIN outbox.events AS events
+                  ON events.event_id = attempts.event_id
+                JOIN outbox.outbox_attempt_archive AS archive
+                  ON archive.event_id = attempts.event_id
+                 AND archive.attempt_number = attempts.attempt_number
+                WHERE events.delivery_status IN ('published', 'quarantined')
+                  AND events.retain_until IS NOT NULL
+                  AND events.retain_until <= $1
+                  AND (
+                    archive.relay_name IS DISTINCT FROM attempts.relay_name
+                    OR archive.claimed_at IS DISTINCT FROM attempts.claimed_at
+                    OR archive.claimed_until IS DISTINCT FROM attempts.claimed_until
+                    OR archive.finished_at IS DISTINCT FROM attempts.finished_at
+                    OR archive.failure_class IS DISTINCT FROM attempts.failure_class
+                    OR archive.failure_code IS DISTINCT FROM attempts.failure_code
+                    OR archive.failure_detail IS DISTINCT FROM attempts.failure_detail
+                    OR archive.external_idempotency_key
+                        IS DISTINCT FROM attempts.external_idempotency_key
+                  )
+                ",
+                &[&now],
+            )
+            .await
+            .map_err(database_error)?
+            .get("count");
+
+        let preexisting_mismatched_command_inbox_archives: i64 = tx
+            .query_one(
+                "
+                SELECT COUNT(*) AS count
+                FROM outbox.command_inbox AS command
+                JOIN outbox.command_inbox_archive AS archive
+                  ON archive.consumer_name = command.consumer_name
+                 AND archive.command_id = command.command_id
+                WHERE command.status IN ('completed', 'quarantined')
+                  AND command.retain_until IS NOT NULL
+                  AND command.retain_until <= $1
+                  AND (
+                    archive.source_event_id IS DISTINCT FROM command.source_event_id
+                    OR archive.command_type IS DISTINCT FROM command.command_type
+                    OR archive.schema_version IS DISTINCT FROM command.schema_version
+                    OR archive.status IS DISTINCT FROM command.status
+                    OR archive.attempt_count IS DISTINCT FROM command.attempt_count
+                    OR archive.payload_checksum IS DISTINCT FROM command.payload_checksum
+                    OR archive.received_at IS DISTINCT FROM command.received_at
+                    OR archive.processed_at IS DISTINCT FROM command.processed_at
+                    OR archive.completed_at IS DISTINCT FROM command.completed_at
+                    OR archive.last_error_class IS DISTINCT FROM command.last_error_class
+                    OR archive.last_error_code IS DISTINCT FROM command.last_error_code
+                    OR archive.last_error_detail IS DISTINCT FROM command.last_error_detail
+                    OR archive.quarantine_reason IS DISTINCT FROM command.quarantine_reason
+                    OR archive.result_type IS DISTINCT FROM command.result_type
+                    OR archive.result_json IS DISTINCT FROM command.result_json
+                    OR archive.retain_until IS DISTINCT FROM command.retain_until
+                  )
+                ",
+                &[&now],
+            )
+            .await
+            .map_err(database_error)?
+            .get("count");
+
+        if preexisting_mismatched_outbox_event_archives > 0
+            || preexisting_mismatched_outbox_attempt_archives > 0
+            || preexisting_mismatched_command_inbox_archives > 0
+        {
+            return Err(OrchestrationError::Database(
+                "coordination archive evidence mismatch before prune".to_owned(),
+            ));
+        }
+
         tx.execute(
             "
             INSERT INTO outbox.outbox_event_archive (

--- a/apps/backend/crates/orchestration/tests/postgres_contract.rs
+++ b/apps/backend/crates/orchestration/tests/postgres_contract.rs
@@ -2446,6 +2446,567 @@ async fn postgres_prune_archive_conflict_mismatch_fails_closed() {
 }
 
 #[tokio::test]
+async fn postgres_prune_archive_conflict_mismatch_does_not_expand_archives() {
+    let Ok(database_url) = std::env::var("MUSUBI_TEST_DATABASE_URL") else {
+        return;
+    };
+
+    let (mut client, connection) = tokio_postgres::connect(&database_url, NoTls)
+        .await
+        .expect("failed to connect to MUSUBI_TEST_DATABASE_URL");
+    tokio::spawn(async move {
+        let _ = connection.await;
+    });
+
+    {
+        let tx = client
+            .transaction()
+            .await
+            .expect("failed to open transaction");
+        tx.batch_execute(include_str!(
+            "../../../migrations/0004_create_outbox_schema.sql"
+        ))
+        .await
+        .expect("failed to apply outbox schema");
+        tx.batch_execute(include_str!(
+            "../../../migrations/0006_orchestration_runtime_baseline.sql"
+        ))
+        .await
+        .expect("failed to apply orchestration baseline migration");
+
+        let aggregate_id = Uuid::from_u128(0x8a0);
+        let event_id = Uuid::from_u128(0x8a1);
+        let absent_command_id = Uuid::from_u128(0x8a2);
+        let message = NewOutboxMessage::new(NewOutboxMessageSpec {
+            event_id,
+            idempotency_key: Uuid::from_u128(0x8a3),
+            stream_key: "settlement_case:archive-conflict-mismatch-side-effect-attempt".to_owned(),
+            aggregate_type: "settlement_case".to_owned(),
+            aggregate_id,
+            event_type: "settlement.submit_action".to_owned(),
+            schema_version: 1,
+            payload_json: json!({
+                "intent_id": "intent-archive-conflict-mismatch-side-effect-attempt",
+                "retention_probe": { "kind": "archive_conflict_mismatch_side_effect_attempt" }
+            }),
+            available_at: ts(0),
+            created_at: ts(0),
+        })
+        .unwrap();
+
+        PostgresOrchestrationStore::insert_outbox_message(&tx, &message)
+            .await
+            .expect("failed to insert attempt side-effect outbox message");
+        tx.execute(
+            "
+            UPDATE outbox.events
+            SET delivery_status = 'published',
+                attempt_count = 1,
+                published_at = $2,
+                last_attempt_at = $2,
+                retain_until = $3,
+                published_external_idempotency_key = $4
+            WHERE event_id = $1
+            ",
+            &[
+                &event_id,
+                &ts(10),
+                &ts(100),
+                &"provider-key-archive-conflict-mismatch-side-effect-attempt",
+            ],
+        )
+        .await
+        .expect("failed to mark attempt side-effect outbox event terminal");
+        tx.execute(
+            "
+            INSERT INTO outbox.outbox_attempts (
+                event_id,
+                attempt_number,
+                relay_name,
+                claimed_at,
+                claimed_until,
+                finished_at,
+                failure_class,
+                failure_code,
+                failure_detail,
+                external_idempotency_key
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, NULL, NULL, NULL, $7)
+            ",
+            &[
+                &event_id,
+                &1_i32,
+                &"settlement-relay",
+                &ts(0),
+                &ts(300),
+                &ts(10),
+                &"provider-key-archive-conflict-mismatch-side-effect-attempt",
+            ],
+        )
+        .await
+        .expect("failed to insert attempt side-effect outbox attempt");
+        tx.execute(
+            "
+            INSERT INTO outbox.outbox_attempt_archive (
+                event_id,
+                attempt_number,
+                archived_at,
+                relay_name,
+                claimed_at,
+                claimed_until,
+                finished_at,
+                failure_class,
+                failure_code,
+                failure_detail,
+                external_idempotency_key
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, NULL, NULL, NULL, $8)
+            ",
+            &[
+                &event_id,
+                &1_i32,
+                &ts(150),
+                &"unexpected-relay",
+                &ts(0),
+                &ts(300),
+                &ts(10),
+                &"mismatched-side-effect-attempt-provider-key",
+            ],
+        )
+        .await
+        .expect("failed to seed mismatched attempt side-effect archive row");
+
+        let before_event_archive_count: i64 = tx
+            .query_one(
+                "SELECT COUNT(*) AS count FROM outbox.outbox_event_archive WHERE event_id = $1",
+                &[&event_id],
+            )
+            .await
+            .expect("failed to count attempt side-effect event archives before prune")
+            .get("count");
+        let before_attempt_archive_count: i64 = tx
+            .query_one(
+                "
+                SELECT COUNT(*) AS count
+                FROM outbox.outbox_attempt_archive
+                WHERE event_id = $1
+                  AND attempt_number = $2
+                ",
+                &[&event_id, &1_i32],
+            )
+            .await
+            .expect("failed to count attempt side-effect attempt archives before prune")
+            .get("count");
+        let before_command_archive_count: i64 = tx
+            .query_one(
+                "
+                SELECT COUNT(*) AS count
+                FROM outbox.command_inbox_archive
+                WHERE consumer_name = $1
+                  AND command_id = $2
+                ",
+                &[&"projection-builder", &absent_command_id],
+            )
+            .await
+            .expect("failed to count attempt side-effect command archives before prune")
+            .get("count");
+
+        assert_eq!(before_event_archive_count, 0);
+        assert_eq!(before_attempt_archive_count, 1);
+        assert_eq!(before_command_archive_count, 0);
+
+        let prune_error = PostgresOrchestrationStore::prune_coordination(&tx, ts(200))
+            .await
+            .expect_err("attempt archive mismatch must fail without expanding archives");
+        assert!(matches!(
+            prune_error,
+            OrchestrationError::Database(message)
+                if message == "coordination archive evidence mismatch before prune"
+        ));
+
+        let after_event_archive_count: i64 = tx
+            .query_one(
+                "SELECT COUNT(*) AS count FROM outbox.outbox_event_archive WHERE event_id = $1",
+                &[&event_id],
+            )
+            .await
+            .expect("failed to count attempt side-effect event archives after prune")
+            .get("count");
+        let after_attempt_archive_count: i64 = tx
+            .query_one(
+                "
+                SELECT COUNT(*) AS count
+                FROM outbox.outbox_attempt_archive
+                WHERE event_id = $1
+                  AND attempt_number = $2
+                ",
+                &[&event_id, &1_i32],
+            )
+            .await
+            .expect("failed to count attempt side-effect attempt archives after prune")
+            .get("count");
+        let after_command_archive_count: i64 = tx
+            .query_one(
+                "
+                SELECT COUNT(*) AS count
+                FROM outbox.command_inbox_archive
+                WHERE consumer_name = $1
+                  AND command_id = $2
+                ",
+                &[&"projection-builder", &absent_command_id],
+            )
+            .await
+            .expect("failed to count attempt side-effect command archives after prune")
+            .get("count");
+        let hot_event_count: i64 = tx
+            .query_one(
+                "SELECT COUNT(*) AS count FROM outbox.events WHERE event_id = $1",
+                &[&event_id],
+            )
+            .await
+            .expect("failed to count hot attempt side-effect event after prune")
+            .get("count");
+        let hot_attempt_count: i64 = tx
+            .query_one(
+                "SELECT COUNT(*) AS count FROM outbox.outbox_attempts WHERE event_id = $1",
+                &[&event_id],
+            )
+            .await
+            .expect("failed to count hot attempt side-effect attempt after prune")
+            .get("count");
+
+        assert_eq!(after_event_archive_count, before_event_archive_count);
+        assert_eq!(after_attempt_archive_count, before_attempt_archive_count);
+        assert_eq!(after_command_archive_count, before_command_archive_count);
+        assert_eq!(hot_event_count, 1);
+        assert_eq!(hot_attempt_count, 1);
+
+        tx.rollback()
+            .await
+            .expect("rollback should clean up attempt side-effect test state");
+    }
+
+    {
+        let tx = client
+            .transaction()
+            .await
+            .expect("failed to open transaction");
+        tx.batch_execute(include_str!(
+            "../../../migrations/0004_create_outbox_schema.sql"
+        ))
+        .await
+        .expect("failed to apply outbox schema");
+        tx.batch_execute(include_str!(
+            "../../../migrations/0006_orchestration_runtime_baseline.sql"
+        ))
+        .await
+        .expect("failed to apply orchestration baseline migration");
+
+        let aggregate_id = Uuid::from_u128(0x8b0);
+        let event_id = Uuid::from_u128(0x8b1);
+        let command_id = Uuid::from_u128(0x8b2);
+        let message = NewOutboxMessage::new(NewOutboxMessageSpec {
+            event_id,
+            idempotency_key: Uuid::from_u128(0x8b3),
+            stream_key: "settlement_case:archive-conflict-mismatch-side-effect-command".to_owned(),
+            aggregate_type: "settlement_case".to_owned(),
+            aggregate_id,
+            event_type: "settlement.submit_action".to_owned(),
+            schema_version: 1,
+            payload_json: json!({
+                "intent_id": "intent-archive-conflict-mismatch-side-effect-command",
+                "retention_probe": { "kind": "archive_conflict_mismatch_side_effect_command" }
+            }),
+            available_at: ts(0),
+            created_at: ts(0),
+        })
+        .unwrap();
+
+        PostgresOrchestrationStore::insert_outbox_message(&tx, &message)
+            .await
+            .expect("failed to insert command side-effect outbox message");
+        tx.execute(
+            "
+            UPDATE outbox.events
+            SET delivery_status = 'published',
+                attempt_count = 1,
+                published_at = $2,
+                last_attempt_at = $2,
+                retain_until = $3,
+                published_external_idempotency_key = $4
+            WHERE event_id = $1
+            ",
+            &[
+                &event_id,
+                &ts(10),
+                &ts(100),
+                &"provider-key-archive-conflict-mismatch-side-effect-command",
+            ],
+        )
+        .await
+        .expect("failed to mark command side-effect outbox event terminal");
+        tx.execute(
+            "
+            INSERT INTO outbox.outbox_attempts (
+                event_id,
+                attempt_number,
+                relay_name,
+                claimed_at,
+                claimed_until,
+                finished_at,
+                failure_class,
+                failure_code,
+                failure_detail,
+                external_idempotency_key
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, NULL, NULL, NULL, $7)
+            ",
+            &[
+                &event_id,
+                &1_i32,
+                &"settlement-relay",
+                &ts(0),
+                &ts(300),
+                &ts(10),
+                &"provider-key-archive-conflict-mismatch-side-effect-command",
+            ],
+        )
+        .await
+        .expect("failed to insert command side-effect outbox attempt");
+
+        let command = CommandEnvelope::new(
+            command_id,
+            event_id,
+            "projection.refresh",
+            1,
+            json!({ "settlement_case_id": aggregate_id }),
+        )
+        .unwrap();
+        let result_json = json!({
+            "projection_id": "projection-archive-conflict-mismatch-side-effect-command",
+            "archive_conflict_seen": true
+        });
+        tx.execute(
+            "
+            INSERT INTO outbox.command_inbox (
+                inbox_entry_id,
+                consumer_name,
+                command_id,
+                source_event_id,
+                payload_checksum,
+                received_at,
+                status,
+                available_at,
+                attempt_count,
+                command_type,
+                schema_version,
+                completed_at,
+                result_type,
+                result_json,
+                retain_until
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, 'completed', $6, 1, $7, $8, $9, $10, $11, $12)
+            ",
+            &[
+                &Uuid::from_u128(0x8b4),
+                &"projection-builder",
+                &command_id,
+                &event_id,
+                &command.payload_hash,
+                &ts(20),
+                &command.command_type,
+                &command.schema_version,
+                &ts(30),
+                &"projected",
+                &result_json,
+                &ts(100),
+            ],
+        )
+        .await
+        .expect("failed to insert command side-effect inbox row");
+        tx.execute(
+            "
+            INSERT INTO outbox.command_inbox_archive (
+                consumer_name,
+                command_id,
+                source_event_id,
+                archived_at,
+                command_type,
+                schema_version,
+                status,
+                attempt_count,
+                payload_checksum,
+                received_at,
+                processed_at,
+                completed_at,
+                last_error_class,
+                last_error_code,
+                last_error_detail,
+                quarantine_reason,
+                result_type,
+                result_json,
+                retain_until
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, 'completed', 1, $7, $8, NULL, $9, NULL, NULL, NULL, NULL, $10, $11, $12)
+            ",
+            &[
+                &"projection-builder",
+                &command_id,
+                &event_id,
+                &ts(152),
+                &"projection.unexpected",
+                &command.schema_version,
+                &"mismatched-command-side-effect-checksum",
+                &ts(20),
+                &ts(30),
+                &"projected",
+                &result_json,
+                &ts(100),
+            ],
+        )
+        .await
+        .expect("failed to seed mismatched command side-effect archive row");
+
+        let before_event_archive_count: i64 = tx
+            .query_one(
+                "SELECT COUNT(*) AS count FROM outbox.outbox_event_archive WHERE event_id = $1",
+                &[&event_id],
+            )
+            .await
+            .expect("failed to count command side-effect event archives before prune")
+            .get("count");
+        let before_attempt_archive_count: i64 = tx
+            .query_one(
+                "
+                SELECT COUNT(*) AS count
+                FROM outbox.outbox_attempt_archive
+                WHERE event_id = $1
+                  AND attempt_number = $2
+                ",
+                &[&event_id, &1_i32],
+            )
+            .await
+            .expect("failed to count command side-effect attempt archives before prune")
+            .get("count");
+        let before_command_archive_count: i64 = tx
+            .query_one(
+                "
+                SELECT COUNT(*) AS count
+                FROM outbox.command_inbox_archive
+                WHERE consumer_name = $1
+                  AND command_id = $2
+                ",
+                &[&"projection-builder", &command_id],
+            )
+            .await
+            .expect("failed to count command side-effect command archives before prune")
+            .get("count");
+
+        assert_eq!(before_event_archive_count, 0);
+        assert_eq!(before_attempt_archive_count, 0);
+        assert_eq!(before_command_archive_count, 1);
+
+        let prune_error = PostgresOrchestrationStore::prune_coordination(&tx, ts(200))
+            .await
+            .expect_err("command archive mismatch must fail without expanding archives");
+        assert!(matches!(
+            prune_error,
+            OrchestrationError::Database(message)
+                if message == "coordination archive evidence mismatch before prune"
+        ));
+
+        let after_event_archive_count: i64 = tx
+            .query_one(
+                "SELECT COUNT(*) AS count FROM outbox.outbox_event_archive WHERE event_id = $1",
+                &[&event_id],
+            )
+            .await
+            .expect("failed to count command side-effect event archives after prune")
+            .get("count");
+        let after_attempt_archive_count: i64 = tx
+            .query_one(
+                "
+                SELECT COUNT(*) AS count
+                FROM outbox.outbox_attempt_archive
+                WHERE event_id = $1
+                  AND attempt_number = $2
+                ",
+                &[&event_id, &1_i32],
+            )
+            .await
+            .expect("failed to count command side-effect attempt archives after prune")
+            .get("count");
+        let after_command_archive = tx
+            .query_one(
+                "
+                SELECT COUNT(*) AS count, MIN(command_type) AS command_type, MIN(payload_checksum) AS payload_checksum
+                FROM outbox.command_inbox_archive
+                WHERE consumer_name = $1
+                  AND command_id = $2
+                ",
+                &[&"projection-builder", &command_id],
+            )
+            .await
+            .expect("failed to read command side-effect command archive after prune");
+        let hot_event_count: i64 = tx
+            .query_one(
+                "SELECT COUNT(*) AS count FROM outbox.events WHERE event_id = $1",
+                &[&event_id],
+            )
+            .await
+            .expect("failed to count hot command side-effect event after prune")
+            .get("count");
+        let hot_attempt_count: i64 = tx
+            .query_one(
+                "SELECT COUNT(*) AS count FROM outbox.outbox_attempts WHERE event_id = $1",
+                &[&event_id],
+            )
+            .await
+            .expect("failed to count hot command side-effect attempt after prune")
+            .get("count");
+        let hot_command_count: i64 = tx
+            .query_one(
+                "
+                SELECT COUNT(*) AS count
+                FROM outbox.command_inbox
+                WHERE consumer_name = $1
+                  AND command_id = $2
+                ",
+                &[&"projection-builder", &command_id],
+            )
+            .await
+            .expect("failed to count hot command side-effect command after prune")
+            .get("count");
+
+        assert_eq!(after_event_archive_count, before_event_archive_count);
+        assert_eq!(after_attempt_archive_count, before_attempt_archive_count);
+        assert_eq!(
+            after_command_archive.get::<_, i64>("count"),
+            before_command_archive_count
+        );
+        assert_eq!(
+            after_command_archive
+                .get::<_, Option<String>>("command_type")
+                .as_deref(),
+            Some("projection.unexpected")
+        );
+        assert_eq!(
+            after_command_archive
+                .get::<_, Option<String>>("payload_checksum")
+                .as_deref(),
+            Some("mismatched-command-side-effect-checksum")
+        );
+        assert_eq!(hot_event_count, 1);
+        assert_eq!(hot_attempt_count, 1);
+        assert_eq!(hot_command_count, 1);
+
+        tx.rollback()
+            .await
+            .expect("rollback should clean up command side-effect test state");
+    }
+}
+
+#[tokio::test]
 async fn postgres_prune_preserves_terminal_rows_before_retain_until() {
     let Ok(database_url) = std::env::var("MUSUBI_TEST_DATABASE_URL") else {
         return;

--- a/apps/backend/docs/guardrails.md
+++ b/apps/backend/docs/guardrails.md
@@ -133,6 +133,7 @@ Current executable tests:
 - `postgres_prune_preserves_terminal_quarantine_archive_diagnostics`
 - `postgres_prune_is_idempotent_with_existing_archive_rows`
 - `postgres_prune_archive_conflict_mismatch_fails_closed`
+- `postgres_prune_archive_conflict_mismatch_does_not_expand_archives`
 - `postgres_prune_preserves_terminal_rows_before_retain_until`
 - `postgres_prune_separates_mixed_retention_eligibility_rows`
 - `postgres_prune_returns_deterministic_outcome_ordering`
@@ -152,7 +153,10 @@ not archived or deleted by the same prune helper, even when their retention
 timestamp is already in the past. The archive conflict mismatch contract proves
 that key-only preexisting archive conflicts with mismatched event, attempt, or
 command evidence fail closed before hot rows are removed or reported as pruned,
-without overwriting or duplicating the preexisting archive rows. The terminal
+without overwriting or duplicating the preexisting archive rows. The archive
+conflict mismatch side-effect contract proves that mismatched attempt or command
+archive evidence fails before the prune path inserts absent event, attempt, or
+command archive rows. The terminal
 retention eligibility contract proves that terminal published/quarantined
 outbox rows, their hot attempt rows, and completed/quarantined command-inbox
 rows are not archived or deleted when their `retain_until` is NULL or later

--- a/apps/backend/docs/raw_transaction_inventory.txt
+++ b/apps/backend/docs/raw_transaction_inventory.txt
@@ -1,6 +1,6 @@
 1 apps/backend/crates/db-runtime/src/migrations.rs
 4 apps/backend/crates/orchestration/src/postgres.rs
-19 apps/backend/crates/orchestration/tests/postgres_contract.rs
+21 apps/backend/crates/orchestration/tests/postgres_contract.rs
 37 apps/backend/src/services/happy_route/repository.rs
 6 apps/backend/src/services/operator_review/repository.rs
 7 apps/backend/src/services/realm_bootstrap/repository.rs

--- a/docs/foundation_lock.md
+++ b/docs/foundation_lock.md
@@ -1,6 +1,6 @@
 # Foundation Lock
 
-Status: Draft; aligned to accepted foundation commit `5ceba0d`
+Status: Draft; aligned to accepted foundation commit `cac6b16`
 Applies to: `mt4110/pi-musubi-core`
 Purpose: Pin the constitutional and architectural source of truth that this implementation repository must follow.
 
@@ -26,14 +26,14 @@ Upstream repository:
 Pinned reference for implementation work:
 
 - Foundation reference type: `commit`
-- Foundation commit SHA: `5ceba0dd77031feda2f0dc385b6b101dc54d4dfa`
-- Foundation commit title: `Merge pull request #293 from mt4110/feat/post-c2-orchestration-prune-archive-conflict-mismatch-corrective-handoff`
-- Foundation PR title: `docs: evaluate post-C2 orchestration prune archive conflict mismatch corrective handoff`
-- Foundation PR URL: `https://github.com/mt4110/musubi-foundation/pull/293`
-- Date pinned: `2026-06-13`
+- Foundation commit SHA: `cac6b164ce21aa389c1dde7d6b867d2f60fac73c`
+- Foundation commit title: `Merge pull request #303 from mt4110/feat/post-c2-orchestration-prune-archive-conflict-mismatch-side-effect-corrective-handoff`
+- Foundation PR title: `docs: evaluate post-C2 orchestration prune archive conflict mismatch side-effect corrective handoff`
+- Foundation PR URL: `https://github.com/mt4110/musubi-foundation/pull/303`
+- Date pinned: `2026-06-14`
 - Pinned by: `Masaki Takemura`
-- Pinned commit URL: `https://github.com/mt4110/musubi-foundation/commit/5ceba0dd77031feda2f0dc385b6b101dc54d4dfa`
-- Previous pinned reference: `17ee7d9` / `Merge pull request #283 from mt4110/feat/post-c2-orchestration-prune-command-inbox-formatting-compliance-handoff`
+- Pinned commit URL: `https://github.com/mt4110/musubi-foundation/commit/cac6b164ce21aa389c1dde7d6b867d2f60fac73c`
+- Previous pinned reference: `5ceba0d` / `Merge pull request #293 from mt4110/feat/post-c2-orchestration-prune-archive-conflict-mismatch-corrective-handoff`
 - Post-C2 evidence source: `cfdba28` / `Merge pull request #114 from mt4110/feat/post-c2-runtime-handoff-evidence-package`
 - Alignment allowance source: `69b7aa4` / `Merge pull request #116 from mt4110/feat/evaluate-post-c2-runtime-handoff-gate`
 - Post-C2 implementation handoff evidence source: `ef23e88` / `Merge pull request #122 from mt4110/feat/post-c2-implementation-handoff-evidence-package`
@@ -126,6 +126,11 @@ Pinned reference for implementation work:
 - Post-C2 orchestration prune archive conflict mismatch fail-closed handoff source: `6de5734` / `Merge pull request #289 from mt4110/feat/post-c2-orchestration-prune-archive-conflict-mismatch-fail-closed-handoff`
 - Post-C2 orchestration prune archive conflict mismatch corrective evidence source: `59ed92b` / `Merge pull request #291 from mt4110/feat/orchestration-prune-archive-conflict-mismatch-corrective-evidence`
 - Post-C2 orchestration prune archive conflict mismatch corrective handoff source: `5ceba0d` / `Merge pull request #293 from mt4110/feat/post-c2-orchestration-prune-archive-conflict-mismatch-corrective-handoff`
+- Post-C2 orchestration prune archive conflict mismatch corrective implementation closeout source: `2bf19af` / `Merge pull request #295 from mt4110/feat/close-orchestration-prune-archive-conflict-mismatch-corrective-handoff`
+- Post-C2 orchestration prune archive conflict mismatch side-effect containment evidence source: `14f26c4` / `Merge pull request #297 from mt4110/feat/orchestration-prune-archive-conflict-mismatch-side-effect-containment-evidence`
+- Post-C2 orchestration prune archive conflict mismatch side-effect containment handoff source: `1e3a8ae` / `Merge pull request #299 from mt4110/feat/post-c2-orchestration-prune-archive-conflict-mismatch-side-effect-containment-handoff`
+- Post-C2 orchestration prune archive conflict mismatch side-effect containment corrective evidence source: `2b73582` / `Merge pull request #301 from mt4110/feat/orchestration-prune-archive-conflict-mismatch-side-effect-corrective-evidence`
+- Post-C2 orchestration prune archive conflict mismatch side-effect containment corrective handoff source: `cac6b16` / `Merge pull request #303 from mt4110/feat/post-c2-orchestration-prune-archive-conflict-mismatch-side-effect-corrective-handoff`
 
 No release tag is asserted for this alignment.
 Do not invent a foundation version label for this commit.


### PR DESCRIPTION
Closes #154

## Summary
- Pins foundation_lock to the merged side-effect containment corrective handoff at musubi-foundation commit cac6b164ce21aa389c1dde7d6b867d2f60fac73c.
- Adds a preexisting archive mismatch precheck before prune archive inserts so mismatched archive evidence returns the deterministic database error without expanding archive rows first.
- Adds postgres_prune_archive_conflict_mismatch_does_not_expand_archives and records it in backend guardrails/raw transaction inventory.

## Validation
- rustfmt --edition 2024 --check apps/backend/crates/orchestration/src/postgres.rs apps/backend/crates/orchestration/tests/postgres_contract.rs
- MUSUBI_TEST_DATABASE_URL=postgres://musubi:musubi_local_dev@127.0.0.1:55432/musubi_test cargo test -p musubi_orchestration --test postgres_contract postgres_prune_archive_conflict_mismatch_does_not_expand_archives -- --exact --nocapture
- MUSUBI_TEST_DATABASE_URL=postgres://musubi:musubi_local_dev@127.0.0.1:55432/musubi_test cargo test -p musubi_orchestration --test postgres_contract postgres_prune_archive_conflict_mismatch_fails_closed -- --exact --nocapture
- MUSUBI_TEST_DATABASE_URL=postgres://musubi:musubi_local_dev@127.0.0.1:55432/musubi_test cargo test -p musubi_orchestration --test postgres_contract postgres_prune_is_idempotent_with_existing_archive_rows -- --exact --nocapture
- MUSUBI_TEST_DATABASE_URL=postgres://musubi:musubi_local_dev@127.0.0.1:55432/musubi_test cargo test -p musubi_orchestration --test postgres_contract
- make guardrail-sweep
- git diff --check origin/main...HEAD

Note: the first full postgres_contract run exposed three old committed local outbox rows in musubi_test from 2026-06-07; I truncated only local test-db outbox coordination tables, reran the existing exact test, then reran the full suite successfully.