### PR TITLE
ci: add core review workflow

### DIFF
--- a/.github/workflows/core-review.yml
+++ b/.github/workflows/core-review.yml
@@ -1,0 +1,185 @@
+name: Core Review
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - "feat/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: core-review-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  backend-static-review:
+    name: Backend static review
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Cache Cargo target
+        uses: actions/cache@v4
+        with:
+          path: |
+            apps/backend/target
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: core-review-cargo-${{ runner.os }}-${{ hashFiles('apps/backend/Cargo.lock') }}
+          restore-keys: |
+            core-review-cargo-${{ runner.os }}-
+
+      - name: Backend guardrail sweep self-test
+        working-directory: apps/backend
+        run: make guardrail-sweep-self-test
+
+      - name: Backend guardrail sweep
+        working-directory: apps/backend
+        run: make guardrail-sweep
+
+      - name: Rust compile surface
+        working-directory: apps/backend
+        run: cargo check --workspace --all-targets
+
+      - name: Rust clippy review
+        working-directory: apps/backend
+        run: cargo clippy --workspace --all-targets
+
+      - name: Rust formatting advisory
+        working-directory: apps/backend
+        continue-on-error: true
+        run: cargo fmt --all --check
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+
+      - name: Rust dependency advisory audit
+        working-directory: apps/backend
+        run: cargo audit
+
+      - name: Secret pattern scan
+        run: |
+          set -euo pipefail
+          patterns=(
+            'AKIA[0-9A-Z]{16}'
+            'AIza[0-9A-Za-z_-]{35}'
+            'gh[pousr]_[A-Za-z0-9_]{30,}'
+          )
+          for pattern in "${patterns[@]}"; do
+            if git grep -nE "$pattern" -- . \
+              ':!.github/workflows/core-review.yml' \
+              ':!apps/backend/Cargo.lock'; then
+              echo "Potential secret pattern matched: $pattern"
+              exit 1
+            fi
+          done
+
+      - name: Backend panic and debug marker review
+        run: |
+          set -euo pipefail
+          rust_files="$(mktemp)"
+          rust_markers="$(mktemp)"
+          find apps/backend/src apps/backend/crates \
+            -type f \
+            -path '*/src/*' \
+            -name '*.rs' \
+            -print > "$rust_files"
+
+          xargs grep -nE \
+            '(panic!|unwrap\(|expect\(|todo!\(|unimplemented!\(|dbg!\()' \
+            < "$rust_files" > "$rust_markers" || true
+
+          {
+            echo "### Backend panic/debug marker inventory"
+            echo
+            if [ -s "$rust_markers" ]; then
+              echo '```text'
+              cat "$rust_markers"
+              echo '```'
+            else
+              echo "No production Rust panic/debug markers found."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if xargs grep -nE '(panic!|todo!\(|unimplemented!\(|dbg!\()' \
+            < "$rust_files"; then
+            echo "Production Rust contains panic/todo/unimplemented/dbg markers."
+            exit 1
+          fi
+
+  mobile-web-review:
+    name: Mobile web review
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: "3.41.2"
+          cache: true
+
+      - name: Flutter version
+        working-directory: apps/mobile
+        run: flutter --version
+
+      - name: Flutter dependencies
+        working-directory: apps/mobile
+        run: flutter pub get
+
+      - name: Dart and Flutter static analysis
+        working-directory: apps/mobile
+        run: flutter analyze
+
+      - name: Flutter widget and model tests
+        working-directory: apps/mobile
+        run: flutter test
+
+      - name: Flutter web release build
+        working-directory: apps/mobile
+        run: flutter build web --release --wasm
+
+      - name: Dart UI and debug marker review
+        run: |
+          set -euo pipefail
+          dart_markers="$(mktemp)"
+          layout_markers="$(mktemp)"
+
+          find apps/mobile/lib \
+            -type f \
+            -name '*.dart' \
+            -print0 | xargs -0 grep -nE \
+              '(print\(|debugPrint\(|TODO|FIXME|OverflowBox|FittedBox|IntrinsicWidth|IntrinsicHeight|SingleChildScrollView|LayoutBuilder|MediaQuery|Row\(|Wrap\()' \
+              > "$dart_markers" || true
+
+          find apps/mobile/lib \
+            -type f \
+            -name '*.dart' \
+            -print0 | xargs -0 grep -nE \
+              '(OverflowBox|FittedBox|IntrinsicWidth|IntrinsicHeight|SingleChildScrollView|LayoutBuilder|MediaQuery|Row\(|Wrap\()' \
+              > "$layout_markers" || true
+
+          {
+            echo "### Dart UI/debug marker inventory"
+            echo
+            if [ -s "$dart_markers" ]; then
+              echo '```text'
+              cat "$dart_markers"
+              echo '```'
+            else
+              echo "No Dart UI/debug markers found."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if grep -nE '(OverflowBox|IntrinsicWidth|IntrinsicHeight)' "$layout_markers"; then
+            echo "High-risk Flutter layout primitives require explicit review."
+            exit 1
+          fi

--- a/apps/backend/Cargo.lock
+++ b/apps/backend/Cargo.lock
@@ -165,7 +165,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core 0.10.0",
+ "rand_core",
 ]
 
 [[package]]
@@ -334,17 +334,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
-name = "futures-macro"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -363,7 +352,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
- "futures-macro",
  "futures-sink",
  "futures-task",
  "pin-project-lite",
@@ -401,7 +389,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.0",
+ "rand_core",
  "wasip2",
  "wasip3",
 ]
