### PR TITLE
feat: derive Promise completion projection snapshots narrowly

### DIFF
--- a/apps/backend/src/services/promise_completion/mod.rs
+++ b/apps/backend/src/services/promise_completion/mod.rs
@@ -4,6 +4,7 @@ mod types;
 pub use repository::PromiseCompletionWriterFactStore;
 pub use types::{
     PromiseCompletionAuthorityPosture, PromiseCompletionForbiddenSourceRouteClass,
+    PromiseCompletionNonAuthorityProjectionSnapshot,
     PromiseCompletionProjectionNonAuthorityPosture, PromiseCompletionSourceRouteClass,
     PromiseCompletionStateClass, PromiseCompletionWriterFactFamily,
     PromiseCompletionWriterFactPersistenceError, PromiseCompletionWriterFactReplayStatus,

--- a/apps/backend/src/services/promise_completion/repository.rs
+++ b/apps/backend/src/services/promise_completion/repository.rs
@@ -1046,10 +1046,44 @@ async fn load_accepted_completion_non_authority_projection_snapshots(
     let rows = client
         .query(
             "
-            WITH eligible AS (
+            WITH accepted_boundary AS (
                 SELECT
                     accepted.writer_fact_id AS accepted_writer_fact_id,
                     accepted.prior_writer_fact_id AS prior_writer_fact_id,
+                    accepted.promise_reference,
+                    accepted.realm_id,
+                    accepted.fact_family,
+                    accepted.previous_completion_state_class,
+                    accepted.promise_terms_reference,
+                    accepted.participant_set_reference,
+                    accepted.ordinary_participant_acknowledgement_reference,
+                    accepted.source_route_class,
+                    accepted.completion_state_class,
+                    accepted.completed_reference_eligible,
+                    accepted.fact_idempotency_key,
+                    accepted.policy_version,
+                    accepted.governed_review_reference,
+                    accepted.review_authority_reference,
+                    accepted.projection_non_authority_posture,
+                    accepted.authority_posture,
+                    accepted.created_at AS writer_recorded_at,
+                    COUNT(*) OVER (
+                        PARTITION BY
+                            accepted.promise_reference,
+                            accepted.realm_id,
+                            accepted.promise_terms_reference,
+                            accepted.participant_set_reference
+                    ) AS boundary_accepted_count
+                FROM promise_completion.writer_fact_records accepted
+                WHERE accepted.promise_reference = $1
+                  AND accepted.realm_id = $2
+                  AND accepted.fact_family = 'completion_state_transition'
+                  AND accepted.completion_state_class = 'completion_accepted'
+            ),
+            eligible AS (
+                SELECT
+                    accepted.accepted_writer_fact_id,
+                    accepted.prior_writer_fact_id,
                     accepted.promise_reference,
                     accepted.realm_id,
                     accepted.promise_terms_reference,
@@ -1060,25 +1094,16 @@ async fn load_accepted_completion_non_authority_projection_snapshots(
                     accepted.policy_version,
                     accepted.projection_non_authority_posture,
                     accepted.authority_posture,
-                    accepted.created_at AS writer_recorded_at,
-                    COUNT(*) OVER (
-                        PARTITION BY
-                            accepted.promise_reference,
-                            accepted.realm_id,
-                            accepted.promise_terms_reference,
-                            accepted.participant_set_reference
-                    ) AS boundary_snapshot_count
-                FROM promise_completion.writer_fact_records accepted
+                    accepted.writer_recorded_at,
+                    accepted.boundary_accepted_count
+                FROM accepted_boundary accepted
                 JOIN promise_completion.writer_fact_records prior
                   ON prior.writer_fact_id = accepted.prior_writer_fact_id
-                WHERE accepted.promise_reference = $1
-                  AND accepted.realm_id = $2
-                  AND accepted.fact_family = 'completion_state_transition'
+                WHERE accepted.fact_family = 'completion_state_transition'
                   AND accepted.previous_completion_state_class =
                       'completion_pending_mutual_acknowledgement'
                   AND accepted.source_route_class =
                       'mutual_accountable_completion_acknowledgement'
-                  AND accepted.completion_state_class = 'completion_accepted'
                   AND accepted.completed_reference_eligible = TRUE
                   AND accepted.prior_writer_fact_id IS NOT NULL
                   AND accepted.fact_idempotency_key =
@@ -1118,7 +1143,7 @@ async fn load_accepted_completion_non_authority_projection_snapshots(
                 projection_non_authority_posture,
                 authority_posture,
                 writer_recorded_at,
-                boundary_snapshot_count
+                boundary_accepted_count
             FROM eligible
             ORDER BY writer_recorded_at ASC, accepted_writer_fact_id ASC
             ",
@@ -1129,8 +1154,8 @@ async fn load_accepted_completion_non_authority_projection_snapshots(
 
     let mut snapshots = Vec::with_capacity(rows.len());
     for row in rows {
-        let boundary_snapshot_count: i64 = row.get("boundary_snapshot_count");
-        if boundary_snapshot_count > 1 {
+        let boundary_accepted_count: i64 = row.get("boundary_accepted_count");
+        if boundary_accepted_count > 1 {
             return Err(PromiseCompletionWriterFactPersistenceError::BadRequest(
                 "Promise completion non-authority projection refuses contradictory accepted writer truth"
                     .to_owned(),

--- a/apps/backend/src/services/promise_completion/repository.rs
+++ b/apps/backend/src/services/promise_completion/repository.rs
@@ -1066,34 +1066,16 @@ async fn load_accepted_completion_non_authority_projection_snapshots(
                     writer_truth.review_authority_reference,
                     writer_truth.projection_non_authority_posture,
                     writer_truth.authority_posture,
-                    writer_truth.created_at AS writer_recorded_at,
-                    COUNT(*) OVER (
-                        PARTITION BY
-                            writer_truth.promise_reference,
-                            writer_truth.realm_id,
-                            writer_truth.promise_terms_reference,
-                            writer_truth.participant_set_reference,
-                            writer_truth.policy_version
-                    ) AS boundary_writer_truth_count
+                    writer_truth.created_at AS writer_recorded_at
                 FROM promise_completion.writer_fact_records writer_truth
                 WHERE writer_truth.promise_reference = $1
                   AND writer_truth.realm_id = $2
-                  AND (
-                      writer_truth.fact_family IN (
+                  AND writer_truth.fact_family IN (
                           'completion_state_transition',
                           'completion_outcome_reference',
-                          'correction_or_supersession'
+                          'correction_or_supersession',
+                          'source_route_candidate'
                       )
-                      OR (
-                          writer_truth.fact_family = 'source_route_candidate'
-                          AND (
-                              writer_truth.source_route_class =
-                                  'governed_review_completion'
-                              OR writer_truth.governed_review_reference IS NOT NULL
-                              OR writer_truth.review_authority_reference IS NOT NULL
-                          )
-                      )
-                  )
             ),
             eligible AS (
                 SELECT
@@ -1110,7 +1092,24 @@ async fn load_accepted_completion_non_authority_projection_snapshots(
                     accepted.projection_non_authority_posture,
                     accepted.authority_posture,
                     accepted.writer_recorded_at,
-                    accepted.boundary_writer_truth_count
+                    (
+                        SELECT COUNT(*)
+                        FROM writer_truth_boundary boundary_truth
+                        WHERE boundary_truth.promise_reference =
+                              accepted.promise_reference
+                          AND boundary_truth.realm_id = accepted.realm_id
+                          AND boundary_truth.promise_terms_reference =
+                              accepted.promise_terms_reference
+                          AND boundary_truth.participant_set_reference =
+                              accepted.participant_set_reference
+                          AND boundary_truth.policy_version =
+                              accepted.policy_version
+                          AND (
+                              boundary_truth.fact_family <> 'source_route_candidate'
+                              OR boundary_truth.boundary_writer_fact_id <>
+                                  prior.writer_fact_id
+                          )
+                    ) AS boundary_writer_truth_count
                 FROM writer_truth_boundary accepted
                 JOIN promise_completion.writer_fact_records prior
                   ON prior.writer_fact_id = accepted.prior_writer_fact_id

--- a/apps/backend/src/services/promise_completion/repository.rs
+++ b/apps/backend/src/services/promise_completion/repository.rs
@@ -1064,6 +1064,8 @@ async fn load_accepted_completion_non_authority_projection_snapshots(
                     writer_truth.policy_version,
                     writer_truth.governed_review_reference,
                     writer_truth.review_authority_reference,
+                    writer_truth.proof_eligibility_reference,
+                    writer_truth.proof_evidence_writer_fact_reference,
                     writer_truth.projection_non_authority_posture,
                     writer_truth.authority_posture,
                     writer_truth.created_at AS writer_recorded_at
@@ -1129,6 +1131,8 @@ async fn load_accepted_completion_non_authority_projection_snapshots(
                   AND accepted.authority_posture = 'writer_truth_only'
                   AND accepted.governed_review_reference IS NULL
                   AND accepted.review_authority_reference IS NULL
+                  AND accepted.proof_eligibility_reference IS NULL
+                  AND accepted.proof_evidence_writer_fact_reference IS NULL
                   AND prior.promise_reference = accepted.promise_reference
                   AND prior.realm_id = accepted.realm_id
                   AND prior.promise_terms_reference = accepted.promise_terms_reference
@@ -1143,6 +1147,8 @@ async fn load_accepted_completion_non_authority_projection_snapshots(
                       'completion_pending_mutual_acknowledgement'
                   AND prior.governed_review_reference IS NULL
                   AND prior.review_authority_reference IS NULL
+                  AND prior.proof_eligibility_reference IS NULL
+                  AND prior.proof_evidence_writer_fact_reference IS NULL
             )
             SELECT
                 accepted_writer_fact_id,

--- a/apps/backend/src/services/promise_completion/repository.rs
+++ b/apps/backend/src/services/promise_completion/repository.rs
@@ -1118,6 +1118,8 @@ async fn load_accepted_completion_non_authority_projection_snapshots(
                               )
                               OR boundary_truth.prior_writer_fact_id =
                                   accepted.boundary_writer_fact_id
+                              OR boundary_truth.prior_writer_fact_id =
+                                  prior.writer_fact_id
                           )
                           AND (
                               boundary_truth.fact_family <> 'source_route_candidate'

--- a/apps/backend/src/services/promise_completion/repository.rs
+++ b/apps/backend/src/services/promise_completion/repository.rs
@@ -7,12 +7,12 @@ use tokio_postgres::{Client, GenericClient, Row, error::SqlState};
 use uuid::Uuid;
 
 use super::types::{
-    PromiseCompletionAuthorityPosture, PromiseCompletionProjectionNonAuthorityPosture,
-    PromiseCompletionSourceRouteClass, PromiseCompletionStateClass,
-    PromiseCompletionWriterFactFamily, PromiseCompletionWriterFactPersistenceError,
-    PromiseCompletionWriterFactReplayStatus, PromiseCompletionWriterFactSnapshot,
-    ProposedPromiseCompletionWriterFact, RecordMutualAcknowledgementAcceptedTransitionInput,
-    RecordPromiseCompletionWriterFactInput,
+    PromiseCompletionAuthorityPosture, PromiseCompletionNonAuthorityProjectionSnapshot,
+    PromiseCompletionProjectionNonAuthorityPosture, PromiseCompletionSourceRouteClass,
+    PromiseCompletionStateClass, PromiseCompletionWriterFactFamily,
+    PromiseCompletionWriterFactPersistenceError, PromiseCompletionWriterFactReplayStatus,
+    PromiseCompletionWriterFactSnapshot, ProposedPromiseCompletionWriterFact,
+    RecordMutualAcknowledgementAcceptedTransitionInput, RecordPromiseCompletionWriterFactInput,
 };
 
 const DECISION_KIND: &str = "accepted_for_writer_fact_persistence";
@@ -228,6 +228,25 @@ impl PromiseCompletionWriterFactStore {
         }
         self.record_writer_fact(RecordPromiseCompletionWriterFactInput { fact })
             .await
+    }
+
+    pub async fn derive_accepted_completion_non_authority_projection_snapshots(
+        &self,
+        promise_reference: &str,
+        realm_id: &str,
+    ) -> Result<
+        Vec<PromiseCompletionNonAuthorityProjectionSnapshot>,
+        PromiseCompletionWriterFactPersistenceError,
+    > {
+        let promise_reference = required_ref(Some(promise_reference), "Promise reference")?;
+        let realm_id = required_ref(Some(realm_id), "realm_id")?;
+        let client = self.client.lock().await;
+        load_accepted_completion_non_authority_projection_snapshots(
+            &*client,
+            &promise_reference,
+            &realm_id,
+        )
+        .await
     }
 }
 
@@ -1001,6 +1020,124 @@ async fn load_snapshot_by_writer_fact_id(
         replay_status,
         created_at: row.get("created_at"),
     })
+}
+
+async fn load_accepted_completion_non_authority_projection_snapshots(
+    client: &impl GenericClient,
+    promise_reference: &str,
+    realm_id: &str,
+) -> Result<
+    Vec<PromiseCompletionNonAuthorityProjectionSnapshot>,
+    PromiseCompletionWriterFactPersistenceError,
+> {
+    let rows = client
+        .query(
+            "
+            WITH eligible AS (
+                SELECT
+                    accepted.writer_fact_id AS accepted_writer_fact_id,
+                    accepted.prior_writer_fact_id AS prior_writer_fact_id,
+                    accepted.promise_reference,
+                    accepted.realm_id,
+                    accepted.promise_terms_reference,
+                    accepted.participant_set_reference,
+                    accepted.source_route_class,
+                    accepted.completion_state_class,
+                    accepted.completed_reference_eligible,
+                    accepted.policy_version,
+                    accepted.projection_non_authority_posture,
+                    accepted.authority_posture,
+                    accepted.created_at AS writer_recorded_at,
+                    COUNT(*) OVER (
+                        PARTITION BY
+                            accepted.promise_reference,
+                            accepted.realm_id,
+                            accepted.promise_terms_reference,
+                            accepted.participant_set_reference
+                    ) AS boundary_snapshot_count
+                FROM promise_completion.writer_fact_records accepted
+                JOIN promise_completion.writer_fact_records prior
+                  ON prior.writer_fact_id = accepted.prior_writer_fact_id
+                WHERE accepted.promise_reference = $1
+                  AND accepted.realm_id = $2
+                  AND accepted.fact_family = 'completion_state_transition'
+                  AND accepted.previous_completion_state_class =
+                      'completion_pending_mutual_acknowledgement'
+                  AND accepted.source_route_class =
+                      'mutual_accountable_completion_acknowledgement'
+                  AND accepted.completion_state_class = 'completion_accepted'
+                  AND accepted.completed_reference_eligible = TRUE
+                  AND accepted.prior_writer_fact_id IS NOT NULL
+                  AND accepted.fact_idempotency_key =
+                      'completion-accepted-from-prior-' ||
+                      accepted.prior_writer_fact_id::text
+                  AND accepted.projection_non_authority_posture =
+                      'projection_non_authoritative'
+                  AND accepted.authority_posture = 'writer_truth_only'
+                  AND prior.promise_reference = accepted.promise_reference
+                  AND prior.realm_id = accepted.realm_id
+                  AND prior.promise_terms_reference = accepted.promise_terms_reference
+                  AND prior.participant_set_reference = accepted.participant_set_reference
+                  AND prior.ordinary_participant_acknowledgement_reference =
+                      accepted.ordinary_participant_acknowledgement_reference
+                  AND prior.policy_version = accepted.policy_version
+                  AND prior.fact_family = 'source_route_candidate'
+                  AND prior.source_route_class =
+                      'mutual_accountable_completion_acknowledgement'
+                  AND prior.completion_state_class =
+                      'completion_pending_mutual_acknowledgement'
+            )
+            SELECT
+                accepted_writer_fact_id,
+                prior_writer_fact_id,
+                promise_reference,
+                realm_id,
+                promise_terms_reference,
+                participant_set_reference,
+                source_route_class,
+                completion_state_class,
+                completed_reference_eligible,
+                policy_version,
+                projection_non_authority_posture,
+                authority_posture,
+                writer_recorded_at,
+                boundary_snapshot_count
+            FROM eligible
+            ORDER BY writer_recorded_at ASC, accepted_writer_fact_id ASC
+            ",
+            &[&promise_reference, &realm_id],
+        )
+        .await
+        .map_err(db_error)?;
+
+    let mut snapshots = Vec::with_capacity(rows.len());
+    for row in rows {
+        let boundary_snapshot_count: i64 = row.get("boundary_snapshot_count");
+        if boundary_snapshot_count > 1 {
+            return Err(PromiseCompletionWriterFactPersistenceError::BadRequest(
+                "Promise completion non-authority projection refuses contradictory accepted writer truth"
+                    .to_owned(),
+            ));
+        }
+
+        snapshots.push(PromiseCompletionNonAuthorityProjectionSnapshot {
+            accepted_writer_fact_id: row.get::<_, Uuid>("accepted_writer_fact_id").to_string(),
+            prior_writer_fact_id: row.get::<_, Uuid>("prior_writer_fact_id").to_string(),
+            promise_reference: row.get("promise_reference"),
+            realm_id: row.get("realm_id"),
+            promise_terms_reference: row.get("promise_terms_reference"),
+            participant_set_reference: row.get("participant_set_reference"),
+            source_route_class: row.get("source_route_class"),
+            completion_state_class: row.get("completion_state_class"),
+            completed_reference_eligible: row.get("completed_reference_eligible"),
+            policy_version: row.get("policy_version"),
+            projection_non_authority_posture: row.get("projection_non_authority_posture"),
+            authority_posture: row.get("authority_posture"),
+            writer_recorded_at: row.get("writer_recorded_at"),
+        });
+    }
+
+    Ok(snapshots)
 }
 
 fn replay_writer_fact_id(

--- a/apps/backend/src/services/promise_completion/repository.rs
+++ b/apps/backend/src/services/promise_completion/repository.rs
@@ -1072,7 +1072,8 @@ async fn load_accepted_completion_non_authority_projection_snapshots(
                             accepted.promise_reference,
                             accepted.realm_id,
                             accepted.promise_terms_reference,
-                            accepted.participant_set_reference
+                            accepted.participant_set_reference,
+                            accepted.policy_version
                     ) AS boundary_accepted_count
                 FROM promise_completion.writer_fact_records accepted
                 WHERE accepted.promise_reference = $1

--- a/apps/backend/src/services/promise_completion/repository.rs
+++ b/apps/backend/src/services/promise_completion/repository.rs
@@ -1066,6 +1066,7 @@ async fn load_accepted_completion_non_authority_projection_snapshots(
                     writer_truth.review_authority_reference,
                     writer_truth.proof_eligibility_reference,
                     writer_truth.proof_evidence_writer_fact_reference,
+                    writer_truth.correction_or_supersession_reference,
                     writer_truth.projection_non_authority_posture,
                     writer_truth.authority_posture,
                     writer_truth.created_at AS writer_recorded_at
@@ -1133,6 +1134,7 @@ async fn load_accepted_completion_non_authority_projection_snapshots(
                   AND accepted.review_authority_reference IS NULL
                   AND accepted.proof_eligibility_reference IS NULL
                   AND accepted.proof_evidence_writer_fact_reference IS NULL
+                  AND accepted.correction_or_supersession_reference IS NULL
                   AND prior.promise_reference = accepted.promise_reference
                   AND prior.realm_id = accepted.realm_id
                   AND prior.promise_terms_reference = accepted.promise_terms_reference
@@ -1149,6 +1151,7 @@ async fn load_accepted_completion_non_authority_projection_snapshots(
                   AND prior.review_authority_reference IS NULL
                   AND prior.proof_eligibility_reference IS NULL
                   AND prior.proof_evidence_writer_fact_reference IS NULL
+                  AND prior.correction_or_supersession_reference IS NULL
             )
             SELECT
                 accepted_writer_fact_id,

--- a/apps/backend/src/services/promise_completion/repository.rs
+++ b/apps/backend/src/services/promise_completion/repository.rs
@@ -1078,10 +1078,21 @@ async fn load_accepted_completion_non_authority_projection_snapshots(
                 FROM promise_completion.writer_fact_records writer_truth
                 WHERE writer_truth.promise_reference = $1
                   AND writer_truth.realm_id = $2
-                  AND writer_truth.fact_family IN (
-                      'completion_state_transition',
-                      'completion_outcome_reference',
-                      'correction_or_supersession'
+                  AND (
+                      writer_truth.fact_family IN (
+                          'completion_state_transition',
+                          'completion_outcome_reference',
+                          'correction_or_supersession'
+                      )
+                      OR (
+                          writer_truth.fact_family = 'source_route_candidate'
+                          AND (
+                              writer_truth.source_route_class =
+                                  'governed_review_completion'
+                              OR writer_truth.governed_review_reference IS NOT NULL
+                              OR writer_truth.review_authority_reference IS NOT NULL
+                          )
+                      )
                   )
             ),
             eligible AS (

--- a/apps/backend/src/services/promise_completion/repository.rs
+++ b/apps/backend/src/services/promise_completion/repository.rs
@@ -1046,43 +1046,46 @@ async fn load_accepted_completion_non_authority_projection_snapshots(
     let rows = client
         .query(
             "
-            WITH transition_boundary AS (
+            WITH writer_truth_boundary AS (
                 SELECT
-                    transition.writer_fact_id AS transition_writer_fact_id,
-                    transition.prior_writer_fact_id AS prior_writer_fact_id,
-                    transition.promise_reference,
-                    transition.realm_id,
-                    transition.fact_family,
-                    transition.previous_completion_state_class,
-                    transition.promise_terms_reference,
-                    transition.participant_set_reference,
-                    transition.ordinary_participant_acknowledgement_reference,
-                    transition.source_route_class,
-                    transition.completion_state_class,
-                    transition.completed_reference_eligible,
-                    transition.fact_idempotency_key,
-                    transition.policy_version,
-                    transition.governed_review_reference,
-                    transition.review_authority_reference,
-                    transition.projection_non_authority_posture,
-                    transition.authority_posture,
-                    transition.created_at AS writer_recorded_at,
+                    writer_truth.writer_fact_id AS boundary_writer_fact_id,
+                    writer_truth.prior_writer_fact_id AS prior_writer_fact_id,
+                    writer_truth.promise_reference,
+                    writer_truth.realm_id,
+                    writer_truth.fact_family,
+                    writer_truth.previous_completion_state_class,
+                    writer_truth.promise_terms_reference,
+                    writer_truth.participant_set_reference,
+                    writer_truth.ordinary_participant_acknowledgement_reference,
+                    writer_truth.source_route_class,
+                    writer_truth.completion_state_class,
+                    writer_truth.completed_reference_eligible,
+                    writer_truth.fact_idempotency_key,
+                    writer_truth.policy_version,
+                    writer_truth.governed_review_reference,
+                    writer_truth.review_authority_reference,
+                    writer_truth.projection_non_authority_posture,
+                    writer_truth.authority_posture,
+                    writer_truth.created_at AS writer_recorded_at,
                     COUNT(*) OVER (
                         PARTITION BY
-                            transition.promise_reference,
-                            transition.realm_id,
-                            transition.promise_terms_reference,
-                            transition.participant_set_reference,
-                            transition.policy_version
-                    ) AS boundary_transition_count
-                FROM promise_completion.writer_fact_records transition
-                WHERE transition.promise_reference = $1
-                  AND transition.realm_id = $2
-                  AND transition.fact_family = 'completion_state_transition'
+                            writer_truth.promise_reference,
+                            writer_truth.realm_id,
+                            writer_truth.promise_terms_reference,
+                            writer_truth.participant_set_reference,
+                            writer_truth.policy_version
+                    ) AS boundary_writer_truth_count
+                FROM promise_completion.writer_fact_records writer_truth
+                WHERE writer_truth.promise_reference = $1
+                  AND writer_truth.realm_id = $2
+                  AND writer_truth.fact_family IN (
+                      'completion_state_transition',
+                      'correction_or_supersession'
+                  )
             ),
             eligible AS (
                 SELECT
-                    accepted.transition_writer_fact_id AS accepted_writer_fact_id,
+                    accepted.boundary_writer_fact_id AS accepted_writer_fact_id,
                     accepted.prior_writer_fact_id,
                     accepted.promise_reference,
                     accepted.realm_id,
@@ -1095,8 +1098,8 @@ async fn load_accepted_completion_non_authority_projection_snapshots(
                     accepted.projection_non_authority_posture,
                     accepted.authority_posture,
                     accepted.writer_recorded_at,
-                    accepted.boundary_transition_count
-                FROM transition_boundary accepted
+                    accepted.boundary_writer_truth_count
+                FROM writer_truth_boundary accepted
                 JOIN promise_completion.writer_fact_records prior
                   ON prior.writer_fact_id = accepted.prior_writer_fact_id
                 WHERE accepted.fact_family = 'completion_state_transition'
@@ -1144,7 +1147,7 @@ async fn load_accepted_completion_non_authority_projection_snapshots(
                 projection_non_authority_posture,
                 authority_posture,
                 writer_recorded_at,
-                boundary_transition_count
+                boundary_writer_truth_count
             FROM eligible
             ORDER BY writer_recorded_at ASC, accepted_writer_fact_id ASC
             ",
@@ -1155,10 +1158,10 @@ async fn load_accepted_completion_non_authority_projection_snapshots(
 
     let mut snapshots = Vec::with_capacity(rows.len());
     for row in rows {
-        let boundary_transition_count: i64 = row.get("boundary_transition_count");
-        if boundary_transition_count > 1 {
+        let boundary_writer_truth_count: i64 = row.get("boundary_writer_truth_count");
+        if boundary_writer_truth_count > 1 {
             return Err(PromiseCompletionWriterFactPersistenceError::BadRequest(
-                "Promise completion non-authority projection refuses contradictory transition writer truth"
+                "Promise completion non-authority projection refuses contradictory writer truth"
                     .to_owned(),
             ));
         }

--- a/apps/backend/src/services/promise_completion/repository.rs
+++ b/apps/backend/src/services/promise_completion/repository.rs
@@ -1080,6 +1080,7 @@ async fn load_accepted_completion_non_authority_projection_snapshots(
                   AND writer_truth.realm_id = $2
                   AND writer_truth.fact_family IN (
                       'completion_state_transition',
+                      'completion_outcome_reference',
                       'correction_or_supersession'
                   )
             ),

--- a/apps/backend/src/services/promise_completion/repository.rs
+++ b/apps/backend/src/services/promise_completion/repository.rs
@@ -1046,44 +1046,43 @@ async fn load_accepted_completion_non_authority_projection_snapshots(
     let rows = client
         .query(
             "
-            WITH accepted_boundary AS (
+            WITH transition_boundary AS (
                 SELECT
-                    accepted.writer_fact_id AS accepted_writer_fact_id,
-                    accepted.prior_writer_fact_id AS prior_writer_fact_id,
-                    accepted.promise_reference,
-                    accepted.realm_id,
-                    accepted.fact_family,
-                    accepted.previous_completion_state_class,
-                    accepted.promise_terms_reference,
-                    accepted.participant_set_reference,
-                    accepted.ordinary_participant_acknowledgement_reference,
-                    accepted.source_route_class,
-                    accepted.completion_state_class,
-                    accepted.completed_reference_eligible,
-                    accepted.fact_idempotency_key,
-                    accepted.policy_version,
-                    accepted.governed_review_reference,
-                    accepted.review_authority_reference,
-                    accepted.projection_non_authority_posture,
-                    accepted.authority_posture,
-                    accepted.created_at AS writer_recorded_at,
+                    transition.writer_fact_id AS transition_writer_fact_id,
+                    transition.prior_writer_fact_id AS prior_writer_fact_id,
+                    transition.promise_reference,
+                    transition.realm_id,
+                    transition.fact_family,
+                    transition.previous_completion_state_class,
+                    transition.promise_terms_reference,
+                    transition.participant_set_reference,
+                    transition.ordinary_participant_acknowledgement_reference,
+                    transition.source_route_class,
+                    transition.completion_state_class,
+                    transition.completed_reference_eligible,
+                    transition.fact_idempotency_key,
+                    transition.policy_version,
+                    transition.governed_review_reference,
+                    transition.review_authority_reference,
+                    transition.projection_non_authority_posture,
+                    transition.authority_posture,
+                    transition.created_at AS writer_recorded_at,
                     COUNT(*) OVER (
                         PARTITION BY
-                            accepted.promise_reference,
-                            accepted.realm_id,
-                            accepted.promise_terms_reference,
-                            accepted.participant_set_reference,
-                            accepted.policy_version
-                    ) AS boundary_accepted_count
-                FROM promise_completion.writer_fact_records accepted
-                WHERE accepted.promise_reference = $1
-                  AND accepted.realm_id = $2
-                  AND accepted.fact_family = 'completion_state_transition'
-                  AND accepted.completion_state_class = 'completion_accepted'
+                            transition.promise_reference,
+                            transition.realm_id,
+                            transition.promise_terms_reference,
+                            transition.participant_set_reference,
+                            transition.policy_version
+                    ) AS boundary_transition_count
+                FROM promise_completion.writer_fact_records transition
+                WHERE transition.promise_reference = $1
+                  AND transition.realm_id = $2
+                  AND transition.fact_family = 'completion_state_transition'
             ),
             eligible AS (
                 SELECT
-                    accepted.accepted_writer_fact_id,
+                    accepted.transition_writer_fact_id AS accepted_writer_fact_id,
                     accepted.prior_writer_fact_id,
                     accepted.promise_reference,
                     accepted.realm_id,
@@ -1096,8 +1095,8 @@ async fn load_accepted_completion_non_authority_projection_snapshots(
                     accepted.projection_non_authority_posture,
                     accepted.authority_posture,
                     accepted.writer_recorded_at,
-                    accepted.boundary_accepted_count
-                FROM accepted_boundary accepted
+                    accepted.boundary_transition_count
+                FROM transition_boundary accepted
                 JOIN promise_completion.writer_fact_records prior
                   ON prior.writer_fact_id = accepted.prior_writer_fact_id
                 WHERE accepted.fact_family = 'completion_state_transition'
@@ -1105,6 +1104,7 @@ async fn load_accepted_completion_non_authority_projection_snapshots(
                       'completion_pending_mutual_acknowledgement'
                   AND accepted.source_route_class =
                       'mutual_accountable_completion_acknowledgement'
+                  AND accepted.completion_state_class = 'completion_accepted'
                   AND accepted.completed_reference_eligible = TRUE
                   AND accepted.prior_writer_fact_id IS NOT NULL
                   AND accepted.fact_idempotency_key =
@@ -1144,7 +1144,7 @@ async fn load_accepted_completion_non_authority_projection_snapshots(
                 projection_non_authority_posture,
                 authority_posture,
                 writer_recorded_at,
-                boundary_accepted_count
+                boundary_transition_count
             FROM eligible
             ORDER BY writer_recorded_at ASC, accepted_writer_fact_id ASC
             ",
@@ -1155,10 +1155,10 @@ async fn load_accepted_completion_non_authority_projection_snapshots(
 
     let mut snapshots = Vec::with_capacity(rows.len());
     for row in rows {
-        let boundary_accepted_count: i64 = row.get("boundary_accepted_count");
-        if boundary_accepted_count > 1 {
+        let boundary_transition_count: i64 = row.get("boundary_transition_count");
+        if boundary_transition_count > 1 {
             return Err(PromiseCompletionWriterFactPersistenceError::BadRequest(
-                "Promise completion non-authority projection refuses contradictory accepted writer truth"
+                "Promise completion non-authority projection refuses contradictory transition writer truth"
                     .to_owned(),
             ));
         }

--- a/apps/backend/src/services/promise_completion/repository.rs
+++ b/apps/backend/src/services/promise_completion/repository.rs
@@ -1097,19 +1097,31 @@ async fn load_accepted_completion_non_authority_projection_snapshots(
                     accepted.writer_recorded_at,
                     (
                         SELECT COUNT(*)
-                        FROM writer_truth_boundary boundary_truth
-                        WHERE boundary_truth.promise_reference =
-                              accepted.promise_reference
-                          AND boundary_truth.realm_id = accepted.realm_id
-                          AND boundary_truth.promise_terms_reference =
-                              accepted.promise_terms_reference
-                          AND boundary_truth.participant_set_reference =
-                              accepted.participant_set_reference
-                          AND boundary_truth.policy_version =
-                              accepted.policy_version
+                        FROM promise_completion.writer_fact_records boundary_truth
+                        WHERE boundary_truth.fact_family IN (
+                                  'completion_state_transition',
+                                  'completion_outcome_reference',
+                                  'correction_or_supersession',
+                                  'source_route_candidate'
+                              )
+                          AND (
+                              (
+                                  boundary_truth.promise_reference =
+                                      accepted.promise_reference
+                                  AND boundary_truth.realm_id = accepted.realm_id
+                                  AND boundary_truth.promise_terms_reference =
+                                      accepted.promise_terms_reference
+                                  AND boundary_truth.participant_set_reference =
+                                      accepted.participant_set_reference
+                                  AND boundary_truth.policy_version =
+                                      accepted.policy_version
+                              )
+                              OR boundary_truth.prior_writer_fact_id =
+                                  accepted.boundary_writer_fact_id
+                          )
                           AND (
                               boundary_truth.fact_family <> 'source_route_candidate'
-                              OR boundary_truth.boundary_writer_fact_id <>
+                              OR boundary_truth.writer_fact_id <>
                                   prior.writer_fact_id
                           )
                     ) AS boundary_writer_truth_count

--- a/apps/backend/src/services/promise_completion/repository.rs
+++ b/apps/backend/src/services/promise_completion/repository.rs
@@ -238,8 +238,8 @@ impl PromiseCompletionWriterFactStore {
         Vec<PromiseCompletionNonAuthorityProjectionSnapshot>,
         PromiseCompletionWriterFactPersistenceError,
     > {
-        let promise_reference = required_ref(Some(promise_reference), "Promise reference")?;
-        let realm_id = required_ref(Some(realm_id), "realm_id")?;
+        let promise_reference = required_projection_ref(promise_reference, "Promise reference")?;
+        let realm_id = required_projection_ref(realm_id, "realm_id")?;
         let client = self.client.lock().await;
         load_accepted_completion_non_authority_projection_snapshots(
             &*client,
@@ -906,6 +906,19 @@ fn required_ref(
         })
 }
 
+fn required_projection_ref(
+    value: &str,
+    label: &'static str,
+) -> Result<String, PromiseCompletionWriterFactPersistenceError> {
+    let value = value.trim();
+    if value.is_empty() {
+        return Err(PromiseCompletionWriterFactPersistenceError::BadRequest(
+            format!("Promise completion non-authority projection read requires {label}"),
+        ));
+    }
+    Ok(value.to_owned())
+}
+
 fn optional_ref(
     value: Option<&str>,
     label: &'static str,
@@ -1074,6 +1087,8 @@ async fn load_accepted_completion_non_authority_projection_snapshots(
                   AND accepted.projection_non_authority_posture =
                       'projection_non_authoritative'
                   AND accepted.authority_posture = 'writer_truth_only'
+                  AND accepted.governed_review_reference IS NULL
+                  AND accepted.review_authority_reference IS NULL
                   AND prior.promise_reference = accepted.promise_reference
                   AND prior.realm_id = accepted.realm_id
                   AND prior.promise_terms_reference = accepted.promise_terms_reference
@@ -1086,6 +1101,8 @@ async fn load_accepted_completion_non_authority_projection_snapshots(
                       'mutual_accountable_completion_acknowledgement'
                   AND prior.completion_state_class =
                       'completion_pending_mutual_acknowledgement'
+                  AND prior.governed_review_reference IS NULL
+                  AND prior.review_authority_reference IS NULL
             )
             SELECT
                 accepted_writer_fact_id,

--- a/apps/backend/src/services/promise_completion/types.rs
+++ b/apps/backend/src/services/promise_completion/types.rs
@@ -241,3 +241,20 @@ pub struct PromiseCompletionWriterFactSnapshot {
     pub replay_status: PromiseCompletionWriterFactReplayStatus,
     pub created_at: DateTime<Utc>,
 }
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PromiseCompletionNonAuthorityProjectionSnapshot {
+    pub accepted_writer_fact_id: String,
+    pub prior_writer_fact_id: String,
+    pub promise_reference: String,
+    pub realm_id: String,
+    pub promise_terms_reference: String,
+    pub participant_set_reference: String,
+    pub source_route_class: String,
+    pub completion_state_class: String,
+    pub completed_reference_eligible: bool,
+    pub policy_version: i32,
+    pub projection_non_authority_posture: String,
+    pub authority_posture: String,
+    pub writer_recorded_at: DateTime<Utc>,
+}

--- a/apps/backend/tests/promise_completion_projection_non_authority.rs
+++ b/apps/backend/tests/promise_completion_projection_non_authority.rs
@@ -407,6 +407,50 @@ async fn non_accepted_transition_truth_coexisting_with_valid_acceptance_fails_cl
 }
 
 #[tokio::test]
+async fn correction_or_supersession_truth_coexisting_with_valid_acceptance_fails_closed() {
+    let (_test_state, config, _client) = test_context().await;
+    let store = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let idempotency_key = unique_idempotency_key("projection-correction-coexists");
+    let prior = record_prior_pending_mutual_acknowledgement(&store, &idempotency_key).await;
+
+    let accepted = store
+        .record_mutual_acknowledgement_accepted_transition(transition_input(
+            accepted_transition_fact(&idempotency_key, &prior.writer_fact_id),
+        ))
+        .await
+        .expect("valid accepted transition should persist");
+
+    let mut correction = accepted_transition_fact(&idempotency_key, &accepted.writer_fact_id);
+    correction.fact_family = PromiseCompletionWriterFactFamily::CorrectionOrSupersession;
+    correction.previous_completion_state_class =
+        Some(PromiseCompletionStateClass::CompletionAccepted);
+    correction.completion_state_class =
+        PromiseCompletionStateClass::CompletionCorrectedOrSuperseded;
+    correction.completed_reference_eligible = false;
+    correction.fact_idempotency_key = Some(format!("correction-or-supersession-{idempotency_key}"));
+    correction.reason_code_class = Some(format!("correction-or-supersession-{idempotency_key}"));
+    correction.correction_or_supersession_reference = Some(format!(
+        "correction-or-supersession-reference-{idempotency_key}"
+    ));
+    record_writer_fact(&store, correction).await;
+
+    let error = store
+        .derive_accepted_completion_non_authority_projection_snapshots(
+            &prior.promise_reference,
+            &prior.realm_id,
+        )
+        .await
+        .expect_err("coexisting correction or supersession writer truth must fail closed");
+
+    assert!(matches!(
+        error,
+        PromiseCompletionWriterFactPersistenceError::BadRequest(_)
+    ));
+}
+
+#[tokio::test]
 async fn distinct_policy_versions_for_same_boundary_do_not_conflict() {
     let (_test_state, config, _client) = test_context().await;
     let store = PromiseCompletionWriterFactStore::connect(&config)

--- a/apps/backend/tests/promise_completion_projection_non_authority.rs
+++ b/apps/backend/tests/promise_completion_projection_non_authority.rs
@@ -1,0 +1,563 @@
+use std::path::PathBuf;
+
+use musubi_backend::{
+    new_test_state,
+    services::promise_completion::{
+        PromiseCompletionAuthorityPosture, PromiseCompletionForbiddenSourceRouteClass,
+        PromiseCompletionProjectionNonAuthorityPosture, PromiseCompletionSourceRouteClass,
+        PromiseCompletionStateClass, PromiseCompletionWriterFactFamily,
+        PromiseCompletionWriterFactPersistenceError, PromiseCompletionWriterFactStore,
+        ProposedMutualAcknowledgementAcceptedTransition, ProposedPromiseCompletionWriterFact,
+        RecordMutualAcknowledgementAcceptedTransitionInput, RecordPromiseCompletionWriterFactInput,
+    },
+};
+use musubi_db_runtime::DbConfig;
+use tokio_postgres::NoTls;
+
+fn lookup(database_url: &str, migrations_dir: &str, name: &'static str) -> Option<String> {
+    match name {
+        "APP_ENV" => Some("test".to_owned()),
+        "DATABASE_URL" => Some(database_url.to_owned()),
+        "MIGRATIONS_DIR" => Some(migrations_dir.to_owned()),
+        "REQUIRE_LATEST_SCHEMA" => Some("true".to_owned()),
+        _ => None,
+    }
+}
+
+#[tokio::test]
+async fn accepted_writer_truth_derives_non_authoritative_projection_snapshot() {
+    let (_test_state, config, _client) = test_context().await;
+    let store = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let idempotency_key = unique_idempotency_key("projection-positive");
+    let prior = record_prior_pending_mutual_acknowledgement(&store, &idempotency_key).await;
+    let accepted = store
+        .record_mutual_acknowledgement_accepted_transition(transition_input(
+            accepted_transition_fact(&idempotency_key, &prior.writer_fact_id),
+        ))
+        .await
+        .expect("accepted transition should persist");
+
+    let snapshots = store
+        .derive_accepted_completion_non_authority_projection_snapshots(
+            &accepted.promise_reference,
+            &accepted.realm_id,
+        )
+        .await
+        .expect("projection snapshot should derive from accepted writer truth");
+
+    assert_eq!(snapshots.len(), 1);
+    let snapshot = &snapshots[0];
+    assert_eq!(snapshot.accepted_writer_fact_id, accepted.writer_fact_id);
+    assert_eq!(snapshot.prior_writer_fact_id, prior.writer_fact_id);
+    assert_eq!(snapshot.promise_reference, accepted.promise_reference);
+    assert_eq!(snapshot.realm_id, accepted.realm_id);
+    assert_eq!(
+        snapshot.promise_terms_reference,
+        format!("promise-terms-{idempotency_key}")
+    );
+    assert_eq!(
+        snapshot.participant_set_reference,
+        format!("participant-set-{idempotency_key}")
+    );
+    assert_eq!(
+        snapshot.source_route_class,
+        "mutual_accountable_completion_acknowledgement"
+    );
+    assert_eq!(snapshot.completion_state_class, "completion_accepted");
+    assert!(snapshot.completed_reference_eligible);
+    assert_eq!(snapshot.policy_version, 1);
+    assert_eq!(
+        snapshot.projection_non_authority_posture,
+        "projection_non_authoritative"
+    );
+    assert_eq!(snapshot.authority_posture, "writer_truth_only");
+    assert_eq!(snapshot.writer_recorded_at, accepted.created_at);
+}
+
+#[tokio::test]
+async fn missing_required_writer_posture_returns_no_projection_snapshot() {
+    let (_test_state, config, _client) = test_context().await;
+    let store = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("store should connect");
+
+    let pending_key = unique_idempotency_key("projection-pending-only");
+    let pending_prior = record_prior_pending_mutual_acknowledgement(&store, &pending_key).await;
+    assert!(
+        store
+            .derive_accepted_completion_non_authority_projection_snapshots(
+                &pending_prior.promise_reference,
+                &pending_prior.realm_id,
+            )
+            .await
+            .expect("pending-only posture should be readable")
+            .is_empty()
+    );
+
+    let ineligible_key = unique_idempotency_key("projection-ineligible");
+    let ineligible_prior =
+        record_prior_pending_mutual_acknowledgement(&store, &ineligible_key).await;
+    let mut ineligible =
+        accepted_transition_fact(&ineligible_key, &ineligible_prior.writer_fact_id);
+    ineligible.completed_reference_eligible = false;
+    let ineligible = record_writer_fact(&store, ineligible).await;
+    assert!(
+        store
+            .derive_accepted_completion_non_authority_projection_snapshots(
+                &ineligible.promise_reference,
+                &ineligible.realm_id,
+            )
+            .await
+            .expect("ineligible accepted posture should be readable")
+            .is_empty()
+    );
+
+    let missing_prior_key = unique_idempotency_key("projection-missing-prior");
+    let mut missing_prior =
+        accepted_transition_fact(&missing_prior_key, &uuid::Uuid::new_v4().to_string());
+    missing_prior.prior_writer_fact_id = None;
+    missing_prior.fact_idempotency_key = Some(format!("missing-prior-{missing_prior_key}"));
+    let missing_prior = record_writer_fact(&store, missing_prior).await;
+    assert!(
+        store
+            .derive_accepted_completion_non_authority_projection_snapshots(
+                &missing_prior.promise_reference,
+                &missing_prior.realm_id,
+            )
+            .await
+            .expect("missing-prior accepted posture should be readable")
+            .is_empty()
+    );
+
+    let wrong_prior_key = unique_idempotency_key("projection-wrong-prior");
+    let wrong_prior = record_prior_with_completion_state(
+        &store,
+        &wrong_prior_key,
+        PromiseCompletionStateClass::CompletionRejected,
+    )
+    .await;
+    let wrong_prior_accepted = record_writer_fact(
+        &store,
+        accepted_transition_fact(&wrong_prior_key, &wrong_prior.writer_fact_id),
+    )
+    .await;
+    assert!(
+        store
+            .derive_accepted_completion_non_authority_projection_snapshots(
+                &wrong_prior_accepted.promise_reference,
+                &wrong_prior_accepted.realm_id,
+            )
+            .await
+            .expect("wrong-prior accepted posture should be readable")
+            .is_empty()
+    );
+
+    let unbound_key = unique_idempotency_key("projection-unbound-accepted");
+    let unbound_prior = record_prior_pending_mutual_acknowledgement(&store, &unbound_key).await;
+    let mut unbound = accepted_transition_fact(&unbound_key, &unbound_prior.writer_fact_id);
+    unbound.fact_idempotency_key = Some(format!("unbound-accepted-{unbound_key}"));
+    let unbound = record_writer_fact(&store, unbound).await;
+    assert!(
+        store
+            .derive_accepted_completion_non_authority_projection_snapshots(
+                &unbound.promise_reference,
+                &unbound.realm_id,
+            )
+            .await
+            .expect("unbound accepted posture should be readable")
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn governed_review_and_forbidden_routes_do_not_enter_first_projection_route() {
+    let (_test_state, config, _client) = test_context().await;
+    let store = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("store should connect");
+
+    let governed_key = unique_idempotency_key("projection-governed");
+    let governed_prior = record_prior_pending_mutual_acknowledgement(&store, &governed_key).await;
+    let mut governed = accepted_transition_fact(&governed_key, &governed_prior.writer_fact_id);
+    governed.source_route_class = PromiseCompletionSourceRouteClass::GovernedReviewCompletion;
+    governed.governed_review_reference = Some(format!("governed-review-{governed_key}"));
+    governed.review_authority_reference = Some(format!("review-authority-{governed_key}"));
+    let governed = record_writer_fact(&store, governed).await;
+    assert!(
+        store
+            .derive_accepted_completion_non_authority_projection_snapshots(
+                &governed.promise_reference,
+                &governed.realm_id,
+            )
+            .await
+            .expect("governed route writer fact should be readable")
+            .is_empty()
+    );
+
+    let forbidden_key = unique_idempotency_key("projection-forbidden");
+    let forbidden_prior = record_prior_pending_mutual_acknowledgement(&store, &forbidden_key).await;
+    let mut forbidden = accepted_transition_fact(&forbidden_key, &forbidden_prior.writer_fact_id);
+    forbidden.source_route_class = PromiseCompletionSourceRouteClass::Forbidden(
+        PromiseCompletionForbiddenSourceRouteClass::ProjectionOnlyCompletion,
+    );
+    let promise_reference = forbidden
+        .promise_reference
+        .clone()
+        .expect("promise reference");
+    let realm_id = forbidden.realm_id.clone().expect("realm_id");
+
+    let error = store
+        .record_writer_fact(RecordPromiseCompletionWriterFactInput { fact: forbidden })
+        .await
+        .expect_err("forbidden source route should fail before persistence");
+    assert!(matches!(
+        error,
+        PromiseCompletionWriterFactPersistenceError::BadRequest(_)
+    ));
+    assert!(
+        store
+            .derive_accepted_completion_non_authority_projection_snapshots(
+                &promise_reference,
+                &realm_id,
+            )
+            .await
+            .expect("forbidden route absence should be readable")
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn contradictory_writer_truth_for_same_boundary_fails_closed() {
+    let (_test_state, config, client) = test_context().await;
+    let store = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let idempotency_key = unique_idempotency_key("projection-contradiction");
+    let first_prior = record_prior_pending_mutual_acknowledgement(&store, &idempotency_key).await;
+    let mut second_prior = prior_mutual_acknowledgement_fact(
+        &idempotency_key,
+        PromiseCompletionStateClass::CompletionPendingMutualAcknowledgement,
+    );
+    second_prior.fact_idempotency_key = Some(format!("prior-second-{idempotency_key}"));
+    second_prior.reason_code_class = Some(format!(
+        "completion-pending-mutual-ack-second-{idempotency_key}"
+    ));
+    let second_prior = record_writer_fact(&store, second_prior).await;
+
+    record_writer_fact(
+        &store,
+        accepted_transition_fact(&idempotency_key, &first_prior.writer_fact_id),
+    )
+    .await;
+    record_writer_fact(
+        &store,
+        accepted_transition_fact(&idempotency_key, &second_prior.writer_fact_id),
+    )
+    .await;
+
+    let error = store
+        .derive_accepted_completion_non_authority_projection_snapshots(
+            &first_prior.promise_reference,
+            &first_prior.realm_id,
+        )
+        .await
+        .expect_err("contradictory accepted writer truth must fail closed");
+
+    assert!(matches!(
+        error,
+        PromiseCompletionWriterFactPersistenceError::BadRequest(_)
+    ));
+    assert_eq!(
+        writer_fact_count_for_promise(&client, &first_prior.promise_reference).await,
+        4
+    );
+}
+
+#[tokio::test]
+async fn duplicate_projection_reads_are_deterministic_and_side_effect_free() {
+    let (_test_state, config, client) = test_context().await;
+    let store = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let idempotency_key = unique_idempotency_key("projection-repeat-read");
+    let prior = record_prior_pending_mutual_acknowledgement(&store, &idempotency_key).await;
+    let accepted = store
+        .record_mutual_acknowledgement_accepted_transition(transition_input(
+            accepted_transition_fact(&idempotency_key, &prior.writer_fact_id),
+        ))
+        .await
+        .expect("accepted transition should persist");
+    let writer_fact_count_before =
+        writer_fact_count_for_promise(&client, &accepted.promise_reference).await;
+    let side_effects_before = side_effect_counts(&client).await;
+
+    let first = store
+        .derive_accepted_completion_non_authority_projection_snapshots(
+            &accepted.promise_reference,
+            &accepted.realm_id,
+        )
+        .await
+        .expect("first projection read should derive");
+    let second = store
+        .derive_accepted_completion_non_authority_projection_snapshots(
+            &accepted.promise_reference,
+            &accepted.realm_id,
+        )
+        .await
+        .expect("second projection read should derive");
+
+    assert_eq!(first, second);
+    assert_eq!(
+        writer_fact_count_for_promise(&client, &accepted.promise_reference).await,
+        writer_fact_count_before
+    );
+    assert_eq!(side_effect_counts(&client).await, side_effects_before);
+}
+
+async fn test_context() -> (musubi_backend::TestState, DbConfig, tokio_postgres::Client) {
+    let test_state = new_test_state()
+        .await
+        .expect("test database state should initialize");
+    let database_url = std::env::var("MUSUBI_TEST_DATABASE_URL")
+        .or_else(|_| std::env::var("DATABASE_URL"))
+        .expect("integration tests require MUSUBI_TEST_DATABASE_URL or DATABASE_URL to be set");
+    let migrations_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("migrations")
+        .canonicalize()
+        .expect("migrations directory should resolve");
+    let migrations_dir = migrations_dir
+        .to_str()
+        .expect("migrations directory should be utf-8")
+        .to_owned();
+    let config = DbConfig::from_lookup(|name| lookup(&database_url, &migrations_dir, name))
+        .expect("test db config should parse");
+
+    let (client, connection) = tokio_postgres::connect(&database_url, NoTls)
+        .await
+        .expect("failed to connect to test database");
+    tokio::spawn(async move {
+        if let Err(error) = connection.await {
+            eprintln!("test database connection error: {error}");
+        }
+    });
+
+    (test_state, config, client)
+}
+
+fn unique_idempotency_key(label: &str) -> String {
+    format!("{label}-{}", uuid::Uuid::new_v4())
+}
+
+async fn record_writer_fact(
+    store: &PromiseCompletionWriterFactStore,
+    fact: ProposedPromiseCompletionWriterFact,
+) -> musubi_backend::services::promise_completion::PromiseCompletionWriterFactSnapshot {
+    store
+        .record_writer_fact(RecordPromiseCompletionWriterFactInput { fact })
+        .await
+        .expect("writer fact should persist")
+}
+
+async fn record_prior_pending_mutual_acknowledgement(
+    store: &PromiseCompletionWriterFactStore,
+    idempotency_key: &str,
+) -> musubi_backend::services::promise_completion::PromiseCompletionWriterFactSnapshot {
+    record_prior_with_completion_state(
+        store,
+        idempotency_key,
+        PromiseCompletionStateClass::CompletionPendingMutualAcknowledgement,
+    )
+    .await
+}
+
+async fn record_prior_with_completion_state(
+    store: &PromiseCompletionWriterFactStore,
+    idempotency_key: &str,
+    completion_state: PromiseCompletionStateClass,
+) -> musubi_backend::services::promise_completion::PromiseCompletionWriterFactSnapshot {
+    record_writer_fact(
+        store,
+        prior_mutual_acknowledgement_fact(idempotency_key, completion_state),
+    )
+    .await
+}
+
+fn prior_mutual_acknowledgement_fact(
+    idempotency_key: &str,
+    completion_state: PromiseCompletionStateClass,
+) -> ProposedPromiseCompletionWriterFact {
+    let mut fact = base_fact(idempotency_key);
+    fact.fact_family = PromiseCompletionWriterFactFamily::SourceRouteCandidate;
+    fact.previous_completion_state_class = None;
+    fact.completion_state_class = completion_state;
+    fact.completed_reference_eligible = false;
+    fact.fact_idempotency_key = Some(format!("prior-{idempotency_key}"));
+    fact.reason_code_class = Some(format!("completion-pending-mutual-ack-{idempotency_key}"));
+    fact
+}
+
+fn accepted_transition_fact(
+    idempotency_key: &str,
+    prior_writer_fact_id: &str,
+) -> ProposedPromiseCompletionWriterFact {
+    let mut fact = base_fact(idempotency_key);
+    fact.fact_family = PromiseCompletionWriterFactFamily::CompletionStateTransition;
+    fact.previous_completion_state_class =
+        Some(PromiseCompletionStateClass::CompletionPendingMutualAcknowledgement);
+    fact.completion_state_class = PromiseCompletionStateClass::CompletionAccepted;
+    fact.completed_reference_eligible = true;
+    fact.prior_writer_fact_id = Some(prior_writer_fact_id.to_owned());
+    fact.fact_idempotency_key = Some(format!(
+        "completion-accepted-from-prior-{prior_writer_fact_id}"
+    ));
+    fact.reason_code_class = Some(format!("completion-accepted-{idempotency_key}"));
+    fact
+}
+
+fn base_fact(idempotency_key: &str) -> ProposedPromiseCompletionWriterFact {
+    ProposedPromiseCompletionWriterFact {
+        promise_reference: Some(format!("promise-completion-{idempotency_key}")),
+        realm_id: Some(format!("realm-completion-{idempotency_key}")),
+        fact_family: PromiseCompletionWriterFactFamily::CompletionStateTransition,
+        source_route_class:
+            PromiseCompletionSourceRouteClass::MutualAccountableCompletionAcknowledgement,
+        previous_completion_state_class: Some(
+            PromiseCompletionStateClass::CompletionPendingMutualAcknowledgement,
+        ),
+        completion_state_class: PromiseCompletionStateClass::CompletionAccepted,
+        completed_reference_eligible: true,
+        promise_terms_reference: Some(format!("promise-terms-{idempotency_key}")),
+        participant_set_reference: Some(format!("participant-set-{idempotency_key}")),
+        ordinary_participant_acknowledgement_reference: Some(format!(
+            "ordinary-acknowledgement-{idempotency_key}"
+        )),
+        governed_review_reference: None,
+        review_authority_reference: None,
+        proof_eligibility_reference: None,
+        proof_evidence_writer_fact_reference: None,
+        consent_at_formation_reference: Some(format!("consent-formation-{idempotency_key}")),
+        consent_at_resolution_reference: Some(format!("consent-resolution-{idempotency_key}")),
+        block_withdrawal_state_reference: Some(format!("block-withdrawal-clear-{idempotency_key}")),
+        age_assurance_state_reference: Some(format!(
+            "age-assurance-adult-eligible-{idempotency_key}"
+        )),
+        legal_hold_intersection_reference: Some(format!("legal-hold-clear-{idempotency_key}")),
+        critical_harm_case_reference: Some(format!("critical-harm-clear-{idempotency_key}")),
+        account_lifecycle_reference: Some(format!("account-lifecycle-active-{idempotency_key}")),
+        anti_abuse_continuity_reference: Some(format!("anti-abuse-clear-{idempotency_key}")),
+        safety_case_reference: Some(format!("safety-case-clear-{idempotency_key}")),
+        reason_code_class: Some(format!("completion-accepted-{idempotency_key}")),
+        evidence_level_reference: Some(format!("evidence-level-bounded-{idempotency_key}")),
+        correction_or_supersession_reference: None,
+        prior_writer_fact_id: None,
+        policy_version: Some(1),
+        fact_idempotency_key: Some(format!("accepted-transition-{idempotency_key}")),
+        retention_class_reference: Some("R4 Trust / moderation / case".to_owned()),
+        access_audit_reference: Some(format!("access-audit-{idempotency_key}")),
+        projection_non_authority_posture: Some(
+            PromiseCompletionProjectionNonAuthorityPosture::ProjectionNonAuthoritative,
+        ),
+        authority_posture: Some(PromiseCompletionAuthorityPosture::WriterTruthOnly),
+    }
+}
+
+fn transition_input(
+    fact: ProposedPromiseCompletionWriterFact,
+) -> RecordMutualAcknowledgementAcceptedTransitionInput {
+    RecordMutualAcknowledgementAcceptedTransitionInput {
+        transition: ProposedMutualAcknowledgementAcceptedTransition { fact },
+    }
+}
+
+async fn writer_fact_count_for_promise(
+    client: &tokio_postgres::Client,
+    promise_reference: &str,
+) -> i64 {
+    let row = client
+        .query_one(
+            "
+            SELECT COUNT(*)::bigint AS count
+            FROM promise_completion.writer_fact_records
+            WHERE promise_reference = $1
+            ",
+            &[&promise_reference],
+        )
+        .await
+        .expect("writer fact count should load");
+    row.get("count")
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct SideEffectCounts {
+    projection_promise_views: i64,
+    projection_settlement_views: i64,
+    projection_trust_snapshots: i64,
+    projection_realm_trust_snapshots: i64,
+    projection_room_progression_views: i64,
+    social_trust_intake_attempts: i64,
+    social_trust_categorical_sources: i64,
+    social_trust_categorical_mutations: i64,
+    room_progression_tracks: i64,
+    room_progression_facts: i64,
+    settlement_cases: i64,
+    settlement_intents: i64,
+    settlement_submissions: i64,
+    settlement_observations: i64,
+    provider_attempts: i64,
+    outbox_events: i64,
+    outbox_attempts: i64,
+    command_inbox: i64,
+}
+
+async fn side_effect_counts(client: &tokio_postgres::Client) -> SideEffectCounts {
+    let row = client
+        .query_one(
+            "
+            SELECT
+                (SELECT COUNT(*)::bigint FROM projection.promise_views) AS projection_promise_views,
+                (SELECT COUNT(*)::bigint FROM projection.settlement_views) AS projection_settlement_views,
+                (SELECT COUNT(*)::bigint FROM projection.trust_snapshots) AS projection_trust_snapshots,
+                (SELECT COUNT(*)::bigint FROM projection.realm_trust_snapshots) AS projection_realm_trust_snapshots,
+                (SELECT COUNT(*)::bigint FROM projection.room_progression_views) AS projection_room_progression_views,
+                (SELECT COUNT(*)::bigint FROM social_trust.proposed_mutation_attempts) AS social_trust_intake_attempts,
+                (SELECT COUNT(*)::bigint FROM social_trust.categorical_source_references) AS social_trust_categorical_sources,
+                (SELECT COUNT(*)::bigint FROM social_trust.categorical_mutation_facts) AS social_trust_categorical_mutations,
+                (SELECT COUNT(*)::bigint FROM dao.room_progression_tracks) AS room_progression_tracks,
+                (SELECT COUNT(*)::bigint FROM dao.room_progression_facts) AS room_progression_facts,
+                (SELECT COUNT(*)::bigint FROM dao.settlement_cases) AS settlement_cases,
+                (SELECT COUNT(*)::bigint FROM dao.settlement_intents) AS settlement_intents,
+                (SELECT COUNT(*)::bigint FROM dao.settlement_submissions) AS settlement_submissions,
+                (SELECT COUNT(*)::bigint FROM dao.settlement_observations) AS settlement_observations,
+                (SELECT COUNT(*)::bigint FROM dao.provider_attempts) AS provider_attempts,
+                (SELECT COUNT(*)::bigint FROM outbox.events) AS outbox_events,
+                (SELECT COUNT(*)::bigint FROM outbox.outbox_attempts) AS outbox_attempts,
+                (SELECT COUNT(*)::bigint FROM outbox.command_inbox) AS command_inbox
+            ",
+            &[],
+        )
+        .await
+        .expect("side-effect counts should load");
+
+    SideEffectCounts {
+        projection_promise_views: row.get("projection_promise_views"),
+        projection_settlement_views: row.get("projection_settlement_views"),
+        projection_trust_snapshots: row.get("projection_trust_snapshots"),
+        projection_realm_trust_snapshots: row.get("projection_realm_trust_snapshots"),
+        projection_room_progression_views: row.get("projection_room_progression_views"),
+        social_trust_intake_attempts: row.get("social_trust_intake_attempts"),
+        social_trust_categorical_sources: row.get("social_trust_categorical_sources"),
+        social_trust_categorical_mutations: row.get("social_trust_categorical_mutations"),
+        room_progression_tracks: row.get("room_progression_tracks"),
+        room_progression_facts: row.get("room_progression_facts"),
+        settlement_cases: row.get("settlement_cases"),
+        settlement_intents: row.get("settlement_intents"),
+        settlement_submissions: row.get("settlement_submissions"),
+        settlement_observations: row.get("settlement_observations"),
+        provider_attempts: row.get("provider_attempts"),
+        outbox_events: row.get("outbox_events"),
+        outbox_attempts: row.get("outbox_attempts"),
+        command_inbox: row.get("command_inbox"),
+    }
+}

--- a/apps/backend/tests/promise_completion_projection_non_authority.rs
+++ b/apps/backend/tests/promise_completion_projection_non_authority.rs
@@ -451,6 +451,45 @@ async fn correction_or_supersession_truth_coexisting_with_valid_acceptance_fails
 }
 
 #[tokio::test]
+async fn outcome_reference_truth_coexisting_with_valid_acceptance_fails_closed() {
+    let (_test_state, config, _client) = test_context().await;
+    let store = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let idempotency_key = unique_idempotency_key("projection-outcome-coexists");
+    let prior = record_prior_pending_mutual_acknowledgement(&store, &idempotency_key).await;
+
+    let accepted = store
+        .record_mutual_acknowledgement_accepted_transition(transition_input(
+            accepted_transition_fact(&idempotency_key, &prior.writer_fact_id),
+        ))
+        .await
+        .expect("valid accepted transition should persist");
+
+    let mut outcome = accepted_transition_fact(&idempotency_key, &accepted.writer_fact_id);
+    outcome.fact_family = PromiseCompletionWriterFactFamily::CompletionOutcomeReference;
+    outcome.previous_completion_state_class = Some(PromiseCompletionStateClass::CompletionAccepted);
+    outcome.completion_state_class = PromiseCompletionStateClass::CompletionRejected;
+    outcome.completed_reference_eligible = false;
+    outcome.fact_idempotency_key = Some(format!("outcome-reference-{idempotency_key}"));
+    outcome.reason_code_class = Some(format!("outcome-reference-{idempotency_key}"));
+    record_writer_fact(&store, outcome).await;
+
+    let error = store
+        .derive_accepted_completion_non_authority_projection_snapshots(
+            &prior.promise_reference,
+            &prior.realm_id,
+        )
+        .await
+        .expect_err("coexisting outcome reference writer truth must fail closed");
+
+    assert!(matches!(
+        error,
+        PromiseCompletionWriterFactPersistenceError::BadRequest(_)
+    ));
+}
+
+#[tokio::test]
 async fn distinct_policy_versions_for_same_boundary_do_not_conflict() {
     let (_test_state, config, _client) = test_context().await;
     let store = PromiseCompletionWriterFactStore::connect(&config)

--- a/apps/backend/tests/promise_completion_projection_non_authority.rs
+++ b/apps/backend/tests/promise_completion_projection_non_authority.rs
@@ -701,6 +701,58 @@ async fn prior_linked_correction_truth_with_boundary_drift_fails_closed() {
 }
 
 #[tokio::test]
+async fn source_prior_linked_correction_truth_with_boundary_drift_fails_closed() {
+    let (_test_state, config, _client) = test_context().await;
+    let store = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let idempotency_key = unique_idempotency_key("projection-source-prior-correction-drift");
+    let prior = record_prior_pending_mutual_acknowledgement(&store, &idempotency_key).await;
+
+    store
+        .record_mutual_acknowledgement_accepted_transition(transition_input(
+            accepted_transition_fact(&idempotency_key, &prior.writer_fact_id),
+        ))
+        .await
+        .expect("valid accepted transition should persist");
+
+    let mut correction = accepted_transition_fact(&idempotency_key, &prior.writer_fact_id);
+    correction.fact_family = PromiseCompletionWriterFactFamily::CorrectionOrSupersession;
+    correction.completion_state_class =
+        PromiseCompletionStateClass::CompletionCorrectedOrSuperseded;
+    correction.completed_reference_eligible = false;
+    correction.promise_terms_reference = Some(format!("drifted-promise-terms-{idempotency_key}"));
+    correction.participant_set_reference =
+        Some(format!("drifted-participant-set-{idempotency_key}"));
+    correction.policy_version = Some(2);
+    correction.fact_idempotency_key = Some(format!(
+        "source-prior-linked-correction-drift-{idempotency_key}"
+    ));
+    correction.reason_code_class = Some(format!(
+        "source-prior-linked-correction-drift-{idempotency_key}"
+    ));
+    correction.correction_or_supersession_reference = Some(format!(
+        "source-prior-linked-correction-reference-{idempotency_key}"
+    ));
+    record_writer_fact(&store, correction).await;
+
+    let error = store
+        .derive_accepted_completion_non_authority_projection_snapshots(
+            &prior.promise_reference,
+            &prior.realm_id,
+        )
+        .await
+        .expect_err(
+            "source-prior-linked correction writer truth with boundary drift must fail closed",
+        );
+
+    assert!(matches!(
+        error,
+        PromiseCompletionWriterFactPersistenceError::BadRequest(_)
+    ));
+}
+
+#[tokio::test]
 async fn outcome_reference_truth_coexisting_with_valid_acceptance_fails_closed() {
     let (_test_state, config, _client) = test_context().await;
     let store = PromiseCompletionWriterFactStore::connect(&config)

--- a/apps/backend/tests/promise_completion_projection_non_authority.rs
+++ b/apps/backend/tests/promise_completion_projection_non_authority.rs
@@ -278,6 +278,63 @@ async fn governed_review_and_forbidden_routes_do_not_enter_first_projection_rout
 }
 
 #[tokio::test]
+async fn proof_backed_mutual_rows_do_not_enter_first_projection_route() {
+    let (_test_state, config, _client) = test_context().await;
+    let store = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("store should connect");
+
+    let accepted_with_proof_key = unique_idempotency_key("projection-accepted-proof-fields");
+    let accepted_with_proof_prior =
+        record_prior_pending_mutual_acknowledgement(&store, &accepted_with_proof_key).await;
+    let mut accepted_with_proof = accepted_transition_fact(
+        &accepted_with_proof_key,
+        &accepted_with_proof_prior.writer_fact_id,
+    );
+    accepted_with_proof.proof_eligibility_reference =
+        Some(format!("proof-eligibility-{accepted_with_proof_key}"));
+    accepted_with_proof.proof_evidence_writer_fact_reference =
+        Some(format!("proof-evidence-{accepted_with_proof_key}"));
+    let accepted_with_proof = record_writer_fact(&store, accepted_with_proof).await;
+    assert!(
+        store
+            .derive_accepted_completion_non_authority_projection_snapshots(
+                &accepted_with_proof.promise_reference,
+                &accepted_with_proof.realm_id,
+            )
+            .await
+            .expect("mutual route with accepted proof fields should be readable")
+            .is_empty()
+    );
+
+    let prior_with_proof_key = unique_idempotency_key("projection-prior-proof-fields");
+    let mut prior_with_proof = prior_mutual_acknowledgement_fact(
+        &prior_with_proof_key,
+        PromiseCompletionStateClass::CompletionPendingMutualAcknowledgement,
+    );
+    prior_with_proof.proof_eligibility_reference =
+        Some(format!("proof-eligibility-{prior_with_proof_key}"));
+    prior_with_proof.proof_evidence_writer_fact_reference =
+        Some(format!("proof-evidence-{prior_with_proof_key}"));
+    let prior_with_proof = record_writer_fact(&store, prior_with_proof).await;
+    let accepted_after_proof_prior = record_writer_fact(
+        &store,
+        accepted_transition_fact(&prior_with_proof_key, &prior_with_proof.writer_fact_id),
+    )
+    .await;
+    assert!(
+        store
+            .derive_accepted_completion_non_authority_projection_snapshots(
+                &accepted_after_proof_prior.promise_reference,
+                &accepted_after_proof_prior.realm_id,
+            )
+            .await
+            .expect("mutual route with prior proof fields should be readable")
+            .is_empty()
+    );
+}
+
+#[tokio::test]
 async fn governed_source_candidate_coexisting_with_valid_acceptance_fails_closed() {
     let (_test_state, config, _client) = test_context().await;
     let store = PromiseCompletionWriterFactStore::connect(&config)

--- a/apps/backend/tests/promise_completion_projection_non_authority.rs
+++ b/apps/backend/tests/promise_completion_projection_non_authority.rs
@@ -278,6 +278,52 @@ async fn governed_review_and_forbidden_routes_do_not_enter_first_projection_rout
 }
 
 #[tokio::test]
+async fn governed_source_candidate_coexisting_with_valid_acceptance_fails_closed() {
+    let (_test_state, config, _client) = test_context().await;
+    let store = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let idempotency_key = unique_idempotency_key("projection-governed-candidate-coexists");
+    let prior = record_prior_pending_mutual_acknowledgement(&store, &idempotency_key).await;
+
+    store
+        .record_mutual_acknowledgement_accepted_transition(transition_input(
+            accepted_transition_fact(&idempotency_key, &prior.writer_fact_id),
+        ))
+        .await
+        .expect("valid accepted transition should persist");
+
+    let mut governed_candidate = prior_mutual_acknowledgement_fact(
+        &idempotency_key,
+        PromiseCompletionStateClass::CompletionUnderGovernedReview,
+    );
+    governed_candidate.source_route_class =
+        PromiseCompletionSourceRouteClass::GovernedReviewCompletion;
+    governed_candidate.governed_review_reference =
+        Some(format!("governed-review-{idempotency_key}"));
+    governed_candidate.review_authority_reference =
+        Some(format!("review-authority-{idempotency_key}"));
+    governed_candidate.fact_idempotency_key =
+        Some(format!("governed-source-candidate-{idempotency_key}"));
+    governed_candidate.reason_code_class =
+        Some(format!("governed-source-candidate-{idempotency_key}"));
+    record_writer_fact(&store, governed_candidate).await;
+
+    let error = store
+        .derive_accepted_completion_non_authority_projection_snapshots(
+            &prior.promise_reference,
+            &prior.realm_id,
+        )
+        .await
+        .expect_err("coexisting governed source candidate writer truth must fail closed");
+
+    assert!(matches!(
+        error,
+        PromiseCompletionWriterFactPersistenceError::BadRequest(_)
+    ));
+}
+
+#[tokio::test]
 async fn contradictory_writer_truth_for_same_boundary_fails_closed() {
     let (_test_state, config, client) = test_context().await;
     let store = PromiseCompletionWriterFactStore::connect(&config)

--- a/apps/backend/tests/promise_completion_projection_non_authority.rs
+++ b/apps/backend/tests/promise_completion_projection_non_authority.rs
@@ -196,6 +196,55 @@ async fn governed_review_and_forbidden_routes_do_not_enter_first_projection_rout
             .is_empty()
     );
 
+    let accepted_with_review_key = unique_idempotency_key("projection-accepted-review-fields");
+    let accepted_with_review_prior =
+        record_prior_pending_mutual_acknowledgement(&store, &accepted_with_review_key).await;
+    let mut accepted_with_review = accepted_transition_fact(
+        &accepted_with_review_key,
+        &accepted_with_review_prior.writer_fact_id,
+    );
+    accepted_with_review.governed_review_reference =
+        Some(format!("governed-review-{accepted_with_review_key}"));
+    accepted_with_review.review_authority_reference =
+        Some(format!("review-authority-{accepted_with_review_key}"));
+    let accepted_with_review = record_writer_fact(&store, accepted_with_review).await;
+    assert!(
+        store
+            .derive_accepted_completion_non_authority_projection_snapshots(
+                &accepted_with_review.promise_reference,
+                &accepted_with_review.realm_id,
+            )
+            .await
+            .expect("mutual route with accepted governed review fields should be readable")
+            .is_empty()
+    );
+
+    let prior_with_review_key = unique_idempotency_key("projection-prior-review-fields");
+    let mut prior_with_review = prior_mutual_acknowledgement_fact(
+        &prior_with_review_key,
+        PromiseCompletionStateClass::CompletionPendingMutualAcknowledgement,
+    );
+    prior_with_review.governed_review_reference =
+        Some(format!("governed-review-{prior_with_review_key}"));
+    prior_with_review.review_authority_reference =
+        Some(format!("review-authority-{prior_with_review_key}"));
+    let prior_with_review = record_writer_fact(&store, prior_with_review).await;
+    let accepted_after_review_prior = record_writer_fact(
+        &store,
+        accepted_transition_fact(&prior_with_review_key, &prior_with_review.writer_fact_id),
+    )
+    .await;
+    assert!(
+        store
+            .derive_accepted_completion_non_authority_projection_snapshots(
+                &accepted_after_review_prior.promise_reference,
+                &accepted_after_review_prior.realm_id,
+            )
+            .await
+            .expect("mutual route with prior governed review fields should be readable")
+            .is_empty()
+    );
+
     let forbidden_key = unique_idempotency_key("projection-forbidden");
     let forbidden_prior = record_prior_pending_mutual_acknowledgement(&store, &forbidden_key).await;
     let mut forbidden = accepted_transition_fact(&forbidden_key, &forbidden_prior.writer_fact_id);

--- a/apps/backend/tests/promise_completion_projection_non_authority.rs
+++ b/apps/backend/tests/promise_completion_projection_non_authority.rs
@@ -335,6 +335,64 @@ async fn proof_backed_mutual_rows_do_not_enter_first_projection_route() {
 }
 
 #[tokio::test]
+async fn correction_backed_mutual_rows_do_not_enter_first_projection_route() {
+    let (_test_state, config, _client) = test_context().await;
+    let store = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("store should connect");
+
+    let accepted_with_correction_key =
+        unique_idempotency_key("projection-accepted-correction-fields");
+    let accepted_with_correction_prior =
+        record_prior_pending_mutual_acknowledgement(&store, &accepted_with_correction_key).await;
+    let mut accepted_with_correction = accepted_transition_fact(
+        &accepted_with_correction_key,
+        &accepted_with_correction_prior.writer_fact_id,
+    );
+    accepted_with_correction.correction_or_supersession_reference = Some(format!(
+        "correction-reference-{accepted_with_correction_key}"
+    ));
+    let accepted_with_correction = record_writer_fact(&store, accepted_with_correction).await;
+    assert!(
+        store
+            .derive_accepted_completion_non_authority_projection_snapshots(
+                &accepted_with_correction.promise_reference,
+                &accepted_with_correction.realm_id,
+            )
+            .await
+            .expect("mutual route with accepted correction reference should be readable")
+            .is_empty()
+    );
+
+    let prior_with_correction_key = unique_idempotency_key("projection-prior-correction-fields");
+    let mut prior_with_correction = prior_mutual_acknowledgement_fact(
+        &prior_with_correction_key,
+        PromiseCompletionStateClass::CompletionPendingMutualAcknowledgement,
+    );
+    prior_with_correction.correction_or_supersession_reference =
+        Some(format!("correction-reference-{prior_with_correction_key}"));
+    let prior_with_correction = record_writer_fact(&store, prior_with_correction).await;
+    let accepted_after_correction_prior = record_writer_fact(
+        &store,
+        accepted_transition_fact(
+            &prior_with_correction_key,
+            &prior_with_correction.writer_fact_id,
+        ),
+    )
+    .await;
+    assert!(
+        store
+            .derive_accepted_completion_non_authority_projection_snapshots(
+                &accepted_after_correction_prior.promise_reference,
+                &accepted_after_correction_prior.realm_id,
+            )
+            .await
+            .expect("mutual route with prior correction reference should be readable")
+            .is_empty()
+    );
+}
+
+#[tokio::test]
 async fn governed_source_candidate_coexisting_with_valid_acceptance_fails_closed() {
     let (_test_state, config, _client) = test_context().await;
     let store = PromiseCompletionWriterFactStore::connect(&config)

--- a/apps/backend/tests/promise_completion_projection_non_authority.rs
+++ b/apps/backend/tests/promise_completion_projection_non_authority.rs
@@ -324,6 +324,46 @@ async fn governed_source_candidate_coexisting_with_valid_acceptance_fails_closed
 }
 
 #[tokio::test]
+async fn non_prior_source_candidate_coexisting_with_valid_acceptance_fails_closed() {
+    let (_test_state, config, _client) = test_context().await;
+    let store = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let idempotency_key = unique_idempotency_key("projection-source-candidate-coexists");
+    let prior = record_prior_pending_mutual_acknowledgement(&store, &idempotency_key).await;
+
+    store
+        .record_mutual_acknowledgement_accepted_transition(transition_input(
+            accepted_transition_fact(&idempotency_key, &prior.writer_fact_id),
+        ))
+        .await
+        .expect("valid accepted transition should persist");
+
+    let mut rejected_candidate = prior_mutual_acknowledgement_fact(
+        &idempotency_key,
+        PromiseCompletionStateClass::CompletionRejected,
+    );
+    rejected_candidate.fact_idempotency_key =
+        Some(format!("rejected-source-candidate-{idempotency_key}"));
+    rejected_candidate.reason_code_class =
+        Some(format!("rejected-source-candidate-{idempotency_key}"));
+    record_writer_fact(&store, rejected_candidate).await;
+
+    let error = store
+        .derive_accepted_completion_non_authority_projection_snapshots(
+            &prior.promise_reference,
+            &prior.realm_id,
+        )
+        .await
+        .expect_err("coexisting non-prior source candidate writer truth must fail closed");
+
+    assert!(matches!(
+        error,
+        PromiseCompletionWriterFactPersistenceError::BadRequest(_)
+    ));
+}
+
+#[tokio::test]
 async fn contradictory_writer_truth_for_same_boundary_fails_closed() {
     let (_test_state, config, client) = test_context().await;
     let store = PromiseCompletionWriterFactStore::connect(&config)

--- a/apps/backend/tests/promise_completion_projection_non_authority.rs
+++ b/apps/backend/tests/promise_completion_projection_non_authority.rs
@@ -325,6 +325,43 @@ async fn contradictory_writer_truth_for_same_boundary_fails_closed() {
 }
 
 #[tokio::test]
+async fn wrong_key_accepted_writer_truth_coexisting_with_valid_acceptance_fails_closed() {
+    let (_test_state, config, client) = test_context().await;
+    let store = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let idempotency_key = unique_idempotency_key("projection-wrong-key-coexists");
+    let prior = record_prior_pending_mutual_acknowledgement(&store, &idempotency_key).await;
+
+    store
+        .record_mutual_acknowledgement_accepted_transition(transition_input(
+            accepted_transition_fact(&idempotency_key, &prior.writer_fact_id),
+        ))
+        .await
+        .expect("valid accepted transition should persist");
+    let mut wrong_key = accepted_transition_fact(&idempotency_key, &prior.writer_fact_id);
+    wrong_key.fact_idempotency_key = Some(format!("unbound-accepted-{idempotency_key}"));
+    record_writer_fact(&store, wrong_key).await;
+
+    let error = store
+        .derive_accepted_completion_non_authority_projection_snapshots(
+            &prior.promise_reference,
+            &prior.realm_id,
+        )
+        .await
+        .expect_err("coexisting wrong-key accepted writer truth must fail closed");
+
+    assert!(matches!(
+        error,
+        PromiseCompletionWriterFactPersistenceError::BadRequest(_)
+    ));
+    assert_eq!(
+        writer_fact_count_for_promise(&client, &prior.promise_reference).await,
+        3
+    );
+}
+
+#[tokio::test]
 async fn duplicate_projection_reads_are_deterministic_and_side_effect_free() {
     let (_test_state, config, client) = test_context().await;
     let store = PromiseCompletionWriterFactStore::connect(&config)

--- a/apps/backend/tests/promise_completion_projection_non_authority.rs
+++ b/apps/backend/tests/promise_completion_projection_non_authority.rs
@@ -362,6 +362,53 @@ async fn wrong_key_accepted_writer_truth_coexisting_with_valid_acceptance_fails_
 }
 
 #[tokio::test]
+async fn distinct_policy_versions_for_same_boundary_do_not_conflict() {
+    let (_test_state, config, _client) = test_context().await;
+    let store = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let idempotency_key = unique_idempotency_key("projection-policy-boundary");
+    let policy_one_prior =
+        record_prior_pending_mutual_acknowledgement(&store, &idempotency_key).await;
+    let policy_one = store
+        .record_mutual_acknowledgement_accepted_transition(transition_input(
+            accepted_transition_fact(&idempotency_key, &policy_one_prior.writer_fact_id),
+        ))
+        .await
+        .expect("policy one accepted transition should persist");
+
+    let mut policy_two_prior = prior_mutual_acknowledgement_fact(
+        &idempotency_key,
+        PromiseCompletionStateClass::CompletionPendingMutualAcknowledgement,
+    );
+    policy_two_prior.policy_version = Some(2);
+    let policy_two_prior = record_writer_fact(&store, policy_two_prior).await;
+    let mut policy_two_fact =
+        accepted_transition_fact(&idempotency_key, &policy_two_prior.writer_fact_id);
+    policy_two_fact.policy_version = Some(2);
+    let _policy_two = store
+        .record_mutual_acknowledgement_accepted_transition(transition_input(policy_two_fact))
+        .await
+        .expect("policy two accepted transition should persist");
+
+    let snapshots = store
+        .derive_accepted_completion_non_authority_projection_snapshots(
+            &policy_one.promise_reference,
+            &policy_one.realm_id,
+        )
+        .await
+        .expect("distinct policy versions should remain distinct projection boundaries");
+
+    assert_eq!(snapshots.len(), 2);
+    let policy_versions: Vec<i32> = snapshots
+        .iter()
+        .map(|snapshot| snapshot.policy_version)
+        .collect();
+    assert!(policy_versions.contains(&1));
+    assert!(policy_versions.contains(&2));
+}
+
+#[tokio::test]
 async fn duplicate_projection_reads_are_deterministic_and_side_effect_free() {
     let (_test_state, config, client) = test_context().await;
     let store = PromiseCompletionWriterFactStore::connect(&config)

--- a/apps/backend/tests/promise_completion_projection_non_authority.rs
+++ b/apps/backend/tests/promise_completion_projection_non_authority.rs
@@ -362,6 +362,51 @@ async fn wrong_key_accepted_writer_truth_coexisting_with_valid_acceptance_fails_
 }
 
 #[tokio::test]
+async fn non_accepted_transition_truth_coexisting_with_valid_acceptance_fails_closed() {
+    let (_test_state, config, _client) = test_context().await;
+    let store = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("store should connect");
+
+    for state in [
+        PromiseCompletionStateClass::CompletionRejected,
+        PromiseCompletionStateClass::CompletionExpired,
+        PromiseCompletionStateClass::CompletionCorrectedOrSuperseded,
+    ] {
+        let state_name = state.as_str();
+        let idempotency_key = unique_idempotency_key(&format!("projection-{state_name}-coexists"));
+        let prior = record_prior_pending_mutual_acknowledgement(&store, &idempotency_key).await;
+
+        store
+            .record_mutual_acknowledgement_accepted_transition(transition_input(
+                accepted_transition_fact(&idempotency_key, &prior.writer_fact_id),
+            ))
+            .await
+            .expect("valid accepted transition should persist");
+
+        let mut non_accepted = accepted_transition_fact(&idempotency_key, &prior.writer_fact_id);
+        non_accepted.completion_state_class = state;
+        non_accepted.completed_reference_eligible = false;
+        non_accepted.fact_idempotency_key = Some(format!("{state_name}-{idempotency_key}"));
+        non_accepted.reason_code_class = Some(format!("{state_name}-{idempotency_key}"));
+        record_writer_fact(&store, non_accepted).await;
+
+        let error = store
+            .derive_accepted_completion_non_authority_projection_snapshots(
+                &prior.promise_reference,
+                &prior.realm_id,
+            )
+            .await
+            .expect_err("coexisting non-accepted transition writer truth must fail closed");
+
+        assert!(matches!(
+            error,
+            PromiseCompletionWriterFactPersistenceError::BadRequest(_)
+        ));
+    }
+}
+
+#[tokio::test]
 async fn distinct_policy_versions_for_same_boundary_do_not_conflict() {
     let (_test_state, config, _client) = test_context().await;
     let store = PromiseCompletionWriterFactStore::connect(&config)

--- a/apps/backend/tests/promise_completion_projection_non_authority.rs
+++ b/apps/backend/tests/promise_completion_projection_non_authority.rs
@@ -652,6 +652,55 @@ async fn correction_or_supersession_truth_coexisting_with_valid_acceptance_fails
 }
 
 #[tokio::test]
+async fn prior_linked_correction_truth_with_boundary_drift_fails_closed() {
+    let (_test_state, config, _client) = test_context().await;
+    let store = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let idempotency_key = unique_idempotency_key("projection-linked-correction-drift");
+    let prior = record_prior_pending_mutual_acknowledgement(&store, &idempotency_key).await;
+
+    let accepted = store
+        .record_mutual_acknowledgement_accepted_transition(transition_input(
+            accepted_transition_fact(&idempotency_key, &prior.writer_fact_id),
+        ))
+        .await
+        .expect("valid accepted transition should persist");
+
+    let mut correction = accepted_transition_fact(&idempotency_key, &accepted.writer_fact_id);
+    correction.fact_family = PromiseCompletionWriterFactFamily::CorrectionOrSupersession;
+    correction.previous_completion_state_class =
+        Some(PromiseCompletionStateClass::CompletionAccepted);
+    correction.completion_state_class =
+        PromiseCompletionStateClass::CompletionCorrectedOrSuperseded;
+    correction.completed_reference_eligible = false;
+    correction.promise_terms_reference = Some(format!("drifted-promise-terms-{idempotency_key}"));
+    correction.participant_set_reference =
+        Some(format!("drifted-participant-set-{idempotency_key}"));
+    correction.policy_version = Some(2);
+    correction.fact_idempotency_key =
+        Some(format!("prior-linked-correction-drift-{idempotency_key}"));
+    correction.reason_code_class = Some(format!("prior-linked-correction-drift-{idempotency_key}"));
+    correction.correction_or_supersession_reference = Some(format!(
+        "prior-linked-correction-reference-{idempotency_key}"
+    ));
+    record_writer_fact(&store, correction).await;
+
+    let error = store
+        .derive_accepted_completion_non_authority_projection_snapshots(
+            &prior.promise_reference,
+            &prior.realm_id,
+        )
+        .await
+        .expect_err("prior-linked correction writer truth with boundary drift must fail closed");
+
+    assert!(matches!(
+        error,
+        PromiseCompletionWriterFactPersistenceError::BadRequest(_)
+    ));
+}
+
+#[tokio::test]
 async fn outcome_reference_truth_coexisting_with_valid_acceptance_fails_closed() {
     let (_test_state, config, _client) = test_context().await;
     let store = PromiseCompletionWriterFactStore::connect(&config)

--- a/docs/foundation_lock.md
+++ b/docs/foundation_lock.md
@@ -1,6 +1,6 @@
 # Foundation Lock
 
-Status: Draft; aligned to accepted foundation commit `a5a55ee`
+Status: Draft; aligned to accepted foundation commit `0c7d0c5`
 Applies to: `mt4110/pi-musubi-core`
 Purpose: Pin the constitutional and architectural source of truth that this implementation repository must follow.
 
@@ -26,14 +26,14 @@ Upstream repository:
 Pinned reference for implementation work:
 
 - Foundation reference type: `commit`
-- Foundation commit SHA: `a5a55ee8b86dc20b04890f302bc062301e2e1f6c`
-- Foundation commit title: `Merge pull request #447 from mt4110/feat/promise-completion-state-transition-route`
-- Foundation PR title: `docs: select Promise completion state transition route`
-- Foundation PR URL: `https://github.com/mt4110/musubi-foundation/pull/447`
-- Date pinned: `2026-06-18`
+- Foundation commit SHA: `0c7d0c5a0470bd406432d9318ad5248ad2f1850a`
+- Foundation commit title: `Merge pull request #454 from mt4110/feat/promise-completion-projection-route`
+- Foundation PR title: `docs: select Promise completion projection route`
+- Foundation PR URL: `https://github.com/mt4110/musubi-foundation/pull/454`
+- Date pinned: `2026-06-19`
 - Pinned by: `Masaki Takemura`
-- Pinned commit URL: `https://github.com/mt4110/musubi-foundation/commit/a5a55ee8b86dc20b04890f302bc062301e2e1f6c`
-- Previous pinned reference: `800a69c` / `Merge pull request #438 from mt4110/feat/promise-completion-writer-fact-persistence-route`
+- Pinned commit URL: `https://github.com/mt4110/musubi-foundation/commit/0c7d0c5a0470bd406432d9318ad5248ad2f1850a`
+- Previous pinned reference: `a5a55ee` / `Merge pull request #447 from mt4110/feat/promise-completion-state-transition-route`
 - Post-C2 evidence source: `cfdba28` / `Merge pull request #114 from mt4110/feat/post-c2-runtime-handoff-evidence-package`
 - Alignment allowance source: `69b7aa4` / `Merge pull request #116 from mt4110/feat/evaluate-post-c2-runtime-handoff-gate`
 - Post-C2 implementation handoff evidence source: `ef23e88` / `Merge pull request #122 from mt4110/feat/post-c2-implementation-handoff-evidence-package`
@@ -180,6 +180,10 @@ Pinned reference for implementation work:
 - Promise completion state transition runtime preflight packet source: `fbca981` / `Merge pull request #443 from mt4110/feat/promise-completion-state-transition-preflight-packet`
 - Promise completion state transition runtime preflight packet sufficiency decision source: `3fd5294` / `Merge pull request #445 from mt4110/feat/promise-completion-state-transition-preflight-sufficiency`
 - Promise completion narrow state transition runtime route selection source: `a5a55ee` / `Merge pull request #447 from mt4110/feat/promise-completion-state-transition-route`
+- Promise completion narrow state transition runtime closeout source: `cb4578d` / `Merge pull request #448 from mt4110/feat/promise-completion-state-transition-runtime-closeout`
+- Promise completion projection non-authority preflight packet source: `dfa07f9` / `Merge pull request #450 from mt4110/feat/promise-completion-projection-non-authority-preflight`
+- Promise completion projection non-authority preflight packet sufficiency decision source: `684cfd5` / `Merge pull request #452 from mt4110/feat/promise-completion-projection-preflight-sufficiency`
+- Promise completion narrow projection non-authority route selection source: `0c7d0c5` / `Merge pull request #454 from mt4110/feat/promise-completion-projection-route`
 
 No release tag is asserted for this alignment.
 Do not invent a foundation version label for this commit.
@@ -396,38 +400,42 @@ Before coding, read these upstream documents in order.
 196. `docs/readiness/promise_completion_state_transition_runtime_preflight_decision_packet.md`
 197. `docs/readiness/promise_completion_state_transition_runtime_preflight_packet_sufficiency_decision.md`
 198. `docs/readiness/promise_completion_post_state_transition_preflight_sufficiency_route_selection.md`
+199. `docs/readiness/promise_completion_narrow_state_transition_runtime_closeout_ledger.md`
+200. `docs/readiness/promise_completion_projection_non_authority_preflight_decision_packet.md`
+201. `docs/readiness/promise_completion_projection_non_authority_preflight_packet_sufficiency_decision.md`
+202. `docs/readiness/promise_completion_post_projection_non_authority_preflight_sufficiency_route_selection.md`
 
 ### Operations layer
-199. `docs/operations/readiness_routine.md`
-200. `docs/operations/runalways_readiness_orchestrator_design.md`
-201. `docs/operations/runalways_readiness_orchestrator_stage0.md`
-202. `docs/operations/runalways_lane_controller_v0_1.md`
+203. `docs/operations/readiness_routine.md`
+204. `docs/operations/runalways_readiness_orchestrator_design.md`
+205. `docs/operations/runalways_readiness_orchestrator_stage0.md`
+206. `docs/operations/runalways_lane_controller_v0_1.md`
 
 ### Detail layer
-203. `docs/detail/accountability_matrix.md`
-204. `docs/detail/critical_incident_and_loss.md`
-205. `docs/detail/automated_decisioning_and_human_appeal.md`
-206. `docs/detail/youth_safety_and_age_assurance.md`
-207. `docs/detail/off_platform_handoff_and_scam_prevention.md`
-208. `docs/detail/data_deletion_vs_legal_hold.md`
-209. `docs/detail/security_and_autonomy_hardening.md`
-210. `docs/detail/realm_model.md`
-211. `docs/detail/data_scope_model.md`
-212. `docs/detail/mobility_model.md`
-213. `docs/detail/settlement_model.md`
-214. `docs/detail/settlement_backend_trait.md`
-215. `docs/detail/proof_of_infrastructure.md`
-216. `docs/detail/protected_groups_and_translation_safety.md`
+207. `docs/detail/accountability_matrix.md`
+208. `docs/detail/critical_incident_and_loss.md`
+209. `docs/detail/automated_decisioning_and_human_appeal.md`
+210. `docs/detail/youth_safety_and_age_assurance.md`
+211. `docs/detail/off_platform_handoff_and_scam_prevention.md`
+212. `docs/detail/data_deletion_vs_legal_hold.md`
+213. `docs/detail/security_and_autonomy_hardening.md`
+214. `docs/detail/realm_model.md`
+215. `docs/detail/data_scope_model.md`
+216. `docs/detail/mobility_model.md`
+217. `docs/detail/settlement_model.md`
+218. `docs/detail/settlement_backend_trait.md`
+219. `docs/detail/proof_of_infrastructure.md`
+220. `docs/detail/protected_groups_and_translation_safety.md`
 
 ### Whitepaper layer (contextual, not higher than detail/ADR)
-217. `docs/whitepaper/01_executive_summary.md`
-218. `docs/whitepaper/02_realm_model.md`
-219. `docs/whitepaper/03_experience_model.md`
-220. `docs/whitepaper/04_dm_shield.md`
-221. `docs/whitepaper/05_trust_model.md`
-222. `docs/whitepaper/06_promise_protocol.md`
-223. `docs/whitepaper/07_realm_economy.md`
-224. `docs/whitepaper/08_unlock_engine.md`
+221. `docs/whitepaper/01_executive_summary.md`
+222. `docs/whitepaper/02_realm_model.md`
+223. `docs/whitepaper/03_experience_model.md`
+224. `docs/whitepaper/04_dm_shield.md`
+225. `docs/whitepaper/05_trust_model.md`
+226. `docs/whitepaper/06_promise_protocol.md`
+227. `docs/whitepaper/07_realm_economy.md`
+228. `docs/whitepaper/08_unlock_engine.md`
 
 If any of the above are unavailable or materially inconsistent, stop and escalate.
 
@@ -487,20 +495,25 @@ No remaining work may inherit permission from foundation PR #438 or implementati
 Foundation PR #441 selected post-writer-fact-persistence foundation continuation only.
 Foundation PR #443 prepared state transition runtime preflight decision materials only.
 Foundation PR #445 found that preflight packet sufficient for later route selection only.
-Foundation PR #447 provides the current one-use downstream narrow state transition runtime handoff authority for this implementation-repo PR only.
+Foundation PR #447 provided the consumed one-use downstream narrow state transition runtime handoff authority for one implementation-repo PR only.
+That allowance was consumed by `mt4110/pi-musubi-core` PR #169 and closed out by foundation PR #448.
+No remaining work may inherit permission from foundation PR #447 or implementation PR #169.
+Foundation PR #450 prepared Promise completion projection non-authority preflight decision materials only.
+Foundation PR #452 found that preflight packet sufficient for later route selection only.
+Foundation PR #454 provides the current one-use downstream narrow projection non-authority handoff authority for this implementation-repo PR only.
 This implementation-repo PR consumes that allowance.
-The PR #447 allowance authorizes only:
+The PR #454 allowance authorizes only:
 
 - `docs/foundation_lock.md`
 - `apps/backend/src/services/promise_completion/mod.rs`
 - `apps/backend/src/services/promise_completion/repository.rs`
 - `apps/backend/src/services/promise_completion/types.rs`
-- `apps/backend/tests/promise_completion_state_transition_runtime.rs`
+- `apps/backend/tests/promise_completion_projection_non_authority.rs`
 
-It authorizes only an internal Promise completion helper for the pre-bounded mutual acknowledgement accepted transition:
+It authorizes only an internal repository-derived, read-only, non-authoritative Promise completion projection snapshot helper for:
 
 ```text
-completion_pending_mutual_acknowledgement -> completion_accepted
+completion_accepted
 ```
 
 under:
@@ -510,10 +523,11 @@ mutual_accountable_completion_acknowledgement
 ```
 
 It must use the existing `promise_completion.writer_fact_records` table only.
-It authorizes only one append-only `completion_state_transition` writer fact record for the selected transition attempt, with durable database-enforced idempotency, identical replay, payload-drift fail-closed behavior, writer-truth prior posture validation, PII / raw-evidence / provider-payload segregation, and database contract tests.
-It must set `completed_reference_eligible = true` only because the next state is `completion_accepted`.
-It does not authorize migrations, DDL, new tables, mutable current-state tables, `apps/backend/src/services/mod.rs`, `apps/backend/src/lib.rs`, handlers, routers, `AppState`, source-route evaluation runtime, participant acknowledgement collection runtime, governed review runtime workflow, governed review accepted transition runtime, correction or supersession runtime, API, UI, projection, Social Trust source fact persistence, Social Trust mutation, Relationship Depth mutation, settlement movement, room behavior, contact behavior, discovery, recommendation, proof runtime behavior, proof eligibility runtime behavior, outbox, inbox, worker behavior, provider I/O, provider callbacks, raw Personal Data in immutable truth, raw evidence in immutable truth, hidden distributed transactions, destructive migration, Social Trust score, weight, rank, public display, recovery ceiling, settlement release, settlement refund, settlement forfeiture, escrow movement, reward movement, room progression, direct-message unlock, public accusation labels, sensitive-trait visibility changes, paid romantic advantage, payment-based direct-message unlock, or broad `pi-musubi-core` changes.
-After this downstream PR is merged, closed without merge, or replaced by a different accepted foundation decision, foundation must receive a separate closeout ledger at `docs/readiness/promise_completion_narrow_state_transition_runtime_closeout_ledger.md` before any broader Promise completion route may be considered.
+It authorizes only derived snapshots when writer truth shows `fact_family = completion_state_transition`, `source_route_class = mutual_accountable_completion_acknowledgement`, `completion_state_class = completion_accepted`, `completed_reference_eligible = true`, a present prior writer fact reference, and matching Promise / Realm / terms / participant set / policy references carried from writer truth.
+It authorizes no writer fact writes in the projection helper and no durable projection rows.
+It requires fail-closed or no-snapshot behavior when the required writer posture is missing, governed review is supplied, a forbidden source-route shortcut is supplied, or writer truth is contradictory for the same Promise / Realm / terms / participant set boundary.
+It does not authorize migrations, DDL, new tables, new indexes, triggers, functions, caches, mutable current-state tables, durable projection tables, projection refresh, `apps/backend/src/services/mod.rs`, `apps/backend/src/lib.rs`, handlers, routers, `AppState`, source-route evaluation runtime, participant acknowledgement collection runtime, governed review runtime workflow, governed review accepted transition runtime, correction or supersession runtime, API, UI, participant display, Social Trust source fact persistence, Social Trust mutation, Relationship Depth mutation, settlement movement, room behavior, contact behavior, discovery, recommendation, proof runtime behavior, proof eligibility runtime behavior, outbox, inbox, worker behavior, provider I/O, provider callbacks, raw Personal Data in immutable truth or derived snapshots, raw evidence in immutable truth or derived snapshots, hidden distributed transactions, destructive migration, Social Trust score, weight, rank, public display, recovery ceiling, settlement release, settlement refund, settlement forfeiture, escrow movement, reward movement, room progression, direct-message unlock, public accusation labels, sensitive-trait visibility changes, paid romantic advantage, payment-based direct-message unlock, or broad `pi-musubi-core` changes.
+After this downstream PR is merged, closed without merge, or replaced by a different accepted foundation decision, foundation must receive a separate closeout ledger at `docs/readiness/promise_completion_narrow_projection_non_authority_closeout_ledger.md` before any later Promise completion projection, display, trust, depth, settlement, API, UI, provider, outbox, inbox, worker, governed review, correction, or broader core route may inherit from it.
 
 The C2 and post-C2 readiness and closeout chain is accepted for docs-only foundation semantic scope:
 
@@ -971,11 +985,11 @@ When updating:
 - Review completed by:
 
 ### Current drift note
-- Updated from foundation SHA: `800a69c810e48646c583d2cdd657001d011ff759` -> `a5a55ee8b86dc20b04890f302bc062301e2e1f6c`
-- Reason: Align implementation-repo lock with the accepted Promise completion narrow state transition runtime route selection after foundation PR #447 (`docs: select Promise completion state transition route`) and consume its one-use downstream mutual acknowledgement accepted transition allowance.
-- New required docs: Promise completion narrow writer fact persistence closeout ledger, Promise completion post-writer-fact-persistence closeout route selection, Promise completion state transition runtime preflight decision packet, Promise completion state transition runtime preflight packet sufficiency decision, and Promise completion post-state-transition-preflight sufficiency route selection.
+- Updated from foundation SHA: `a5a55ee8b86dc20b04890f302bc062301e2e1f6c` -> `0c7d0c5a0470bd406432d9318ad5248ad2f1850a`
+- Reason: Align implementation-repo lock with the accepted Promise completion narrow projection non-authority route selection after foundation PR #454 (`docs: select Promise completion projection route`) and consume its one-use downstream accepted completion projection snapshot allowance.
+- New required docs: Promise completion narrow state transition runtime closeout ledger, Promise completion projection non-authority preflight decision packet, Promise completion projection non-authority preflight packet sufficiency decision, and Promise completion post-projection-non-authority-preflight sufficiency route selection.
 - Removed docs: None.
-- Implementation impact: This update consumes the one-use foundation PR #447 allowance and permits only the exact five-file narrow state transition scope listed above. It authorizes only an internal mutual acknowledgement accepted transition helper that writes one append-only `completion_state_transition` fact to the existing `promise_completion.writer_fact_records` table, with durable database-enforced idempotency, identical replay, payload drift fail-closed behavior, writer-truth prior posture validation, PII / raw-evidence / provider-payload segregation, and database contract tests. Migrations, DDL, new tables, source-route evaluation runtime, participant acknowledgement collection runtime, governed review runtime, correction/supersession runtime, API, UI, projection, Social Trust source fact persistence, Social Trust mutation, Relationship Depth mutation, settlement movement, room behavior, contact behavior, discovery, recommendation, outbox, inbox, worker behavior, provider I/O, provider callbacks, participant display implementation, paid romantic advantage, payment-based direct-message unlock, and broader `pi-musubi-core` changes remain NO-GO.
+- Implementation impact: This update consumes the one-use foundation PR #454 allowance and permits only the exact five-file narrow projection non-authority scope listed above. It authorizes only an internal repository-derived read-only helper that derives minimized accepted completion snapshots from the existing `promise_completion.writer_fact_records` table when writer truth is `completion_state_transition`, `mutual_accountable_completion_acknowledgement`, `completion_accepted`, `completed_reference_eligible = true`, prior-bound, and boundary-consistent. The helper must not write writer facts or projection rows. Migrations, DDL, new tables, projection refresh, source-route evaluation runtime, participant acknowledgement collection runtime, governed review runtime, correction/supersession runtime, API, UI, participant display, Social Trust source fact persistence, Social Trust mutation, Relationship Depth mutation, settlement movement, room behavior, contact behavior, discovery, recommendation, outbox, inbox, worker behavior, provider I/O, provider callbacks, raw Personal Data / raw evidence / provider payloads in derived snapshots, paid romantic advantage, payment-based direct-message unlock, and broader `pi-musubi-core` changes remain NO-GO.
 - Review completed by: Masaki Takemura
 
 ---


### PR DESCRIPTION
## Summary
- Pins `docs/foundation_lock.md` to musubi-foundation PR #454 / commit `0c7d0c5a0470bd406432d9318ad5248ad2f1850a`.
- Adds an internal read-only Promise completion non-authority projection snapshot helper derived only from existing `promise_completion.writer_fact_records` writer truth.
- Adds database contract coverage for accepted writer truth, missing/ineligible posture, governed/forbidden route exclusion, contradictory writer truth fail-closed behavior, and deterministic side-effect-free repeat reads.

## Scope Guard
- Uses only the existing `promise_completion.writer_fact_records` table.
- No DDL, migrations, durable projection table, projection refresh, API, UI, AppState, handlers, routers, Social Trust mutation, Relationship Depth mutation, settlement movement, provider, outbox, inbox, worker, room, contact, discovery, or recommendation changes.
- Projection helper performs no writer fact writes and creates no projection rows.

Closes #170.

## Validation
- `git diff --check origin/main...HEAD`
- `git diff --name-only origin/main...HEAD`
  - `apps/backend/src/services/promise_completion/mod.rs`
  - `apps/backend/src/services/promise_completion/repository.rs`
  - `apps/backend/src/services/promise_completion/types.rs`
  - `apps/backend/tests/promise_completion_projection_non_authority.rs`
  - `docs/foundation_lock.md`
- `rustfmt --edition 2024 --config skip_children=true --check apps/backend/src/services/promise_completion/mod.rs apps/backend/src/services/promise_completion/repository.rs apps/backend/src/services/promise_completion/types.rs apps/backend/tests/promise_completion_projection_non_authority.rs`
- `cargo test -p musubi_backend --test promise_completion_projection_non_authority` from `apps/backend`
- `cargo test -p musubi_backend --test promise_completion_state_transition_runtime` from `apps/backend`
- `cargo test -p musubi_backend --test promise_completion_writer_fact_persistence` from `apps/backend`
- `make guardrail-sweep`

Note: running the DB tests in parallel first hit migration lock/deadlock contention in test setup; the affected tests were rerun sequentially and passed.
