### PR TITLE
feat: record Promise completion mutual acknowledgement accepted transition narrowly

### DIFF
--- a/apps/backend/src/services/promise_completion/mod.rs
+++ b/apps/backend/src/services/promise_completion/mod.rs
@@ -7,6 +7,7 @@ pub use types::{
     PromiseCompletionProjectionNonAuthorityPosture, PromiseCompletionSourceRouteClass,
     PromiseCompletionStateClass, PromiseCompletionWriterFactFamily,
     PromiseCompletionWriterFactPersistenceError, PromiseCompletionWriterFactReplayStatus,
-    PromiseCompletionWriterFactSnapshot, ProposedPromiseCompletionWriterFact,
+    PromiseCompletionWriterFactSnapshot, ProposedMutualAcknowledgementAcceptedTransition,
+    ProposedPromiseCompletionWriterFact, RecordMutualAcknowledgementAcceptedTransitionInput,
     RecordPromiseCompletionWriterFactInput,
 };

--- a/apps/backend/src/services/promise_completion/repository.rs
+++ b/apps/backend/src/services/promise_completion/repository.rs
@@ -11,7 +11,8 @@ use super::types::{
     PromiseCompletionSourceRouteClass, PromiseCompletionStateClass,
     PromiseCompletionWriterFactFamily, PromiseCompletionWriterFactPersistenceError,
     PromiseCompletionWriterFactReplayStatus, PromiseCompletionWriterFactSnapshot,
-    ProposedPromiseCompletionWriterFact, RecordPromiseCompletionWriterFactInput,
+    ProposedPromiseCompletionWriterFact, RecordMutualAcknowledgementAcceptedTransitionInput,
+    RecordPromiseCompletionWriterFactInput,
 };
 
 const DECISION_KIND: &str = "accepted_for_writer_fact_persistence";
@@ -213,6 +214,243 @@ impl PromiseCompletionWriterFactStore {
             load_snapshot_by_writer_fact_id(&*client, &writer_fact_id, replay_status).await?;
         Ok(snapshot)
     }
+
+    pub async fn record_mutual_acknowledgement_accepted_transition(
+        &self,
+        input: RecordMutualAcknowledgementAcceptedTransitionInput,
+    ) -> Result<PromiseCompletionWriterFactSnapshot, PromiseCompletionWriterFactPersistenceError>
+    {
+        let fact = validate_mutual_acknowledgement_accepted_transition(input.transition.fact)?;
+        ensure_mutual_acknowledgement_prior_writer_fact(&self.client, &fact).await?;
+        self.record_writer_fact(RecordPromiseCompletionWriterFactInput { fact })
+            .await
+    }
+}
+
+fn validate_mutual_acknowledgement_accepted_transition(
+    fact: ProposedPromiseCompletionWriterFact,
+) -> Result<ProposedPromiseCompletionWriterFact, PromiseCompletionWriterFactPersistenceError> {
+    if fact.fact_family != PromiseCompletionWriterFactFamily::CompletionStateTransition {
+        return Err(PromiseCompletionWriterFactPersistenceError::BadRequest(
+            "Promise completion mutual acknowledgement accepted transition requires completion_state_transition fact family"
+                .to_owned(),
+        ));
+    }
+
+    if fact.source_route_class
+        != PromiseCompletionSourceRouteClass::MutualAccountableCompletionAcknowledgement
+    {
+        return Err(PromiseCompletionWriterFactPersistenceError::BadRequest(
+            "Promise completion mutual acknowledgement accepted transition rejects non-mutual acknowledgement source routes"
+                .to_owned(),
+        ));
+    }
+
+    if fact.previous_completion_state_class
+        != Some(PromiseCompletionStateClass::CompletionPendingMutualAcknowledgement)
+    {
+        return Err(PromiseCompletionWriterFactPersistenceError::BadRequest(
+            "Promise completion mutual acknowledgement accepted transition requires previous state completion_pending_mutual_acknowledgement"
+                .to_owned(),
+        ));
+    }
+
+    if fact.completion_state_class != PromiseCompletionStateClass::CompletionAccepted {
+        return Err(PromiseCompletionWriterFactPersistenceError::BadRequest(
+            "Promise completion mutual acknowledgement accepted transition requires next state completion_accepted"
+                .to_owned(),
+        ));
+    }
+
+    if !fact.completed_reference_eligible {
+        return Err(PromiseCompletionWriterFactPersistenceError::BadRequest(
+            "Promise completion mutual acknowledgement accepted transition requires completed reference eligibility for completion_accepted"
+                .to_owned(),
+        ));
+    }
+
+    if fact
+        .ordinary_participant_acknowledgement_reference
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .is_none()
+    {
+        return Err(PromiseCompletionWriterFactPersistenceError::BadRequest(
+            "Promise completion mutual acknowledgement accepted transition requires Ordinary Account participant acknowledgement reference"
+                .to_owned(),
+        ));
+    }
+
+    if fact
+        .governed_review_reference
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .is_some()
+        || fact
+            .review_authority_reference
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .is_some()
+    {
+        return Err(PromiseCompletionWriterFactPersistenceError::BadRequest(
+            "Promise completion mutual acknowledgement accepted transition does not accept governed review references"
+                .to_owned(),
+        ));
+    }
+
+    if fact
+        .proof_eligibility_reference
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .is_some()
+        || fact
+            .proof_evidence_writer_fact_reference
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .is_some()
+    {
+        return Err(PromiseCompletionWriterFactPersistenceError::BadRequest(
+            "Promise completion mutual acknowledgement accepted transition does not accept proof references"
+                .to_owned(),
+        ));
+    }
+
+    if fact
+        .correction_or_supersession_reference
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .is_some()
+    {
+        return Err(PromiseCompletionWriterFactPersistenceError::BadRequest(
+            "Promise completion mutual acknowledgement accepted transition does not accept correction or supersession references"
+                .to_owned(),
+        ));
+    }
+
+    if fact
+        .prior_writer_fact_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .is_none()
+    {
+        return Err(PromiseCompletionWriterFactPersistenceError::BadRequest(
+            "Promise completion mutual acknowledgement accepted transition requires prior writer fact reference"
+                .to_owned(),
+        ));
+    }
+
+    Ok(fact)
+}
+
+async fn ensure_mutual_acknowledgement_prior_writer_fact(
+    client: &Arc<Mutex<Client>>,
+    fact: &ProposedPromiseCompletionWriterFact,
+) -> Result<(), PromiseCompletionWriterFactPersistenceError> {
+    let prior_writer_fact_id = fact
+        .prior_writer_fact_id
+        .as_deref()
+        .map(str::trim)
+        .and_then(|value| {
+            if value.is_empty() {
+                None
+            } else {
+                Some(value)
+            }
+        })
+        .ok_or_else(|| {
+            PromiseCompletionWriterFactPersistenceError::BadRequest(
+                "Promise completion mutual acknowledgement accepted transition requires prior writer fact reference"
+                    .to_owned(),
+            )
+        })?;
+    let prior_writer_fact_id = Uuid::parse_str(prior_writer_fact_id).map_err(|_| {
+        PromiseCompletionWriterFactPersistenceError::BadRequest(
+            "prior writer fact id must be a valid UUID".to_owned(),
+        )
+    })?;
+    let promise_reference = fact
+        .promise_reference
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            PromiseCompletionWriterFactPersistenceError::BadRequest(
+                "Promise completion mutual acknowledgement accepted transition requires Promise reference"
+                    .to_owned(),
+            )
+        })?;
+    let realm_id = fact
+        .realm_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            PromiseCompletionWriterFactPersistenceError::BadRequest(
+                "Promise completion mutual acknowledgement accepted transition requires realm_id"
+                    .to_owned(),
+            )
+        })?;
+
+    let row = {
+        let client = client.lock().await;
+        client
+            .query_opt(
+                "
+                SELECT
+                    promise_reference,
+                    realm_id,
+                    fact_family,
+                    source_route_class,
+                    completion_state_class
+                FROM promise_completion.writer_fact_records
+                WHERE writer_fact_id = $1
+                ",
+                &[&prior_writer_fact_id],
+            )
+            .await
+            .map_err(db_error)?
+    };
+
+    let row = row.ok_or_else(|| {
+        PromiseCompletionWriterFactPersistenceError::BadRequest(
+            "Promise completion mutual acknowledgement accepted transition requires existing prior writer fact posture"
+                .to_owned(),
+        )
+    })?;
+    let prior_promise_reference: String = row.get("promise_reference");
+    let prior_realm_id: String = row.get("realm_id");
+    let prior_fact_family: String = row.get("fact_family");
+    let prior_source_route_class: String = row.get("source_route_class");
+    let prior_completion_state_class: String = row.get("completion_state_class");
+
+    if prior_promise_reference != promise_reference || prior_realm_id != realm_id {
+        return Err(PromiseCompletionWriterFactPersistenceError::BadRequest(
+            "Promise completion mutual acknowledgement accepted transition prior writer fact must match Promise reference and realm_id"
+                .to_owned(),
+        ));
+    }
+
+    if prior_fact_family != PromiseCompletionWriterFactFamily::SourceRouteCandidate.as_str()
+        || prior_source_route_class
+            != PromiseCompletionSourceRouteClass::MutualAccountableCompletionAcknowledgement
+                .as_str()
+        || prior_completion_state_class
+            != PromiseCompletionStateClass::CompletionPendingMutualAcknowledgement.as_str()
+    {
+        return Err(PromiseCompletionWriterFactPersistenceError::BadRequest(
+            "Promise completion mutual acknowledgement accepted transition prior writer fact must be mutual acknowledgement pending posture"
+                .to_owned(),
+        ));
+    }
+
+    Ok(())
 }
 
 fn normalize_writer_fact(

--- a/apps/backend/src/services/promise_completion/repository.rs
+++ b/apps/backend/src/services/promise_completion/repository.rs
@@ -430,6 +430,9 @@ async fn ensure_mutual_acknowledgement_prior_writer_fact(
                     .to_owned(),
             )
         })?;
