### PR TITLE
test: cover Promise completion hard exclusions

### DIFF
--- a/apps/backend/crates/social-trust-domain/tests/c1_first_positive_source_scope_contract.rs
+++ b/apps/backend/crates/social-trust-domain/tests/c1_first_positive_source_scope_contract.rs
@@ -73,6 +73,22 @@ fn rejected_promise_reliability_sources_fail_closed_for_c1_first_positive_scope(
 }
 
 #[test]
+fn hard_exclusion_shortcuts_never_enter_c1_first_positive_scope() {
+    for source in hard_exclusion_shortcuts() {
+        assert_eq!(
+            decide_c1_first_positive_source_scope(
+                C2BoundedPromiseReliabilitySourceFactCandidate::Rejected(source),
+            ),
+            C1FirstPositiveSourceScopeDecision::Reject(
+                C1FirstPositiveSourceScopeRejection::RejectedSourceFact { source }
+            ),
+            "{} must not become a C1 first positive source",
+            source.as_str(),
+        );
+    }
+}
+
+#[test]
 fn unknown_source_fact_fails_closed_for_c1_first_positive_scope() {
     assert_eq!(
         decide_c1_first_positive_source_scope(
@@ -173,6 +189,35 @@ fn rejected_source_facts() -> Vec<RejectedC2BoundedPromiseReliabilitySourceFact>
         RejectedC2BoundedPromiseReliabilitySourceFact::AntiAbuseContinuityMarkerExistence,
         RejectedC2BoundedPromiseReliabilitySourceFact::AccountLifecycleStateByItself,
         RejectedC2BoundedPromiseReliabilitySourceFact::DeletionClosureTombstoneAnonymizationKeyShreddingOrReEntry,
+        RejectedC2BoundedPromiseReliabilitySourceFact::ImplementationConvenience,
+    ]
+}
+
+fn hard_exclusion_shortcuts() -> Vec<RejectedC2BoundedPromiseReliabilitySourceFact> {
+    vec![
+        RejectedC2BoundedPromiseReliabilitySourceFact::EscrowRelease,
+        RejectedC2BoundedPromiseReliabilitySourceFact::Forfeiture,
+        RejectedC2BoundedPromiseReliabilitySourceFact::PaymentAmount,
+        RejectedC2BoundedPromiseReliabilitySourceFact::SupportStatus,
+        RejectedC2BoundedPromiseReliabilitySourceFact::TokenHoldings,
+        RejectedC2BoundedPromiseReliabilitySourceFact::RawVenuePresence,
+        RejectedC2BoundedPromiseReliabilitySourceFact::RawGps,
+        RejectedC2BoundedPromiseReliabilitySourceFact::StaticQrScan,
+        RejectedC2BoundedPromiseReliabilitySourceFact::DeviceAttestationAlone,
+        RejectedC2BoundedPromiseReliabilitySourceFact::ProximityProofAlone,
+        RejectedC2BoundedPromiseReliabilitySourceFact::ProofCallbackAlone,
+        RejectedC2BoundedPromiseReliabilitySourceFact::VendorCallbackAlone,
+        RejectedC2BoundedPromiseReliabilitySourceFact::ProjectionReadiness,
+        RejectedC2BoundedPromiseReliabilitySourceFact::OperatorNote,
+        RejectedC2BoundedPromiseReliabilitySourceFact::SinglePartyNarrative,
+        RejectedC2BoundedPromiseReliabilitySourceFact::Popularity,
+        RejectedC2BoundedPromiseReliabilitySourceFact::MessageVolume,
+        RejectedC2BoundedPromiseReliabilitySourceFact::RomanticDesirability,
+        RejectedC2BoundedPromiseReliabilitySourceFact::RelationshipDepth,
+        RejectedC2BoundedPromiseReliabilitySourceFact::ControlledExceptionalAccountActivity,
+        RejectedC2BoundedPromiseReliabilitySourceFact::AgeAssurancePosture,
+        RejectedC2BoundedPromiseReliabilitySourceFact::LegalHoldExistence,
+        RejectedC2BoundedPromiseReliabilitySourceFact::AntiAbuseContinuityMarkerExistence,
         RejectedC2BoundedPromiseReliabilitySourceFact::ImplementationConvenience,
     ]
 }

--- a/apps/backend/crates/social-trust-domain/tests/c2_bounded_promise_reliability_contract.rs
+++ b/apps/backend/crates/social-trust-domain/tests/c2_bounded_promise_reliability_contract.rs
@@ -87,6 +87,25 @@ fn rejected_source_facts_fail_closed() {
 }
 
 #[test]
+fn representable_hard_exclusion_source_families_fail_closed_for_c2_mutation() {
+    for (family, sources) in hard_exclusion_source_families() {
+        for source in sources {
+            let mut proposal = complete_proposal();
+            proposal.source_fact = C2BoundedPromiseReliabilitySourceFactCandidate::Rejected(source);
+
+            assert_eq!(
+                decide_c2_bounded_promise_reliability_mutation(&proposal),
+                C2BoundedPromiseReliabilityMutationDecision::Reject(
+                    C2BoundedPromiseReliabilityRejection::RejectedSourceFact { source }
+                ),
+                "{family} shortcut {} must fail closed for C2 mutation",
+                source.as_str(),
+            );
+        }
+    }
+}
+
+#[test]
 fn unknown_source_or_mutation_fact_fails_closed() {
     let mut unknown_source = complete_proposal();
     unknown_source.source_fact = C2BoundedPromiseReliabilitySourceFactCandidate::Unknown;
@@ -135,6 +154,24 @@ fn projection_authority_and_unresolved_boundaries_fail_closed() {
             }
         )
     );
