### PR TITLE
Add participant-safe Promise completion display availability

### DIFF
--- a/apps/backend/src/services/promise_completion/mod.rs
+++ b/apps/backend/src/services/promise_completion/mod.rs
@@ -5,6 +5,7 @@ pub use repository::PromiseCompletionWriterFactStore;
 pub use types::{
     PromiseCompletionAuthorityPosture, PromiseCompletionForbiddenSourceRouteClass,
     PromiseCompletionNonAuthorityProjectionSnapshot,
+    PromiseCompletionParticipantSafeDisplayAvailabilitySnapshot,
     PromiseCompletionProjectionNonAuthorityPosture, PromiseCompletionSourceRouteClass,
     PromiseCompletionStateClass, PromiseCompletionWriterFactFamily,
     PromiseCompletionWriterFactPersistenceError, PromiseCompletionWriterFactReplayStatus,

--- a/apps/backend/src/services/promise_completion/repository.rs
+++ b/apps/backend/src/services/promise_completion/repository.rs
@@ -255,6 +255,7 @@ impl PromiseCompletionWriterFactStore {
         promise_reference: &str,
         realm_id: &str,
         participant_set_reference: &str,
+        ordinary_participant_acknowledgement_reference: &str,
     ) -> Result<
         Option<PromiseCompletionParticipantSafeDisplayAvailabilitySnapshot>,
         PromiseCompletionWriterFactPersistenceError,
@@ -263,6 +264,10 @@ impl PromiseCompletionWriterFactStore {
         let realm_id = required_projection_ref(realm_id, "realm_id")?;
         let participant_set_reference =
             required_projection_ref(participant_set_reference, "participant set reference")?;
+        let ordinary_participant_acknowledgement_reference = required_projection_ref(
+            ordinary_participant_acknowledgement_reference,
+            "Ordinary Account participant acknowledgement reference",
+        )?;
         let client = self.client.lock().await;
         let snapshots = load_accepted_completion_non_authority_projection_snapshots(
             &*client,
@@ -275,7 +280,13 @@ impl PromiseCompletionWriterFactStore {
         else {
             return Ok(None);
         };
-        if !participant_safe_display_boundary_is_unsuppressed(&*client, &snapshot).await? {
+        if !participant_safe_display_boundary_is_authorized_and_unsuppressed(
+            &*client,
+            &snapshot,
+            &ordinary_participant_acknowledgement_reference,
+        )
+        .await?
+        {
             return Ok(None);
         }
 
@@ -1290,9 +1301,10 @@ fn participant_safe_display_projection_snapshot(
     Ok(Some(snapshot))
 }
 
-async fn participant_safe_display_boundary_is_unsuppressed(
+async fn participant_safe_display_boundary_is_authorized_and_unsuppressed(
     client: &impl GenericClient,
     snapshot: &PromiseCompletionNonAuthorityProjectionSnapshot,
+    ordinary_participant_acknowledgement_reference: &str,
 ) -> Result<bool, PromiseCompletionWriterFactPersistenceError> {
     let accepted_writer_fact_id =
         required_projection_uuid_ref(&snapshot.accepted_writer_fact_id, "accepted writer fact id")?;
@@ -1302,6 +1314,8 @@ async fn participant_safe_display_boundary_is_unsuppressed(
         .query_opt(
             "
             SELECT
+                accepted.ordinary_participant_acknowledgement_reference
+                    AS accepted_ordinary_participant_acknowledgement_reference,
                 accepted.block_withdrawal_state_reference
                     AS accepted_block_withdrawal_state_reference,
                 accepted.age_assurance_state_reference
@@ -1316,6 +1330,8 @@ async fn participant_safe_display_boundary_is_unsuppressed(
                     AS accepted_anti_abuse_continuity_reference,
                 accepted.safety_case_reference
                     AS accepted_safety_case_reference,
+                prior.ordinary_participant_acknowledgement_reference
+                    AS prior_ordinary_participant_acknowledgement_reference,
                 prior.block_withdrawal_state_reference
                     AS prior_block_withdrawal_state_reference,
                 prior.age_assurance_state_reference
@@ -1347,10 +1363,30 @@ async fn participant_safe_display_boundary_is_unsuppressed(
         ));
     };
 
-    Ok(participant_safe_display_boundary_row_is_unsuppressed(&row))
+    Ok(
+        participant_safe_display_boundary_row_is_authorized_and_unsuppressed(
+            &row,
+            ordinary_participant_acknowledgement_reference,
+        ),
+    )
 }
 
-fn participant_safe_display_boundary_row_is_unsuppressed(row: &Row) -> bool {
+fn participant_safe_display_boundary_row_is_authorized_and_unsuppressed(
+    row: &Row,
+    ordinary_participant_acknowledgement_reference: &str,
+) -> bool {
+    if !row_optional_reference_equals(
+        row,
+        "accepted_ordinary_participant_acknowledgement_reference",
+        ordinary_participant_acknowledgement_reference,
+    ) || !row_optional_reference_equals(
+        row,
+        "prior_ordinary_participant_acknowledgement_reference",
+        ordinary_participant_acknowledgement_reference,
+    ) {
+        return false;
+    }
+
     [
         (
             "accepted_block_withdrawal_state_reference",
@@ -1399,6 +1435,11 @@ fn participant_safe_display_boundary_row_is_unsuppressed(row: &Row) -> bool {
     ]
     .into_iter()
     .all(|(column, posture)| row_reference_has_posture(row, column, posture))
+}
+
+fn row_optional_reference_equals(row: &Row, column: &str, expected: &str) -> bool {
+    let value: Option<String> = row.get(column);
+    value.as_deref() == Some(expected)
 }
 
 fn row_reference_has_posture(row: &Row, column: &str, posture: &str) -> bool {

--- a/apps/backend/src/services/promise_completion/repository.rs
+++ b/apps/backend/src/services/promise_completion/repository.rs
@@ -8,6 +8,7 @@ use uuid::Uuid;
 
 use super::types::{
     PromiseCompletionAuthorityPosture, PromiseCompletionNonAuthorityProjectionSnapshot,
+    PromiseCompletionParticipantSafeDisplayAvailabilitySnapshot,
     PromiseCompletionProjectionNonAuthorityPosture, PromiseCompletionSourceRouteClass,
     PromiseCompletionStateClass, PromiseCompletionWriterFactFamily,
     PromiseCompletionWriterFactPersistenceError, PromiseCompletionWriterFactReplayStatus,
@@ -247,6 +248,29 @@ impl PromiseCompletionWriterFactStore {
             &realm_id,
         )
         .await
+    }
+
+    pub async fn derive_participant_safe_completed_reference_display_availability(
+        &self,
+        promise_reference: &str,
+        realm_id: &str,
+        participant_set_reference: &str,
+    ) -> Result<
+        Option<PromiseCompletionParticipantSafeDisplayAvailabilitySnapshot>,
+        PromiseCompletionWriterFactPersistenceError,
+    > {
+        let participant_set_reference =
+            required_projection_ref(participant_set_reference, "participant set reference")?;
+        let snapshots = self
+            .derive_accepted_completion_non_authority_projection_snapshots(
+                promise_reference,
+                realm_id,
+            )
+            .await?;
+        participant_safe_display_availability_from_projection_snapshots(
+            snapshots,
+            &participant_set_reference,
+        )
     }
 }
 
@@ -1218,6 +1242,40 @@ async fn load_accepted_completion_non_authority_projection_snapshots(
     }
 
     Ok(snapshots)
+}
+
+fn participant_safe_display_availability_from_projection_snapshots(
+    snapshots: Vec<PromiseCompletionNonAuthorityProjectionSnapshot>,
+    participant_set_reference: &str,
+) -> Result<
+    Option<PromiseCompletionParticipantSafeDisplayAvailabilitySnapshot>,
+    PromiseCompletionWriterFactPersistenceError,
+> {
+    let mut matching = snapshots
+        .into_iter()
+        .filter(|snapshot| snapshot.participant_set_reference == participant_set_reference);
+    let Some(snapshot) = matching.next() else {
+        return Ok(None);
+    };
+    if matching.next().is_some() {
+        return Err(PromiseCompletionWriterFactPersistenceError::BadRequest(
+            "Promise completion participant-safe display refuses ambiguous projection availability"
+                .to_owned(),
+        ));
+    }
+
+    Ok(Some(
+        PromiseCompletionParticipantSafeDisplayAvailabilitySnapshot {
+            promise_reference: snapshot.promise_reference,
+            realm_id: snapshot.realm_id,
+            display_class: "promise_completed_reference".to_owned(),
+            display_audience: "involved_participant_only".to_owned(),
+            display_availability: "available".to_owned(),
+            display_meaning: "availability_posture_only".to_owned(),
+            completed_reference_available: true,
+            policy_version: snapshot.policy_version,
+        },
+    ))
 }
 
 fn replay_writer_fact_id(

--- a/apps/backend/src/services/promise_completion/repository.rs
+++ b/apps/backend/src/services/promise_completion/repository.rs
@@ -259,18 +259,29 @@ impl PromiseCompletionWriterFactStore {
         Option<PromiseCompletionParticipantSafeDisplayAvailabilitySnapshot>,
         PromiseCompletionWriterFactPersistenceError,
     > {
+        let promise_reference = required_projection_ref(promise_reference, "Promise reference")?;
+        let realm_id = required_projection_ref(realm_id, "realm_id")?;
         let participant_set_reference =
             required_projection_ref(participant_set_reference, "participant set reference")?;
-        let snapshots = self
-            .derive_accepted_completion_non_authority_projection_snapshots(
-                promise_reference,
-                realm_id,
-            )
-            .await?;
-        participant_safe_display_availability_from_projection_snapshots(
-            snapshots,
-            &participant_set_reference,
+        let client = self.client.lock().await;
+        let snapshots = load_accepted_completion_non_authority_projection_snapshots(
+            &*client,
+            &promise_reference,
+            &realm_id,
         )
+        .await?;
+        let Some(snapshot) =
+            participant_safe_display_projection_snapshot(snapshots, &participant_set_reference)?
+        else {
+            return Ok(None);
+        };
+        if !participant_safe_display_boundary_is_unsuppressed(&*client, &snapshot).await? {
+            return Ok(None);
+        }
+
+        Ok(Some(
+            participant_safe_display_availability_from_projection_snapshot(snapshot),
+        ))
     }
 }
 
@@ -943,6 +954,18 @@ fn required_projection_ref(
     Ok(value.to_owned())
 }
 
+fn required_projection_uuid_ref(
+    value: &str,
+    label: &'static str,
+) -> Result<Uuid, PromiseCompletionWriterFactPersistenceError> {
+    let value = required_projection_ref(value, label)?;
+    Uuid::parse_str(&value).map_err(|_| {
+        PromiseCompletionWriterFactPersistenceError::BadRequest(format!(
+            "Promise completion non-authority projection read requires {label} to be a valid UUID"
+        ))
+    })
+}
+
 fn optional_ref(
     value: Option<&str>,
     label: &'static str,
@@ -1244,11 +1267,11 @@ async fn load_accepted_completion_non_authority_projection_snapshots(
     Ok(snapshots)
 }
 
-fn participant_safe_display_availability_from_projection_snapshots(
+fn participant_safe_display_projection_snapshot(
     snapshots: Vec<PromiseCompletionNonAuthorityProjectionSnapshot>,
     participant_set_reference: &str,
 ) -> Result<
-    Option<PromiseCompletionParticipantSafeDisplayAvailabilitySnapshot>,
+    Option<PromiseCompletionNonAuthorityProjectionSnapshot>,
     PromiseCompletionWriterFactPersistenceError,
 > {
     let mut matching = snapshots
@@ -1264,18 +1287,146 @@ fn participant_safe_display_availability_from_projection_snapshots(
         ));
     }
 
-    Ok(Some(
-        PromiseCompletionParticipantSafeDisplayAvailabilitySnapshot {
-            promise_reference: snapshot.promise_reference,
-            realm_id: snapshot.realm_id,
-            display_class: "promise_completed_reference".to_owned(),
-            display_audience: "involved_participant_only".to_owned(),
-            display_availability: "available".to_owned(),
-            display_meaning: "availability_posture_only".to_owned(),
-            completed_reference_available: true,
-            policy_version: snapshot.policy_version,
-        },
-    ))
+    Ok(Some(snapshot))
+}
+
+async fn participant_safe_display_boundary_is_unsuppressed(
+    client: &impl GenericClient,
+    snapshot: &PromiseCompletionNonAuthorityProjectionSnapshot,
+) -> Result<bool, PromiseCompletionWriterFactPersistenceError> {
+    let accepted_writer_fact_id =
+        required_projection_uuid_ref(&snapshot.accepted_writer_fact_id, "accepted writer fact id")?;
+    let prior_writer_fact_id =
+        required_projection_uuid_ref(&snapshot.prior_writer_fact_id, "prior writer fact id")?;
+    let row = client
+        .query_opt(
+            "
+            SELECT
+                accepted.block_withdrawal_state_reference
+                    AS accepted_block_withdrawal_state_reference,
+                accepted.age_assurance_state_reference
+                    AS accepted_age_assurance_state_reference,
+                accepted.legal_hold_intersection_reference
+                    AS accepted_legal_hold_intersection_reference,
+                accepted.critical_harm_case_reference
+                    AS accepted_critical_harm_case_reference,
+                accepted.account_lifecycle_reference
+                    AS accepted_account_lifecycle_reference,
+                accepted.anti_abuse_continuity_reference
+                    AS accepted_anti_abuse_continuity_reference,
+                accepted.safety_case_reference
+                    AS accepted_safety_case_reference,
+                prior.block_withdrawal_state_reference
+                    AS prior_block_withdrawal_state_reference,
+                prior.age_assurance_state_reference
+                    AS prior_age_assurance_state_reference,
+                prior.legal_hold_intersection_reference
+                    AS prior_legal_hold_intersection_reference,
+                prior.critical_harm_case_reference
+                    AS prior_critical_harm_case_reference,
+                prior.account_lifecycle_reference
+                    AS prior_account_lifecycle_reference,
+                prior.anti_abuse_continuity_reference
+                    AS prior_anti_abuse_continuity_reference,
+                prior.safety_case_reference
+                    AS prior_safety_case_reference
+            FROM promise_completion.writer_fact_records accepted
+            JOIN promise_completion.writer_fact_records prior
+              ON prior.writer_fact_id = $2
+            WHERE accepted.writer_fact_id = $1
+            ",
+            &[&accepted_writer_fact_id, &prior_writer_fact_id],
+        )
+        .await
+        .map_err(db_error)?;
+
+    let Some(row) = row else {
+        return Err(PromiseCompletionWriterFactPersistenceError::BadRequest(
+            "Promise completion participant-safe display refuses missing projection writer truth"
+                .to_owned(),
+        ));
+    };
+
+    Ok(participant_safe_display_boundary_row_is_unsuppressed(&row))
+}
+
+fn participant_safe_display_boundary_row_is_unsuppressed(row: &Row) -> bool {
+    [
+        (
+            "accepted_block_withdrawal_state_reference",
+            "block-withdrawal-clear",
+        ),
+        (
+            "accepted_age_assurance_state_reference",
+            "age-assurance-adult-eligible",
+        ),
+        (
+            "accepted_legal_hold_intersection_reference",
+            "legal-hold-clear",
+        ),
+        (
+            "accepted_critical_harm_case_reference",
+            "critical-harm-clear",
+        ),
+        (
+            "accepted_account_lifecycle_reference",
+            "account-lifecycle-active",
+        ),
+        (
+            "accepted_anti_abuse_continuity_reference",
+            "anti-abuse-clear",
+        ),
+        ("accepted_safety_case_reference", "safety-case-clear"),
+        (
+            "prior_block_withdrawal_state_reference",
+            "block-withdrawal-clear",
+        ),
+        (
+            "prior_age_assurance_state_reference",
+            "age-assurance-adult-eligible",
+        ),
+        (
+            "prior_legal_hold_intersection_reference",
+            "legal-hold-clear",
+        ),
+        ("prior_critical_harm_case_reference", "critical-harm-clear"),
+        (
+            "prior_account_lifecycle_reference",
+            "account-lifecycle-active",
+        ),
+        ("prior_anti_abuse_continuity_reference", "anti-abuse-clear"),
+        ("prior_safety_case_reference", "safety-case-clear"),
+    ]
+    .into_iter()
+    .all(|(column, posture)| row_reference_has_posture(row, column, posture))
+}
+
+fn row_reference_has_posture(row: &Row, column: &str, posture: &str) -> bool {
+    let value: String = row.get(column);
+    reference_has_posture(&value, posture)
+}
+
+fn reference_has_posture(value: &str, posture: &str) -> bool {
+    let value = value.trim();
+    value == posture
+        || value
+            .strip_prefix(posture)
+            .is_some_and(|remaining| remaining.starts_with('-'))
+}
+
+fn participant_safe_display_availability_from_projection_snapshot(
+    snapshot: PromiseCompletionNonAuthorityProjectionSnapshot,
+) -> PromiseCompletionParticipantSafeDisplayAvailabilitySnapshot {
+    PromiseCompletionParticipantSafeDisplayAvailabilitySnapshot {
+        promise_reference: snapshot.promise_reference,
+        realm_id: snapshot.realm_id,
+        display_class: "promise_completed_reference".to_owned(),
+        display_audience: "involved_participant_only".to_owned(),
+        display_availability: "available".to_owned(),
+        display_meaning: "availability_posture_only".to_owned(),
+        completed_reference_available: true,
+        policy_version: snapshot.policy_version,
+    }
 }
 
 fn replay_writer_fact_id(

--- a/apps/backend/src/services/promise_completion/types.rs
+++ b/apps/backend/src/services/promise_completion/types.rs
@@ -258,3 +258,15 @@ pub struct PromiseCompletionNonAuthorityProjectionSnapshot {
     pub authority_posture: String,
     pub writer_recorded_at: DateTime<Utc>,
 }
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PromiseCompletionParticipantSafeDisplayAvailabilitySnapshot {
+    pub promise_reference: String,
+    pub realm_id: String,
+    pub display_class: String,
+    pub display_audience: String,
+    pub display_availability: String,
+    pub display_meaning: String,
+    pub completed_reference_available: bool,
+    pub policy_version: i32,
+}

--- a/apps/backend/tests/promise_completion_projection_non_authority.rs
+++ b/apps/backend/tests/promise_completion_projection_non_authority.rs
@@ -133,6 +133,134 @@ async fn accepted_projection_snapshot_remains_non_display_and_non_converting() {
 }
 
 #[tokio::test]
+async fn participant_safe_display_availability_is_redacted_and_side_effect_free() {
+    let (_test_state, config, client) = test_context().await;
+    let store = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let idempotency_key = unique_idempotency_key("participant-display-available");
+    let prior = record_prior_pending_mutual_acknowledgement(&store, &idempotency_key).await;
+    let accepted = store
+        .record_mutual_acknowledgement_accepted_transition(transition_input(
+            accepted_transition_fact(&idempotency_key, &prior.writer_fact_id),
+        ))
+        .await
+        .expect("accepted transition should persist");
+    let writer_fact_count_before =
+        writer_fact_count_for_promise(&client, &accepted.promise_reference).await;
+    let side_effects_before = side_effect_counts(&client).await;
+    let display_catalog_entries_before = blocked_completion_display_catalog_entries(&client).await;
+
+    let display = store
+        .derive_participant_safe_completed_reference_display_availability(
+            &accepted.promise_reference,
+            &accepted.realm_id,
+            &format!("participant-set-{idempotency_key}"),
+        )
+        .await
+        .expect("participant-safe display availability should derive")
+        .expect("involved participant set should receive availability");
+
+    assert_eq!(display.promise_reference, accepted.promise_reference);
+    assert_eq!(display.realm_id, accepted.realm_id);
+    assert_eq!(display.display_class, "promise_completed_reference");
+    assert_eq!(display.display_audience, "involved_participant_only");
+    assert_eq!(display.display_availability, "available");
+    assert_eq!(display.display_meaning, "availability_posture_only");
+    assert!(display.completed_reference_available);
+    assert_eq!(display.policy_version, 1);
+
+    let debug_display = format!("{display:?}");
+    assert!(!debug_display.contains(&accepted.writer_fact_id));
+    assert!(!debug_display.contains(&prior.writer_fact_id));
+    assert!(!debug_display.contains("mutual_accountable_completion_acknowledgement"));
+    assert!(!debug_display.contains("participant-set-"));
+    assert!(!debug_display.contains("ordinary-acknowledgement-"));
+    assert!(!debug_display.contains("completion-accepted-"));
+    assert_eq!(
+        writer_fact_count_for_promise(&client, &accepted.promise_reference).await,
+        writer_fact_count_before
+    );
+    assert_eq!(side_effect_counts(&client).await, side_effects_before);
+    assert_eq!(
+        blocked_completion_display_catalog_entries(&client).await,
+        display_catalog_entries_before
+    );
+}
+
+#[tokio::test]
+async fn participant_safe_display_availability_is_unavailable_for_non_involved_participant_set() {
+    let (_test_state, config, _client) = test_context().await;
+    let store = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let idempotency_key = unique_idempotency_key("participant-display-outsider");
+    let prior = record_prior_pending_mutual_acknowledgement(&store, &idempotency_key).await;
+    let accepted = store
+        .record_mutual_acknowledgement_accepted_transition(transition_input(
+            accepted_transition_fact(&idempotency_key, &prior.writer_fact_id),
+        ))
+        .await
+        .expect("accepted transition should persist");
+
+    let display = store
+        .derive_participant_safe_completed_reference_display_availability(
+            &accepted.promise_reference,
+            &accepted.realm_id,
+            &format!("participant-set-outsider-{idempotency_key}"),
+        )
+        .await
+        .expect("non-involved participant set should be handled as unavailable");
+
+    assert!(display.is_none());
+}
+
+#[tokio::test]
+async fn participant_safe_display_availability_fails_closed_when_current_projection_is_ambiguous() {
+    let (_test_state, config, _client) = test_context().await;
+    let store = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let idempotency_key = unique_idempotency_key("participant-display-ambiguous");
+    let policy_one_prior =
+        record_prior_pending_mutual_acknowledgement(&store, &idempotency_key).await;
+    store
+        .record_mutual_acknowledgement_accepted_transition(transition_input(
+            accepted_transition_fact(&idempotency_key, &policy_one_prior.writer_fact_id),
+        ))
+        .await
+        .expect("policy one accepted transition should persist");
+
+    let mut policy_two_prior = prior_mutual_acknowledgement_fact(
+        &idempotency_key,
+        PromiseCompletionStateClass::CompletionPendingMutualAcknowledgement,
+    );
+    policy_two_prior.policy_version = Some(2);
+    let policy_two_prior = record_writer_fact(&store, policy_two_prior).await;
+    let mut policy_two_fact =
+        accepted_transition_fact(&idempotency_key, &policy_two_prior.writer_fact_id);
+    policy_two_fact.policy_version = Some(2);
+    store
+        .record_mutual_acknowledgement_accepted_transition(transition_input(policy_two_fact))
+        .await
+        .expect("policy two accepted transition should persist");
+
+    let error = store
+        .derive_participant_safe_completed_reference_display_availability(
+            &policy_one_prior.promise_reference,
+            &policy_one_prior.realm_id,
+            &format!("participant-set-{idempotency_key}"),
+        )
+        .await
+        .expect_err("ambiguous current projection availability must fail closed");
+
+    assert!(matches!(
+        error,
+        PromiseCompletionWriterFactPersistenceError::BadRequest(_)
+    ));
+}
+
+#[tokio::test]
 async fn missing_required_writer_posture_returns_no_projection_snapshot() {
     let (_test_state, config, _client) = test_context().await;
     let store = PromiseCompletionWriterFactStore::connect(&config)

--- a/apps/backend/tests/promise_completion_projection_non_authority.rs
+++ b/apps/backend/tests/promise_completion_projection_non_authority.rs
@@ -156,6 +156,7 @@ async fn participant_safe_display_availability_is_redacted_and_side_effect_free(
             &accepted.promise_reference,
             &accepted.realm_id,
             &format!("participant-set-{idempotency_key}"),
+            &format!("ordinary-acknowledgement-{idempotency_key}"),
         )
         .await
         .expect("participant-safe display availability should derive")
@@ -208,9 +209,38 @@ async fn participant_safe_display_availability_is_unavailable_for_non_involved_p
             &accepted.promise_reference,
             &accepted.realm_id,
             &format!("participant-set-outsider-{idempotency_key}"),
+            &format!("ordinary-acknowledgement-{idempotency_key}"),
         )
         .await
         .expect("non-involved participant set should be handled as unavailable");
+
+    assert!(display.is_none());
+}
+
+#[tokio::test]
+async fn participant_safe_display_availability_requires_matching_ordinary_acknowledgement() {
+    let (_test_state, config, _client) = test_context().await;
+    let store = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let idempotency_key = unique_idempotency_key("participant-display-wrong-ack");
+    let prior = record_prior_pending_mutual_acknowledgement(&store, &idempotency_key).await;
+    let accepted = store
+        .record_mutual_acknowledgement_accepted_transition(transition_input(
+            accepted_transition_fact(&idempotency_key, &prior.writer_fact_id),
+        ))
+        .await
+        .expect("accepted transition should persist");
+
+    let display = store
+        .derive_participant_safe_completed_reference_display_availability(
+            &accepted.promise_reference,
+            &accepted.realm_id,
+            &format!("participant-set-{idempotency_key}"),
+            &format!("ordinary-acknowledgement-outsider-{idempotency_key}"),
+        )
+        .await
+        .expect("wrong Ordinary Account acknowledgement should be handled as unavailable");
 
     assert!(display.is_none());
 }
@@ -245,6 +275,7 @@ async fn participant_safe_display_availability_is_unavailable_for_suppressed_wri
             &accepted.promise_reference,
             &accepted.realm_id,
             &format!("participant-set-{idempotency_key}"),
+            &format!("ordinary-acknowledgement-{idempotency_key}"),
         )
         .await
         .expect("suppressed writer truth should be handled as unavailable");
@@ -287,6 +318,7 @@ async fn participant_safe_display_availability_fails_closed_when_current_project
             &policy_one_prior.promise_reference,
             &policy_one_prior.realm_id,
             &format!("participant-set-{idempotency_key}"),
+            &format!("ordinary-acknowledgement-{idempotency_key}"),
         )
         .await
         .expect_err("ambiguous current projection availability must fail closed");

--- a/apps/backend/tests/promise_completion_projection_non_authority.rs
+++ b/apps/backend/tests/promise_completion_projection_non_authority.rs
@@ -216,6 +216,43 @@ async fn participant_safe_display_availability_is_unavailable_for_non_involved_p
 }
 
 #[tokio::test]
+async fn participant_safe_display_availability_is_unavailable_for_suppressed_writer_truth() {
+    let (_test_state, config, _client) = test_context().await;
+    let store = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let idempotency_key = unique_idempotency_key("participant-display-suppressed");
+    let prior = record_prior_pending_mutual_acknowledgement(&store, &idempotency_key).await;
+    let mut accepted_fact = accepted_transition_fact(&idempotency_key, &prior.writer_fact_id);
+    accepted_fact.legal_hold_intersection_reference =
+        Some(format!("legal-hold-active-{idempotency_key}"));
+    let accepted = store
+        .record_mutual_acknowledgement_accepted_transition(transition_input(accepted_fact))
+        .await
+        .expect("suppressed accepted transition should persist as writer truth");
+
+    let snapshots = store
+        .derive_accepted_completion_non_authority_projection_snapshots(
+            &accepted.promise_reference,
+            &accepted.realm_id,
+        )
+        .await
+        .expect("accepted projection snapshot should still derive");
+    assert_eq!(snapshots.len(), 1);
+
+    let display = store
+        .derive_participant_safe_completed_reference_display_availability(
+            &accepted.promise_reference,
+            &accepted.realm_id,
+            &format!("participant-set-{idempotency_key}"),
+        )
+        .await
+        .expect("suppressed writer truth should be handled as unavailable");
+
+    assert!(display.is_none());
+}
+
+#[tokio::test]
 async fn participant_safe_display_availability_fails_closed_when_current_projection_is_ambiguous() {
     let (_test_state, config, _client) = test_context().await;
     let store = PromiseCompletionWriterFactStore::connect(&config)

--- a/docs/foundation_lock.md
+++ b/docs/foundation_lock.md
@@ -1,6 +1,6 @@
 # Foundation Lock
 
-Status: Draft; aligned to accepted foundation commit `e1080dd`
+Status: Draft; aligned to accepted foundation commit `0cd0e2b`
 Applies to: `mt4110/pi-musubi-core`
 Purpose: Pin the constitutional and architectural source of truth that this implementation repository must follow.
 
@@ -26,14 +26,14 @@ Upstream repository:
 Pinned reference for implementation work:
 
 - Foundation reference type: `commit`
-- Foundation commit SHA: `e1080dd21b8fb16041520e7ee68e6edbae4ba46f`
-- Foundation commit title: `Merge pull request #462 from mt4110/feat/promise-completion-display-runway`
-- Foundation PR title: `docs: map Promise completion display runway`
-- Foundation PR URL: `https://github.com/mt4110/musubi-foundation/pull/462`
-- Date pinned: `2026-06-19`
+- Foundation commit SHA: `0cd0e2b2d2cee4470480b5e499b918d6e46573b4`
+- Foundation commit title: `Merge pull request #472 from mt4110/feat/promise-completion-display-implementation-handoff-route`
+- Foundation PR title: `docs: select Promise completion display implementation handoff route`
+- Foundation PR URL: `https://github.com/mt4110/musubi-foundation/pull/472`
+- Date pinned: `2026-06-20`
 - Pinned by: `Masaki Takemura`
-- Pinned commit URL: `https://github.com/mt4110/musubi-foundation/commit/e1080dd21b8fb16041520e7ee68e6edbae4ba46f`
-- Previous pinned reference: `0c7d0c5` / `Merge pull request #454 from mt4110/feat/promise-completion-projection-route`
+- Pinned commit URL: `https://github.com/mt4110/musubi-foundation/commit/0cd0e2b2d2cee4470480b5e499b918d6e46573b4`
+- Previous pinned reference: `e1080dd` / `Merge pull request #462 from mt4110/feat/promise-completion-display-runway`
 - Post-C2 evidence source: `cfdba28` / `Merge pull request #114 from mt4110/feat/post-c2-runtime-handoff-evidence-package`
 - Alignment allowance source: `69b7aa4` / `Merge pull request #116 from mt4110/feat/evaluate-post-c2-runtime-handoff-gate`
 - Post-C2 implementation handoff evidence source: `ef23e88` / `Merge pull request #122 from mt4110/feat/post-c2-implementation-handoff-evidence-package`
@@ -189,6 +189,16 @@ Pinned reference for implementation work:
 - Promise completion participant-safe completed reference display preflight packet sufficiency decision source: `e19a5ab` / `Merge pull request #458 from mt4110/feat/promise-completion-display-sufficiency`
 - Promise completion display non-exposure test-only route selection source: `104f45a` / `Merge pull request #460 from mt4110/feat/promise-completion-display-route`
 - Promise completion display readiness runway map source: `e1080dd` / `Merge pull request #462 from mt4110/feat/promise-completion-display-runway`
+- Promise completion display non-exposure test-only closeout source: `4ebac53` / `Merge pull request #463 from mt4110/feat/promise-completion-display-non-exposure-closeout`
+- Promise completion display non-exposure closeout sufficiency decision source: `2b45c47` / `Merge pull request #464 from mt4110/feat/promise-completion-display-closeout-sufficiency`
+- Promise completion display post-sufficiency readiness runway source: `9629405` / `Merge pull request #465 from mt4110/feat/promise-completion-display-post-sufficiency-runway`
+- Promise completion display post-non-exposure route selection source: `569962c` / `Merge pull request #466 from mt4110/feat/promise-completion-display-post-non-exposure-route`
+- Promise completion participant-safe display audience and redaction packet source: `333dc8f` / `Merge pull request #467 from mt4110/feat/promise-completion-display-audience-redaction-packet`
+- Promise completion participant-safe display audience and redaction packet sufficiency decision source: `46efc26` / `Merge pull request #468 from mt4110/feat/promise-completion-display-audience-redaction-sufficiency`
+- Promise completion participant-safe display handoff packet route selection source: `c7a06ac` / `Merge pull request #469 from mt4110/feat/promise-completion-display-handoff-packet-route`
+- Promise completion participant-safe display handoff decision packet source: `ef2915e` / `Merge pull request #470 from mt4110/feat/promise-completion-display-handoff-packet`
+- Promise completion participant-safe display handoff packet sufficiency decision source: `f2e23e4` / `Merge pull request #471 from mt4110/feat/promise-completion-display-handoff-packet-sufficiency`
+- Promise completion participant-safe display implementation handoff route source: `0cd0e2b` / `Merge pull request #472 from mt4110/feat/promise-completion-display-implementation-handoff-route`
 
 No release tag is asserted for this alignment.
 Do not invent a foundation version label for this commit.
@@ -417,6 +427,16 @@ Current Promise completion display chain:
 - `docs/readiness/promise_completion_participant_safe_completed_reference_display_preflight_packet_sufficiency_decision.md`
 - `docs/readiness/promise_completion_post_display_preflight_sufficiency_route_selection.md`
 - `docs/readiness/promise_completion_display_readiness_runway_design.md`
+- `docs/readiness/promise_completion_display_non_exposure_test_only_closeout_ledger.md`
+- `docs/readiness/promise_completion_display_non_exposure_closeout_sufficiency_decision.md`
+- `docs/readiness/promise_completion_display_post_sufficiency_readiness_runway.md`
+- `docs/readiness/promise_completion_display_post_non_exposure_route_selection.md`
+- `docs/readiness/promise_completion_participant_safe_display_audience_redaction_decision_packet.md`
+- `docs/readiness/promise_completion_participant_safe_display_audience_redaction_packet_sufficiency_decision.md`
+- `docs/readiness/promise_completion_participant_safe_display_post_audience_redaction_sufficiency_route_selection.md`
+- `docs/readiness/promise_completion_participant_safe_display_handoff_decision_packet.md`
+- `docs/readiness/promise_completion_participant_safe_display_handoff_packet_sufficiency_decision.md`
+- `docs/readiness/promise_completion_participant_safe_display_post_handoff_packet_sufficiency_route_selection.md`
 
 ### Operations layer
 203. `docs/operations/readiness_routine.md`
@@ -543,8 +563,7 @@ It did not authorize migrations, DDL, new tables, new indexes, triggers, functio
 No remaining work may inherit permission from foundation PR #454 or implementation PR #171.
 Foundation PR #456 prepared Promise completion participant-safe completed reference display preflight decision materials only.
 Foundation PR #458 found that preflight packet sufficient for later route selection only.
-Foundation PR #460 provides the current one-use downstream display non-exposure test-only authority for this implementation-repo PR only.
-This implementation-repo PR consumes that allowance.
+Foundation PR #460 provided the consumed one-use downstream display non-exposure test-only authority for one implementation-repo PR only.
 The PR #460 allowance authorizes only:
 
 - `docs/foundation_lock.md`
@@ -552,11 +571,35 @@ The PR #460 allowance authorizes only:
 
 It authorizes only test coverage proving that the existing accepted completion non-authority projection snapshot remains non-exposed and non-converting before any participant-safe display implementation route exists.
 It authorizes no production backend code, frontend code, mobile code, schema files, migrations, fixtures that alter product meaning, public API routes, UI routes, outbox, inbox, worker, provider, queue, adapter, external side-effect code, Social Trust source fact persistence code, Social Trust mutation code, Relationship Depth code, settlement code, room or contact code, discovery code, recommendation code, additional writer fact persistence, additional state transition runtime behavior, projection refresh, durable projection schema, participant display behavior, public completed-reference display, raw Personal Data exposure, raw evidence exposure, provider payload exposure, proof payload exposure, operator-note exposure, review-narrative exposure, sensitive-trait visibility, shame labels, public accusation labels, paid romantic advantage, payment-based direct-message unlock, new durable product vocabulary, or broad `pi-musubi-core` changes.
-After this downstream PR is merged, closed without merge, or replaced by a different accepted foundation decision, foundation must receive a separate closeout ledger at `docs/readiness/promise_completion_display_non_exposure_test_only_closeout_ledger.md` before any later Promise completion participant display, public display, trust, depth, settlement, API, UI, provider, outbox, inbox, worker, governed review, correction, or broader core route may inherit from it.
+That allowance was consumed by `mt4110/pi-musubi-core` PR #173 and closed out by foundation PR #463.
+No remaining work may inherit permission from foundation PR #460 or implementation PR #173.
 Foundation PR #462 maps the Promise completion display readiness runway only.
 It does not consume the PR #460 allowance.
 It does not create a new downstream allowance, test-only handoff, implementation handoff, runtime implementation authority, or `pi-musubi-core` authority.
 It keeps `readiness runway` as an operational planning label only, not a MUSUBI product term, domain term, Glossary term, or canonical noun.
+Foundation PR #463 recorded that the PR #460 test-only allowance was consumed by `mt4110/pi-musubi-core` PR #173 and returned participant display, public display, trust, depth, settlement, API, UI, provider, outbox, inbox, worker, governed review, correction, and broader core surfaces to NO-GO.
+Foundation PR #464 found the non-exposure closeout sufficient for later route selection only.
+Foundation PR #465 maps the post-sufficiency readiness runway only and does not create product or domain vocabulary.
+Foundation PR #466 selected the participant-safe display audience and redaction packet route only.
+Foundation PR #467 prepared the audience and redaction packet.
+Foundation PR #468 found that packet sufficient for later route selection only.
+Foundation PR #469 selected the participant-safe display handoff packet route only.
+Foundation PR #470 prepared the participant-safe display handoff packet.
+Foundation PR #471 found that handoff packet sufficient for later route selection only.
+Foundation PR #472 provides the current one-use downstream narrow participant-safe display implementation handoff authority for one later implementation-repo PR only.
+This implementation-repo PR consumes that allowance.
+The PR #472 allowance authorizes only:
+
+- `docs/foundation_lock.md`
+- `apps/backend/src/services/promise_completion/mod.rs`
+- `apps/backend/src/services/promise_completion/repository.rs`
+- `apps/backend/src/services/promise_completion/types.rs`
+- `apps/backend/tests/promise_completion_projection_non_authority.rs`
+
+It authorizes only a narrow participant-safe completed reference availability display path for already accepted, current, unsuppressed, writer-backed Promise completion projection availability, visible only to directly involved Ordinary Accounts subject to suppression, plus deterministic verification inside the same implementation-repo PR.
+It may update this foundation lock before consuming the allowance.
+It does not authorize public completed-reference display, public profile display, public count, public badge, public trust label, public accusation label, public API behavior, mobile UI behavior, DDL, migrations, durable projection schema, projection refresh, Promise completion source-route evaluation from raw user input, participant acknowledgement collection, governed review runtime workflow, governed review accepted transition runtime, correction or supersession runtime, proof runtime behavior, proof eligibility runtime behavior, additional writer fact persistence, additional state transition runtime behavior, Social Trust source fact persistence, Social Trust mutation, Relationship Depth mutation, settlement release, refund, forfeiture, escrow movement, reward movement, room progression, contact unlock, discovery priority, recommendation boost, outbox, inbox, worker, provider, queue, adapter, external side-effect behavior, raw Personal Data exposure, raw evidence exposure, provider payload exposure, proof payload exposure, operator-note exposure, review-narrative exposure, Legal Hold material exposure, Critical Harm material exposure, child-safety material exposure, sensitive-trait exposure, shame labels, paid romantic advantage, payment-based direct-message unlock, new durable product vocabulary, or broad `pi-musubi-core` changes.
+After this downstream PR is merged, closed without merge, or replaced by a different accepted foundation decision, foundation must receive a separate closeout ledger before any later Promise completion display, public display, trust, depth, settlement, API, UI, provider, outbox, inbox, worker, governed review, correction, or broader core route may inherit from it.
 
 The C2 and post-C2 readiness and closeout chain is accepted for docs-only foundation semantic scope:
 


### PR DESCRIPTION
## Summary
- Pin `docs/foundation_lock.md` to musubi-foundation #472 / `0cd0e2b` and record the consumed one-use implementation handoff allowance.
- Add a narrow participant-safe Promise completion completed-reference availability derivation over the existing accepted non-authority projection path.
- Keep display availability redacted and side-effect free: no writer fact IDs, prior IDs, participant-set refs, source route, public API, UI, DDL, migrations, or external effects.

## Validation
- `make guardrail-sweep-self-test && make guardrail-sweep && cargo check --workspace --all-targets && cargo clippy --workspace --all-targets`
- `cargo test --test promise_completion_projection_non_authority`
- `cargo test -p musubi_backend`
