### PR TITLE
feat: persist Promise completion writer facts narrowly

### DIFF
--- a/apps/backend/migrations/0023_promise_completion_writer_fact_persistence.sql
+++ b/apps/backend/migrations/0023_promise_completion_writer_fact_persistence.sql
@@ -1,0 +1,215 @@
+CREATE SCHEMA IF NOT EXISTS promise_completion;
+
+COMMENT ON SCHEMA promise_completion IS
+'Writer-owned Promise completion fact persistence. This schema does not contain projection truth, Social Trust mutations, Relationship Depth facts, settlement movement, provider payloads, or raw Personal Data.';
+
+CREATE TABLE IF NOT EXISTS promise_completion.writer_fact_records (
+    writer_fact_id UUID PRIMARY KEY,
+    promise_reference TEXT NOT NULL CHECK (char_length(trim(promise_reference)) > 0),
+    realm_id TEXT NOT NULL CHECK (char_length(trim(realm_id)) > 0),
+    fact_family TEXT NOT NULL CHECK (
+        fact_family IN (
+            'source_route_candidate',
+            'completion_state_transition',
+            'completion_outcome_reference',
+            'correction_or_supersession',
+            'access_audit_retention_support'
+        )
+    ),
+    source_route_class TEXT NOT NULL CHECK (
+        source_route_class IN (
+            'mutual_accountable_completion_acknowledgement',
+            'governed_review_completion'
+        )
+    ),
+    previous_completion_state_class TEXT CHECK (
+        previous_completion_state_class IS NULL
+        OR previous_completion_state_class IN (
+            'completion_unavailable',
+            'completion_pending_mutual_acknowledgement',
+            'completion_review_required',
+            'completion_under_governed_review',
+            'completion_accepted',
+            'completion_rejected',
+            'completion_expired',
+            'completion_corrected_or_superseded',
+            'completion_closed'
+        )
+    ),
+    completion_state_class TEXT NOT NULL CHECK (
+        completion_state_class IN (
+            'completion_unavailable',
+            'completion_pending_mutual_acknowledgement',
+            'completion_review_required',
+            'completion_under_governed_review',
+            'completion_accepted',
+            'completion_rejected',
+            'completion_expired',
+            'completion_corrected_or_superseded',
+            'completion_closed'
+        )
+    ),
+    completed_reference_eligible BOOLEAN NOT NULL DEFAULT FALSE,
+    promise_terms_reference TEXT NOT NULL CHECK (
+        char_length(trim(promise_terms_reference)) > 0
+    ),
+    participant_set_reference TEXT NOT NULL CHECK (
+        char_length(trim(participant_set_reference)) > 0
+    ),
+    ordinary_participant_acknowledgement_reference TEXT CHECK (
+        ordinary_participant_acknowledgement_reference IS NULL
+        OR char_length(trim(ordinary_participant_acknowledgement_reference)) > 0
+    ),
+    governed_review_reference TEXT CHECK (
+        governed_review_reference IS NULL
+        OR char_length(trim(governed_review_reference)) > 0
+    ),
+    review_authority_reference TEXT CHECK (
+        review_authority_reference IS NULL
+        OR char_length(trim(review_authority_reference)) > 0
+    ),
+    proof_eligibility_reference TEXT CHECK (
+        proof_eligibility_reference IS NULL
+        OR char_length(trim(proof_eligibility_reference)) > 0
+    ),
+    proof_evidence_writer_fact_reference TEXT CHECK (
+        proof_evidence_writer_fact_reference IS NULL
+        OR char_length(trim(proof_evidence_writer_fact_reference)) > 0
+    ),
+    consent_at_formation_reference TEXT NOT NULL CHECK (
+        char_length(trim(consent_at_formation_reference)) > 0
+    ),
+    consent_at_resolution_reference TEXT NOT NULL CHECK (
+        char_length(trim(consent_at_resolution_reference)) > 0
+    ),
+    block_withdrawal_state_reference TEXT NOT NULL CHECK (
+        char_length(trim(block_withdrawal_state_reference)) > 0
+    ),
+    age_assurance_state_reference TEXT NOT NULL CHECK (
+        char_length(trim(age_assurance_state_reference)) > 0
+    ),
+    legal_hold_intersection_reference TEXT NOT NULL CHECK (
+        char_length(trim(legal_hold_intersection_reference)) > 0
+    ),
+    critical_harm_case_reference TEXT NOT NULL CHECK (
+        char_length(trim(critical_harm_case_reference)) > 0
+    ),
+    account_lifecycle_reference TEXT NOT NULL CHECK (
+        char_length(trim(account_lifecycle_reference)) > 0
+    ),
+    anti_abuse_continuity_reference TEXT NOT NULL CHECK (
+        char_length(trim(anti_abuse_continuity_reference)) > 0
+    ),
+    safety_case_reference TEXT NOT NULL CHECK (char_length(trim(safety_case_reference)) > 0),
+    reason_code_class TEXT NOT NULL CHECK (char_length(trim(reason_code_class)) > 0),
+    evidence_level_reference TEXT NOT NULL CHECK (
+        char_length(trim(evidence_level_reference)) > 0
+    ),
+    correction_or_supersession_reference TEXT CHECK (
+        correction_or_supersession_reference IS NULL
+        OR char_length(trim(correction_or_supersession_reference)) > 0
+    ),
+    prior_writer_fact_id UUID REFERENCES promise_completion.writer_fact_records(writer_fact_id),
+    policy_version INTEGER NOT NULL CHECK (policy_version > 0),
+    fact_idempotency_key TEXT NOT NULL CHECK (
+        char_length(trim(fact_idempotency_key)) > 0
+    ),
+    request_payload_hash TEXT NOT NULL CHECK (request_payload_hash ~ '^[0-9a-f]{64}$'),
+    decision_payload_hash TEXT NOT NULL CHECK (decision_payload_hash ~ '^[0-9a-f]{64}$'),
+    retention_class_reference TEXT NOT NULL CHECK (
+        char_length(trim(retention_class_reference)) > 0
+    ),
+    access_audit_reference TEXT NOT NULL CHECK (
+        char_length(trim(access_audit_reference)) > 0
+    ),
+    projection_non_authority_posture TEXT NOT NULL CHECK (
+        projection_non_authority_posture = 'projection_non_authoritative'
+    ),
+    authority_posture TEXT NOT NULL CHECK (authority_posture = 'writer_truth_only'),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CHECK (
+        completed_reference_eligible = FALSE
+        OR completion_state_class = 'completion_accepted'
+    ),
+    CHECK (
+        source_route_class <> 'mutual_accountable_completion_acknowledgement'
+        OR ordinary_participant_acknowledgement_reference IS NOT NULL
+    ),
+    CHECK (
+        source_route_class <> 'governed_review_completion'
+        OR (
+            governed_review_reference IS NOT NULL
+            AND review_authority_reference IS NOT NULL
+        )
+    ),
+    CHECK (
+        (
+            proof_eligibility_reference IS NULL
+            AND proof_evidence_writer_fact_reference IS NULL
+        )
+        OR (
+            proof_eligibility_reference IS NOT NULL
+            AND proof_evidence_writer_fact_reference IS NOT NULL
+        )
+    ),
+    CHECK (
+        fact_family <> 'correction_or_supersession'
+        OR (
+            correction_or_supersession_reference IS NOT NULL
+            OR prior_writer_fact_id IS NOT NULL
+        )
+    )
+);
+
+COMMENT ON TABLE promise_completion.writer_fact_records IS
+'Append-only Promise completion writer fact envelopes. These records preserve writer truth references only and do not run Promise completion runtime behavior.';
+
+COMMENT ON COLUMN promise_completion.writer_fact_records.completed_reference_eligible IS
+'Participant-safe completed reference eligibility. Database constraint limits true to completion_accepted.';
+
+COMMENT ON COLUMN promise_completion.writer_fact_records.request_payload_hash IS
+'SHA-256 hash of minimized writer fact meaning used for deterministic duplicate-delivery drift checks. Raw evidence, raw provider payloads, and raw PII do not belong here.';
+
+CREATE OR REPLACE FUNCTION promise_completion.reject_writer_fact_record_mutation()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION 'promise_completion.writer_fact_records is append-only';
+END;
+$$;
+
+COMMENT ON FUNCTION promise_completion.reject_writer_fact_record_mutation() IS
+'Rejects UPDATE and DELETE against Promise completion writer fact records. Corrections must be new facts.';
+
+DROP TRIGGER IF EXISTS promise_completion_writer_fact_records_no_update
+    ON promise_completion.writer_fact_records;
+
+CREATE TRIGGER promise_completion_writer_fact_records_no_update
+    BEFORE UPDATE OR DELETE ON promise_completion.writer_fact_records
+    FOR EACH ROW
+    EXECUTE FUNCTION promise_completion.reject_writer_fact_record_mutation();
+
+CREATE UNIQUE INDEX IF NOT EXISTS promise_completion_writer_fact_dedupe_unique
+    ON promise_completion.writer_fact_records (
+        realm_id,
+        promise_reference,
+        policy_version,
+        fact_idempotency_key
+    );
+
+COMMENT ON INDEX promise_completion.promise_completion_writer_fact_dedupe_unique IS
+'Durable database-enforced idempotency boundary for Promise completion writer fact envelopes.';
+
+CREATE INDEX IF NOT EXISTS promise_completion_writer_fact_promise_created_idx
+    ON promise_completion.writer_fact_records (promise_reference, created_at);
+
+CREATE INDEX IF NOT EXISTS promise_completion_writer_fact_realm_created_idx
+    ON promise_completion.writer_fact_records (realm_id, created_at);
+
+CREATE INDEX IF NOT EXISTS promise_completion_writer_fact_retention_idx
+    ON promise_completion.writer_fact_records (retention_class_reference, created_at);
+
+CREATE INDEX IF NOT EXISTS promise_completion_writer_fact_prior_idx
+    ON promise_completion.writer_fact_records (prior_writer_fact_id)
+    WHERE prior_writer_fact_id IS NOT NULL;

--- a/apps/backend/src/services/mod.rs
+++ b/apps/backend/src/services/mod.rs
@@ -3,6 +3,7 @@ pub mod happy_route;
 pub mod launch_posture;
 pub mod operator_review;
 pub mod ops_observability;
+pub mod promise_completion;
 pub mod proof;
 pub mod realm_bootstrap;
 pub mod room_progression;

--- a/apps/backend/src/services/promise_completion/mod.rs
+++ b/apps/backend/src/services/promise_completion/mod.rs
@@ -1,0 +1,12 @@
+mod repository;
+mod types;
+
+pub use repository::PromiseCompletionWriterFactStore;
+pub use types::{
+    PromiseCompletionAuthorityPosture, PromiseCompletionForbiddenSourceRouteClass,
+    PromiseCompletionProjectionNonAuthorityPosture, PromiseCompletionSourceRouteClass,
+    PromiseCompletionStateClass, PromiseCompletionWriterFactFamily,
+    PromiseCompletionWriterFactPersistenceError, PromiseCompletionWriterFactReplayStatus,
+    PromiseCompletionWriterFactSnapshot, ProposedPromiseCompletionWriterFact,
+    RecordPromiseCompletionWriterFactInput,
+};