+}
+
+#[test]
+fn ordinary_positive_completion_paths_fail_closed_on_each_boundary_intersection() {
+    for boundary in boundary_intersections() {
+        let mut proposal = complete_proposal();
+        proposal.boundary_posture =
+            C2BoundedPromiseReliabilityBoundaryPosture::Unresolved(boundary);
+
+        assert_eq!(
+            decide_c2_bounded_promise_reliability_mutation(&proposal),
+            C2BoundedPromiseReliabilityMutationDecision::Reject(
+                C2BoundedPromiseReliabilityRejection::BoundaryUnresolved { boundary }
+            ),
+            "ordinary positive completion path must not bypass {}",
+            boundary.as_str(),
+        );
+    }
 }
 
 #[test]
@@ -410,5 +447,117 @@ fn rejected_source_facts() -> Vec<RejectedC2BoundedPromiseReliabilitySourceFact>
         RejectedC2BoundedPromiseReliabilitySourceFact::AccountLifecycleStateByItself,
         RejectedC2BoundedPromiseReliabilitySourceFact::DeletionClosureTombstoneAnonymizationKeyShreddingOrReEntry,
         RejectedC2BoundedPromiseReliabilitySourceFact::ImplementationConvenience,
+    ]
+}
+
+fn hard_exclusion_source_families() -> Vec<(
+    &'static str,
+    Vec<RejectedC2BoundedPromiseReliabilitySourceFact>,
+)> {
+    vec![
+        (
+            "payment_support_and_settlement",
+            vec![
+                RejectedC2BoundedPromiseReliabilitySourceFact::PromiseEscrowCreation,
+                RejectedC2BoundedPromiseReliabilitySourceFact::EscrowAmount,
+                RejectedC2BoundedPromiseReliabilitySourceFact::EscrowRelease,
+                RejectedC2BoundedPromiseReliabilitySourceFact::Forfeiture,
+                RejectedC2BoundedPromiseReliabilitySourceFact::PaymentAmount,
+                RejectedC2BoundedPromiseReliabilitySourceFact::PaymentFrequency,
+                RejectedC2BoundedPromiseReliabilitySourceFact::SupportAmount,
+                RejectedC2BoundedPromiseReliabilitySourceFact::SupportStatus,
+                RejectedC2BoundedPromiseReliabilitySourceFact::TokenHoldings,
+            ],
+        ),
+        (
+            "proof_provider_and_raw_presence",
+            vec![
+                RejectedC2BoundedPromiseReliabilitySourceFact::MeetingAttendanceClaimByOneParty,
+                RejectedC2BoundedPromiseReliabilitySourceFact::RawVenuePresence,
+                RejectedC2BoundedPromiseReliabilitySourceFact::RawGps,
+                RejectedC2BoundedPromiseReliabilitySourceFact::StaticQrScan,
+                RejectedC2BoundedPromiseReliabilitySourceFact::NfcTapAlone,
+                RejectedC2BoundedPromiseReliabilitySourceFact::BleObservationAlone,
+                RejectedC2BoundedPromiseReliabilitySourceFact::BleMacAddress,
+                RejectedC2BoundedPromiseReliabilitySourceFact::DeviceAttestationAlone,
+                RejectedC2BoundedPromiseReliabilitySourceFact::MissingDeviceAttestationAlone,
+                RejectedC2BoundedPromiseReliabilitySourceFact::ProximityProofAlone,
+                RejectedC2BoundedPromiseReliabilitySourceFact::ProofEligibilityAlone,
+                RejectedC2BoundedPromiseReliabilitySourceFact::ProofCallbackAlone,
+                RejectedC2BoundedPromiseReliabilitySourceFact::VendorCallbackAlone,
+                RejectedC2BoundedPromiseReliabilitySourceFact::ProviderDashboardState,
+            ],
+        ),
+        (
+            "projection_client_model_and_observability",
+            vec![
+                RejectedC2BoundedPromiseReliabilitySourceFact::ProjectionReadiness,
+                RejectedC2BoundedPromiseReliabilitySourceFact::RoomProjection,
+                RejectedC2BoundedPromiseReliabilitySourceFact::ObservabilityState,
+                RejectedC2BoundedPromiseReliabilitySourceFact::ModelOutput,
+                RejectedC2BoundedPromiseReliabilitySourceFact::FrontendState,
+                RejectedC2BoundedPromiseReliabilitySourceFact::ClientState,
+            ],
+        ),
+        (
+            "subjective_narrative_and_operator_notes",
+            vec![
+                RejectedC2BoundedPromiseReliabilitySourceFact::ReflectionPraise,
+                RejectedC2BoundedPromiseReliabilitySourceFact::ApologyText,
+                RejectedC2BoundedPromiseReliabilitySourceFact::SubjectiveGratitude,
+                RejectedC2BoundedPromiseReliabilitySourceFact::SinglePartyNarrative,
+                RejectedC2BoundedPromiseReliabilitySourceFact::ReportCount,
+                RejectedC2BoundedPromiseReliabilitySourceFact::MassReportCount,
+                RejectedC2BoundedPromiseReliabilitySourceFact::OperatorNote,
+                RejectedC2BoundedPromiseReliabilitySourceFact::StewardEndorsementByItself,
+                RejectedC2BoundedPromiseReliabilitySourceFact::SupportTicket,
+                RejectedC2BoundedPromiseReliabilitySourceFact::IssueComment,
+            ],
+        ),
+        (
+            "popularity_engagement_and_relationship_depth",
+            vec![
+                RejectedC2BoundedPromiseReliabilitySourceFact::Popularity,
+                RejectedC2BoundedPromiseReliabilitySourceFact::FollowerCount,
+                RejectedC2BoundedPromiseReliabilitySourceFact::ReplySpeed,
+                RejectedC2BoundedPromiseReliabilitySourceFact::DwellTime,
+                RejectedC2BoundedPromiseReliabilitySourceFact::MessageVolume,
+                RejectedC2BoundedPromiseReliabilitySourceFact::AccountTenure,
+                RejectedC2BoundedPromiseReliabilitySourceFact::RomanticDesirability,
+                RejectedC2BoundedPromiseReliabilitySourceFact::EngagementTelemetry,
+                RejectedC2BoundedPromiseReliabilitySourceFact::RelationshipDepth,
+                RejectedC2BoundedPromiseReliabilitySourceFact::RoomStateByItself,
+                RejectedC2BoundedPromiseReliabilitySourceFact::DiscoveryRanking,
+                RejectedC2BoundedPromiseReliabilitySourceFact::RecommendationState,
+            ],
+        ),
+        (
+            "identity_lifecycle_and_convenience",
+            vec![
+                RejectedC2BoundedPromiseReliabilitySourceFact::ControlledExceptionalAccountActivity,
+                RejectedC2BoundedPromiseReliabilitySourceFact::AgeAssurancePosture,
+                RejectedC2BoundedPromiseReliabilitySourceFact::VerifiedAdultPosture,
+                RejectedC2BoundedPromiseReliabilitySourceFact::LegalHoldExistence,
+                RejectedC2BoundedPromiseReliabilitySourceFact::AntiAbuseContinuityMarkerExistence,
+                RejectedC2BoundedPromiseReliabilitySourceFact::AccountLifecycleStateByItself,
+                RejectedC2BoundedPromiseReliabilitySourceFact::DeletionClosureTombstoneAnonymizationKeyShreddingOrReEntry,
+                RejectedC2BoundedPromiseReliabilitySourceFact::ImplementationConvenience,
+            ],
+        ),
+    ]
+}
+
+fn boundary_intersections() -> Vec<C2BoundedPromiseReliabilityBoundaryIntersection> {
+    vec![
+        C2BoundedPromiseReliabilityBoundaryIntersection::Consent,
+        C2BoundedPromiseReliabilityBoundaryIntersection::BlockMuteRefusalOrWithdrawal,
+        C2BoundedPromiseReliabilityBoundaryIntersection::AgeAssurance,
+        C2BoundedPromiseReliabilityBoundaryIntersection::LegalHold,
+        C2BoundedPromiseReliabilityBoundaryIntersection::CriticalHarm,
+        C2BoundedPromiseReliabilityBoundaryIntersection::AccountLifecycle,
+        C2BoundedPromiseReliabilityBoundaryIntersection::AppealCorrectionOrSafetyReview,
+        C2BoundedPromiseReliabilityBoundaryIntersection::AntiAbuseSuppression,
+        C2BoundedPromiseReliabilityBoundaryIntersection::CollusionScamOrCoercion,
+        C2BoundedPromiseReliabilityBoundaryIntersection::SensitiveExposure,
     ]
 }