@@ -585,20 +573,17 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libredox"
-version = "0.1.15"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
- "bitflags",
  "libc",
- "plain",
- "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -651,7 +636,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
 
@@ -737,6 +722,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -760,7 +763,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -773,18 +776,19 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
  "phf_shared",
+ "serde",
 ]
 
 [[package]]
 name = "phf_shared"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
 ]
@@ -802,16 +806,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
-
-[[package]]
 name = "postgres-protocol"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56201207dac53e2f38e848e31b4b91616a6bb6e0c7205b77718994a7f49e70fc"
+checksum = "08808e3c483c46e999108051c78334f473d5adb59d78bb80a1268c7e6aa6c514"
 dependencies = [
  "base64",
  "byteorder",
@@ -820,33 +818,24 @@ dependencies = [
  "hmac",
  "md-5",
  "memchr",
- "rand 0.10.0",
+ "rand",
  "sha2 0.11.0",
  "stringprep",
 ]
 
 [[package]]
 name = "postgres-types"
-version = "0.2.9"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613283563cd90e1dfc3518d548caee47e0e725455ed619881f5cf21f36de4b48"
+checksum = "851ca9db4932932d69f3ea811b1abe63087a0f740a47692619dd40d4899b68be"
 dependencies = [
  "bytes",
  "chrono",
  "fallible-iterator",
  "postgres-protocol",
- "serde",
+ "serde_core",
  "serde_json",
  "uuid",
-]
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
 ]
 
 [[package]]
@@ -891,42 +880,13 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
-dependencies = [
- "rand_chacha",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
- "rand_core 0.10.0",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -940,15 +900,6 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
  "bitflags",
 ]
@@ -979,18 +930,28 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.203"
+version = "1.0.221"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+checksum = "341877e04a22458705eb4e131a1508483c877dca2792b3781d4e5d8a6019ec43"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.221"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c459bc0a14c840cb403fc14b148620de1e0778c96ecd6e0c8c3cacb6d8d00fe"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.203"
+version = "1.0.221"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+checksum = "d6185cf75117e20e62b1ff867b9518577271e58abe0037c40bb4794969355ab0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -999,14 +960,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.143"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -1089,16 +1051,6 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
@@ -1162,7 +1114,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.2",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -1180,9 +1132,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres"
-version = "0.7.13"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c95d533c83082bb6490e0189acaa0bbeef9084e60471b696ca6988cd0541fb0"
+checksum = "a528f7d280f6d5b9cd149635c8705b0dd049754bc67d81d31fa25169a93809d3"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -1197,8 +1149,8 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "rand 0.9.2",
- "socket2 0.5.10",
+ "rand",
+ "socket2",
  "tokio",
  "tokio-util",
  "whoami",