--- a/apps/backend/src/services/promise_completion/repository.rs
+++ b/apps/backend/src/services/promise_completion/repository.rs
@@ -1,0 +1,793 @@
+use std::{fmt::Write as _, sync::Arc};
+
+use musubi_db_runtime::{DbConfig, connect_writer};
+use sha2::{Digest, Sha256};
+use tokio::sync::Mutex;
+use tokio_postgres::{Client, GenericClient, Row, error::SqlState};
+use uuid::Uuid;
+
+use super::types::{
+    PromiseCompletionAuthorityPosture, PromiseCompletionProjectionNonAuthorityPosture,
+    PromiseCompletionSourceRouteClass, PromiseCompletionStateClass,
+    PromiseCompletionWriterFactFamily, PromiseCompletionWriterFactPersistenceError,
+    PromiseCompletionWriterFactReplayStatus, PromiseCompletionWriterFactSnapshot,
+    ProposedPromiseCompletionWriterFact, RecordPromiseCompletionWriterFactInput,
+};
+
+const DECISION_KIND: &str = "accepted_for_writer_fact_persistence";
+
+#[derive(Clone)]
+pub struct PromiseCompletionWriterFactStore {
+    client: Arc<Mutex<Client>>,
+}
+
+struct NormalizedWriterFact {
+    promise_reference: String,
+    realm_id: String,
+    fact_family: &'static str,
+    source_route_class: &'static str,
+    previous_completion_state_class: Option<&'static str>,
+    completion_state_class: &'static str,
+    completed_reference_eligible: bool,
+    promise_terms_reference: String,
+    participant_set_reference: String,
+    ordinary_participant_acknowledgement_reference: Option<String>,
+    governed_review_reference: Option<String>,
+    review_authority_reference: Option<String>,
+    proof_eligibility_reference: Option<String>,
+    proof_evidence_writer_fact_reference: Option<String>,
+    consent_at_formation_reference: String,
+    consent_at_resolution_reference: String,
+    block_withdrawal_state_reference: String,
+    age_assurance_state_reference: String,
+    legal_hold_intersection_reference: String,
+    critical_harm_case_reference: String,
+    account_lifecycle_reference: String,
+    anti_abuse_continuity_reference: String,
+    safety_case_reference: String,
+    reason_code_class: String,
+    evidence_level_reference: String,
+    correction_or_supersession_reference: Option<String>,
+    prior_writer_fact_id: Option<Uuid>,
+    policy_version: i32,
+    fact_idempotency_key: String,
+    retention_class_reference: String,
+    access_audit_reference: String,
+    projection_non_authority_posture: &'static str,
+    authority_posture: &'static str,
+    request_payload_hash: String,
+    decision_payload_hash: String,
+}
+
+impl PromiseCompletionWriterFactStore {
+    pub async fn connect(config: &DbConfig) -> musubi_db_runtime::Result<Self> {
+        let client = connect_writer(config, "musubi-backend promise-completion").await?;
+        Ok(Self {
+            client: Arc::new(Mutex::new(client)),
+        })
+    }
+
+    pub async fn record_writer_fact(
+        &self,
+        input: RecordPromiseCompletionWriterFactInput,
+    ) -> Result<PromiseCompletionWriterFactSnapshot, PromiseCompletionWriterFactPersistenceError>
+    {
+        let normalized = normalize_writer_fact(&input.fact)?;
+        let client = self.client.lock().await;
+
+        if let Some(existing) = find_existing_writer_fact_by_dedupe(&*client, &normalized).await? {
+            let writer_fact_id = replay_writer_fact_id(existing, &normalized)?;
+            return load_snapshot_by_writer_fact_id(
+                &*client,
+                &writer_fact_id,
+                PromiseCompletionWriterFactReplayStatus::ReplayedIdentical,
+            )
+            .await;
+        }
+
+        let inserted_writer_fact_id = Uuid::new_v4();
+        let inserted = client
+            .query_opt(
+                "
+                INSERT INTO promise_completion.writer_fact_records (
+                    writer_fact_id,
+                    promise_reference,
+                    realm_id,
+                    fact_family,
+                    source_route_class,
+                    previous_completion_state_class,
+                    completion_state_class,
+                    completed_reference_eligible,
+                    promise_terms_reference,
+                    participant_set_reference,
+                    ordinary_participant_acknowledgement_reference,
+                    governed_review_reference,
+                    review_authority_reference,
+                    proof_eligibility_reference,
+                    proof_evidence_writer_fact_reference,
+                    consent_at_formation_reference,
+                    consent_at_resolution_reference,
+                    block_withdrawal_state_reference,
+                    age_assurance_state_reference,
+                    legal_hold_intersection_reference,
+                    critical_harm_case_reference,
+                    account_lifecycle_reference,
+                    anti_abuse_continuity_reference,
+                    safety_case_reference,
+                    reason_code_class,
+                    evidence_level_reference,
+                    correction_or_supersession_reference,
+                    prior_writer_fact_id,
+                    policy_version,
+                    fact_idempotency_key,
+                    request_payload_hash,
+                    decision_payload_hash,
+                    retention_class_reference,
+                    access_audit_reference,
+                    projection_non_authority_posture,
+                    authority_posture
+                )
+                VALUES (
+                    $1, $2, $3, $4, $5, $6, $7, $8,
+                    $9, $10, $11, $12, $13, $14, $15, $16,
+                    $17, $18, $19, $20, $21, $22, $23, $24,
+                    $25, $26, $27, $28, $29, $30, $31, $32,
+                    $33, $34, $35, $36
+                )
+                ON CONFLICT (
+                    realm_id,
+                    promise_reference,
+                    policy_version,
+                    fact_idempotency_key
+                ) DO NOTHING
+                RETURNING writer_fact_id
+                ",
+                &[
+                    &inserted_writer_fact_id,
+                    &normalized.promise_reference,
+                    &normalized.realm_id,
+                    &normalized.fact_family,
+                    &normalized.source_route_class,
+                    &normalized.previous_completion_state_class,
+                    &normalized.completion_state_class,
+                    &normalized.completed_reference_eligible,
+                    &normalized.promise_terms_reference,
+                    &normalized.participant_set_reference,
+                    &normalized.ordinary_participant_acknowledgement_reference,
+                    &normalized.governed_review_reference,
+                    &normalized.review_authority_reference,
+                    &normalized.proof_eligibility_reference,
+                    &normalized.proof_evidence_writer_fact_reference,
+                    &normalized.consent_at_formation_reference,
+                    &normalized.consent_at_resolution_reference,
+                    &normalized.block_withdrawal_state_reference,
+                    &normalized.age_assurance_state_reference,
+                    &normalized.legal_hold_intersection_reference,
+                    &normalized.critical_harm_case_reference,
+                    &normalized.account_lifecycle_reference,
+                    &normalized.anti_abuse_continuity_reference,
+                    &normalized.safety_case_reference,
+                    &normalized.reason_code_class,
+                    &normalized.evidence_level_reference,
+                    &normalized.correction_or_supersession_reference,
+                    &normalized.prior_writer_fact_id,
+                    &normalized.policy_version,
+                    &normalized.fact_idempotency_key,
+                    &normalized.request_payload_hash,
+                    &normalized.decision_payload_hash,
+                    &normalized.retention_class_reference,
+                    &normalized.access_audit_reference,
+                    &normalized.projection_non_authority_posture,
+                    &normalized.authority_posture,
+                ],
+            )
+            .await
+            .map_err(writer_fact_insert_error)?;
+
+        let (writer_fact_id, replay_status) = match inserted {
+            Some(row) => {
+                let writer_fact_id: Uuid = row.get("writer_fact_id");
+                (
+                    writer_fact_id,
+                    PromiseCompletionWriterFactReplayStatus::Inserted,
+                )
+            }
+            None => {
+                let existing = find_existing_writer_fact_by_dedupe(&*client, &normalized)
+                    .await?
+                    .ok_or_else(|| {
+                        PromiseCompletionWriterFactPersistenceError::Internal(
+                            "idempotency conflict did not return existing Promise completion writer fact"
+                                .to_owned(),
+                        )
+                    })?;
+                let writer_fact_id = replay_writer_fact_id(existing, &normalized)?;
+                (
+                    writer_fact_id,
+                    PromiseCompletionWriterFactReplayStatus::ReplayedIdentical,
+                )
+            }
+        };
+
+        let snapshot =
+            load_snapshot_by_writer_fact_id(&*client, &writer_fact_id, replay_status).await?;
+        Ok(snapshot)
+    }
+}
+
+fn normalize_writer_fact(
+    fact: &ProposedPromiseCompletionWriterFact,
+) -> Result<NormalizedWriterFact, PromiseCompletionWriterFactPersistenceError> {
+    if !fact.source_route_class.is_allowed() {
+        return Err(PromiseCompletionWriterFactPersistenceError::BadRequest(
+            "Promise completion writer fact persistence rejects forbidden source route classes before persistence"
+                .to_owned(),
+        ));
+    }
+
+    if fact.completed_reference_eligible
+        && fact.completion_state_class != PromiseCompletionStateClass::CompletionAccepted
+    {
+        return Err(PromiseCompletionWriterFactPersistenceError::BadRequest(
+            "Promise completion completed reference eligibility requires completion_accepted"
+                .to_owned(),
+        ));
+    }
+
+    let promise_reference = required_ref(fact.promise_reference.as_deref(), "Promise reference")?;
+    let realm_id = required_ref(fact.realm_id.as_deref(), "realm_id")?;
+    let fact_family = fact.fact_family.as_str();
+    let source_route_class = fact.source_route_class.as_str();
+    let previous_completion_state_class = fact
+        .previous_completion_state_class
+        .map(|state| state.as_str());
+    let completion_state_class = fact.completion_state_class.as_str();
+    let promise_terms_reference = required_ref(
+        fact.promise_terms_reference.as_deref(),
+        "Promise terms reference",
+    )?;
+    let participant_set_reference = required_ref(
+        fact.participant_set_reference.as_deref(),
+        "participant set reference",
+    )?;
+    let ordinary_participant_acknowledgement_reference = optional_ref(
+        fact.ordinary_participant_acknowledgement_reference
+            .as_deref(),
+        "Ordinary Account participant acknowledgement reference",
+    )?;
+    let governed_review_reference = optional_ref(
+        fact.governed_review_reference.as_deref(),
+        "governed review reference",
+    )?;
+    let review_authority_reference = optional_ref(
+        fact.review_authority_reference.as_deref(),
+        "review authority reference",
+    )?;
+    let proof_eligibility_reference = optional_ref(
+        fact.proof_eligibility_reference.as_deref(),
+        "Proof Eligibility reference",
+    )?;
+    let proof_evidence_writer_fact_reference = optional_ref(
+        fact.proof_evidence_writer_fact_reference.as_deref(),
+        "proof evidence writer fact reference",
+    )?;
+    let consent_at_formation_reference = required_ref(
+        fact.consent_at_formation_reference.as_deref(),
+        "Consent at Promise formation reference",
+    )?;
+    let consent_at_resolution_reference = required_ref(
+        fact.consent_at_resolution_reference.as_deref(),
+        "Consent at resolution reference",
+    )?;
+    let block_withdrawal_state_reference = required_ref(
+        fact.block_withdrawal_state_reference.as_deref(),
+        "block, mute, refusal, or Withdrawal state reference",
+    )?;
+    let age_assurance_state_reference = required_ref(
+        fact.age_assurance_state_reference.as_deref(),
+        "Age Assurance state reference",
+    )?;
+    let legal_hold_intersection_reference = required_ref(
+        fact.legal_hold_intersection_reference.as_deref(),
+        "Legal Hold intersection reference",
+    )?;
+    let critical_harm_case_reference = required_ref(
+        fact.critical_harm_case_reference.as_deref(),
+        "Critical Harm case reference",
+    )?;
+    let account_lifecycle_reference = required_ref(
+        fact.account_lifecycle_reference.as_deref(),
+        "account lifecycle reference",
+    )?;
+    let anti_abuse_continuity_reference = required_ref(
+        fact.anti_abuse_continuity_reference.as_deref(),
+        "Anti-Abuse Continuity Marker reference",
+    )?;
+    let safety_case_reference = required_ref(
+        fact.safety_case_reference.as_deref(),
+        "safety case reference",
+    )?;
+    let reason_code_class = required_ref(fact.reason_code_class.as_deref(), "reason-code class")?;
+    let evidence_level_reference = required_ref(
+        fact.evidence_level_reference.as_deref(),
+        "evidence level reference",
+    )?;
+    let correction_or_supersession_reference = optional_ref(
+        fact.correction_or_supersession_reference.as_deref(),
+        "correction or supersession reference",
+    )?;
+    let prior_writer_fact_id =
+        optional_uuid_ref(fact.prior_writer_fact_id.as_deref(), "prior writer fact id")?;
+    let prior_writer_fact_id_hash = prior_writer_fact_id.map(|id| id.to_string());
+    let policy_version = required_policy_version(fact.policy_version)?;
+    let fact_idempotency_key =
+        required_ref(fact.fact_idempotency_key.as_deref(), "fact idempotency key")?;
+    let retention_class_reference = required_ref(
+        fact.retention_class_reference.as_deref(),
+        "retention class reference",
+    )?;
+    let access_audit_reference = required_ref(
+        fact.access_audit_reference.as_deref(),
+        "access-audit reference",
+    )?;
+    let projection_non_authority_posture =
+        projection_non_authority_posture(fact.projection_non_authority_posture)?;
+    let authority_posture = authority_posture(fact.authority_posture)?;
+
+    if fact.source_route_class
+        == PromiseCompletionSourceRouteClass::MutualAccountableCompletionAcknowledgement
+        && ordinary_participant_acknowledgement_reference.is_none()
+    {
+        return Err(PromiseCompletionWriterFactPersistenceError::BadRequest(
+            "Promise completion mutual acknowledgement route requires Ordinary Account participant acknowledgement reference"
+                .to_owned(),
+        ));
+    }
+
+    if fact.source_route_class == PromiseCompletionSourceRouteClass::GovernedReviewCompletion
+        && (governed_review_reference.is_none() || review_authority_reference.is_none())
+    {
+        return Err(PromiseCompletionWriterFactPersistenceError::BadRequest(
+            "Promise completion governed review route requires governed review and review authority references"
+                .to_owned(),
+        ));
+    }
+
+    if proof_eligibility_reference.is_some() != proof_evidence_writer_fact_reference.is_some() {
+        return Err(PromiseCompletionWriterFactPersistenceError::BadRequest(
+            "Promise completion proof references require both Proof Eligibility and proof evidence writer fact references"
+                .to_owned(),
+        ));
+    }
+
+    if fact.fact_family == PromiseCompletionWriterFactFamily::CorrectionOrSupersession
+        && correction_or_supersession_reference.is_none()
+        && prior_writer_fact_id.is_none()
+    {
+        return Err(PromiseCompletionWriterFactPersistenceError::BadRequest(
+            "Promise completion correction or supersession facts require correction/supersession or prior writer fact reference"
+                .to_owned(),
+        ));
+    }
+
+    let policy_version_string = policy_version.to_string();
+    let completed_reference_eligible = if fact.completed_reference_eligible {
+        "true"
+    } else {
+        "false"
+    };
+    let (previous_state_presence, previous_state_value) =
+        optional_static_hash_value(&previous_completion_state_class);
+    let (ordinary_ack_presence, ordinary_ack_value) =
+        optional_hash_value(&ordinary_participant_acknowledgement_reference);
+    let (governed_review_presence, governed_review_value) =
+        optional_hash_value(&governed_review_reference);
+    let (review_authority_presence, review_authority_value) =
+        optional_hash_value(&review_authority_reference);
+    let (proof_eligibility_presence, proof_eligibility_value) =
+        optional_hash_value(&proof_eligibility_reference);
+    let (proof_evidence_presence, proof_evidence_value) =
+        optional_hash_value(&proof_evidence_writer_fact_reference);
+    let (correction_presence, correction_value) =
+        optional_hash_value(&correction_or_supersession_reference);
+    let (prior_fact_presence, prior_fact_value) = optional_hash_value(&prior_writer_fact_id_hash);
+
+    let request_payload_hash = hash_parts(&[
+        (
+            "hash_kind",
+            "promise_completion_writer_fact_persistence_request",
+        ),
+        ("policy_version", &policy_version_string),
+        ("promise_reference", &promise_reference),
+        ("realm_id", &realm_id),
+        ("fact_family", fact_family),
+        ("source_route_class", source_route_class),
+        (
+            "previous_completion_state_class_presence",
+            previous_state_presence,
+        ),
+        ("previous_completion_state_class", previous_state_value),
+        ("completion_state_class", completion_state_class),
+        ("completed_reference_eligible", completed_reference_eligible),
+        ("promise_terms_reference", &promise_terms_reference),
+        ("participant_set_reference", &participant_set_reference),
+        (
+            "ordinary_participant_acknowledgement_reference_presence",
+            ordinary_ack_presence,
+        ),
+        (
+            "ordinary_participant_acknowledgement_reference",
+            ordinary_ack_value,
+        ),
+        (
+            "governed_review_reference_presence",
+            governed_review_presence,
+        ),
+        ("governed_review_reference", governed_review_value),
+        (
+            "review_authority_reference_presence",
+            review_authority_presence,
+        ),
+        ("review_authority_reference", review_authority_value),
+        (
+            "proof_eligibility_reference_presence",
+            proof_eligibility_presence,
+        ),
+        ("proof_eligibility_reference", proof_eligibility_value),
+        (
+            "proof_evidence_writer_fact_reference_presence",
+            proof_evidence_presence,
+        ),
+        ("proof_evidence_writer_fact_reference", proof_evidence_value),
+        (
+            "consent_at_formation_reference",
+            &consent_at_formation_reference,
+        ),
+        (
+            "consent_at_resolution_reference",
+            &consent_at_resolution_reference,
+        ),
+        (
+            "block_withdrawal_state_reference",
+            &block_withdrawal_state_reference,
+        ),
+        (
+            "age_assurance_state_reference",
+            &age_assurance_state_reference,
+        ),
+        (
+            "legal_hold_intersection_reference",
+            &legal_hold_intersection_reference,
+        ),
+        (
+            "critical_harm_case_reference",
+            &critical_harm_case_reference,
+        ),
+        ("account_lifecycle_reference", &account_lifecycle_reference),
+        (
+            "anti_abuse_continuity_reference",
+            &anti_abuse_continuity_reference,
+        ),
+        ("safety_case_reference", &safety_case_reference),
+        ("reason_code_class", &reason_code_class),
+        ("evidence_level_reference", &evidence_level_reference),
+        (
+            "correction_or_supersession_reference_presence",
+            correction_presence,
+        ),
+        ("correction_or_supersession_reference", correction_value),
+        ("prior_writer_fact_id_presence", prior_fact_presence),
+        ("prior_writer_fact_id", prior_fact_value),
+        ("fact_idempotency_key", &fact_idempotency_key),
+        ("retention_class_reference", &retention_class_reference),
+        ("access_audit_reference", &access_audit_reference),
+        (
+            "projection_non_authority_posture",
+            projection_non_authority_posture,
+        ),
+        ("authority_posture", authority_posture),
+    ]);
+    let decision_payload_hash = hash_parts(&[
+        (
+            "hash_kind",
+            "promise_completion_writer_fact_persistence_decision",
+        ),
+        ("request_payload_hash", &request_payload_hash),
+        ("decision_kind", DECISION_KIND),
+        ("completion_state_class", completion_state_class),
+        ("completed_reference_eligible", completed_reference_eligible),
+    ]);
+
+    Ok(NormalizedWriterFact {
+        promise_reference,
+        realm_id,
+        fact_family,
+        source_route_class,
+        previous_completion_state_class,
+        completion_state_class,
+        completed_reference_eligible: fact.completed_reference_eligible,
+        promise_terms_reference,
+        participant_set_reference,
+        ordinary_participant_acknowledgement_reference,
+        governed_review_reference,
+        review_authority_reference,
+        proof_eligibility_reference,
+        proof_evidence_writer_fact_reference,
+        consent_at_formation_reference,
+        consent_at_resolution_reference,
+        block_withdrawal_state_reference,
+        age_assurance_state_reference,
+        legal_hold_intersection_reference,
+        critical_harm_case_reference,
+        account_lifecycle_reference,
+        anti_abuse_continuity_reference,
+        safety_case_reference,
+        reason_code_class,
+        evidence_level_reference,
+        correction_or_supersession_reference,
+        prior_writer_fact_id,
+        policy_version,
+        fact_idempotency_key,
+        retention_class_reference,
+        access_audit_reference,
+        projection_non_authority_posture,
+        authority_posture,
+        request_payload_hash,
+        decision_payload_hash,
+    })
+}
+
+fn projection_non_authority_posture(
+    posture: Option<PromiseCompletionProjectionNonAuthorityPosture>,
+) -> Result<&'static str, PromiseCompletionWriterFactPersistenceError> {
+    match posture {
+        Some(PromiseCompletionProjectionNonAuthorityPosture::ProjectionNonAuthoritative) => {
+            Ok(PromiseCompletionProjectionNonAuthorityPosture::ProjectionNonAuthoritative.as_str())
+        }
+        Some(PromiseCompletionProjectionNonAuthorityPosture::ProjectionAuthority) => Err(
+            PromiseCompletionWriterFactPersistenceError::BadRequest(
+                "Promise completion writer fact persistence requires projection non-authority posture"
+                    .to_owned(),
+            ),
+        ),
+        None => Err(PromiseCompletionWriterFactPersistenceError::BadRequest(
+            "Promise completion writer fact persistence requires projection non-authority posture"
+                .to_owned(),
+        )),
+    }
+}
+
+fn authority_posture(
+    posture: Option<PromiseCompletionAuthorityPosture>,
+) -> Result<&'static str, PromiseCompletionWriterFactPersistenceError> {
+    match posture {
+        Some(PromiseCompletionAuthorityPosture::WriterTruthOnly) => {
+            Ok(PromiseCompletionAuthorityPosture::WriterTruthOnly.as_str())
+        }
+        Some(PromiseCompletionAuthorityPosture::ProjectionOnly) => Err(
+            PromiseCompletionWriterFactPersistenceError::BadRequest(
+                "Promise completion writer fact persistence requires writer truth authority posture"
+                    .to_owned(),
+            ),
+        ),
+        None => Err(PromiseCompletionWriterFactPersistenceError::BadRequest(
+            "Promise completion writer fact persistence requires authority posture".to_owned(),
+        )),
+    }
+}
+
+fn required_policy_version(
+    value: Option<i32>,
+) -> Result<i32, PromiseCompletionWriterFactPersistenceError> {
+    match value {
+        Some(value) if value > 0 => Ok(value),
+        _ => Err(PromiseCompletionWriterFactPersistenceError::BadRequest(
+            "Promise completion writer fact persistence requires positive policy version"
+                .to_owned(),
+        )),
+    }
+}
+
+fn required_ref(
+    value: Option<&str>,
+    label: &'static str,
+) -> Result<String, PromiseCompletionWriterFactPersistenceError> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| {
+            PromiseCompletionWriterFactPersistenceError::BadRequest(format!(
+                "Promise completion writer fact persistence requires {label}"
+            ))
+        })
+}
+
+fn optional_ref(
+    value: Option<&str>,
+    label: &'static str,
+) -> Result<Option<String>, PromiseCompletionWriterFactPersistenceError> {
+    value
+        .map(str::trim)
+        .map(|value| {
+            if value.is_empty() {
+                Err(PromiseCompletionWriterFactPersistenceError::BadRequest(
+                    format!(
+                        "Promise completion writer fact persistence requires {label} when provided"
+                    ),
+                ))
+            } else {
+                Ok(value.to_owned())
+            }
+        })
+        .transpose()
+}
+
+fn optional_uuid_ref(
+    value: Option<&str>,
+    label: &'static str,
+) -> Result<Option<Uuid>, PromiseCompletionWriterFactPersistenceError> {
+    optional_ref(value, label)?
+        .map(|value| {
+            Uuid::parse_str(&value).map_err(|_| {
+                PromiseCompletionWriterFactPersistenceError::BadRequest(format!(
+                    "{label} must be a valid UUID"
+                ))
+            })
+        })
+        .transpose()
+}
+
+fn optional_hash_value(value: &Option<String>) -> (&'static str, &str) {
+    match value {
+        Some(value) => ("present", value.as_str()),
+        None => ("absent", ""),
+    }
+}
+
+fn optional_static_hash_value(value: &Option<&'static str>) -> (&'static str, &'static str) {
+    match value {
+        Some(value) => ("present", value),
+        None => ("absent", ""),
+    }
+}
+
+async fn find_existing_writer_fact_by_dedupe(
+    client: &impl GenericClient,
+    normalized: &NormalizedWriterFact,
+) -> Result<Option<Row>, PromiseCompletionWriterFactPersistenceError> {
+    client
+        .query_opt(
+            "
+            SELECT writer_fact_id, request_payload_hash, decision_payload_hash
+            FROM promise_completion.writer_fact_records
+            WHERE realm_id = $1
+              AND promise_reference = $2
+              AND policy_version = $3
+              AND fact_idempotency_key = $4
+            ",
+            &[
+                &normalized.realm_id,
+                &normalized.promise_reference,
+                &normalized.policy_version,
+                &normalized.fact_idempotency_key,
+            ],
+        )
+        .await
+        .map_err(db_error)
+}
+
+async fn load_snapshot_by_writer_fact_id(
+    client: &impl GenericClient,
+    writer_fact_id: &Uuid,
+    replay_status: PromiseCompletionWriterFactReplayStatus,
+) -> Result<PromiseCompletionWriterFactSnapshot, PromiseCompletionWriterFactPersistenceError> {
+    let row = client
+        .query_one(
+            "
+            SELECT
+                writer_fact_id,
+                promise_reference,
+                realm_id,
+                fact_family,
+                source_route_class,
+                completion_state_class,
+                completed_reference_eligible,
+                request_payload_hash,
+                decision_payload_hash,
+                created_at
+            FROM promise_completion.writer_fact_records
+            WHERE writer_fact_id = $1
+            ",
+            &[writer_fact_id],
+        )
+        .await
+        .map_err(db_error)?;
+
+    Ok(PromiseCompletionWriterFactSnapshot {
+        writer_fact_id: row.get::<_, Uuid>("writer_fact_id").to_string(),
+        promise_reference: row.get("promise_reference"),
+        realm_id: row.get("realm_id"),
+        fact_family: row.get("fact_family"),
+        source_route_class: row.get("source_route_class"),
+        completion_state_class: row.get("completion_state_class"),
+        completed_reference_eligible: row.get("completed_reference_eligible"),
+        request_payload_hash: row.get("request_payload_hash"),
+        decision_payload_hash: row.get("decision_payload_hash"),
+        replay_status,
+        created_at: row.get("created_at"),
+    })
+}
+
+fn replay_writer_fact_id(
+    existing: Row,
+    normalized: &NormalizedWriterFact,
+) -> Result<Uuid, PromiseCompletionWriterFactPersistenceError> {
+    let existing_request_hash: String = existing.get("request_payload_hash");
+    let existing_decision_hash: String = existing.get("decision_payload_hash");
+    let existing_writer_fact_id: Uuid = existing.get("writer_fact_id");
+    if existing_request_hash != normalized.request_payload_hash
+        || existing_decision_hash != normalized.decision_payload_hash
+    {
+        return Err(
+            PromiseCompletionWriterFactPersistenceError::IdempotencyConflict {
+                message: "duplicate Promise completion writer fact has payload drift".to_owned(),
+                existing_writer_fact_id: existing_writer_fact_id.to_string(),
+            },
+        );
+    }
+    Ok(existing_writer_fact_id)
+}
+
+fn writer_fact_insert_error(
+    error: tokio_postgres::Error,
+) -> PromiseCompletionWriterFactPersistenceError {
+    if matches!(
+        error.code(),
+        Some(&SqlState::FOREIGN_KEY_VIOLATION) | Some(&SqlState::CHECK_VIOLATION)
+    ) {
+        return PromiseCompletionWriterFactPersistenceError::BadRequest(error.to_string());
+    }
+
+    db_error(error)
+}
+
+fn hash_parts(parts: &[(&str, &str)]) -> String {
+    let mut hasher = Sha256::new();
+    for (name, value) in parts {
+        hasher.update(name.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(value.len().to_string().as_bytes());
+        hasher.update(b":");
+        hasher.update(value.as_bytes());
+        hasher.update(b"\n");
+    }
+    hex_digest(hasher.finalize().as_slice())
+}
+
+fn hex_digest(bytes: &[u8]) -> String {
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        write!(&mut output, "{byte:02x}").expect("writing sha256 hex cannot fail");
+    }
+    output
+}
+
+fn db_error(error: tokio_postgres::Error) -> PromiseCompletionWriterFactPersistenceError {
+    let code = error.code().map(SqlState::code).map(ToOwned::to_owned);
+    let constraint = error
+        .as_db_error()
+        .and_then(|db_error| db_error.constraint())
+        .map(ToOwned::to_owned);
+    let retryable = matches!(
+        error.code(),
+        Some(&SqlState::T_R_SERIALIZATION_FAILURE) | Some(&SqlState::T_R_DEADLOCK_DETECTED)
+    );
+
+    PromiseCompletionWriterFactPersistenceError::Database {
+        message: error.to_string(),
+        code,
+        constraint,
+        retryable,
+    }
+}