--- a/apps/backend/crates/social-trust-domain/tests/post_c2_non_consumption_guard_contract.rs
+++ b/apps/backend/crates/social-trust-domain/tests/post_c2_non_consumption_guard_contract.rs
@@ -5,6 +5,8 @@ use musubi_social_trust_domain::{
     SocialTrustAuthorityPosture, decide_c2_categorical_fact_consumption,
 };
 
+type TargetFamily = (&'static str, C2CategoricalFactConsumptionTarget);
+
 #[test]
 fn exact_c2_pairs_may_remain_internal_writer_fact_references_only() {
     for (source_fact, mutation_fact) in accepted_mappings() {
@@ -64,6 +66,26 @@ fn blocked_consumption_targets_fail_closed_for_all_c2_facts() {
                     C2CategoricalFactConsumptionRejection::BlockedConsumptionTarget { target }
                 ),
                 "target {} must remain blocked for {} / {}",
+                target.as_str(),
+                source_fact.as_str(),
+                mutation_fact.as_str(),
+            );
+        }
+    }
+}
+
+#[test]
+fn promise_completion_product_effect_shortcuts_remain_blocked() {
+    for (source_fact, mutation_fact) in positive_completion_mappings() {
+        for (family, target) in hard_exclusion_product_effect_targets() {
+            let attempt = attempt(source_fact, mutation_fact, target);
+
+            assert_eq!(
+                decide_c2_categorical_fact_consumption(&attempt),
+                C2CategoricalFactConsumptionDecision::Reject(
+                    C2CategoricalFactConsumptionRejection::BlockedConsumptionTarget { target }
+                ),
+                "{family} target {} must remain blocked for {} / {}",
                 target.as_str(),
                 source_fact.as_str(),
                 mutation_fact.as_str(),
@@ -208,6 +230,22 @@ fn accepted_mappings() -> Vec<(
     ]
 }
 
+fn positive_completion_mappings() -> Vec<(
+    C2BoundedPromiseReliabilitySourceFact,
+    C2BoundedPromiseReliabilityMutationFact,
+)> {
+    vec![
+        (
+            C2BoundedPromiseReliabilitySourceFact::CompletedAsAgreed,
+            C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityPositive,
+        ),
+        (
+            C2BoundedPromiseReliabilitySourceFact::CompletedAfterGovernedReview,
+            C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityPositive,
+        ),
+    ]
+}
+
 fn accepted_mutation_facts() -> Vec<C2BoundedPromiseReliabilityMutationFact> {
     vec![
         C2BoundedPromiseReliabilityMutationFact::BoundedPromiseReliabilityPositive,
@@ -240,5 +278,56 @@ fn blocked_targets() -> Vec<C2CategoricalFactConsumptionTarget> {
         C2CategoricalFactConsumptionTarget::ProjectionRefresh,
         C2CategoricalFactConsumptionTarget::PublicApiResponse,
         C2CategoricalFactConsumptionTarget::MobileUiState,
+    ]
+}
+
+fn hard_exclusion_product_effect_targets() -> Vec<TargetFamily> {
+    vec![
+        (
+            "social_trust_display",
+            C2CategoricalFactConsumptionTarget::PublicSocialTrustDisplay,
+        ),
+        (
+            "social_trust_scoring",
+            C2CategoricalFactConsumptionTarget::NumericSocialTrustScore,
+        ),
+        (
+            "relationship_depth",
+            C2CategoricalFactConsumptionTarget::RelationshipDepthFact,
+        ),
+        (
+            "settlement",
+            C2CategoricalFactConsumptionTarget::SettlementProgression,
+        ),
+        ("contact", C2CategoricalFactConsumptionTarget::ContactUnlock),
+        (
+            "discovery",
+            C2CategoricalFactConsumptionTarget::DiscoveryPriority,
+        ),
+        (
+            "recommendation",
+            C2CategoricalFactConsumptionTarget::RecommendationBoost,
+        ),
+        ("room", C2CategoricalFactConsumptionTarget::RoomTransition),
+        (
+            "projection",
+            C2CategoricalFactConsumptionTarget::ProjectionRefresh,
+        ),
+        (
+            "public_api",
+            C2CategoricalFactConsumptionTarget::PublicApiResponse,
+        ),
+        (
+            "mobile_ui",
+            C2CategoricalFactConsumptionTarget::MobileUiState,
+        ),
+        (
+            "promise_runtime",
+            C2CategoricalFactConsumptionTarget::PromiseRuntimeOutcome,
+        ),
+        (
+            "proof_runtime",
+            C2CategoricalFactConsumptionTarget::ProofRuntimeOutcome,
+        ),
     ]
 }


### PR DESCRIPTION
Closes #165.\n\nSummary:\n- Adds Promise completion hard-exclusion coverage to the selected pure social-trust-domain contract tests authorized by musubi-foundation PR #434.\n- Proves representable forbidden source families fail closed for C2 bounded Promise reliability mutation.\n- Proves hard-exclusion shortcuts do not enter the C1 first positive source scope.\n- Proves positive Promise completion C2 facts do not escape into Social Trust display/scoring, Relationship Depth, settlement, contact, discovery, recommendation, room, projection, API, mobile UI, Promise runtime, or proof runtime targets.\n\nScope:\n- Modified only the three selected test files under apps/backend/crates/social-trust-domain/tests/.\n- No docs/foundation_lock.md changes.\n- No production source, DDL, migrations, schema-only work, API, UI, projection refresh, writer fact persistence, Social Trust mutation, Relationship Depth mutation, settlement movement, or broad downstream changes.\n\nValidation:\n- git diff --check origin/main...HEAD\n- git diff --name-status origin/main...HEAD\n- rustfmt --edition 2024 --check crates/social-trust-domain/tests/c1_first_positive_source_scope_contract.rs crates/social-trust-domain/tests/c2_bounded_promise_reliability_contract.rs crates/social-trust-domain/tests/post_c2_non_consumption_guard_contract.rs\n- cargo test -p musubi_social_trust_domain --test c1_first_positive_source_scope_contract --test c2_bounded_promise_reliability_contract --test post_c2_non_consumption_guard_contract