+    let policy_version = required_policy_version(fact.policy_version)?;
+    let fact_idempotency_key =
+        required_ref(fact.fact_idempotency_key.as_deref(), "fact idempotency key")?;
 
     let row = {
         let client = client.lock().await;
@@ -444,9 +447,29 @@ async fn ensure_mutual_acknowledgement_prior_writer_fact(
                     completion_state_class,
                     promise_terms_reference,
                     participant_set_reference,
-                    ordinary_participant_acknowledgement_reference
-                FROM promise_completion.writer_fact_records
-                WHERE writer_fact_id = $1
+                    ordinary_participant_acknowledgement_reference,
+                    (
+                        SELECT existing.fact_idempotency_key
+                        FROM promise_completion.writer_fact_records existing
+                        WHERE existing.prior_writer_fact_id = prior.writer_fact_id
+                          AND existing.fact_family = 'completion_state_transition'
+                          AND existing.source_route_class = 'mutual_accountable_completion_acknowledgement'
+                          AND existing.completion_state_class = 'completion_accepted'
+                        ORDER BY existing.created_at ASC, existing.writer_fact_id ASC
+                        LIMIT 1
+                    ) AS existing_transition_idempotency_key,
+                    (
+                        SELECT existing.policy_version
+                        FROM promise_completion.writer_fact_records existing
+                        WHERE existing.prior_writer_fact_id = prior.writer_fact_id
+                          AND existing.fact_family = 'completion_state_transition'
+                          AND existing.source_route_class = 'mutual_accountable_completion_acknowledgement'
+                          AND existing.completion_state_class = 'completion_accepted'
+                        ORDER BY existing.created_at ASC, existing.writer_fact_id ASC
+                        LIMIT 1
+                    ) AS existing_transition_policy_version
+                FROM promise_completion.writer_fact_records prior
+                WHERE prior.writer_fact_id = $1
                 ",
                 &[&prior_writer_fact_id],
             )
@@ -469,6 +492,10 @@ async fn ensure_mutual_acknowledgement_prior_writer_fact(
     let prior_participant_set_reference: String = row.get("participant_set_reference");
     let prior_ordinary_participant_acknowledgement_reference: Option<String> =
         row.get("ordinary_participant_acknowledgement_reference");
+    let existing_transition_idempotency_key: Option<String> =
+        row.get("existing_transition_idempotency_key");
+    let existing_transition_policy_version: Option<i32> =
+        row.get("existing_transition_policy_version");
 
     if prior_promise_reference != promise_reference || prior_realm_id != realm_id {
         return Err(PromiseCompletionWriterFactPersistenceError::BadRequest(
@@ -486,6 +513,20 @@ async fn ensure_mutual_acknowledgement_prior_writer_fact(
             "Promise completion mutual acknowledgement accepted transition prior writer fact must match Promise terms, participant set, and Ordinary Account acknowledgement references"
                 .to_owned(),
         ));
+    }
+
+    if let (Some(existing_transition_idempotency_key), Some(existing_transition_policy_version)) = (
+        existing_transition_idempotency_key,
+        existing_transition_policy_version,
+    ) {
+        if existing_transition_idempotency_key != fact_idempotency_key
+            || existing_transition_policy_version != policy_version
+        {
+            return Err(PromiseCompletionWriterFactPersistenceError::BadRequest(
+                "Promise completion mutual acknowledgement accepted transition prior writer fact is already consumed by another accepted transition"
+                    .to_owned(),
+            ));
+        }
     }
 
     if prior_fact_family != PromiseCompletionWriterFactFamily::SourceRouteCandidate.as_str()

--- a/apps/backend/src/services/promise_completion/repository.rs
+++ b/apps/backend/src/services/promise_completion/repository.rs
@@ -221,7 +221,11 @@ impl PromiseCompletionWriterFactStore {
     ) -> Result<PromiseCompletionWriterFactSnapshot, PromiseCompletionWriterFactPersistenceError>
     {
         let fact = validate_mutual_acknowledgement_accepted_transition(input.transition.fact)?;
-        ensure_mutual_acknowledgement_prior_writer_fact(&self.client, &fact).await?;
+        let normalized = normalize_writer_fact(&fact)?;
+        {
+            let client = self.client.lock().await;
+            ensure_mutual_acknowledgement_prior_writer_fact(&*client, &normalized).await?;
+        }
         self.record_writer_fact(RecordPromiseCompletionWriterFactInput { fact })
             .await
     }
@@ -350,132 +354,55 @@ fn validate_mutual_acknowledgement_accepted_transition(
 }
 
 async fn ensure_mutual_acknowledgement_prior_writer_fact(
-    client: &Arc<Mutex<Client>>,
-    fact: &ProposedPromiseCompletionWriterFact,
+    client: &impl GenericClient,
+    normalized: &NormalizedWriterFact,
 ) -> Result<(), PromiseCompletionWriterFactPersistenceError> {
-    let prior_writer_fact_id = fact
-        .prior_writer_fact_id
-        .as_deref()
-        .map(str::trim)
-        .and_then(|value| {
-            if value.is_empty() {
-                None
-            } else {
-                Some(value)
-            }
-        })
-        .ok_or_else(|| {
-            PromiseCompletionWriterFactPersistenceError::BadRequest(
-                "Promise completion mutual acknowledgement accepted transition requires prior writer fact reference"
-                    .to_owned(),
-            )
-        })?;
-    let prior_writer_fact_id = Uuid::parse_str(prior_writer_fact_id).map_err(|_| {
+    let prior_writer_fact_id = normalized.prior_writer_fact_id.ok_or_else(|| {
         PromiseCompletionWriterFactPersistenceError::BadRequest(
-            "prior writer fact id must be a valid UUID".to_owned(),
+            "Promise completion mutual acknowledgement accepted transition requires prior writer fact reference"
+                .to_owned(),
         )
     })?;
-    let promise_reference = fact
-        .promise_reference
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .ok_or_else(|| {
-            PromiseCompletionWriterFactPersistenceError::BadRequest(
-                "Promise completion mutual acknowledgement accepted transition requires Promise reference"
-                    .to_owned(),
-            )
-        })?;
-    let realm_id = fact
-        .realm_id
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .ok_or_else(|| {
-            PromiseCompletionWriterFactPersistenceError::BadRequest(
-                "Promise completion mutual acknowledgement accepted transition requires realm_id"
-                    .to_owned(),
-            )
-        })?;
-    let promise_terms_reference = fact
-        .promise_terms_reference
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .ok_or_else(|| {
-            PromiseCompletionWriterFactPersistenceError::BadRequest(
-                "Promise completion mutual acknowledgement accepted transition requires Promise terms reference"
-                    .to_owned(),
-            )
-        })?;
-    let participant_set_reference = fact
-        .participant_set_reference
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .ok_or_else(|| {
-            PromiseCompletionWriterFactPersistenceError::BadRequest(
-                "Promise completion mutual acknowledgement accepted transition requires participant set reference"
-                    .to_owned(),
-            )
-        })?;
-    let ordinary_participant_acknowledgement_reference = fact
+    let ordinary_participant_acknowledgement_reference = normalized
         .ordinary_participant_acknowledgement_reference
         .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
         .ok_or_else(|| {
             PromiseCompletionWriterFactPersistenceError::BadRequest(
                 "Promise completion mutual acknowledgement accepted transition requires Ordinary Account participant acknowledgement reference"
                     .to_owned(),
             )
         })?;
-    let policy_version = required_policy_version(fact.policy_version)?;
-    let fact_idempotency_key =
-        required_ref(fact.fact_idempotency_key.as_deref(), "fact idempotency key")?;
+    let expected_fact_idempotency_key =
+        prior_bound_accepted_transition_idempotency_key(&prior_writer_fact_id);
 
-    let row = {
-        let client = client.lock().await;
-        client
-            .query_opt(
-                "
-                SELECT
-                    promise_reference,
-                    realm_id,
-                    fact_family,
-                    source_route_class,
-                    completion_state_class,
-                    promise_terms_reference,
-                    participant_set_reference,
-                    ordinary_participant_acknowledgement_reference,
-                    (
-                        SELECT existing.fact_idempotency_key
-                        FROM promise_completion.writer_fact_records existing
-                        WHERE existing.prior_writer_fact_id = prior.writer_fact_id
-                          AND existing.fact_family = 'completion_state_transition'
-                          AND existing.source_route_class = 'mutual_accountable_completion_acknowledgement'
-                          AND existing.completion_state_class = 'completion_accepted'
-                        ORDER BY existing.created_at ASC, existing.writer_fact_id ASC
-                        LIMIT 1
-                    ) AS existing_transition_idempotency_key,
-                    (
-                        SELECT existing.policy_version
-                        FROM promise_completion.writer_fact_records existing
-                        WHERE existing.prior_writer_fact_id = prior.writer_fact_id
-                          AND existing.fact_family = 'completion_state_transition'
-                          AND existing.source_route_class = 'mutual_accountable_completion_acknowledgement'
-                          AND existing.completion_state_class = 'completion_accepted'
-                        ORDER BY existing.created_at ASC, existing.writer_fact_id ASC
-                        LIMIT 1
-                    ) AS existing_transition_policy_version
-                FROM promise_completion.writer_fact_records prior
-                WHERE prior.writer_fact_id = $1
-                ",
-                &[&prior_writer_fact_id],
-            )
-            .await
-            .map_err(db_error)?
-    };
+    // Bind consumption to the prior fact so the existing DB idempotency index is the atomic guard.
+    if normalized.fact_idempotency_key != expected_fact_idempotency_key {
+        return Err(PromiseCompletionWriterFactPersistenceError::BadRequest(
+            "Promise completion mutual acknowledgement accepted transition requires prior-bound fact idempotency key"
+                .to_owned(),
+        ));
+    }
+
+    let row = client
+        .query_opt(
+            "
+            SELECT
+                promise_reference,
+                realm_id,
+                fact_family,
+                source_route_class,
+                completion_state_class,
+                promise_terms_reference,
+                participant_set_reference,
+                ordinary_participant_acknowledgement_reference,
+                policy_version
+            FROM promise_completion.writer_fact_records
+            WHERE writer_fact_id = $1
+            ",
+            &[&prior_writer_fact_id],
+        )
+        .await
+        .map_err(db_error)?;
 
     let row = row.ok_or_else(|| {
         PromiseCompletionWriterFactPersistenceError::BadRequest(
@@ -492,20 +419,19 @@ async fn ensure_mutual_acknowledgement_prior_writer_fact(
     let prior_participant_set_reference: String = row.get("participant_set_reference");
     let prior_ordinary_participant_acknowledgement_reference: Option<String> =
         row.get("ordinary_participant_acknowledgement_reference");
-    let existing_transition_idempotency_key: Option<String> =
-        row.get("existing_transition_idempotency_key");
-    let existing_transition_policy_version: Option<i32> =
-        row.get("existing_transition_policy_version");
+    let prior_policy_version: i32 = row.get("policy_version");
 
-    if prior_promise_reference != promise_reference || prior_realm_id != realm_id {
+    if prior_promise_reference != normalized.promise_reference
+        || prior_realm_id != normalized.realm_id
+    {
         return Err(PromiseCompletionWriterFactPersistenceError::BadRequest(
             "Promise completion mutual acknowledgement accepted transition prior writer fact must match Promise reference and realm_id"
                 .to_owned(),
         ));
     }
 
-    if prior_promise_terms_reference != promise_terms_reference
-        || prior_participant_set_reference != participant_set_reference
+    if prior_promise_terms_reference != normalized.promise_terms_reference
+        || prior_participant_set_reference != normalized.participant_set_reference
         || prior_ordinary_participant_acknowledgement_reference.as_deref()
             != Some(ordinary_participant_acknowledgement_reference)
     {
@@ -515,12 +441,36 @@ async fn ensure_mutual_acknowledgement_prior_writer_fact(
         ));
     }
 
-    if let (Some(existing_transition_idempotency_key), Some(existing_transition_policy_version)) = (
-        existing_transition_idempotency_key,
-        existing_transition_policy_version,
-    ) {
-        if existing_transition_idempotency_key != fact_idempotency_key
-            || existing_transition_policy_version != policy_version
+    if prior_policy_version != normalized.policy_version {
+        return Err(PromiseCompletionWriterFactPersistenceError::BadRequest(
+            "Promise completion mutual acknowledgement accepted transition prior writer fact must match policy version"
+                .to_owned(),
+        ));
+    }
+
+    let existing_transition = client
+        .query_opt(
+            "
+            SELECT fact_idempotency_key, policy_version
+            FROM promise_completion.writer_fact_records
+            WHERE prior_writer_fact_id = $1
+              AND fact_family = 'completion_state_transition'
+              AND source_route_class = 'mutual_accountable_completion_acknowledgement'
+              AND completion_state_class = 'completion_accepted'
+            ORDER BY created_at ASC, writer_fact_id ASC
+            LIMIT 1
+            ",
+            &[&prior_writer_fact_id],
+        )
+        .await
+        .map_err(db_error)?;
+
+    if let Some(existing_transition) = existing_transition {
+        let existing_transition_idempotency_key: String =
+            existing_transition.get("fact_idempotency_key");
+        let existing_transition_policy_version: i32 = existing_transition.get("policy_version");
+        if existing_transition_idempotency_key != normalized.fact_idempotency_key
+            || existing_transition_policy_version != normalized.policy_version
         {
             return Err(PromiseCompletionWriterFactPersistenceError::BadRequest(
                 "Promise completion mutual acknowledgement accepted transition prior writer fact is already consumed by another accepted transition"
@@ -543,6 +493,10 @@ async fn ensure_mutual_acknowledgement_prior_writer_fact(
     }
 
     Ok(())
+}
+
+fn prior_bound_accepted_transition_idempotency_key(prior_writer_fact_id: &Uuid) -> String {
+    format!("completion-accepted-from-prior-{prior_writer_fact_id}")
 }
 
 fn normalize_writer_fact(

--- a/apps/backend/src/services/promise_completion/repository.rs
+++ b/apps/backend/src/services/promise_completion/repository.rs
@@ -397,6 +397,39 @@ async fn ensure_mutual_acknowledgement_prior_writer_fact(
                     .to_owned(),
             )
         })?;
+    let promise_terms_reference = fact
+        .promise_terms_reference
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            PromiseCompletionWriterFactPersistenceError::BadRequest(
+                "Promise completion mutual acknowledgement accepted transition requires Promise terms reference"
+                    .to_owned(),
+            )
+        })?;
+    let participant_set_reference = fact
+        .participant_set_reference
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            PromiseCompletionWriterFactPersistenceError::BadRequest(
+                "Promise completion mutual acknowledgement accepted transition requires participant set reference"
+                    .to_owned(),
+            )
+        })?;
+    let ordinary_participant_acknowledgement_reference = fact
+        .ordinary_participant_acknowledgement_reference
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            PromiseCompletionWriterFactPersistenceError::BadRequest(
+                "Promise completion mutual acknowledgement accepted transition requires Ordinary Account participant acknowledgement reference"
+                    .to_owned(),
+            )
+        })?;
 
     let row = {
         let client = client.lock().await;
@@ -408,7 +441,10 @@ async fn ensure_mutual_acknowledgement_prior_writer_fact(
                     realm_id,
                     fact_family,
                     source_route_class,
-                    completion_state_class
+                    completion_state_class,
+                    promise_terms_reference,
+                    participant_set_reference,
+                    ordinary_participant_acknowledgement_reference
                 FROM promise_completion.writer_fact_records
                 WHERE writer_fact_id = $1
                 ",
@@ -429,10 +465,25 @@ async fn ensure_mutual_acknowledgement_prior_writer_fact(
     let prior_fact_family: String = row.get("fact_family");
     let prior_source_route_class: String = row.get("source_route_class");
     let prior_completion_state_class: String = row.get("completion_state_class");
+    let prior_promise_terms_reference: String = row.get("promise_terms_reference");
+    let prior_participant_set_reference: String = row.get("participant_set_reference");
+    let prior_ordinary_participant_acknowledgement_reference: Option<String> =
+        row.get("ordinary_participant_acknowledgement_reference");
 
     if prior_promise_reference != promise_reference || prior_realm_id != realm_id {
         return Err(PromiseCompletionWriterFactPersistenceError::BadRequest(
             "Promise completion mutual acknowledgement accepted transition prior writer fact must match Promise reference and realm_id"
+                .to_owned(),
+        ));
+    }
+
+    if prior_promise_terms_reference != promise_terms_reference
+        || prior_participant_set_reference != participant_set_reference
+        || prior_ordinary_participant_acknowledgement_reference.as_deref()
+            != Some(ordinary_participant_acknowledgement_reference)
+    {
+        return Err(PromiseCompletionWriterFactPersistenceError::BadRequest(
+            "Promise completion mutual acknowledgement accepted transition prior writer fact must match Promise terms, participant set, and Ordinary Account acknowledgement references"
                 .to_owned(),
         ));
     }

--- a/apps/backend/src/services/promise_completion/types.rs
+++ b/apps/backend/src/services/promise_completion/types.rs
@@ -181,6 +181,16 @@ pub struct RecordPromiseCompletionWriterFactInput {
 }
 
 #[derive(Clone, Debug)]
+pub struct RecordMutualAcknowledgementAcceptedTransitionInput {
+    pub transition: ProposedMutualAcknowledgementAcceptedTransition,
+}
+
+#[derive(Clone, Debug)]
+pub struct ProposedMutualAcknowledgementAcceptedTransition {
+    pub fact: ProposedPromiseCompletionWriterFact,
+}
+
+#[derive(Clone, Debug)]
 pub struct ProposedPromiseCompletionWriterFact {
     pub promise_reference: Option<String>,
     pub realm_id: Option<String>,

--- a/apps/backend/tests/promise_completion_state_transition_runtime.rs
+++ b/apps/backend/tests/promise_completion_state_transition_runtime.rs
@@ -113,6 +113,42 @@ async fn duplicate_accepted_transition_with_payload_drift_fails_closed() {
 }
 
 #[tokio::test]
+async fn accepted_transition_with_new_idempotency_key_cannot_reconsume_prior_fact() {
+    let (_test_state, config, client) = test_context().await;
+    let store = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let idempotency_key = unique_idempotency_key("prior-consumed");
+    let prior = record_prior_pending_mutual_acknowledgement(&store, &idempotency_key).await;
+    let first = accepted_transition_fact(&idempotency_key, &prior.writer_fact_id);
+    let mut reconsume = accepted_transition_fact(&idempotency_key, &prior.writer_fact_id);
+    reconsume.fact_idempotency_key = Some(format!("reconsume-{idempotency_key}"));
+
+    let snapshot = store
+        .record_mutual_acknowledgement_accepted_transition(transition_input(first))
+        .await
+        .expect("first accepted transition should persist");
+    let error = store
+        .record_mutual_acknowledgement_accepted_transition(transition_input(reconsume))
+        .await
+        .expect_err("same prior writer fact cannot be consumed by a new idempotency key");
+
+    assert!(matches!(
+        error,
+        PromiseCompletionWriterFactPersistenceError::BadRequest(_)
+    ));
+    assert_eq!(
+        writer_fact_count_for_promise_and_family(
+            &client,
+            &snapshot.promise_reference,
+            "completion_state_transition",
+        )
+        .await,
+        1
+    );
+}
+
+#[tokio::test]
 async fn governed_review_completion_is_rejected_before_transition_persistence() {
     let (_test_state, config, client) = test_context().await;
     let store = PromiseCompletionWriterFactStore::connect(&config)

--- a/apps/backend/tests/promise_completion_state_transition_runtime.rs
+++ b/apps/backend/tests/promise_completion_state_transition_runtime.rs
@@ -417,6 +417,61 @@ async fn accepted_transition_requires_matching_prior_writer_truth_posture() {
 }
 
 #[tokio::test]
+async fn accepted_transition_requires_matching_prior_boundary_references() {
+    let (_test_state, config, client) = test_context().await;
+    let store = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let cases: &[(&str, fn(&mut ProposedPromiseCompletionWriterFact))] = &[
+        (
+            "drifted-terms",
+            |fact: &mut ProposedPromiseCompletionWriterFact| {
+                fact.promise_terms_reference = Some("promise-terms-drifted".to_owned());
+            },
+        ),
+        (
+            "drifted-participant-set",
+            |fact: &mut ProposedPromiseCompletionWriterFact| {
+                fact.participant_set_reference = Some("participant-set-drifted".to_owned());
+            },
+        ),
+        (
+            "drifted-ordinary-ack",
+            |fact: &mut ProposedPromiseCompletionWriterFact| {
+                fact.ordinary_participant_acknowledgement_reference =
+                    Some("ordinary-acknowledgement-drifted".to_owned());
+            },
+        ),
+    ];
+
+    for &(suffix, mutation) in cases {
+        let idempotency_key = unique_idempotency_key(suffix);
+        let prior = record_prior_pending_mutual_acknowledgement(&store, &idempotency_key).await;
+        let mut fact = accepted_transition_fact(&idempotency_key, &prior.writer_fact_id);
+        mutation(&mut fact);
+
+        let error = store
+            .record_mutual_acknowledgement_accepted_transition(transition_input(fact))
+            .await
+            .expect_err("prior boundary reference drift should fail closed");
+
+        assert!(matches!(
+            error,
+            PromiseCompletionWriterFactPersistenceError::BadRequest(_)
+        ));
+        assert_eq!(
+            writer_fact_count_for_promise_and_family(
+                &client,
+                &prior.promise_reference,
+                "completion_state_transition",
+            )
+            .await,
+            0
+        );
+    }
+}
+
+#[tokio::test]
 async fn accepted_transition_creates_no_projection_trust_depth_settlement_or_coordination_effects()
 {
     let (_test_state, config, client) = test_context().await;

--- a/apps/backend/tests/promise_completion_state_transition_runtime.rs
+++ b/apps/backend/tests/promise_completion_state_transition_runtime.rs
@@ -149,6 +149,99 @@ async fn accepted_transition_with_new_idempotency_key_cannot_reconsume_prior_fac
 }
 
 #[tokio::test]
+async fn concurrent_payload_drift_for_same_prior_uses_database_idempotency_guard() {
+    let (_test_state, config, client) = test_context().await;
+    let prior_store = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("prior store should connect");
+    let idempotency_key = unique_idempotency_key("concurrent-drift");
+    let prior = record_prior_pending_mutual_acknowledgement(&prior_store, &idempotency_key).await;
+    let store_a = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("first competing store should connect");
+    let store_b = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("second competing store should connect");
+    let input_a = transition_input(accepted_transition_fact(
+        &idempotency_key,
+        &prior.writer_fact_id,
+    ));
+    let mut drifted = accepted_transition_fact(&idempotency_key, &prior.writer_fact_id);
+    drifted.reason_code_class = Some(format!("completion-accepted-drifted-{idempotency_key}"));
+    let input_b = transition_input(drifted);
+
+    let (result_a, result_b) = tokio::join!(
+        store_a.record_mutual_acknowledgement_accepted_transition(input_a),
+        store_b.record_mutual_acknowledgement_accepted_transition(input_b)
+    );
+
+    let mut inserted_count = 0;
+    let mut conflict_count = 0;
+
+    for result in [result_a, result_b] {
+        match result {
+            Ok(snapshot) => {
+                inserted_count += 1;
+                assert_eq!(
+                    snapshot.replay_status,
+                    PromiseCompletionWriterFactReplayStatus::Inserted
+                );
+                assert_eq!(snapshot.promise_reference, prior.promise_reference);
+            }
+            Err(PromiseCompletionWriterFactPersistenceError::IdempotencyConflict { .. }) => {
+                conflict_count += 1;
+            }
+            other => {
+                panic!("expected one insert and one idempotency conflict, got {other:?}")
+            }
+        }
+    }
+
+    assert_eq!(inserted_count, 1);
+    assert_eq!(conflict_count, 1);
+    assert_eq!(
+        writer_fact_count_for_promise_and_family(
+            &client,
+            &prior.promise_reference,
+            "completion_state_transition",
+        )
+        .await,
+        1
+    );
+}
+
+#[tokio::test]
+async fn accepted_transition_requires_prior_policy_version_for_consumption_scope() {
+    let (_test_state, config, client) = test_context().await;
+    let store = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let idempotency_key = unique_idempotency_key("prior-policy");
+    let prior = record_prior_pending_mutual_acknowledgement(&store, &idempotency_key).await;
+    let mut fact = accepted_transition_fact(&idempotency_key, &prior.writer_fact_id);
+    fact.policy_version = Some(2);
+
+    let error = store
+        .record_mutual_acknowledgement_accepted_transition(transition_input(fact))
+        .await
+        .expect_err("transition policy version must match the prior writer fact");
+
+    assert!(matches!(
+        error,
+        PromiseCompletionWriterFactPersistenceError::BadRequest(_)
+    ));
+    assert_eq!(
+        writer_fact_count_for_promise_and_family(
+            &client,
+            &prior.promise_reference,
+            "completion_state_transition",
+        )
+        .await,
+        0
+    );
+}
+
+#[tokio::test]
 async fn governed_review_completion_is_rejected_before_transition_persistence() {
     let (_test_state, config, client) = test_context().await;
     let store = PromiseCompletionWriterFactStore::connect(&config)
@@ -622,9 +715,15 @@ fn accepted_transition_fact(
     fact.completion_state_class = PromiseCompletionStateClass::CompletionAccepted;
     fact.completed_reference_eligible = true;
     fact.prior_writer_fact_id = Some(prior_writer_fact_id.to_owned());
-    fact.fact_idempotency_key = Some(format!("accepted-transition-{idempotency_key}"));
+    fact.fact_idempotency_key = Some(accepted_transition_fact_idempotency_key(
+        prior_writer_fact_id,
+    ));
     fact.reason_code_class = Some(format!("completion-accepted-{idempotency_key}"));
     fact
+}
+
+fn accepted_transition_fact_idempotency_key(prior_writer_fact_id: &str) -> String {
+    format!("completion-accepted-from-prior-{prior_writer_fact_id}")
 }
 
 fn base_fact(idempotency_key: &str) -> ProposedPromiseCompletionWriterFact {

--- a/apps/backend/tests/promise_completion_state_transition_runtime.rs
+++ b/apps/backend/tests/promise_completion_state_transition_runtime.rs
@@ -1,0 +1,685 @@
+use std::path::PathBuf;
+
+use musubi_backend::{
+    new_test_state,
+    services::promise_completion::{
+        PromiseCompletionAuthorityPosture, PromiseCompletionForbiddenSourceRouteClass,
+        PromiseCompletionProjectionNonAuthorityPosture, PromiseCompletionSourceRouteClass,
+        PromiseCompletionStateClass, PromiseCompletionWriterFactFamily,
+        PromiseCompletionWriterFactPersistenceError, PromiseCompletionWriterFactReplayStatus,
+        PromiseCompletionWriterFactStore, ProposedMutualAcknowledgementAcceptedTransition,
+        ProposedPromiseCompletionWriterFact, RecordMutualAcknowledgementAcceptedTransitionInput,
+        RecordPromiseCompletionWriterFactInput,
+    },
+};
+use musubi_db_runtime::DbConfig;
+use tokio_postgres::NoTls;
+
+fn lookup(database_url: &str, migrations_dir: &str, name: &'static str) -> Option<String> {
+    match name {
+        "APP_ENV" => Some("test".to_owned()),
+        "DATABASE_URL" => Some(database_url.to_owned()),
+        "MIGRATIONS_DIR" => Some(migrations_dir.to_owned()),
+        "REQUIRE_LATEST_SCHEMA" => Some("true".to_owned()),
+        _ => None,
+    }
+}
+
+#[tokio::test]
+async fn mutual_acknowledgement_accepted_transition_persists_once_and_replays_identically() {
+    let (_test_state, config, client) = test_context().await;
+    let store = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let idempotency_key = unique_idempotency_key("accepted-replay");
+    let prior = record_prior_pending_mutual_acknowledgement(&store, &idempotency_key).await;
+    let input = transition_input(accepted_transition_fact(
+        &idempotency_key,
+        &prior.writer_fact_id,
+    ));
+
+    let first = store
+        .record_mutual_acknowledgement_accepted_transition(input.clone())
+        .await
+        .expect("first accepted transition should persist");
+    let replay = store
+        .record_mutual_acknowledgement_accepted_transition(input)
+        .await
+        .expect("identical accepted transition should replay");
+
+    assert_eq!(first.fact_family, "completion_state_transition");
+    assert_eq!(
+        first.source_route_class,
+        "mutual_accountable_completion_acknowledgement"
+    );
+    assert_eq!(first.completion_state_class, "completion_accepted");
+    assert!(first.completed_reference_eligible);
+    assert_eq!(
+        first.replay_status,
+        PromiseCompletionWriterFactReplayStatus::Inserted
+    );
+    assert_eq!(
+        replay.replay_status,
+        PromiseCompletionWriterFactReplayStatus::ReplayedIdentical
+    );
+    assert_eq!(first.writer_fact_id, replay.writer_fact_id);
+    assert_eq!(first.request_payload_hash, replay.request_payload_hash);
+    assert_eq!(first.decision_payload_hash, replay.decision_payload_hash);
+    assert_eq!(
+        writer_fact_count_for_promise_and_family(
+            &client,
+            &first.promise_reference,
+            "completion_state_transition",
+        )
+        .await,
+        1
+    );
+}
+
+#[tokio::test]
+async fn duplicate_accepted_transition_with_payload_drift_fails_closed() {
+    let (_test_state, config, client) = test_context().await;
+    let store = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let idempotency_key = unique_idempotency_key("accepted-drift");
+    let prior = record_prior_pending_mutual_acknowledgement(&store, &idempotency_key).await;
+    let first = accepted_transition_fact(&idempotency_key, &prior.writer_fact_id);
+    let mut drifted = accepted_transition_fact(&idempotency_key, &prior.writer_fact_id);
+    drifted.reason_code_class = Some(format!("completion-accepted-drifted-{idempotency_key}"));
+
+    let snapshot = store
+        .record_mutual_acknowledgement_accepted_transition(transition_input(first))
+        .await
+        .expect("first accepted transition should persist");
+    let error = store
+        .record_mutual_acknowledgement_accepted_transition(transition_input(drifted))
+        .await
+        .expect_err("payload drift must fail closed");
+
+    match error {
+        PromiseCompletionWriterFactPersistenceError::IdempotencyConflict { .. } => {}
+        other => panic!("expected idempotency conflict, got {other:?}"),
+    }
+    assert_eq!(
+        writer_fact_count_for_promise_and_family(
+            &client,
+            &snapshot.promise_reference,
+            "completion_state_transition",
+        )
+        .await,
+        1
+    );
+}
+
+#[tokio::test]
+async fn governed_review_completion_is_rejected_before_transition_persistence() {
+    let (_test_state, config, client) = test_context().await;
+    let store = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let idempotency_key = unique_idempotency_key("governed-rejected");
+    let mut fact = accepted_transition_fact(&idempotency_key, &uuid::Uuid::new_v4().to_string());
+    fact.source_route_class = PromiseCompletionSourceRouteClass::GovernedReviewCompletion;
+    fact.governed_review_reference = Some(format!("governed-review-{idempotency_key}"));
+    fact.review_authority_reference = Some(format!("review-authority-{idempotency_key}"));
+    let promise_reference = fact.promise_reference.clone().expect("promise reference");
+
+    let error = store
+        .record_mutual_acknowledgement_accepted_transition(transition_input(fact))
+        .await
+        .expect_err("governed review completion must be rejected by first candidate helper");
+
+    assert!(matches!(
+        error,
+        PromiseCompletionWriterFactPersistenceError::BadRequest(_)
+    ));
+    assert_eq!(
+        writer_fact_count_for_promise_and_family(
+            &client,
+            &promise_reference,
+            "completion_state_transition",
+        )
+        .await,
+        0
+    );
+}
+
+#[tokio::test]
+async fn forbidden_source_route_classes_fail_before_transition_persistence() {
+    let (_test_state, config, client) = test_context().await;
+    let store = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("store should connect");
+
+    for (suffix, forbidden_route) in [
+        (
+            "proof-only",
+            PromiseCompletionForbiddenSourceRouteClass::ProofOnlyCompletion,
+        ),
+        (
+            "settlement-only",
+            PromiseCompletionForbiddenSourceRouteClass::SettlementOnlyCompletion,
+        ),
+        (
+            "payment-only",
+            PromiseCompletionForbiddenSourceRouteClass::PaymentOnlyCompletion,
+        ),
+        (
+            "provider-only",
+            PromiseCompletionForbiddenSourceRouteClass::ProviderCallbackOnlyCompletion,
+        ),
+        (
+            "operator-note-only",
+            PromiseCompletionForbiddenSourceRouteClass::OperatorNoteOnlyCompletion,
+        ),
+        (
+            "projection-only",
+            PromiseCompletionForbiddenSourceRouteClass::ProjectionOnlyCompletion,
+        ),
+        (
+            "model-output-only",
+            PromiseCompletionForbiddenSourceRouteClass::ModelOutputOnlyCompletion,
+        ),
+        (
+            "venue-staff-judgment-only",
+            PromiseCompletionForbiddenSourceRouteClass::VenueStaffJudgmentOnlyCompletion,
+        ),
+        (
+            "client-state-only",
+            PromiseCompletionForbiddenSourceRouteClass::ClientStateOnlyCompletion,
+        ),
+        (
+            "support-status",
+            PromiseCompletionForbiddenSourceRouteClass::SupportStatusCompletion,
+        ),
+        (
+            "implementation-convenience",
+            PromiseCompletionForbiddenSourceRouteClass::ImplementationConvenienceCompletion,
+        ),
+        (
+            "silence-based",
+            PromiseCompletionForbiddenSourceRouteClass::SilenceBasedCompletion,
+        ),
+        (
+            "popularity-based",
+            PromiseCompletionForbiddenSourceRouteClass::PopularityBasedCompletion,
+        ),
+    ] {
+        let idempotency_key = unique_idempotency_key(suffix);
+        let mut fact =
+            accepted_transition_fact(&idempotency_key, &uuid::Uuid::new_v4().to_string());
+        fact.source_route_class = PromiseCompletionSourceRouteClass::Forbidden(forbidden_route);
+        let promise_reference = fact.promise_reference.clone().expect("promise reference");
+
+        let error = store
+            .record_mutual_acknowledgement_accepted_transition(transition_input(fact))
+            .await
+            .expect_err("forbidden source route should fail closed");
+
+        assert!(matches!(
+            error,
+            PromiseCompletionWriterFactPersistenceError::BadRequest(_)
+        ));
+        assert_eq!(
+            writer_fact_count_for_promise_and_family(
+                &client,
+                &promise_reference,
+                "completion_state_transition",
+            )
+            .await,
+            0
+        );
+    }
+}
+
+#[tokio::test]
+async fn non_selected_transition_shapes_fail_before_persistence() {
+    let (_test_state, config, client) = test_context().await;
+    let store = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("store should connect");
+
+    let cases: &[(&str, fn(&mut ProposedPromiseCompletionWriterFact))] = &[
+        (
+            "wrong-family",
+            |fact: &mut ProposedPromiseCompletionWriterFact| {
+                fact.fact_family = PromiseCompletionWriterFactFamily::CompletionOutcomeReference;
+            },
+        ),
+        (
+            "wrong-previous-state",
+            |fact: &mut ProposedPromiseCompletionWriterFact| {
+                fact.previous_completion_state_class =
+                    Some(PromiseCompletionStateClass::CompletionUnavailable);
+            },
+        ),
+        (
+            "wrong-next-state",
+            |fact: &mut ProposedPromiseCompletionWriterFact| {
+                fact.completion_state_class = PromiseCompletionStateClass::CompletionRejected;
+                fact.completed_reference_eligible = false;
+            },
+        ),
+        (
+            "non-accepted-eligible",
+            |fact: &mut ProposedPromiseCompletionWriterFact| {
+                fact.completion_state_class = PromiseCompletionStateClass::CompletionRejected;
+                fact.completed_reference_eligible = true;
+            },
+        ),
+    ];
+
+    for &(suffix, mutation) in cases {
+        let idempotency_key = unique_idempotency_key(suffix);
+        let mut fact =
+            accepted_transition_fact(&idempotency_key, &uuid::Uuid::new_v4().to_string());
+        mutation(&mut fact);
+        let promise_reference = fact.promise_reference.clone().expect("promise reference");
+
+        let error = store
+            .record_mutual_acknowledgement_accepted_transition(transition_input(fact))
+            .await
+            .expect_err("non-selected transition shape should fail closed");
+
+        assert!(matches!(
+            error,
+            PromiseCompletionWriterFactPersistenceError::BadRequest(_)
+        ));
+        assert_eq!(
+            writer_fact_count_for_promise_and_family(
+                &client,
+                &promise_reference,
+                "completion_state_transition",
+            )
+            .await,
+            0
+        );
+    }
+}
+
+#[tokio::test]
+async fn missing_acknowledgement_prior_or_boundary_references_fail_closed() {
+    let (_test_state, config, client) = test_context().await;
+    let store = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("store should connect");
+
+    let missing_ack_key = unique_idempotency_key("missing-ack");
+    let mut missing_ack =
+        accepted_transition_fact(&missing_ack_key, &uuid::Uuid::new_v4().to_string());
+    missing_ack.ordinary_participant_acknowledgement_reference = None;
+    let missing_ack_promise = missing_ack
+        .promise_reference
+        .clone()
+        .expect("promise reference");
+    let missing_ack_error = store
+        .record_mutual_acknowledgement_accepted_transition(transition_input(missing_ack))
+        .await
+        .expect_err("missing Ordinary Account acknowledgement should fail");
+    assert!(matches!(
+        missing_ack_error,
+        PromiseCompletionWriterFactPersistenceError::BadRequest(_)
+    ));
+    assert_eq!(
+        writer_fact_count_for_promise_and_family(
+            &client,
+            &missing_ack_promise,
+            "completion_state_transition",
+        )
+        .await,
+        0
+    );
+
+    let missing_prior_key = unique_idempotency_key("missing-prior");
+    let mut missing_prior =
+        accepted_transition_fact(&missing_prior_key, &uuid::Uuid::new_v4().to_string());
+    missing_prior.prior_writer_fact_id = None;
+    let missing_prior_promise = missing_prior
+        .promise_reference
+        .clone()
+        .expect("promise reference");
+    let missing_prior_error = store
+        .record_mutual_acknowledgement_accepted_transition(transition_input(missing_prior))
+        .await
+        .expect_err("missing prior writer fact reference should fail");
+    assert!(matches!(
+        missing_prior_error,
+        PromiseCompletionWriterFactPersistenceError::BadRequest(_)
+    ));
+    assert_eq!(
+        writer_fact_count_for_promise_and_family(
+            &client,
+            &missing_prior_promise,
+            "completion_state_transition",
+        )
+        .await,
+        0
+    );
+
+    let missing_boundary_key = unique_idempotency_key("missing-boundary");
+    let prior = record_prior_pending_mutual_acknowledgement(&store, &missing_boundary_key).await;
+    let mut missing_boundary =
+        accepted_transition_fact(&missing_boundary_key, &prior.writer_fact_id);
+    missing_boundary.participant_set_reference = None;
+    let missing_boundary_error = store
+        .record_mutual_acknowledgement_accepted_transition(transition_input(missing_boundary))
+        .await
+        .expect_err("missing boundary reference should fail");
+    assert!(matches!(
+        missing_boundary_error,
+        PromiseCompletionWriterFactPersistenceError::BadRequest(_)
+    ));
+    assert_eq!(
+        writer_fact_count_for_promise_and_family(
+            &client,
+            &prior.promise_reference,
+            "completion_state_transition",
+        )
+        .await,
+        0
+    );
+}
+
+#[tokio::test]
+async fn accepted_transition_requires_matching_prior_writer_truth_posture() {
+    let (_test_state, config, client) = test_context().await;
+    let store = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let idempotency_key = unique_idempotency_key("wrong-prior");
+    let wrong_prior = record_prior_with_completion_state(
+        &store,
+        &idempotency_key,
+        PromiseCompletionStateClass::CompletionRejected,
+    )
+    .await;
+    let fact = accepted_transition_fact(&idempotency_key, &wrong_prior.writer_fact_id);
+
+    let error = store
+        .record_mutual_acknowledgement_accepted_transition(transition_input(fact))
+        .await
+        .expect_err("wrong prior writer truth posture should fail");
+
+    assert!(matches!(
+        error,
+        PromiseCompletionWriterFactPersistenceError::BadRequest(_)
+    ));
+    assert_eq!(
+        writer_fact_count_for_promise_and_family(
+            &client,
+            &wrong_prior.promise_reference,
+            "completion_state_transition",
+        )
+        .await,
+        0
+    );
+}
+
+#[tokio::test]
+async fn accepted_transition_creates_no_projection_trust_depth_settlement_or_coordination_effects()
+{
+    let (_test_state, config, client) = test_context().await;
+    let store = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let before = side_effect_counts(&client).await;
+    let idempotency_key = unique_idempotency_key("side-effect-free");
+    let prior = record_prior_pending_mutual_acknowledgement(&store, &idempotency_key).await;
+
+    let snapshot = store
+        .record_mutual_acknowledgement_accepted_transition(transition_input(
+            accepted_transition_fact(&idempotency_key, &prior.writer_fact_id),
+        ))
+        .await
+        .expect("accepted transition should persist without product side effects");
+    let after = side_effect_counts(&client).await;
+
+    assert_eq!(before, after);
+    assert_eq!(
+        writer_fact_count_for_promise_and_family(
+            &client,
+            &snapshot.promise_reference,
+            "completion_state_transition",
+        )
+        .await,
+        1
+    );
+}
+
+async fn test_context() -> (musubi_backend::TestState, DbConfig, tokio_postgres::Client) {
+    let test_state = new_test_state()
+        .await
+        .expect("test database state should initialize");
+    let database_url = std::env::var("MUSUBI_TEST_DATABASE_URL")
+        .or_else(|_| std::env::var("DATABASE_URL"))
+        .expect("integration tests require MUSUBI_TEST_DATABASE_URL or DATABASE_URL to be set");
+    let migrations_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("migrations")
+        .canonicalize()
+        .expect("migrations directory should resolve");
+    let migrations_dir = migrations_dir
+        .to_str()
+        .expect("migrations directory should be utf-8")
+        .to_owned();
+    let config = DbConfig::from_lookup(|name| lookup(&database_url, &migrations_dir, name))
+        .expect("test db config should parse");
+
+    let (client, connection) = tokio_postgres::connect(&database_url, NoTls)
+        .await
+        .expect("failed to connect to test database");
+    tokio::spawn(async move {
+        if let Err(error) = connection.await {
+            eprintln!("test database connection error: {error}");
+        }
+    });
+
+    (test_state, config, client)
+}
+
+fn unique_idempotency_key(label: &str) -> String {
+    format!("{label}-{}", uuid::Uuid::new_v4())
+}
+
+async fn record_prior_pending_mutual_acknowledgement(
+    store: &PromiseCompletionWriterFactStore,
+    idempotency_key: &str,
+) -> musubi_backend::services::promise_completion::PromiseCompletionWriterFactSnapshot {
+    record_prior_with_completion_state(
+        store,
+        idempotency_key,
+        PromiseCompletionStateClass::CompletionPendingMutualAcknowledgement,
+    )
+    .await
+}
+
+async fn record_prior_with_completion_state(
+    store: &PromiseCompletionWriterFactStore,
+    idempotency_key: &str,
+    completion_state: PromiseCompletionStateClass,
+) -> musubi_backend::services::promise_completion::PromiseCompletionWriterFactSnapshot {
+    store
+        .record_writer_fact(RecordPromiseCompletionWriterFactInput {
+            fact: prior_mutual_acknowledgement_fact(idempotency_key, completion_state),
+        })
+        .await
+        .expect("prior writer fact should persist")
+}
+
+fn prior_mutual_acknowledgement_fact(
+    idempotency_key: &str,
+    completion_state: PromiseCompletionStateClass,
+) -> ProposedPromiseCompletionWriterFact {
+    let mut fact = base_fact(idempotency_key);
+    fact.fact_family = PromiseCompletionWriterFactFamily::SourceRouteCandidate;
+    fact.previous_completion_state_class = None;
+    fact.completion_state_class = completion_state;
+    fact.completed_reference_eligible = false;
+    fact.fact_idempotency_key = Some(format!("prior-{idempotency_key}"));
+    fact.reason_code_class = Some(format!("completion-pending-mutual-ack-{idempotency_key}"));
+    fact
+}
+
+fn accepted_transition_fact(
+    idempotency_key: &str,
+    prior_writer_fact_id: &str,
+) -> ProposedPromiseCompletionWriterFact {
+    let mut fact = base_fact(idempotency_key);
+    fact.fact_family = PromiseCompletionWriterFactFamily::CompletionStateTransition;
+    fact.previous_completion_state_class =
+        Some(PromiseCompletionStateClass::CompletionPendingMutualAcknowledgement);
+    fact.completion_state_class = PromiseCompletionStateClass::CompletionAccepted;
+    fact.completed_reference_eligible = true;
+    fact.prior_writer_fact_id = Some(prior_writer_fact_id.to_owned());
+    fact.fact_idempotency_key = Some(format!("accepted-transition-{idempotency_key}"));
+    fact.reason_code_class = Some(format!("completion-accepted-{idempotency_key}"));
+    fact
+}
+
+fn base_fact(idempotency_key: &str) -> ProposedPromiseCompletionWriterFact {
+    ProposedPromiseCompletionWriterFact {
+        promise_reference: Some(format!("promise-completion-{idempotency_key}")),
+        realm_id: Some(format!("realm-completion-{idempotency_key}")),
+        fact_family: PromiseCompletionWriterFactFamily::CompletionStateTransition,
+        source_route_class:
+            PromiseCompletionSourceRouteClass::MutualAccountableCompletionAcknowledgement,
+        previous_completion_state_class: Some(
+            PromiseCompletionStateClass::CompletionPendingMutualAcknowledgement,
+        ),
+        completion_state_class: PromiseCompletionStateClass::CompletionAccepted,
+        completed_reference_eligible: true,
+        promise_terms_reference: Some(format!("promise-terms-{idempotency_key}")),
+        participant_set_reference: Some(format!("participant-set-{idempotency_key}")),
+        ordinary_participant_acknowledgement_reference: Some(format!(
+            "ordinary-acknowledgement-{idempotency_key}"
+        )),
+        governed_review_reference: None,
+        review_authority_reference: None,
+        proof_eligibility_reference: None,
+        proof_evidence_writer_fact_reference: None,
+        consent_at_formation_reference: Some(format!("consent-formation-{idempotency_key}")),
+        consent_at_resolution_reference: Some(format!("consent-resolution-{idempotency_key}")),
+        block_withdrawal_state_reference: Some(format!("block-withdrawal-clear-{idempotency_key}")),
+        age_assurance_state_reference: Some(format!(
+            "age-assurance-adult-eligible-{idempotency_key}"
+        )),
+        legal_hold_intersection_reference: Some(format!("legal-hold-clear-{idempotency_key}")),
+        critical_harm_case_reference: Some(format!("critical-harm-clear-{idempotency_key}")),
+        account_lifecycle_reference: Some(format!("account-lifecycle-active-{idempotency_key}")),
+        anti_abuse_continuity_reference: Some(format!("anti-abuse-clear-{idempotency_key}")),
+        safety_case_reference: Some(format!("safety-case-clear-{idempotency_key}")),
+        reason_code_class: Some(format!("completion-accepted-{idempotency_key}")),
+        evidence_level_reference: Some(format!("evidence-level-bounded-{idempotency_key}")),
+        correction_or_supersession_reference: None,
+        prior_writer_fact_id: None,
+        policy_version: Some(1),
+        fact_idempotency_key: Some(format!("accepted-transition-{idempotency_key}")),
+        retention_class_reference: Some("R4 Trust / moderation / case".to_owned()),
+        access_audit_reference: Some(format!("access-audit-{idempotency_key}")),
+        projection_non_authority_posture: Some(
+            PromiseCompletionProjectionNonAuthorityPosture::ProjectionNonAuthoritative,
+        ),
+        authority_posture: Some(PromiseCompletionAuthorityPosture::WriterTruthOnly),
+    }
+}
+
+fn transition_input(
+    fact: ProposedPromiseCompletionWriterFact,
+) -> RecordMutualAcknowledgementAcceptedTransitionInput {
+    RecordMutualAcknowledgementAcceptedTransitionInput {
+        transition: ProposedMutualAcknowledgementAcceptedTransition { fact },
+    }
+}
+
+async fn writer_fact_count_for_promise_and_family(
+    client: &tokio_postgres::Client,
+    promise_reference: &str,
+    fact_family: &str,
+) -> i64 {
+    let row = client
+        .query_one(
+            "
+            SELECT COUNT(*)::bigint AS count
+            FROM promise_completion.writer_fact_records
+            WHERE promise_reference = $1
+              AND fact_family = $2
+            ",
+            &[&promise_reference, &fact_family],
+        )
+        .await
+        .expect("writer fact count should load");
+    row.get("count")
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct SideEffectCounts {
+    projection_promise_views: i64,
+    projection_settlement_views: i64,
+    projection_trust_snapshots: i64,
+    projection_realm_trust_snapshots: i64,
+    projection_room_progression_views: i64,
+    social_trust_intake_attempts: i64,
+    social_trust_categorical_sources: i64,
+    social_trust_categorical_mutations: i64,
+    room_progression_tracks: i64,
+    room_progression_facts: i64,
+    settlement_cases: i64,
+    settlement_intents: i64,
+    settlement_submissions: i64,
+    settlement_observations: i64,
+    provider_attempts: i64,
+    outbox_events: i64,
+    outbox_attempts: i64,
+    command_inbox: i64,
+}
+
+async fn side_effect_counts(client: &tokio_postgres::Client) -> SideEffectCounts {
+    let row = client
+        .query_one(
+            "
+            SELECT
+                (SELECT COUNT(*)::bigint FROM projection.promise_views) AS projection_promise_views,
+                (SELECT COUNT(*)::bigint FROM projection.settlement_views) AS projection_settlement_views,
+                (SELECT COUNT(*)::bigint FROM projection.trust_snapshots) AS projection_trust_snapshots,
+                (SELECT COUNT(*)::bigint FROM projection.realm_trust_snapshots) AS projection_realm_trust_snapshots,
+                (SELECT COUNT(*)::bigint FROM projection.room_progression_views) AS projection_room_progression_views,
+                (SELECT COUNT(*)::bigint FROM social_trust.proposed_mutation_attempts) AS social_trust_intake_attempts,
+                (SELECT COUNT(*)::bigint FROM social_trust.categorical_source_references) AS social_trust_categorical_sources,
+                (SELECT COUNT(*)::bigint FROM social_trust.categorical_mutation_facts) AS social_trust_categorical_mutations,
+                (SELECT COUNT(*)::bigint FROM dao.room_progression_tracks) AS room_progression_tracks,
+                (SELECT COUNT(*)::bigint FROM dao.room_progression_facts) AS room_progression_facts,
+                (SELECT COUNT(*)::bigint FROM dao.settlement_cases) AS settlement_cases,
+                (SELECT COUNT(*)::bigint FROM dao.settlement_intents) AS settlement_intents,
+                (SELECT COUNT(*)::bigint FROM dao.settlement_submissions) AS settlement_submissions,
+                (SELECT COUNT(*)::bigint FROM dao.settlement_observations) AS settlement_observations,
+                (SELECT COUNT(*)::bigint FROM dao.provider_attempts) AS provider_attempts,
+                (SELECT COUNT(*)::bigint FROM outbox.events) AS outbox_events,
+                (SELECT COUNT(*)::bigint FROM outbox.outbox_attempts) AS outbox_attempts,
+                (SELECT COUNT(*)::bigint FROM outbox.command_inbox) AS command_inbox
+            ",
+            &[],
+        )
+        .await
+        .expect("side-effect counts should load");
+
+    SideEffectCounts {
+        projection_promise_views: row.get("projection_promise_views"),
+        projection_settlement_views: row.get("projection_settlement_views"),
+        projection_trust_snapshots: row.get("projection_trust_snapshots"),
+        projection_realm_trust_snapshots: row.get("projection_realm_trust_snapshots"),
+        projection_room_progression_views: row.get("projection_room_progression_views"),
+        social_trust_intake_attempts: row.get("social_trust_intake_attempts"),
+        social_trust_categorical_sources: row.get("social_trust_categorical_sources"),
+        social_trust_categorical_mutations: row.get("social_trust_categorical_mutations"),
+        room_progression_tracks: row.get("room_progression_tracks"),
+        room_progression_facts: row.get("room_progression_facts"),
+        settlement_cases: row.get("settlement_cases"),
+        settlement_intents: row.get("settlement_intents"),
+        settlement_submissions: row.get("settlement_submissions"),
+        settlement_observations: row.get("settlement_observations"),
+        provider_attempts: row.get("provider_attempts"),
+        outbox_events: row.get("outbox_events"),
+        outbox_attempts: row.get("outbox_attempts"),
+        command_inbox: row.get("command_inbox"),
+    }
+}

--- a/docs/foundation_lock.md
+++ b/docs/foundation_lock.md
@@ -1,6 +1,6 @@
 # Foundation Lock
 
-Status: Draft; aligned to accepted foundation commit `800a69c`
+Status: Draft; aligned to accepted foundation commit `a5a55ee`
 Applies to: `mt4110/pi-musubi-core`
 Purpose: Pin the constitutional and architectural source of truth that this implementation repository must follow.
 
@@ -26,14 +26,14 @@ Upstream repository:
 Pinned reference for implementation work:
 
 - Foundation reference type: `commit`
-- Foundation commit SHA: `800a69c810e48646c583d2cdd657001d011ff759`
-- Foundation commit title: `Merge pull request #438 from mt4110/feat/promise-completion-writer-fact-persistence-route`
-- Foundation PR title: `docs: select Promise completion writer fact persistence route`
-- Foundation PR URL: `https://github.com/mt4110/musubi-foundation/pull/438`
-- Date pinned: `2026-06-17`
+- Foundation commit SHA: `a5a55ee8b86dc20b04890f302bc062301e2e1f6c`
+- Foundation commit title: `Merge pull request #447 from mt4110/feat/promise-completion-state-transition-route`
+- Foundation PR title: `docs: select Promise completion state transition route`
+- Foundation PR URL: `https://github.com/mt4110/musubi-foundation/pull/447`
+- Date pinned: `2026-06-18`
 - Pinned by: `Masaki Takemura`
-- Pinned commit URL: `https://github.com/mt4110/musubi-foundation/commit/800a69c810e48646c583d2cdd657001d011ff759`
-- Previous pinned reference: `81e127b` / `Merge pull request #430 from mt4110/feat/promise-completion-post-test-exclusion-route`
+- Pinned commit URL: `https://github.com/mt4110/musubi-foundation/commit/a5a55ee8b86dc20b04890f302bc062301e2e1f6c`
+- Previous pinned reference: `800a69c` / `Merge pull request #438 from mt4110/feat/promise-completion-writer-fact-persistence-route`
 - Post-C2 evidence source: `cfdba28` / `Merge pull request #114 from mt4110/feat/post-c2-runtime-handoff-evidence-package`
 - Alignment allowance source: `69b7aa4` / `Merge pull request #116 from mt4110/feat/evaluate-post-c2-runtime-handoff-gate`
 - Post-C2 implementation handoff evidence source: `ef23e88` / `Merge pull request #122 from mt4110/feat/post-c2-implementation-handoff-evidence-package`
@@ -175,6 +175,11 @@ Pinned reference for implementation work:
 - Promise completion test-only hard-exclusion route selection source: `9e500b2` / `Merge pull request #434 from mt4110/feat/promise-completion-test-only-hard-exclusion-route`
 - Promise completion test-only hard-exclusion closeout source: `69488af` / `Merge pull request #436 from mt4110/feat/promise-completion-hard-exclusion-closeout`
 - Promise completion narrow writer fact persistence route selection source: `800a69c` / `Merge pull request #438 from mt4110/feat/promise-completion-writer-fact-persistence-route`
+- Promise completion narrow writer fact persistence closeout source: `fbc68a8` / `Merge pull request #439 from mt4110/feat/promise-completion-writer-fact-persistence-closeout`
+- Promise completion post-writer-fact-persistence route selection source: `89b4228` / `Merge pull request #441 from mt4110/feat/promise-completion-post-writer-fact-persistence-route`
+- Promise completion state transition runtime preflight packet source: `fbca981` / `Merge pull request #443 from mt4110/feat/promise-completion-state-transition-preflight-packet`
+- Promise completion state transition runtime preflight packet sufficiency decision source: `3fd5294` / `Merge pull request #445 from mt4110/feat/promise-completion-state-transition-preflight-sufficiency`
+- Promise completion narrow state transition runtime route selection source: `a5a55ee` / `Merge pull request #447 from mt4110/feat/promise-completion-state-transition-route`
 
 No release tag is asserted for this alignment.
 Do not invent a foundation version label for this commit.
@@ -386,38 +391,43 @@ Before coding, read these upstream documents in order.
 191. `docs/readiness/promise_completion_post_lock_alignment_test_only_hard_exclusion_route_selection.md`
 192. `docs/readiness/promise_completion_test_only_hard_exclusion_closeout_ledger.md`
 193. `docs/readiness/promise_completion_narrow_writer_fact_persistence_route_selection.md`
+194. `docs/readiness/promise_completion_narrow_writer_fact_persistence_closeout_ledger.md`
+195. `docs/readiness/promise_completion_post_writer_fact_persistence_closeout_route_selection.md`
+196. `docs/readiness/promise_completion_state_transition_runtime_preflight_decision_packet.md`
+197. `docs/readiness/promise_completion_state_transition_runtime_preflight_packet_sufficiency_decision.md`
+198. `docs/readiness/promise_completion_post_state_transition_preflight_sufficiency_route_selection.md`
 
 ### Operations layer
-194. `docs/operations/readiness_routine.md`
-195. `docs/operations/runalways_readiness_orchestrator_design.md`
-196. `docs/operations/runalways_readiness_orchestrator_stage0.md`
-197. `docs/operations/runalways_lane_controller_v0_1.md`
+199. `docs/operations/readiness_routine.md`
+200. `docs/operations/runalways_readiness_orchestrator_design.md`
+201. `docs/operations/runalways_readiness_orchestrator_stage0.md`
+202. `docs/operations/runalways_lane_controller_v0_1.md`
 
 ### Detail layer
-198. `docs/detail/accountability_matrix.md`
-199. `docs/detail/critical_incident_and_loss.md`
-200. `docs/detail/automated_decisioning_and_human_appeal.md`
-201. `docs/detail/youth_safety_and_age_assurance.md`
-202. `docs/detail/off_platform_handoff_and_scam_prevention.md`
-203. `docs/detail/data_deletion_vs_legal_hold.md`
-204. `docs/detail/security_and_autonomy_hardening.md`
-205. `docs/detail/realm_model.md`
-206. `docs/detail/data_scope_model.md`
-207. `docs/detail/mobility_model.md`
-208. `docs/detail/settlement_model.md`
-209. `docs/detail/settlement_backend_trait.md`
-210. `docs/detail/proof_of_infrastructure.md`
-211. `docs/detail/protected_groups_and_translation_safety.md`
+203. `docs/detail/accountability_matrix.md`
+204. `docs/detail/critical_incident_and_loss.md`
+205. `docs/detail/automated_decisioning_and_human_appeal.md`
+206. `docs/detail/youth_safety_and_age_assurance.md`
+207. `docs/detail/off_platform_handoff_and_scam_prevention.md`
+208. `docs/detail/data_deletion_vs_legal_hold.md`
+209. `docs/detail/security_and_autonomy_hardening.md`
+210. `docs/detail/realm_model.md`
+211. `docs/detail/data_scope_model.md`
+212. `docs/detail/mobility_model.md`
+213. `docs/detail/settlement_model.md`
+214. `docs/detail/settlement_backend_trait.md`
+215. `docs/detail/proof_of_infrastructure.md`
+216. `docs/detail/protected_groups_and_translation_safety.md`
 
 ### Whitepaper layer (contextual, not higher than detail/ADR)
-212. `docs/whitepaper/01_executive_summary.md`
-213. `docs/whitepaper/02_realm_model.md`
-214. `docs/whitepaper/03_experience_model.md`
-215. `docs/whitepaper/04_dm_shield.md`
-216. `docs/whitepaper/05_trust_model.md`
-217. `docs/whitepaper/06_promise_protocol.md`
-218. `docs/whitepaper/07_realm_economy.md`
-219. `docs/whitepaper/08_unlock_engine.md`
+217. `docs/whitepaper/01_executive_summary.md`
+218. `docs/whitepaper/02_realm_model.md`
+219. `docs/whitepaper/03_experience_model.md`
+220. `docs/whitepaper/04_dm_shield.md`
+221. `docs/whitepaper/05_trust_model.md`
+222. `docs/whitepaper/06_promise_protocol.md`
+223. `docs/whitepaper/07_realm_economy.md`
+224. `docs/whitepaper/08_unlock_engine.md`
 
 If any of the above are unavailable or materially inconsistent, stop and escalate.
 
@@ -471,23 +481,39 @@ Foundation PR #430 provided the consumed one-use downstream docs-only lock align
 That allowance was consumed by `mt4110/pi-musubi-core` PR #164 and closed out by foundation PR #432.
 Foundation PR #434 provided the consumed one-use downstream test-only hard-exclusion authority for one implementation-repo PR only.
 That allowance was consumed by `mt4110/pi-musubi-core` PR #166 and closed out by foundation PR #436.
-Foundation PR #438 provides the current one-use downstream narrow writer fact persistence handoff authority for this implementation-repo PR only.
+Foundation PR #438 provided the consumed one-use downstream narrow writer fact persistence handoff authority for one implementation-repo PR only.
+That allowance was consumed by `mt4110/pi-musubi-core` PR #167 and closed out by foundation PR #439.
+No remaining work may inherit permission from foundation PR #438 or implementation PR #167.
+Foundation PR #441 selected post-writer-fact-persistence foundation continuation only.
+Foundation PR #443 prepared state transition runtime preflight decision materials only.
+Foundation PR #445 found that preflight packet sufficient for later route selection only.
+Foundation PR #447 provides the current one-use downstream narrow state transition runtime handoff authority for this implementation-repo PR only.
 This implementation-repo PR consumes that allowance.
-The PR #438 allowance authorizes only:
+The PR #447 allowance authorizes only:
 
 - `docs/foundation_lock.md`
-- `apps/backend/migrations/0023_promise_completion_writer_fact_persistence.sql`
-- `apps/backend/src/services/mod.rs`
 - `apps/backend/src/services/promise_completion/mod.rs`
 - `apps/backend/src/services/promise_completion/repository.rs`
 - `apps/backend/src/services/promise_completion/types.rs`
-- `apps/backend/tests/promise_completion_writer_fact_persistence.rs`
+- `apps/backend/tests/promise_completion_state_transition_runtime.rs`
 
-It authorizes only append-only PostgreSQL Promise completion writer fact envelope persistence with durable database-enforced idempotency, identical replay, payload-drift fail-closed behavior, PII / raw-evidence / provider-payload segregation, and database contract tests.
-It authorizes only source routes `mutual_accountable_completion_acknowledgement` and `governed_review_completion`.
-It authorizes only the state classes accepted by the foundation Promise completion state-machine authority, and `completed_reference_eligible = true` only for `completion_accepted`.
-It does not authorize source-route evaluation runtime, API, UI, projection, Social Trust mutation, Relationship Depth mutation, settlement movement, room behavior, contact behavior, outbox, inbox, worker behavior, provider I/O, provider callbacks, state transition runtime behavior, participant display implementation, raw Personal Data in immutable truth, raw evidence in immutable truth, hidden distributed transactions, destructive migration, Social Trust score, weight, rank, public display, recovery ceiling, settlement release, settlement refund, settlement forfeiture, escrow movement, reward movement, room progression, direct-message unlock, discovery priority, recommendation boost, public accusation labels, sensitive-trait visibility changes, paid romantic advantage, payment-based direct-message unlock, or broad `pi-musubi-core` changes.
-After this downstream PR is merged, closed without merge, or replaced by a different accepted foundation decision, foundation must receive a separate closeout ledger at `docs/readiness/promise_completion_narrow_writer_fact_persistence_closeout_ledger.md` before any broader Promise completion route may be considered.
+It authorizes only an internal Promise completion helper for the pre-bounded mutual acknowledgement accepted transition:
+
+```text
+completion_pending_mutual_acknowledgement -> completion_accepted
+```
+
+under:
+
+```text
+mutual_accountable_completion_acknowledgement
+```
+
+It must use the existing `promise_completion.writer_fact_records` table only.
+It authorizes only one append-only `completion_state_transition` writer fact record for the selected transition attempt, with durable database-enforced idempotency, identical replay, payload-drift fail-closed behavior, writer-truth prior posture validation, PII / raw-evidence / provider-payload segregation, and database contract tests.
+It must set `completed_reference_eligible = true` only because the next state is `completion_accepted`.
+It does not authorize migrations, DDL, new tables, mutable current-state tables, `apps/backend/src/services/mod.rs`, `apps/backend/src/lib.rs`, handlers, routers, `AppState`, source-route evaluation runtime, participant acknowledgement collection runtime, governed review runtime workflow, governed review accepted transition runtime, correction or supersession runtime, API, UI, projection, Social Trust source fact persistence, Social Trust mutation, Relationship Depth mutation, settlement movement, room behavior, contact behavior, discovery, recommendation, proof runtime behavior, proof eligibility runtime behavior, outbox, inbox, worker behavior, provider I/O, provider callbacks, raw Personal Data in immutable truth, raw evidence in immutable truth, hidden distributed transactions, destructive migration, Social Trust score, weight, rank, public display, recovery ceiling, settlement release, settlement refund, settlement forfeiture, escrow movement, reward movement, room progression, direct-message unlock, public accusation labels, sensitive-trait visibility changes, paid romantic advantage, payment-based direct-message unlock, or broad `pi-musubi-core` changes.
+After this downstream PR is merged, closed without merge, or replaced by a different accepted foundation decision, foundation must receive a separate closeout ledger at `docs/readiness/promise_completion_narrow_state_transition_runtime_closeout_ledger.md` before any broader Promise completion route may be considered.
 
 The C2 and post-C2 readiness and closeout chain is accepted for docs-only foundation semantic scope:
 
@@ -945,11 +971,11 @@ When updating:
 - Review completed by:
 
 ### Current drift note
-- Updated from foundation SHA: `81e127b0abcb87fb29621bef0bb5e4eb5603588c` -> `800a69c810e48646c583d2cdd657001d011ff759`
-- Reason: Align implementation-repo lock with the accepted Promise completion narrow writer fact persistence route selection after foundation PR #438 (`docs: select Promise completion writer fact persistence route`) and consume its one-use downstream narrow writer fact persistence allowance.
-- New required docs: Promise completion post-test-only-exclusion foundation lock alignment closeout ledger, Promise completion post-lock-alignment test-only hard-exclusion route selection, Promise completion test-only hard-exclusion closeout ledger, and Promise completion narrow writer fact persistence route selection.
+- Updated from foundation SHA: `800a69c810e48646c583d2cdd657001d011ff759` -> `a5a55ee8b86dc20b04890f302bc062301e2e1f6c`
+- Reason: Align implementation-repo lock with the accepted Promise completion narrow state transition runtime route selection after foundation PR #447 (`docs: select Promise completion state transition route`) and consume its one-use downstream mutual acknowledgement accepted transition allowance.
+- New required docs: Promise completion narrow writer fact persistence closeout ledger, Promise completion post-writer-fact-persistence closeout route selection, Promise completion state transition runtime preflight decision packet, Promise completion state transition runtime preflight packet sufficiency decision, and Promise completion post-state-transition-preflight sufficiency route selection.
 - Removed docs: None.
-- Implementation impact: This update consumes the one-use foundation PR #438 allowance and permits only the exact seven-file narrow persistence scope listed above. It authorizes only append-only PostgreSQL Promise completion writer fact envelope persistence with durable database-enforced idempotency, identical replay, payload drift fail-closed behavior, PII / raw-evidence / provider-payload segregation, and database contract tests. Source-route evaluation runtime, API, UI, projection, Social Trust mutation, Relationship Depth mutation, settlement movement, room behavior, contact behavior, outbox, inbox, worker behavior, provider I/O, provider callbacks, state transition runtime behavior, participant display implementation, paid romantic advantage, payment-based direct-message unlock, and broader `pi-musubi-core` changes remain NO-GO.
+- Implementation impact: This update consumes the one-use foundation PR #447 allowance and permits only the exact five-file narrow state transition scope listed above. It authorizes only an internal mutual acknowledgement accepted transition helper that writes one append-only `completion_state_transition` fact to the existing `promise_completion.writer_fact_records` table, with durable database-enforced idempotency, identical replay, payload drift fail-closed behavior, writer-truth prior posture validation, PII / raw-evidence / provider-payload segregation, and database contract tests. Migrations, DDL, new tables, source-route evaluation runtime, participant acknowledgement collection runtime, governed review runtime, correction/supersession runtime, API, UI, projection, Social Trust source fact persistence, Social Trust mutation, Relationship Depth mutation, settlement movement, room behavior, contact behavior, discovery, recommendation, outbox, inbox, worker behavior, provider I/O, provider callbacks, participant display implementation, paid romantic advantage, payment-based direct-message unlock, and broader `pi-musubi-core` changes remain NO-GO.
 - Review completed by: Masaki Takemura
 
 ---


### PR DESCRIPTION
## Scope

Implements the one-use narrow downstream route selected by mt4110/musubi-foundation#447.

This PR records only the first selected Promise completion state transition fact:

- Transition: `completion_pending_mutual_acknowledgement -> completion_accepted`
- Source route: `mutual_accountable_completion_acknowledgement`
- Writer table: existing `promise_completion.writer_fact_records`
- Writer fact family: `completion_state_transition`

The implementation adds an internal `PromiseCompletionWriterFactStore::record_mutual_acknowledgement_accepted_transition` helper. It validates the exact transition envelope, requires an Ordinary Account acknowledgement reference, requires a prior writer fact reference, reads writer truth to confirm the prior posture, and then delegates to the existing `record_writer_fact` path for append-only persistence, database-enforced idempotency, identical replay, and payload-drift fail-closed behavior.

Closes #168.

## Boundaries

Stayed inside the exact file scope selected by #447:

- `docs/foundation_lock.md`
- `apps/backend/src/services/promise_completion/mod.rs`
- `apps/backend/src/services/promise_completion/repository.rs`
- `apps/backend/src/services/promise_completion/types.rs`
- `apps/backend/tests/promise_completion_state_transition_runtime.rs`

This PR does not add migrations, DDL, new tables, mutable current-state tables, handlers, routers, `AppState`, API, UI, projection refresh, Social Trust source fact persistence, Social Trust mutation, Relationship Depth mutation, settlement movement, room/contact/discovery/recommendation behavior, provider I/O, outbox, inbox, worker behavior, governed review runtime, proof runtime, participant display, or broad runtime behavior.

## Validation

- `git diff --check`
- `git diff --check origin/main...HEAD`
- `git diff --name-only origin/main...HEAD`
- `rustfmt --edition 2024 --config skip_children=true --check apps/backend/src/services/promise_completion/mod.rs apps/backend/src/services/promise_completion/repository.rs apps/backend/src/services/promise_completion/types.rs apps/backend/tests/promise_completion_state_transition_runtime.rs`
- `cargo test -p musubi_backend --test promise_completion_state_transition_runtime` - 8 passed
- `cargo test -p musubi_backend --test promise_completion_writer_fact_persistence` - 9 passed
- `cargo test -p musubi_backend --test social_trust_intake_persistence --test c2_bounded_promise_reliability_persistence` - 19 passed
- `make guardrail-sweep`