--- a/apps/backend/src/services/promise_completion/types.rs
+++ b/apps/backend/src/services/promise_completion/types.rs
@@ -1,0 +1,233 @@
+use chrono::{DateTime, Utc};
+
+#[derive(Debug)]
+pub enum PromiseCompletionWriterFactPersistenceError {
+    BadRequest(String),
+    IdempotencyConflict {
+        message: String,
+        existing_writer_fact_id: String,
+    },
+    Database {
+        message: String,
+        code: Option<String>,
+        constraint: Option<String>,
+        retryable: bool,
+    },
+    Internal(String),
+}
+
+impl PromiseCompletionWriterFactPersistenceError {
+    pub fn message(&self) -> &str {
+        match self {
+            Self::BadRequest(message)
+            | Self::IdempotencyConflict { message, .. }
+            | Self::Database { message, .. }
+            | Self::Internal(message) => message,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PromiseCompletionWriterFactReplayStatus {
+    Inserted,
+    ReplayedIdentical,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PromiseCompletionWriterFactFamily {
+    SourceRouteCandidate,
+    CompletionStateTransition,
+    CompletionOutcomeReference,
+    CorrectionOrSupersession,
+    AccessAuditRetentionSupport,
+}
+
+impl PromiseCompletionWriterFactFamily {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::SourceRouteCandidate => "source_route_candidate",
+            Self::CompletionStateTransition => "completion_state_transition",
+            Self::CompletionOutcomeReference => "completion_outcome_reference",
+            Self::CorrectionOrSupersession => "correction_or_supersession",
+            Self::AccessAuditRetentionSupport => "access_audit_retention_support",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PromiseCompletionSourceRouteClass {
+    MutualAccountableCompletionAcknowledgement,
+    GovernedReviewCompletion,
+    Forbidden(PromiseCompletionForbiddenSourceRouteClass),
+}
+
+impl PromiseCompletionSourceRouteClass {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::MutualAccountableCompletionAcknowledgement => {
+                "mutual_accountable_completion_acknowledgement"
+            }
+            Self::GovernedReviewCompletion => "governed_review_completion",
+            Self::Forbidden(route) => route.as_str(),
+        }
+    }
+
+    pub fn is_allowed(self) -> bool {
+        !matches!(self, Self::Forbidden(_))
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PromiseCompletionForbiddenSourceRouteClass {
+    ProofOnlyCompletion,
+    SettlementOnlyCompletion,
+    PaymentOnlyCompletion,
+    ProviderCallbackOnlyCompletion,
+    OperatorNoteOnlyCompletion,
+    ProjectionOnlyCompletion,
+    ModelOutputOnlyCompletion,
+    VenueStaffJudgmentOnlyCompletion,
+    ClientStateOnlyCompletion,
+    SupportStatusCompletion,
+    ImplementationConvenienceCompletion,
+    SilenceBasedCompletion,
+    PopularityBasedCompletion,
+}
+
+impl PromiseCompletionForbiddenSourceRouteClass {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ProofOnlyCompletion => "proof_only_completion",
+            Self::SettlementOnlyCompletion => "settlement_only_completion",
+            Self::PaymentOnlyCompletion => "payment_only_completion",
+            Self::ProviderCallbackOnlyCompletion => "provider_callback_only_completion",
+            Self::OperatorNoteOnlyCompletion => "operator_note_only_completion",
+            Self::ProjectionOnlyCompletion => "projection_only_completion",
+            Self::ModelOutputOnlyCompletion => "model_output_only_completion",
+            Self::VenueStaffJudgmentOnlyCompletion => "venue_staff_judgment_only_completion",
+            Self::ClientStateOnlyCompletion => "client_state_only_completion",
+            Self::SupportStatusCompletion => "support_status_completion",
+            Self::ImplementationConvenienceCompletion => "implementation_convenience_completion",
+            Self::SilenceBasedCompletion => "silence_based_completion",
+            Self::PopularityBasedCompletion => "popularity_based_completion",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PromiseCompletionStateClass {
+    CompletionUnavailable,
+    CompletionPendingMutualAcknowledgement,
+    CompletionReviewRequired,
+    CompletionUnderGovernedReview,
+    CompletionAccepted,
+    CompletionRejected,
+    CompletionExpired,
+    CompletionCorrectedOrSuperseded,
+    CompletionClosed,
+}
+
+impl PromiseCompletionStateClass {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::CompletionUnavailable => "completion_unavailable",
+            Self::CompletionPendingMutualAcknowledgement => {
+                "completion_pending_mutual_acknowledgement"
+            }
+            Self::CompletionReviewRequired => "completion_review_required",
+            Self::CompletionUnderGovernedReview => "completion_under_governed_review",
+            Self::CompletionAccepted => "completion_accepted",
+            Self::CompletionRejected => "completion_rejected",
+            Self::CompletionExpired => "completion_expired",
+            Self::CompletionCorrectedOrSuperseded => "completion_corrected_or_superseded",
+            Self::CompletionClosed => "completion_closed",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PromiseCompletionProjectionNonAuthorityPosture {
+    ProjectionNonAuthoritative,
+    ProjectionAuthority,
+}
+
+impl PromiseCompletionProjectionNonAuthorityPosture {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ProjectionNonAuthoritative => "projection_non_authoritative",
+            Self::ProjectionAuthority => "projection_authority",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PromiseCompletionAuthorityPosture {
+    WriterTruthOnly,
+    ProjectionOnly,
+}
+
+impl PromiseCompletionAuthorityPosture {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::WriterTruthOnly => "writer_truth_only",
+            Self::ProjectionOnly => "projection_only",
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct RecordPromiseCompletionWriterFactInput {
+    pub fact: ProposedPromiseCompletionWriterFact,
+}
+
+#[derive(Clone, Debug)]
+pub struct ProposedPromiseCompletionWriterFact {
+    pub promise_reference: Option<String>,
+    pub realm_id: Option<String>,
+    pub fact_family: PromiseCompletionWriterFactFamily,
+    pub source_route_class: PromiseCompletionSourceRouteClass,
+    pub previous_completion_state_class: Option<PromiseCompletionStateClass>,
+    pub completion_state_class: PromiseCompletionStateClass,
+    pub completed_reference_eligible: bool,
+    pub promise_terms_reference: Option<String>,
+    pub participant_set_reference: Option<String>,
+    pub ordinary_participant_acknowledgement_reference: Option<String>,
+    pub governed_review_reference: Option<String>,
+    pub review_authority_reference: Option<String>,
+    pub proof_eligibility_reference: Option<String>,
+    pub proof_evidence_writer_fact_reference: Option<String>,
+    pub consent_at_formation_reference: Option<String>,
+    pub consent_at_resolution_reference: Option<String>,
+    pub block_withdrawal_state_reference: Option<String>,
+    pub age_assurance_state_reference: Option<String>,
+    pub legal_hold_intersection_reference: Option<String>,
+    pub critical_harm_case_reference: Option<String>,
+    pub account_lifecycle_reference: Option<String>,
+    pub anti_abuse_continuity_reference: Option<String>,
+    pub safety_case_reference: Option<String>,
+    pub reason_code_class: Option<String>,
+    pub evidence_level_reference: Option<String>,
+    pub correction_or_supersession_reference: Option<String>,
+    pub prior_writer_fact_id: Option<String>,
+    pub policy_version: Option<i32>,
+    pub fact_idempotency_key: Option<String>,
+    pub retention_class_reference: Option<String>,
+    pub access_audit_reference: Option<String>,
+    pub projection_non_authority_posture: Option<PromiseCompletionProjectionNonAuthorityPosture>,
+    pub authority_posture: Option<PromiseCompletionAuthorityPosture>,
+}
+
+#[derive(Clone, Debug)]
+pub struct PromiseCompletionWriterFactSnapshot {
+    pub writer_fact_id: String,
+    pub promise_reference: String,
+    pub realm_id: String,
+    pub fact_family: String,
+    pub source_route_class: String,
+    pub completion_state_class: String,
+    pub completed_reference_eligible: bool,
+    pub request_payload_hash: String,
+    pub decision_payload_hash: String,
+    pub replay_status: PromiseCompletionWriterFactReplayStatus,
+    pub created_at: DateTime<Utc>,
+}

--- a/apps/backend/tests/promise_completion_writer_fact_persistence.rs
+++ b/apps/backend/tests/promise_completion_writer_fact_persistence.rs
@@ -1,0 +1,690 @@
+use std::path::PathBuf;
+
+use musubi_backend::{
+    new_test_state,
+    services::promise_completion::{
+        PromiseCompletionAuthorityPosture, PromiseCompletionForbiddenSourceRouteClass,
+        PromiseCompletionProjectionNonAuthorityPosture, PromiseCompletionSourceRouteClass,
+        PromiseCompletionStateClass, PromiseCompletionWriterFactFamily,
+        PromiseCompletionWriterFactPersistenceError, PromiseCompletionWriterFactReplayStatus,
+        PromiseCompletionWriterFactStore, ProposedPromiseCompletionWriterFact,
+        RecordPromiseCompletionWriterFactInput,
+    },
+};
+use musubi_db_runtime::DbConfig;
+use tokio_postgres::NoTls;
+
+fn lookup(database_url: &str, migrations_dir: &str, name: &'static str) -> Option<String> {
+    match name {
+        "APP_ENV" => Some("test".to_owned()),
+        "DATABASE_URL" => Some(database_url.to_owned()),
+        "MIGRATIONS_DIR" => Some(migrations_dir.to_owned()),
+        "REQUIRE_LATEST_SCHEMA" => Some("true".to_owned()),
+        _ => None,
+    }
+}
+
+#[tokio::test]
+async fn mutual_acknowledgement_writer_fact_persists_once_and_replays_identically() {
+    let (_test_state, config, client) = test_context().await;
+    let store = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let idempotency_key = unique_idempotency_key("mutual-replay");
+    let input = record_input(complete_fact(
+        &idempotency_key,
+        PromiseCompletionSourceRouteClass::MutualAccountableCompletionAcknowledgement,
+        PromiseCompletionStateClass::CompletionAccepted,
+    ));
+
+    let first = store
+        .record_writer_fact(input.clone())
+        .await
+        .expect("first mutual acknowledgement writer fact should persist");
+    let replay = store
+        .record_writer_fact(input)
+        .await
+        .expect("identical mutual acknowledgement duplicate should replay");
+
+    assert_eq!(
+        first.source_route_class,
+        "mutual_accountable_completion_acknowledgement"
+    );
+    assert_eq!(first.completion_state_class, "completion_accepted");
+    assert!(first.completed_reference_eligible);
+    assert_eq!(
+        first.replay_status,
+        PromiseCompletionWriterFactReplayStatus::Inserted
+    );
+    assert_eq!(
+        replay.replay_status,
+        PromiseCompletionWriterFactReplayStatus::ReplayedIdentical
+    );
+    assert_eq!(first.writer_fact_id, replay.writer_fact_id);
+    assert_eq!(first.request_payload_hash, replay.request_payload_hash);
+    assert_eq!(first.decision_payload_hash, replay.decision_payload_hash);
+    assert_eq!(
+        writer_fact_count_for_promise(&client, &first.promise_reference).await,
+        1
+    );
+}
+
+#[tokio::test]
+async fn governed_review_writer_fact_persists_once_and_replays_identically() {
+    let (_test_state, config, client) = test_context().await;
+    let store = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let idempotency_key = unique_idempotency_key("governed-replay");
+    let input = record_input(complete_fact(
+        &idempotency_key,
+        PromiseCompletionSourceRouteClass::GovernedReviewCompletion,
+        PromiseCompletionStateClass::CompletionAccepted,
+    ));
+
+    let first = store
+        .record_writer_fact(input.clone())
+        .await
+        .expect("first governed review writer fact should persist");
+    let replay = store
+        .record_writer_fact(input)
+        .await
+        .expect("identical governed review duplicate should replay");
+
+    assert_eq!(first.source_route_class, "governed_review_completion");
+    assert_eq!(first.completion_state_class, "completion_accepted");
+    assert!(first.completed_reference_eligible);
+    assert_eq!(
+        first.replay_status,
+        PromiseCompletionWriterFactReplayStatus::Inserted
+    );
+    assert_eq!(
+        replay.replay_status,
+        PromiseCompletionWriterFactReplayStatus::ReplayedIdentical
+    );
+    assert_eq!(first.writer_fact_id, replay.writer_fact_id);
+    assert_eq!(first.request_payload_hash, replay.request_payload_hash);
+    assert_eq!(first.decision_payload_hash, replay.decision_payload_hash);
+    assert_eq!(
+        writer_fact_count_for_promise(&client, &first.promise_reference).await,
+        1
+    );
+}
+
+#[tokio::test]
+async fn duplicate_delivery_with_payload_drift_fails_closed() {
+    let (_test_state, config, client) = test_context().await;
+    let store = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let idempotency_key = unique_idempotency_key("payload-drift");
+    let first = record_input(complete_fact(
+        &idempotency_key,
+        PromiseCompletionSourceRouteClass::MutualAccountableCompletionAcknowledgement,
+        PromiseCompletionStateClass::CompletionAccepted,
+    ));
+    let mut drifted = complete_fact(
+        &idempotency_key,
+        PromiseCompletionSourceRouteClass::MutualAccountableCompletionAcknowledgement,
+        PromiseCompletionStateClass::CompletionAccepted,
+    );
+    drifted.reason_code_class = Some("completion_accepted_after_drift".to_owned());
+
+    let snapshot = store
+        .record_writer_fact(first)
+        .await
+        .expect("first writer fact should persist");
+    let error = store
+        .record_writer_fact(record_input(drifted))
+        .await
+        .expect_err("payload drift must fail closed");
+
+    match error {
+        PromiseCompletionWriterFactPersistenceError::IdempotencyConflict { .. } => {}
+        other => panic!("expected idempotency conflict, got {other:?}"),
+    }
+    assert_eq!(
+        writer_fact_count_for_promise(&client, &snapshot.promise_reference).await,
+        1
+    );
+}
+
+#[tokio::test]
+async fn completed_reference_eligible_true_fails_unless_completion_is_accepted() {
+    let (_test_state, config, client) = test_context().await;
+    let store = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let idempotency_key = unique_idempotency_key("eligible-rejected-state");
+    let mut fact = complete_fact(
+        &idempotency_key,
+        PromiseCompletionSourceRouteClass::MutualAccountableCompletionAcknowledgement,
+        PromiseCompletionStateClass::CompletionRejected,
+    );
+    fact.completed_reference_eligible = true;
+    let promise_reference = fact.promise_reference.clone().expect("promise reference");
+
+    let error = store
+        .record_writer_fact(record_input(fact))
+        .await
+        .expect_err("completed reference eligibility must fail for non-accepted state");
+
+    assert!(matches!(
+        error,
+        PromiseCompletionWriterFactPersistenceError::BadRequest(_)
+    ));
+    assert_eq!(
+        writer_fact_count_for_promise(&client, &promise_reference).await,
+        0
+    );
+}
+
+#[tokio::test]
+async fn forbidden_source_route_classes_fail_before_persistence() {
+    let (_test_state, config, client) = test_context().await;
+    let store = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("store should connect");
+
+    for (suffix, forbidden_route) in [
+        (
+            "proof-only",
+            PromiseCompletionForbiddenSourceRouteClass::ProofOnlyCompletion,
+        ),
+        (
+            "settlement-only",
+            PromiseCompletionForbiddenSourceRouteClass::SettlementOnlyCompletion,
+        ),
+        (
+            "payment-only",
+            PromiseCompletionForbiddenSourceRouteClass::PaymentOnlyCompletion,
+        ),
+        (
+            "provider-only",
+            PromiseCompletionForbiddenSourceRouteClass::ProviderCallbackOnlyCompletion,
+        ),
+        (
+            "operator-note-only",
+            PromiseCompletionForbiddenSourceRouteClass::OperatorNoteOnlyCompletion,
+        ),
+        (
+            "projection-only",
+            PromiseCompletionForbiddenSourceRouteClass::ProjectionOnlyCompletion,
+        ),
+        (
+            "model-output-only",
+            PromiseCompletionForbiddenSourceRouteClass::ModelOutputOnlyCompletion,
+        ),
+        (
+            "venue-staff-judgment-only",
+            PromiseCompletionForbiddenSourceRouteClass::VenueStaffJudgmentOnlyCompletion,
+        ),
+        (
+            "client-state-only",
+            PromiseCompletionForbiddenSourceRouteClass::ClientStateOnlyCompletion,
+        ),
+        (
+            "support-status",
+            PromiseCompletionForbiddenSourceRouteClass::SupportStatusCompletion,
+        ),
+        (
+            "implementation-convenience",
+            PromiseCompletionForbiddenSourceRouteClass::ImplementationConvenienceCompletion,
+        ),
+        (
+            "silence-based",
+            PromiseCompletionForbiddenSourceRouteClass::SilenceBasedCompletion,
+        ),
+        (
+            "popularity-based",
+            PromiseCompletionForbiddenSourceRouteClass::PopularityBasedCompletion,
+        ),
+    ] {
+        let idempotency_key = unique_idempotency_key(suffix);
+        let fact = complete_fact(
+            &idempotency_key,
+            PromiseCompletionSourceRouteClass::Forbidden(forbidden_route),
+            PromiseCompletionStateClass::CompletionAccepted,
+        );
+        let promise_reference = fact.promise_reference.clone().expect("promise reference");
+        let error = store
+            .record_writer_fact(record_input(fact))
+            .await
+            .expect_err("forbidden source route should fail closed");
+
+        assert!(matches!(
+            error,
+            PromiseCompletionWriterFactPersistenceError::BadRequest(_)
+        ));
+        assert_eq!(
+            writer_fact_count_for_promise(&client, &promise_reference).await,
+            0
+        );
+    }
+}
+
+#[tokio::test]
+async fn missing_required_boundary_references_fail_before_persistence() {
+    let (_test_state, config, client) = test_context().await;
+    let store = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("store should connect");
+
+    let cases: &[(&str, fn(&mut ProposedPromiseCompletionWriterFact))] = &[
+        (
+            "missing-consent-formation",
+            |fact: &mut ProposedPromiseCompletionWriterFact| {
+                fact.consent_at_formation_reference = None;
+            },
+        ),
+        (
+            "missing-mutual-ordinary-ack",
+            |fact: &mut ProposedPromiseCompletionWriterFact| {
+                fact.ordinary_participant_acknowledgement_reference = None;
+            },
+        ),
+        (
+            "missing-governed-review",
+            |fact: &mut ProposedPromiseCompletionWriterFact| {
+                fact.source_route_class =
+                    PromiseCompletionSourceRouteClass::GovernedReviewCompletion;
+                fact.previous_completion_state_class =
+                    Some(PromiseCompletionStateClass::CompletionUnderGovernedReview);
+                fact.ordinary_participant_acknowledgement_reference = None;
+                fact.governed_review_reference = None;
+                fact.review_authority_reference =
+                    Some("review-authority-missing-governed-review".to_owned());
+            },
+        ),
+        (
+            "one-sided-proof-reference",
+            |fact: &mut ProposedPromiseCompletionWriterFact| {
+                fact.proof_eligibility_reference =
+                    Some("proof-eligibility-one-sided-proof-reference".to_owned());
+                fact.proof_evidence_writer_fact_reference = None;
+            },
+        ),
+    ];
+
+    for &(suffix, mutation) in cases {
+        let idempotency_key = unique_idempotency_key(suffix);
+        let mut fact = complete_fact(
+            &idempotency_key,
+            PromiseCompletionSourceRouteClass::MutualAccountableCompletionAcknowledgement,
+            PromiseCompletionStateClass::CompletionAccepted,
+        );
+        mutation(&mut fact);
+        let promise_reference = fact.promise_reference.clone().expect("promise reference");
+
+        let error = store
+            .record_writer_fact(record_input(fact))
+            .await
+            .expect_err("missing required boundary reference should fail closed");
+
+        assert!(matches!(
+            error,
+            PromiseCompletionWriterFactPersistenceError::BadRequest(_)
+        ));
+        assert_eq!(
+            writer_fact_count_for_promise(&client, &promise_reference).await,
+            0
+        );
+    }
+}
+
+#[tokio::test]
+async fn persistence_creates_no_projection_trust_depth_settlement_room_or_coordination_effects() {
+    let (_test_state, config, client) = test_context().await;
+    let store = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let before = side_effect_counts(&client).await;
+    let idempotency_key = unique_idempotency_key("side-effect-free");
+    let input = record_input(complete_fact(
+        &idempotency_key,
+        PromiseCompletionSourceRouteClass::GovernedReviewCompletion,
+        PromiseCompletionStateClass::CompletionAccepted,
+    ));
+
+    let snapshot = store
+        .record_writer_fact(input)
+        .await
+        .expect("writer fact should persist without product side effects");
+    let after = side_effect_counts(&client).await;
+
+    assert_eq!(before, after);
+    assert_eq!(
+        writer_fact_count_for_promise(&client, &snapshot.promise_reference).await,
+        1
+    );
+}
+
+#[tokio::test]
+async fn writer_fact_records_reject_update_and_delete() {
+    let (_test_state, config, client) = test_context().await;
+    let store = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let idempotency_key = unique_idempotency_key("append-only");
+    let snapshot = store
+        .record_writer_fact(record_input(complete_fact(
+            &idempotency_key,
+            PromiseCompletionSourceRouteClass::MutualAccountableCompletionAcknowledgement,
+            PromiseCompletionStateClass::CompletionAccepted,
+        )))
+        .await
+        .expect("writer fact should persist");
+
+    let update_error = client
+        .execute(
+            "
+            UPDATE promise_completion.writer_fact_records
+            SET reason_code_class = 'mutated'
+            WHERE writer_fact_id = $1
+            ",
+            &[&snapshot.writer_fact_id.parse::<uuid::Uuid>().expect("uuid")],
+        )
+        .await
+        .expect_err("writer fact updates must be rejected by the database");
+    assert!(
+        update_error
+            .to_string()
+            .contains("promise_completion.writer_fact_records is append-only")
+    );
+
+    let delete_error = client
+        .execute(
+            "
+            DELETE FROM promise_completion.writer_fact_records
+            WHERE writer_fact_id = $1
+            ",
+            &[&snapshot.writer_fact_id.parse::<uuid::Uuid>().expect("uuid")],
+        )
+        .await
+        .expect_err("writer fact deletes must be rejected by the database");
+    assert!(
+        delete_error
+            .to_string()
+            .contains("promise_completion.writer_fact_records is append-only")
+    );
+    assert_eq!(
+        writer_fact_count_for_promise(&client, &snapshot.promise_reference).await,
+        1
+    );
+}
+
+#[tokio::test]
+async fn promise_completion_schema_is_narrow_and_contains_no_raw_payload_or_product_effect_columns()
+{
+    let (_test_state, _config, client) = test_context().await;
+
+    let table_row = client
+        .query_one(
+            "
+            SELECT COUNT(*)::bigint AS count
+            FROM information_schema.tables
+            WHERE table_schema = 'promise_completion'
+              AND table_name <> 'writer_fact_records'
+            ",
+            &[],
+        )
+        .await
+        .expect("schema table guard should run");
+    let extra_table_count: i64 = table_row.get("count");
+
+    let column_row = client
+        .query_one(
+            "
+            SELECT COUNT(*)::bigint AS count
+            FROM information_schema.columns
+            WHERE table_schema = 'promise_completion'
+              AND (
+                  column_name LIKE '%score%'
+                  OR column_name LIKE '%weight%'
+                  OR column_name LIKE '%rank%'
+                  OR column_name LIKE '%display%'
+                  OR column_name LIKE '%amount%'
+                  OR column_name LIKE '%settlement%'
+                  OR column_name LIKE '%relationship_depth%'
+                  OR column_name LIKE '%room%'
+                  OR column_name LIKE '%direct_message%'
+                  OR column_name LIKE '%recommendation%'
+                  OR column_name LIKE '%discovery%'
+                  OR column_name IN (
+                      'raw_personal_data',
+                      'raw_evidence_payload',
+                      'provider_payload',
+                      'provider_callback_payload',
+                      'api_route',
+                      'ui_state',
+                      'outbox_event_id',
+                      'inbox_entry_id'
+                  )
+              )
+            ",
+            &[],
+        )
+        .await
+        .expect("schema column guard should run");
+    let forbidden_column_count: i64 = column_row.get("count");
+
+    assert_eq!(extra_table_count, 0);
+    assert_eq!(forbidden_column_count, 0);
+
+    let dedupe_row = client
+        .query_one(
+            "
+            SELECT COUNT(*)::bigint AS count
+            FROM pg_indexes
+            WHERE schemaname = 'promise_completion'
+              AND tablename = 'writer_fact_records'
+              AND indexname = 'promise_completion_writer_fact_dedupe_unique'
+              AND indexdef LIKE '%UNIQUE%'
+              AND indexdef LIKE '%realm_id%'
+              AND indexdef LIKE '%promise_reference%'
+              AND indexdef LIKE '%policy_version%'
+              AND indexdef LIKE '%fact_idempotency_key%'
+            ",
+            &[],
+        )
+        .await
+        .expect("schema idempotency guard should run");
+    let dedupe_index_count: i64 = dedupe_row.get("count");
+
+    assert_eq!(dedupe_index_count, 1);
+}
+
+async fn test_context() -> (musubi_backend::TestState, DbConfig, tokio_postgres::Client) {
+    let test_state = new_test_state()
+        .await
+        .expect("test database state should initialize");
+    let database_url = std::env::var("MUSUBI_TEST_DATABASE_URL")
+        .or_else(|_| std::env::var("DATABASE_URL"))
+        .expect("integration tests require MUSUBI_TEST_DATABASE_URL or DATABASE_URL to be set");
+    let migrations_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("migrations")
+        .canonicalize()
+        .expect("migrations directory should resolve");
+    let migrations_dir = migrations_dir
+        .to_str()
+        .expect("migrations directory should be utf-8")
+        .to_owned();
+    let config = DbConfig::from_lookup(|name| lookup(&database_url, &migrations_dir, name))
+        .expect("test db config should parse");
+
+    let (client, connection) = tokio_postgres::connect(&database_url, NoTls)
+        .await
+        .expect("failed to connect to test database");
+    tokio::spawn(async move {
+        if let Err(error) = connection.await {
+            eprintln!("test database connection error: {error}");
+        }
+    });
+
+    (test_state, config, client)
+}
+
+fn unique_idempotency_key(label: &str) -> String {
+    format!("{label}-{}", uuid::Uuid::new_v4())
+}
+
+fn complete_fact(
+    idempotency_key: &str,
+    source_route: PromiseCompletionSourceRouteClass,
+    completion_state: PromiseCompletionStateClass,
+) -> ProposedPromiseCompletionWriterFact {
+    let is_governed = source_route == PromiseCompletionSourceRouteClass::GovernedReviewCompletion;
+    ProposedPromiseCompletionWriterFact {
+        promise_reference: Some(format!("promise-completion-{idempotency_key}")),
+        realm_id: Some(format!("realm-completion-{idempotency_key}")),
+        fact_family: PromiseCompletionWriterFactFamily::CompletionOutcomeReference,
+        source_route_class: source_route,
+        previous_completion_state_class: Some(if is_governed {
+            PromiseCompletionStateClass::CompletionUnderGovernedReview
+        } else {
+            PromiseCompletionStateClass::CompletionPendingMutualAcknowledgement
+        }),
+        completion_state_class: completion_state,
+        completed_reference_eligible: completion_state
+            == PromiseCompletionStateClass::CompletionAccepted,
+        promise_terms_reference: Some(format!("promise-terms-{idempotency_key}")),
+        participant_set_reference: Some(format!("participant-set-{idempotency_key}")),
+        ordinary_participant_acknowledgement_reference: if is_governed {
+            None
+        } else {
+            Some(format!("ordinary-acknowledgement-{idempotency_key}"))
+        },
+        governed_review_reference: if is_governed {
+            Some(format!("governed-review-{idempotency_key}"))
+        } else {
+            None
+        },
+        review_authority_reference: if is_governed {
+            Some(format!("review-authority-{idempotency_key}"))
+        } else {
+            None
+        },
+        proof_eligibility_reference: None,
+        proof_evidence_writer_fact_reference: None,
+        consent_at_formation_reference: Some(format!("consent-formation-{idempotency_key}")),
+        consent_at_resolution_reference: Some(format!("consent-resolution-{idempotency_key}")),
+        block_withdrawal_state_reference: Some(format!("block-withdrawal-clear-{idempotency_key}")),
+        age_assurance_state_reference: Some(format!(
+            "age-assurance-adult-eligible-{idempotency_key}"
+        )),
+        legal_hold_intersection_reference: Some(format!("legal-hold-clear-{idempotency_key}")),
+        critical_harm_case_reference: Some(format!("critical-harm-clear-{idempotency_key}")),
+        account_lifecycle_reference: Some(format!("account-lifecycle-active-{idempotency_key}")),
+        anti_abuse_continuity_reference: Some(format!("anti-abuse-clear-{idempotency_key}")),
+        safety_case_reference: Some(format!("safety-case-clear-{idempotency_key}")),
+        reason_code_class: Some(format!("completion-accepted-{idempotency_key}")),
+        evidence_level_reference: Some(format!("evidence-level-bounded-{idempotency_key}")),
+        correction_or_supersession_reference: None,
+        prior_writer_fact_id: None,
+        policy_version: Some(1),
+        fact_idempotency_key: Some(idempotency_key.to_owned()),
+        retention_class_reference: Some("R4 Trust / moderation / case".to_owned()),
+        access_audit_reference: Some(format!("access-audit-{idempotency_key}")),
+        projection_non_authority_posture: Some(
+            PromiseCompletionProjectionNonAuthorityPosture::ProjectionNonAuthoritative,
+        ),
+        authority_posture: Some(PromiseCompletionAuthorityPosture::WriterTruthOnly),
+    }
+}
+
+fn record_input(
+    fact: ProposedPromiseCompletionWriterFact,
+) -> RecordPromiseCompletionWriterFactInput {
+    RecordPromiseCompletionWriterFactInput { fact }
+}
+
+async fn writer_fact_count_for_promise(
+    client: &tokio_postgres::Client,
+    promise_reference: &str,
+) -> i64 {
+    let row = client
+        .query_one(
+            "
+            SELECT COUNT(*)::bigint AS count
+            FROM promise_completion.writer_fact_records
+            WHERE promise_reference = $1
+            ",
+            &[&promise_reference],
+        )
+        .await
+        .expect("writer fact count should load");
+    row.get("count")
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct SideEffectCounts {
+    projection_promise_views: i64,
+    projection_settlement_views: i64,
+    projection_trust_snapshots: i64,
+    projection_realm_trust_snapshots: i64,
+    projection_room_progression_views: i64,
+    social_trust_intake_attempts: i64,
+    social_trust_categorical_sources: i64,
+    social_trust_categorical_mutations: i64,
+    room_progression_tracks: i64,
+    room_progression_facts: i64,
+    settlement_cases: i64,
+    settlement_intents: i64,
+    settlement_submissions: i64,
+    settlement_observations: i64,
+    provider_attempts: i64,
+    outbox_events: i64,
+    outbox_attempts: i64,
+    command_inbox: i64,
+}
+
+async fn side_effect_counts(client: &tokio_postgres::Client) -> SideEffectCounts {
+    let row = client
+        .query_one(
+            "
+            SELECT
+                (SELECT COUNT(*)::bigint FROM projection.promise_views) AS projection_promise_views,
+                (SELECT COUNT(*)::bigint FROM projection.settlement_views) AS projection_settlement_views,
+                (SELECT COUNT(*)::bigint FROM projection.trust_snapshots) AS projection_trust_snapshots,
+                (SELECT COUNT(*)::bigint FROM projection.realm_trust_snapshots) AS projection_realm_trust_snapshots,
+                (SELECT COUNT(*)::bigint FROM projection.room_progression_views) AS projection_room_progression_views,
+                (SELECT COUNT(*)::bigint FROM social_trust.proposed_mutation_attempts) AS social_trust_intake_attempts,
+                (SELECT COUNT(*)::bigint FROM social_trust.categorical_source_references) AS social_trust_categorical_sources,
+                (SELECT COUNT(*)::bigint FROM social_trust.categorical_mutation_facts) AS social_trust_categorical_mutations,
+                (SELECT COUNT(*)::bigint FROM dao.room_progression_tracks) AS room_progression_tracks,
+                (SELECT COUNT(*)::bigint FROM dao.room_progression_facts) AS room_progression_facts,
+                (SELECT COUNT(*)::bigint FROM dao.settlement_cases) AS settlement_cases,
+                (SELECT COUNT(*)::bigint FROM dao.settlement_intents) AS settlement_intents,
+                (SELECT COUNT(*)::bigint FROM dao.settlement_submissions) AS settlement_submissions,
+                (SELECT COUNT(*)::bigint FROM dao.settlement_observations) AS settlement_observations,
+                (SELECT COUNT(*)::bigint FROM dao.provider_attempts) AS provider_attempts,
+                (SELECT COUNT(*)::bigint FROM outbox.events) AS outbox_events,
+                (SELECT COUNT(*)::bigint FROM outbox.outbox_attempts) AS outbox_attempts,
+                (SELECT COUNT(*)::bigint FROM outbox.command_inbox) AS command_inbox
+            ",
+            &[],
+        )
+        .await
+        .expect("side-effect counts should load");
+
+    SideEffectCounts {
+        projection_promise_views: row.get("projection_promise_views"),
+        projection_settlement_views: row.get("projection_settlement_views"),
+        projection_trust_snapshots: row.get("projection_trust_snapshots"),
+        projection_realm_trust_snapshots: row.get("projection_realm_trust_snapshots"),
+        projection_room_progression_views: row.get("projection_room_progression_views"),
+        social_trust_intake_attempts: row.get("social_trust_intake_attempts"),
+        social_trust_categorical_sources: row.get("social_trust_categorical_sources"),
+        social_trust_categorical_mutations: row.get("social_trust_categorical_mutations"),
+        room_progression_tracks: row.get("room_progression_tracks"),
+        room_progression_facts: row.get("room_progression_facts"),
+        settlement_cases: row.get("settlement_cases"),
+        settlement_intents: row.get("settlement_intents"),
+        settlement_submissions: row.get("settlement_submissions"),
+        settlement_observations: row.get("settlement_observations"),
+        provider_attempts: row.get("provider_attempts"),
+        outbox_events: row.get("outbox_events"),
+        outbox_attempts: row.get("outbox_attempts"),
+        command_inbox: row.get("command_inbox"),
+    }
+}

--- a/docs/foundation_lock.md
+++ b/docs/foundation_lock.md
@@ -1,6 +1,6 @@
 # Foundation Lock
 
-Status: Draft; aligned to accepted foundation commit `81e127b`
+Status: Draft; aligned to accepted foundation commit `800a69c`
 Applies to: `mt4110/pi-musubi-core`
 Purpose: Pin the constitutional and architectural source of truth that this implementation repository must follow.
 
@@ -26,14 +26,14 @@ Upstream repository:
 Pinned reference for implementation work:
 
 - Foundation reference type: `commit`
-- Foundation commit SHA: `81e127b0abcb87fb29621bef0bb5e4eb5603588c`
-- Foundation commit title: `Merge pull request #430 from mt4110/feat/promise-completion-post-test-exclusion-route`
-- Foundation PR title: `docs: select Promise completion post-test-exclusion route`
-- Foundation PR URL: `https://github.com/mt4110/musubi-foundation/pull/430`
+- Foundation commit SHA: `800a69c810e48646c583d2cdd657001d011ff759`
+- Foundation commit title: `Merge pull request #438 from mt4110/feat/promise-completion-writer-fact-persistence-route`
+- Foundation PR title: `docs: select Promise completion writer fact persistence route`
+- Foundation PR URL: `https://github.com/mt4110/musubi-foundation/pull/438`
 - Date pinned: `2026-06-17`
 - Pinned by: `Masaki Takemura`
-- Pinned commit URL: `https://github.com/mt4110/musubi-foundation/commit/81e127b0abcb87fb29621bef0bb5e4eb5603588c`
-- Previous pinned reference: `5f68437` / `Merge pull request #384 from mt4110/feat/promise-completion-downstream-gate-selection`
+- Pinned commit URL: `https://github.com/mt4110/musubi-foundation/commit/800a69c810e48646c583d2cdd657001d011ff759`
+- Previous pinned reference: `81e127b` / `Merge pull request #430 from mt4110/feat/promise-completion-post-test-exclusion-route`
 - Post-C2 evidence source: `cfdba28` / `Merge pull request #114 from mt4110/feat/post-c2-runtime-handoff-evidence-package`
 - Alignment allowance source: `69b7aa4` / `Merge pull request #116 from mt4110/feat/evaluate-post-c2-runtime-handoff-gate`
 - Post-C2 implementation handoff evidence source: `ef23e88` / `Merge pull request #122 from mt4110/feat/post-c2-implementation-handoff-evidence-package`
@@ -171,6 +171,10 @@ Pinned reference for implementation work:
 - Promise completion test-only hard-exclusion decision packet source: `d8f6ece` / `Merge pull request #426 from mt4110/feat/promise-completion-test-only-exclusion-packet`
 - Promise completion test-only hard-exclusion packet sufficiency decision source: `4840779` / `Merge pull request #428 from mt4110/feat/promise-completion-test-only-exclusion-sufficiency`
 - Promise completion post-test-only-exclusion route selection source: `81e127b` / `Merge pull request #430 from mt4110/feat/promise-completion-post-test-exclusion-route`
+- Promise completion post-test-only-exclusion foundation lock alignment closeout source: `09c53e7` / `Merge pull request #432 from mt4110/feat/promise-completion-post-test-exclusion-lock-closeout`
+- Promise completion test-only hard-exclusion route selection source: `9e500b2` / `Merge pull request #434 from mt4110/feat/promise-completion-test-only-hard-exclusion-route`
+- Promise completion test-only hard-exclusion closeout source: `69488af` / `Merge pull request #436 from mt4110/feat/promise-completion-hard-exclusion-closeout`
+- Promise completion narrow writer fact persistence route selection source: `800a69c` / `Merge pull request #438 from mt4110/feat/promise-completion-writer-fact-persistence-route`
 
 No release tag is asserted for this alignment.
 Do not invent a foundation version label for this commit.
@@ -378,38 +382,42 @@ Before coding, read these upstream documents in order.
 187. `docs/readiness/promise_completion_test_only_hard_exclusion_decision_packet.md`
 188. `docs/readiness/promise_completion_test_only_hard_exclusion_packet_sufficiency_decision.md`
 189. `docs/readiness/promise_completion_post_test_only_exclusion_sufficiency_route_selection.md`
+190. `docs/readiness/promise_completion_post_test_only_exclusion_foundation_lock_alignment_closeout_ledger.md`
+191. `docs/readiness/promise_completion_post_lock_alignment_test_only_hard_exclusion_route_selection.md`
+192. `docs/readiness/promise_completion_test_only_hard_exclusion_closeout_ledger.md`
+193. `docs/readiness/promise_completion_narrow_writer_fact_persistence_route_selection.md`
 
 ### Operations layer
-190. `docs/operations/readiness_routine.md`
-191. `docs/operations/runalways_readiness_orchestrator_design.md`
-192. `docs/operations/runalways_readiness_orchestrator_stage0.md`
-193. `docs/operations/runalways_lane_controller_v0_1.md`
+194. `docs/operations/readiness_routine.md`
+195. `docs/operations/runalways_readiness_orchestrator_design.md`
+196. `docs/operations/runalways_readiness_orchestrator_stage0.md`
+197. `docs/operations/runalways_lane_controller_v0_1.md`
 
 ### Detail layer
-194. `docs/detail/accountability_matrix.md`
-195. `docs/detail/critical_incident_and_loss.md`
-196. `docs/detail/automated_decisioning_and_human_appeal.md`
-197. `docs/detail/youth_safety_and_age_assurance.md`
-198. `docs/detail/off_platform_handoff_and_scam_prevention.md`
-199. `docs/detail/data_deletion_vs_legal_hold.md`
-200. `docs/detail/security_and_autonomy_hardening.md`
-201. `docs/detail/realm_model.md`
-202. `docs/detail/data_scope_model.md`
-203. `docs/detail/mobility_model.md`
-204. `docs/detail/settlement_model.md`
-205. `docs/detail/settlement_backend_trait.md`
-206. `docs/detail/proof_of_infrastructure.md`
-207. `docs/detail/protected_groups_and_translation_safety.md`
+198. `docs/detail/accountability_matrix.md`
+199. `docs/detail/critical_incident_and_loss.md`
+200. `docs/detail/automated_decisioning_and_human_appeal.md`
+201. `docs/detail/youth_safety_and_age_assurance.md`
+202. `docs/detail/off_platform_handoff_and_scam_prevention.md`
+203. `docs/detail/data_deletion_vs_legal_hold.md`
+204. `docs/detail/security_and_autonomy_hardening.md`
+205. `docs/detail/realm_model.md`
+206. `docs/detail/data_scope_model.md`
+207. `docs/detail/mobility_model.md`
+208. `docs/detail/settlement_model.md`
+209. `docs/detail/settlement_backend_trait.md`
+210. `docs/detail/proof_of_infrastructure.md`
+211. `docs/detail/protected_groups_and_translation_safety.md`
 
 ### Whitepaper layer (contextual, not higher than detail/ADR)
-208. `docs/whitepaper/01_executive_summary.md`
-209. `docs/whitepaper/02_realm_model.md`
-210. `docs/whitepaper/03_experience_model.md`
-211. `docs/whitepaper/04_dm_shield.md`
-212. `docs/whitepaper/05_trust_model.md`
-213. `docs/whitepaper/06_promise_protocol.md`
-214. `docs/whitepaper/07_realm_economy.md`
-215. `docs/whitepaper/08_unlock_engine.md`
+212. `docs/whitepaper/01_executive_summary.md`
+213. `docs/whitepaper/02_realm_model.md`
+214. `docs/whitepaper/03_experience_model.md`
+215. `docs/whitepaper/04_dm_shield.md`
+216. `docs/whitepaper/05_trust_model.md`
+217. `docs/whitepaper/06_promise_protocol.md`
+218. `docs/whitepaper/07_realm_economy.md`
+219. `docs/whitepaper/08_unlock_engine.md`
 
 If any of the above are unavailable or materially inconsistent, stop and escalate.
 
@@ -459,14 +467,27 @@ No other source label may be treated as part of the C1 first positive source sco
 That handoff did not authorize new source facts, new mutation facts, numeric Social Trust scores, weights, ranks, display levels, public display, recommendation boost, discovery priority, contact unlock, room transition, settlement progression, Promise runtime behavior, proof runtime behavior, proof-derived Social Trust or Relationship Depth behavior, Relationship Depth facts or mutation behavior, projection rows, projection refresh, public API routes, mobile UI, schema-only work, DDL, migrations, provider guarantees, new durable product vocabulary in core docs, or broader `pi-musubi-core` changes.
 The foundation closeout for that consumed allowance is recorded in `docs/readiness/c1_social_trust_positive_source_implementation_closeout_ledger.md`.
 
-Foundation PR #430 provides the current one-use downstream docs-only lock alignment authority for this implementation-repo PR only.
+Foundation PR #430 provided the consumed one-use downstream docs-only lock alignment authority for one implementation-repo PR only.
+That allowance was consumed by `mt4110/pi-musubi-core` PR #164 and closed out by foundation PR #432.
+Foundation PR #434 provided the consumed one-use downstream test-only hard-exclusion authority for one implementation-repo PR only.
+That allowance was consumed by `mt4110/pi-musubi-core` PR #166 and closed out by foundation PR #436.
+Foundation PR #438 provides the current one-use downstream narrow writer fact persistence handoff authority for this implementation-repo PR only.
 This implementation-repo PR consumes that allowance.
-That allowance authorizes only `docs/foundation_lock.md`.
-It authorizes only Promise completion foundation lock alignment to the merge commit of foundation PR #430.
-Foundation PR #430 replaces the older unconsumed post-narrow lock-alignment allowance recorded by foundation PR #418.
-The older PR #418 allowance must not be consumed separately after this alignment.
-It does not authorize runtime implementation, runtime tests, gate invocation for implementation, test-only handoff, implementation handoff beyond the exact docs-only lock-alignment scope, DDL, migrations, schema-only work, backend code, backend docs outside `docs/foundation_lock.md`, frontend code, public API, mobile UI, projection refresh, Promise runtime behavior, proof runtime behavior, proof eligibility runtime behavior, provider guarantees, writer fact persistence, state transition runtime behavior, participant display implementation, raw Personal Data in immutable truth, raw evidence in immutable truth, hidden distributed transactions, destructive migration, Social Trust source fact persistence, Social Trust mutation facts, Social Trust score, weight, rank, public display, or recovery ceiling, Relationship Depth mutation, Relationship Depth display, settlement release, settlement refund, settlement forfeiture, escrow movement, reward movement, room progression, direct-message unlock, discovery priority, recommendation boost, public accusation labels, sensitive-trait visibility changes, paid romantic advantage, payment-based direct-message unlock, or broad `pi-musubi-core` changes.
-After this downstream PR is merged, closed without merge, or replaced by a different accepted foundation decision, foundation must receive a separate closeout ledger at `docs/readiness/promise_completion_post_test_only_exclusion_foundation_lock_alignment_closeout_ledger.md` before test-only, preflight, persistence, state transition, participant display, runtime, or implementation routes may be considered.
+The PR #438 allowance authorizes only:
+
+- `docs/foundation_lock.md`
+- `apps/backend/migrations/0023_promise_completion_writer_fact_persistence.sql`
+- `apps/backend/src/services/mod.rs`
+- `apps/backend/src/services/promise_completion/mod.rs`
+- `apps/backend/src/services/promise_completion/repository.rs`
+- `apps/backend/src/services/promise_completion/types.rs`
+- `apps/backend/tests/promise_completion_writer_fact_persistence.rs`
+
+It authorizes only append-only PostgreSQL Promise completion writer fact envelope persistence with durable database-enforced idempotency, identical replay, payload-drift fail-closed behavior, PII / raw-evidence / provider-payload segregation, and database contract tests.
+It authorizes only source routes `mutual_accountable_completion_acknowledgement` and `governed_review_completion`.
+It authorizes only the state classes accepted by the foundation Promise completion state-machine authority, and `completed_reference_eligible = true` only for `completion_accepted`.
+It does not authorize source-route evaluation runtime, API, UI, projection, Social Trust mutation, Relationship Depth mutation, settlement movement, room behavior, contact behavior, outbox, inbox, worker behavior, provider I/O, provider callbacks, state transition runtime behavior, participant display implementation, raw Personal Data in immutable truth, raw evidence in immutable truth, hidden distributed transactions, destructive migration, Social Trust score, weight, rank, public display, recovery ceiling, settlement release, settlement refund, settlement forfeiture, escrow movement, reward movement, room progression, direct-message unlock, discovery priority, recommendation boost, public accusation labels, sensitive-trait visibility changes, paid romantic advantage, payment-based direct-message unlock, or broad `pi-musubi-core` changes.
+After this downstream PR is merged, closed without merge, or replaced by a different accepted foundation decision, foundation must receive a separate closeout ledger at `docs/readiness/promise_completion_narrow_writer_fact_persistence_closeout_ledger.md` before any broader Promise completion route may be considered.
 
 The C2 and post-C2 readiness and closeout chain is accepted for docs-only foundation semantic scope:
 
@@ -924,11 +945,11 @@ When updating:
 - Review completed by:
 
 ### Current drift note
-- Updated from foundation SHA: `5f68437696b8e2f6b7b6da908e431d6de9a04a77` -> `81e127b0abcb87fb29621bef0bb5e4eb5603588c`
-- Reason: Align implementation-repo lock with the accepted Promise completion post-test-exclusion route selection after foundation PR #430 (`docs: select Promise completion post-test-exclusion route`), under the one-use docs-only foundation lock alignment allowance accepted by foundation PR #430.
-- New required docs: Promise completion foundation lock alignment closeout ledger, Promise completion post-closeout route selection, Promise completion persistence preflight design packet, Promise completion persistence preflight sufficiency decision, Promise completion post-sufficiency route selection, Promise completion persistence authority detail record, Promise completion persistence authority sufficiency decision, Promise completion post-persistence-authority route selection, Promise completion preflight route decision packet, Promise completion preflight route packet sufficiency decision, Promise completion preflight route selection decision, Promise completion writer fact persistence representability preflight, Promise completion writer fact persistence preflight sufficiency decision, Promise completion post-preflight route selection, Promise completion narrow handoff decision packet, Promise completion narrow handoff packet sufficiency decision, Promise completion post-narrow-handoff route selection, Promise completion core touch precondition matrix, Promise completion core touch precondition matrix sufficiency decision, Promise completion post-precondition route selection, Promise completion test-only hard-exclusion decision packet, Promise completion test-only hard-exclusion packet sufficiency decision, and Promise completion post-test-only-exclusion sufficiency route selection.
+- Updated from foundation SHA: `81e127b0abcb87fb29621bef0bb5e4eb5603588c` -> `800a69c810e48646c583d2cdd657001d011ff759`
+- Reason: Align implementation-repo lock with the accepted Promise completion narrow writer fact persistence route selection after foundation PR #438 (`docs: select Promise completion writer fact persistence route`) and consume its one-use downstream narrow writer fact persistence allowance.
+- New required docs: Promise completion post-test-only-exclusion foundation lock alignment closeout ledger, Promise completion post-lock-alignment test-only hard-exclusion route selection, Promise completion test-only hard-exclusion closeout ledger, and Promise completion narrow writer fact persistence route selection.
 - Removed docs: None.
-- Implementation impact: This update consumes the one-use foundation PR #430 allowance and replaces the older unconsumed PR #418 lock-alignment allowance for this Promise completion chain. It pins foundation PR #430 and permits only `docs/foundation_lock.md` alignment. Runtime implementation, runtime tests, gate invocation for implementation, downstream test-only coverage, DDL, migrations, schema-only work, backend code, backend docs outside `docs/foundation_lock.md`, frontend code, public API changes, mobile UI changes, projection refresh, Promise runtime behavior, proof runtime behavior, proof eligibility runtime behavior, writer fact persistence, state transition runtime behavior, participant display implementation, Social Trust source fact persistence, Social Trust mutation facts, Social Trust scoring, display, Relationship Depth mutation behavior, settlement movement, provider guarantees, paid romantic advantage, payment-based direct-message unlock, and broader `pi-musubi-core` changes remain NO-GO.
+- Implementation impact: This update consumes the one-use foundation PR #438 allowance and permits only the exact seven-file narrow persistence scope listed above. It authorizes only append-only PostgreSQL Promise completion writer fact envelope persistence with durable database-enforced idempotency, identical replay, payload drift fail-closed behavior, PII / raw-evidence / provider-payload segregation, and database contract tests. Source-route evaluation runtime, API, UI, projection, Social Trust mutation, Relationship Depth mutation, settlement movement, room behavior, contact behavior, outbox, inbox, worker behavior, provider I/O, provider callbacks, state transition runtime behavior, participant display implementation, paid romantic advantage, payment-based direct-message unlock, and broader `pi-musubi-core` changes remain NO-GO.
 - Review completed by: Masaki Takemura
 
 ---


### PR DESCRIPTION
## Summary

- Align `docs/foundation_lock.md` to foundation PR #438 / commit `800a69c810e48646c583d2cdd657001d011ff759` and record the one-use narrow writer fact persistence scope.
- Add narrow PostgreSQL writer fact persistence for Promise completion under `promise_completion.writer_fact_records`.
- Enforce durable idempotency, identical replay, payload drift fail-closed behavior, append-only DB mutation rejection, allowed source-route classes only, and `completed_reference_eligible = true` only for `completion_accepted`.
- Add database contract tests for accepted routes, forbidden route rejection, boundary-reference rejection, no projection / Social Trust / Relationship Depth / settlement / room / outbox / inbox side effects, schema narrowness, DB-enforced idempotency, and append-only enforcement.

## Scope Guard

This PR intentionally does not add API, UI, projection refresh, Social Trust mutation, Relationship Depth mutation, settlement movement, room/contact behavior, outbox/inbox/worker behavior, provider I/O, provider callbacks, AppState wiring, handlers, or router changes.

After this PR is merged, closed without merge, or replaced, foundation needs the closeout ledger at `docs/readiness/promise_completion_narrow_writer_fact_persistence_closeout_ledger.md`.

## CI Fix Note

The first CI run failed because the initial implementation introduced one new raw transaction surface in `promise_completion/repository.rs`, which changed the reviewed raw transaction inventory. This branch now uses database-enforced idempotency with `INSERT ... ON CONFLICT DO NOTHING` and no explicit transaction, preserving the narrow behavior without touching the guardrail baseline outside the authorized seven-file scope.

## Validation

- Passed: `make guardrail-sweep`
- Passed: `git diff --check origin/main...HEAD`
- Passed: `git diff --name-only origin/main...HEAD` returned only the seven authorized files.
- Passed: `rustfmt --edition 2024 --config skip_children=true --check apps/backend/src/services/mod.rs apps/backend/src/services/promise_completion/mod.rs apps/backend/src/services/promise_completion/repository.rs apps/backend/src/services/promise_completion/types.rs apps/backend/tests/promise_completion_writer_fact_persistence.rs`
- Passed: `cargo test -p musubi_backend --test promise_completion_writer_fact_persistence` (9 tests)
- Passed: `cargo test -p musubi_backend --test social_trust_intake_persistence --test c2_bounded_promise_reliability_persistence` (19 tests)
- Known existing caveat: `cargo fmt --all --check` fails on unmodified files outside the PR #438 seven-file scope: `apps/backend/src/services/operator_review/repository.rs`, `apps/backend/tests/operator_review.rs`, and `apps/backend/tests/post_c2_categorical_fact_controlled_exceptional_account_reclassification_replay.rs`. Those were intentionally not changed.