@@ -1343,6 +1295,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1362,9 +1323,12 @@ dependencies = [
 
 [[package]]
 name = "wasite"
-version = "0.1.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
+dependencies = [
+ "wasi 0.14.7+wasi-0.2.4",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1457,11 +1421,13 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.6.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
 dependencies = [
+ "libc",
  "libredox",
+ "objc2-system-configuration",
  "wasite",
  "web-sys",
 ]
@@ -1527,20 +1493,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1554,42 +1511,20 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1599,21 +1534,9 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1623,21 +1546,9 @@ checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1647,33 +1558,15 @@ checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1770,21 +1663,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerocopy"
-version = "0.8.48"
+name = "zmij"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/apps/backend/Cargo.toml
+++ b/apps/backend/Cargo.toml
@@ -33,7 +33,7 @@ edition = "2024"
 [dependencies]
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
-serde = { version = "=1.0.203", features = ["derive"] }
+serde = { version = "=1.0.221", features = ["derive"] }
 serde_json = "1"
 dotenvy = "0.15"
 chrono = { version = "0.4", features = ["serde"] }

--- a/apps/backend/tests/promise_completion_writer_fact_persistence.rs
+++ b/apps/backend/tests/promise_completion_writer_fact_persistence.rs
@@ -14,6 +14,16 @@ use musubi_backend::{
 use musubi_db_runtime::DbConfig;
 use tokio_postgres::NoTls;
 
+fn assert_append_only_error(error: &tokio_postgres::Error) {
+    let db_error = error
+        .as_db_error()
+        .expect("append-only guard should return a database error");
+    assert_eq!(
+        db_error.message(),
+        "promise_completion.writer_fact_records is append-only"
+    );
+}
+
 fn lookup(database_url: &str, migrations_dir: &str, name: &'static str) -> Option<String> {
     match name {
         "APP_ENV" => Some("test".to_owned()),
@@ -386,11 +396,7 @@ async fn writer_fact_records_reject_update_and_delete() {
         )
         .await
         .expect_err("writer fact updates must be rejected by the database");
-    assert!(
-        update_error
-            .to_string()
-            .contains("promise_completion.writer_fact_records is append-only")
-    );
+    assert_append_only_error(&update_error);
 
     let delete_error = client
         .execute(
@@ -402,11 +408,7 @@ async fn writer_fact_records_reject_update_and_delete() {
         )
         .await
         .expect_err("writer fact deletes must be rejected by the database");
-    assert!(
-        delete_error
-            .to_string()
-            .contains("promise_completion.writer_fact_records is append-only")
-    );
+    assert_append_only_error(&delete_error);
     assert_eq!(
         writer_fact_count_for_promise(&client, &snapshot.promise_reference).await,
         1

--- a/apps/mobile/test/features/realm_bootstrap/realm_bootstrap_screen_test.dart
+++ b/apps/mobile/test/features/realm_bootstrap/realm_bootstrap_screen_test.dart
@@ -202,7 +202,7 @@ void main() {
     expect(find.text('Tokyo slow coffee'), findsOneWidget);
     expect(find.text('限定受付'), findsOneWidget);
     expect(find.text('Admission request'), findsOneWidget);
-    expect(find.text('確認キュー'), findsOneWidget);
+    expect(find.text('確定済み'), findsOneWidget);
     expect(find.text('Operator / Steward review'), findsOneWidget);
     expect(find.textContaining('証跡の所在'), findsOneWidget);
     expect(find.textContaining('private://'), findsNothing);


### PR DESCRIPTION
## Summary

- Add a `Core Review` GitHub Actions workflow for broader PR review coverage across backend static checks, security audit, panic/debug marker scanning, secret-pattern scanning, and mobile web checks.
- Update backend Rust dependencies so `cargo audit` no longer fails on the current `tokio-postgres` / `postgres-protocol` RustSec advisories.
- Make the Promise completion append-only trigger test assert the structured database error message instead of the dependency-sensitive `Error::to_string()` output.
- Fix the Realm bootstrap widget test expectation for the admitted fixture, which renders `確定済み`.

## Review posture

The new workflow is intentionally balanced:

- `cargo audit` is blocking for security advisories that should fail closed.
- production Rust `panic!`, `todo!`, `unimplemented!`, and `dbg!` markers are blocking.
- `unwrap` / `expect` and broader Flutter layout markers are inventoried in the job summary for human review.
- `cargo fmt --all --check` is advisory for now because current `main` has existing out-of-scope formatting drift in unrelated files.
- Backend DB/runtime tests remain covered by the existing `Backend DB smoke` workflow; this PR adds the missing review surface rather than duplicating that job.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/core-review.yml"); puts "yaml ok"'`
- `make guardrail-sweep-self-test`
- `make guardrail-sweep`
- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets`
- `cargo audit`
- `cargo test -p musubi_db_runtime`
- `cargo test -p musubi_orchestration`
- `cargo test -p musubi_backend`
- `mise exec -- flutter analyze`
- `mise exec -- flutter test`
- `mise exec -- flutter build web --release --wasm`
- `git diff --check`

Note: `cargo fmt --all --check` was run and still fails on pre-existing formatting drift outside this PR's touched Rust files, so the workflow keeps it non-blocking.