### PR TITLE
feat: add Promise completion participant-safe display availability API

### DIFF
--- a/apps/backend/docs/http_route_gate_inventory.txt
+++ b/apps/backend/docs/http_route_gate_inventory.txt
@@ -51,6 +51,8 @@ apps/backend/src/lib.rs /api/projection/settlement-views/{settlement_case_id}/ex
 apps/backend/src/lib.rs /api/projection/settlement-views/{settlement_case_id}/expanded HEAD handlers::projection::get_expanded_settlement_view ALWAYS
 apps/backend/src/lib.rs /api/projection/trust-snapshots/{account_id} GET handlers::projection::get_trust_snapshot ALWAYS
 apps/backend/src/lib.rs /api/projection/trust-snapshots/{account_id} HEAD handlers::projection::get_trust_snapshot ALWAYS
+apps/backend/src/lib.rs /api/promise-completion/participant-safe-display-availability/{promise_reference} GET handlers::promise_completion::get_participant_safe_display_availability ALWAYS
+apps/backend/src/lib.rs /api/promise-completion/participant-safe-display-availability/{promise_reference} HEAD handlers::promise_completion::get_participant_safe_display_availability ALWAYS
 apps/backend/src/lib.rs /api/promise/intents POST handlers::promise_intents::create_promise_intent ALWAYS
 apps/backend/src/lib.rs /api/proof/challenges POST handlers::proof::start_proof_challenge ALWAYS
 apps/backend/src/lib.rs /api/proof/submissions POST handlers::proof::submit_proof_envelope ALWAYS

--- a/apps/backend/docs/public_route_inventory.txt
+++ b/apps/backend/docs/public_route_inventory.txt
@@ -16,6 +16,8 @@ apps/backend/src/lib.rs /api/projection/settlement-views/{settlement_case_id}/ex
 apps/backend/src/lib.rs /api/projection/settlement-views/{settlement_case_id}/expanded HEAD handlers::projection::get_expanded_settlement_view
 apps/backend/src/lib.rs /api/projection/trust-snapshots/{account_id} GET handlers::projection::get_trust_snapshot
 apps/backend/src/lib.rs /api/projection/trust-snapshots/{account_id} HEAD handlers::projection::get_trust_snapshot
+apps/backend/src/lib.rs /api/promise-completion/participant-safe-display-availability/{promise_reference} GET handlers::promise_completion::get_participant_safe_display_availability
+apps/backend/src/lib.rs /api/promise-completion/participant-safe-display-availability/{promise_reference} HEAD handlers::promise_completion::get_participant_safe_display_availability
 apps/backend/src/lib.rs /api/promise/intents POST handlers::promise_intents::create_promise_intent
 apps/backend/src/lib.rs /api/proof/challenges POST handlers::proof::start_proof_challenge
 apps/backend/src/lib.rs /api/proof/submissions POST handlers::proof::submit_proof_envelope

--- a/apps/backend/src/handlers/mod.rs
+++ b/apps/backend/src/handlers/mod.rs
@@ -16,6 +16,7 @@ pub mod ops_observability;
 pub mod orchestration;
 pub mod payments;
 pub mod projection;
+pub mod promise_completion;
 pub mod promise_intents;
 pub mod proof;
 pub mod realm_bootstrap;

--- a/apps/backend/src/handlers/promise_completion.rs
+++ b/apps/backend/src/handlers/promise_completion.rs
@@ -1,0 +1,102 @@
+use axum::{
+    Json,
+    extract::{Path, Query, State},
+    http::HeaderMap,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    SharedState,
+    handlers::{
+        ApiError, ApiResult, bad_request, conflict, internal_server_error, require_bearer_token,
+        service_unavailable,
+    },
+    services::{
+        happy_route::authorize_account,
+        promise_completion::PromiseCompletionWriterFactPersistenceError,
+    },
+};
+
+#[derive(Debug, Deserialize)]
+pub struct ParticipantSafeDisplayAvailabilityQuery {
+    pub realm_id: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ParticipantSafeDisplayAvailabilityResponse {
+    pub display_availability: String,
+    pub completed_reference_available: bool,
+}
+
+pub async fn get_participant_safe_display_availability(
+    State(state): State<SharedState>,
+    headers: HeaderMap,
+    Path(promise_reference): Path<String>,
+    Query(query): Query<ParticipantSafeDisplayAvailabilityQuery>,
+) -> ApiResult<ParticipantSafeDisplayAvailabilityResponse> {
+    let bearer_token = require_bearer_token(&headers)?;
+    let account = authorize_account(&state, &bearer_token)
+        .await
+        .map_err(super::map_happy_route_error)?;
+    let Some(realm_id) = query
+        .realm_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+    else {
+        return Ok(Json(participant_safe_display_availability_response(false)));
+    };
+
+    let availability = state
+        .promise_completion
+        .derive_participant_safe_completed_reference_display_availability_for_account(
+            promise_reference.trim(),
+            realm_id,
+            &account.account_id,
+        )
+        .await
+        .map_err(map_promise_completion_error)?;
+
+    Ok(Json(participant_safe_display_availability_response(
+        availability.is_some(),
+    )))
+}
+
+fn participant_safe_display_availability_response(
+    available: bool,
+) -> ParticipantSafeDisplayAvailabilityResponse {
+    if available {
+        return ParticipantSafeDisplayAvailabilityResponse {
+            display_availability: "available".to_owned(),
+            completed_reference_available: true,
+        };
+    }
+
+    ParticipantSafeDisplayAvailabilityResponse {
+        display_availability: "unavailable".to_owned(),
+        completed_reference_available: false,
+    }
+}
+
+fn map_promise_completion_error(error: PromiseCompletionWriterFactPersistenceError) -> ApiError {
+    match error {
+        PromiseCompletionWriterFactPersistenceError::BadRequest(message) => bad_request(message),
+        PromiseCompletionWriterFactPersistenceError::IdempotencyConflict { message, .. } => {
+            conflict(message)
+        }
+        PromiseCompletionWriterFactPersistenceError::Database {
+            message, retryable, ..
+        } => {
+            eprintln!("database Promise completion display availability error: {message}");
+            if retryable {
+                service_unavailable("temporarily unavailable")
+            } else {
+                internal_server_error("internal server error")
+            }
+        }
+        PromiseCompletionWriterFactPersistenceError::Internal(message) => {
+            eprintln!("internal Promise completion display availability error: {message}");
+            internal_server_error("internal server error")
+        }
+    }
+}

--- a/apps/backend/src/lib.rs
+++ b/apps/backend/src/lib.rs
@@ -26,6 +26,7 @@ pub struct AppState {
     pub launch_posture: services::launch_posture::LaunchPostureService,
     pub ops_observability: services::ops_observability::OpsObservabilityStore,
     pub operator_review: services::operator_review::OperatorReviewStore,
+    pub promise_completion: services::promise_completion::PromiseCompletionWriterFactStore,
     pub realm_bootstrap: services::realm_bootstrap::RealmBootstrapStore,
     pub room_progression: services::room_progression::RoomProgressionStore,
     pub proof: RwLock<services::proof::ProofState>,
@@ -50,6 +51,8 @@ pub async fn new_state_from_config(config: &DbConfig) -> musubi_db_runtime::Resu
         ops_observability: services::ops_observability::OpsObservabilityStore::connect(config)
             .await?,
         operator_review: services::operator_review::OperatorReviewStore::connect(config).await?,
+        promise_completion:
+            services::promise_completion::PromiseCompletionWriterFactStore::connect(config).await?,
         realm_bootstrap: services::realm_bootstrap::RealmBootstrapStore::connect(config).await?,
         room_progression: services::room_progression::RoomProgressionStore::connect(config).await?,
         proof: RwLock::new(services::proof::ProofState::default()),
@@ -192,6 +195,10 @@ pub fn build_app(state: SharedState) -> Router {
         .route(
             "/api/projection/realm-trust-snapshots/{realm_id}/{account_id}",
             get(handlers::projection::get_realm_trust_snapshot),
+        )
+        .route(
+            "/api/promise-completion/participant-safe-display-availability/{promise_reference}",
+            get(handlers::promise_completion::get_participant_safe_display_availability),
         )
         .route(
             "/api/review-cases/{review_case_id}/appeals",

--- a/apps/backend/src/services/promise_completion/repository.rs
+++ b/apps/backend/src/services/promise_completion/repository.rs
@@ -294,6 +294,69 @@ impl PromiseCompletionWriterFactStore {
             participant_safe_display_availability_from_projection_snapshot(snapshot),
         ))
     }
+
+    pub async fn derive_participant_safe_completed_reference_display_availability_for_account(
+        &self,
+        promise_reference: &str,
+        realm_id: &str,
+        account_id: &str,
+    ) -> Result<
+        Option<PromiseCompletionParticipantSafeDisplayAvailabilitySnapshot>,
+        PromiseCompletionWriterFactPersistenceError,
+    > {
+        let promise_reference = required_projection_ref(promise_reference, "Promise reference")?;
+        let realm_id = required_projection_ref(realm_id, "realm_id")?;
+        let account_id = required_projection_uuid_ref(account_id, "account id")?;
+        let client = self.client.lock().await;
+
+        if !active_ordinary_account_exists(&*client, &account_id).await? {
+            return Ok(None);
+        }
+        if !promise_participant_membership_exists(
+            &*client,
+            &promise_reference,
+            &realm_id,
+            &account_id,
+        )
+        .await?
+        {
+            return Ok(None);
+        }
+
+        let snapshots = match load_accepted_completion_non_authority_projection_snapshots(
+            &*client,
+            &promise_reference,
+            &realm_id,
+        )
+        .await
+        {
+            Ok(snapshots) => snapshots,
+            Err(PromiseCompletionWriterFactPersistenceError::BadRequest(_)) => return Ok(None),
+            Err(error) => return Err(error),
+        };
+
+        if snapshots.len() != 1 {
+            return Ok(None);
+        }
+
+        let snapshot = snapshots
+            .into_iter()
+            .next()
+            .expect("snapshot length was checked");
+        let authorized =
+            match participant_safe_display_boundary_is_unsuppressed(&*client, &snapshot).await {
+                Ok(authorized) => authorized,
+                Err(PromiseCompletionWriterFactPersistenceError::BadRequest(_)) => false,
+                Err(error) => return Err(error),
+            };
+        if !authorized {
+            return Ok(None);
+        }
+
+        Ok(Some(
+            participant_safe_display_availability_from_projection_snapshot(snapshot),
+        ))
+    }
 }
 
 fn validate_mutual_acknowledgement_accepted_transition(
@@ -1306,6 +1369,27 @@ async fn participant_safe_display_boundary_is_authorized_and_unsuppressed(
     snapshot: &PromiseCompletionNonAuthorityProjectionSnapshot,
     ordinary_participant_acknowledgement_reference: &str,
 ) -> Result<bool, PromiseCompletionWriterFactPersistenceError> {
+    let row = load_participant_safe_display_boundary_row(client, snapshot).await?;
+    Ok(
+        participant_safe_display_boundary_row_is_authorized_and_unsuppressed(
+            &row,
+            ordinary_participant_acknowledgement_reference,
+        ),
+    )
+}
+
+async fn participant_safe_display_boundary_is_unsuppressed(
+    client: &impl GenericClient,
+    snapshot: &PromiseCompletionNonAuthorityProjectionSnapshot,
+) -> Result<bool, PromiseCompletionWriterFactPersistenceError> {
+    let row = load_participant_safe_display_boundary_row(client, snapshot).await?;
+    Ok(participant_safe_display_boundary_row_is_unsuppressed(&row))
+}
+
+async fn load_participant_safe_display_boundary_row(
+    client: &impl GenericClient,
+    snapshot: &PromiseCompletionNonAuthorityProjectionSnapshot,
+) -> Result<Row, PromiseCompletionWriterFactPersistenceError> {
     let accepted_writer_fact_id =
         required_projection_uuid_ref(&snapshot.accepted_writer_fact_id, "accepted writer fact id")?;
     let prior_writer_fact_id =
@@ -1363,12 +1447,7 @@ async fn participant_safe_display_boundary_is_authorized_and_unsuppressed(
         ));
     };
 
-    Ok(
-        participant_safe_display_boundary_row_is_authorized_and_unsuppressed(
-            &row,
-            ordinary_participant_acknowledgement_reference,
-        ),
-    )
+    Ok(row)
 }
 
 fn participant_safe_display_boundary_row_is_authorized_and_unsuppressed(
@@ -1387,6 +1466,10 @@ fn participant_safe_display_boundary_row_is_authorized_and_unsuppressed(
         return false;
     }
 
+    participant_safe_display_boundary_row_is_unsuppressed(row)
+}
+
+fn participant_safe_display_boundary_row_is_unsuppressed(row: &Row) -> bool {
     [
         (
             "accepted_block_withdrawal_state_reference",
@@ -1468,6 +1551,60 @@ fn participant_safe_display_availability_from_projection_snapshot(
         completed_reference_available: true,
         policy_version: snapshot.policy_version,
     }
+}
+
+async fn active_ordinary_account_exists(
+    client: &impl GenericClient,
+    account_id: &Uuid,
+) -> Result<bool, PromiseCompletionWriterFactPersistenceError> {
+    let row = client
+        .query_opt(
+            "
+            SELECT account_class, account_state
+            FROM core.accounts
+            WHERE account_id = $1
+            ",
+            &[account_id],
+        )
+        .await
+        .map_err(db_error)?;
+
+    let Some(row) = row else {
+        return Ok(false);
+    };
+
+    let account_class: String = row.get("account_class");
+    let account_state: String = row.get("account_state");
+    Ok(account_class == "Ordinary Account" && account_state == "active")
+}
+
+async fn promise_participant_membership_exists(
+    client: &impl GenericClient,
+    promise_reference: &str,
+    realm_id: &str,
+    account_id: &Uuid,
+) -> Result<bool, PromiseCompletionWriterFactPersistenceError> {
+    let Ok(promise_intent_id) = Uuid::parse_str(promise_reference) else {
+        return Ok(false);
+    };
+    let row = client
+        .query_opt(
+            "
+            SELECT 1
+            FROM dao.promise_intents
+            WHERE promise_intent_id = $1
+              AND realm_id = $2
+              AND (
+                    initiator_account_id = $3
+                 OR counterparty_account_id = $3
+              )
+            ",
+            &[&promise_intent_id, &realm_id, account_id],
+        )
+        .await
+        .map_err(db_error)?;
+
+    Ok(row.is_some())
 }
 
 fn replay_writer_fact_id(

--- a/apps/backend/tests/promise_completion_participant_safe_display_narrow_api_handoff.rs
+++ b/apps/backend/tests/promise_completion_participant_safe_display_narrow_api_handoff.rs
@@ -1,0 +1,930 @@
+use std::path::PathBuf;
+
+use axum::{
+    Router,
+    body::{Body, to_bytes},
+    http::{Request, StatusCode},
+};
+use musubi_backend::{
+    build_app, new_test_state,
+    services::promise_completion::{
+        PromiseCompletionAuthorityPosture, PromiseCompletionProjectionNonAuthorityPosture,
+        PromiseCompletionSourceRouteClass, PromiseCompletionStateClass,
+        PromiseCompletionWriterFactFamily, PromiseCompletionWriterFactStore,
+        ProposedMutualAcknowledgementAcceptedTransition, ProposedPromiseCompletionWriterFact,
+        RecordMutualAcknowledgementAcceptedTransitionInput, RecordPromiseCompletionWriterFactInput,
+    },
+};
+use musubi_db_runtime::DbConfig;
+use serde_json::{Value, json};
+use tokio_postgres::NoTls;
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn narrow_api_exposes_availability_only_to_directly_involved_ordinary_account() {
+    let (_test_state, app, config, client) = test_context().await;
+    let store = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let involved = sign_in(
+        &app,
+        "pi-user-promise-completion-narrow-api-involved",
+        "promise-completion-narrow-api-involved",
+    )
+    .await;
+    let outsider = sign_in(
+        &app,
+        "pi-user-promise-completion-narrow-api-outsider",
+        "promise-completion-narrow-api-outsider",
+    )
+    .await;
+    let controlled = sign_in(
+        &app,
+        "pi-user-promise-completion-narrow-api-controlled",
+        "promise-completion-narrow-api-controlled",
+    )
+    .await;
+
+    let idempotency_key = unique_idempotency_key("participant-display-narrow-api");
+    let promise_case = create_promise_intent(&app, &involved, &controlled, &idempotency_key).await;
+    set_account_class(
+        &client,
+        &controlled.account_id,
+        "Controlled Exceptional Account",
+    )
+    .await;
+
+    let acknowledgement_reference = format!("ordinary-acknowledgement-{idempotency_key}");
+    let prior = record_prior_pending_mutual_acknowledgement(
+        &store,
+        &idempotency_key,
+        &acknowledgement_reference,
+        &promise_case.promise_reference,
+        &promise_case.realm_id,
+    )
+    .await;
+    let accepted = store
+        .record_mutual_acknowledgement_accepted_transition(transition_input(
+            accepted_transition_fact(
+                &idempotency_key,
+                &prior.writer_fact_id,
+                &acknowledgement_reference,
+                &promise_case.promise_reference,
+                &promise_case.realm_id,
+            ),
+        ))
+        .await
+        .expect("accepted transition should persist");
+    let context = ExposureContext {
+        accepted_writer_fact_id: accepted.writer_fact_id.clone(),
+        prior_writer_fact_id: prior.writer_fact_id.clone(),
+        promise_reference: accepted.promise_reference.clone(),
+        realm_id: accepted.realm_id.clone(),
+        promise_terms_reference: format!("promise-terms-{idempotency_key}"),
+        participant_set_reference: format!("participant-set-{idempotency_key}"),
+        acknowledgement_reference,
+        idempotency_key: idempotency_key.clone(),
+    };
+    let path = availability_path(&context.promise_reference, &context.realm_id);
+    let path_with_caller_supplied_truth = format!(
+        "{}&participant_set_reference={}&ordinary_participant_acknowledgement_reference={}",
+        path, context.participant_set_reference, context.acknowledgement_reference
+    );
+    let path_with_wrong_caller_supplied_truth = format!(
+        "{path}&participant_set_reference=wrong-participant-set-{idempotency_key}&ordinary_participant_acknowledgement_reference=wrong-acknowledgement-{idempotency_key}"
+    );
+    let side_effects_before = side_effect_counts(&client).await;
+
+    let unauthenticated = get_http(&app, &path, None).await;
+    assert_eq!(unauthenticated.status, StatusCode::UNAUTHORIZED);
+    assert_no_completion_exposure(&unauthenticated, &context);
+
+    let unauthenticated_without_realm = get_http(
+        &app,
+        &availability_path_without_realm(&context.promise_reference),
+        None,
+    )
+    .await;
+    assert_eq!(
+        unauthenticated_without_realm.status,
+        StatusCode::UNAUTHORIZED
+    );
+    assert_no_completion_exposure(&unauthenticated_without_realm, &context);
+
+    let involved_without_realm = get_http(
+        &app,
+        &availability_path_without_realm(&context.promise_reference),
+        Some(involved.token.as_str()),
+    )
+    .await;
+    assert_unavailable_response(&involved_without_realm, &context);
+
+    let involved_with_blank_realm = get_http(
+        &app,
+        &format!(
+            "/api/promise-completion/participant-safe-display-availability/{}?realm_id=",
+            context.promise_reference
+        ),
+        Some(involved.token.as_str()),
+    )
+    .await;
+    assert_unavailable_response(&involved_with_blank_realm, &context);
+
+    let outsider_response = get_http(&app, &path, Some(outsider.token.as_str())).await;
+    assert_unavailable_response(&outsider_response, &context);
+
+    let outsider_with_truth = get_http(
+        &app,
+        &path_with_caller_supplied_truth,
+        Some(outsider.token.as_str()),
+    )
+    .await;
+    assert_unavailable_response(&outsider_with_truth, &context);
+
+    let controlled_response = get_http(&app, &path, Some(controlled.token.as_str())).await;
+    assert_unavailable_response(&controlled_response, &context);
+
+    let wrong_promise = get_http(
+        &app,
+        &availability_path(
+            &format!("wrong-promise-{idempotency_key}"),
+            &context.realm_id,
+        ),
+        Some(involved.token.as_str()),
+    )
+    .await;
+    assert_unavailable_response(&wrong_promise, &context);
+
+    let wrong_realm = get_http(
+        &app,
+        &availability_path(
+            &context.promise_reference,
+            &format!("wrong-realm-{idempotency_key}"),
+        ),
+        Some(involved.token.as_str()),
+    )
+    .await;
+    assert_unavailable_response(&wrong_realm, &context);
+
+    let involved_response = get_http(&app, &path, Some(involved.token.as_str())).await;
+    assert_available_response(&involved_response, &context);
+
+    let involved_with_wrong_truth = get_http(
+        &app,
+        &path_with_wrong_caller_supplied_truth,
+        Some(involved.token.as_str()),
+    )
+    .await;
+    assert_available_response(&involved_with_wrong_truth, &context);
+
+    assert_eq!(side_effect_counts(&client).await, side_effects_before);
+}
+
+#[tokio::test]
+async fn narrow_api_returns_unavailable_for_suppressed_writer_truth_without_reason_leakage() {
+    let (_test_state, app, config, client) = test_context().await;
+    let store = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let involved = sign_in(
+        &app,
+        "pi-user-promise-completion-narrow-api-suppressed",
+        "promise-completion-narrow-api-suppressed",
+    )
+    .await;
+    let counterparty = sign_in(
+        &app,
+        "pi-user-promise-completion-narrow-api-suppressed-counterparty",
+        "promise-completion-narrow-api-suppressed-counterparty",
+    )
+    .await;
+    let idempotency_key = unique_idempotency_key("participant-display-narrow-api-suppressed");
+    let promise_case =
+        create_promise_intent(&app, &involved, &counterparty, &idempotency_key).await;
+    let acknowledgement_reference = format!("ordinary-acknowledgement-{idempotency_key}");
+    let prior = record_prior_pending_mutual_acknowledgement(
+        &store,
+        &idempotency_key,
+        &acknowledgement_reference,
+        &promise_case.promise_reference,
+        &promise_case.realm_id,
+    )
+    .await;
+    let mut accepted_fact = accepted_transition_fact(
+        &idempotency_key,
+        &prior.writer_fact_id,
+        &acknowledgement_reference,
+        &promise_case.promise_reference,
+        &promise_case.realm_id,
+    );
+    accepted_fact.legal_hold_intersection_reference =
+        Some(format!("legal-hold-active-{idempotency_key}"));
+    let accepted = store
+        .record_mutual_acknowledgement_accepted_transition(transition_input(accepted_fact))
+        .await
+        .expect("suppressed accepted transition should persist");
+    let context = ExposureContext {
+        accepted_writer_fact_id: accepted.writer_fact_id.clone(),
+        prior_writer_fact_id: prior.writer_fact_id.clone(),
+        promise_reference: accepted.promise_reference.clone(),
+        realm_id: accepted.realm_id.clone(),
+        promise_terms_reference: format!("promise-terms-{idempotency_key}"),
+        participant_set_reference: format!("participant-set-{idempotency_key}"),
+        acknowledgement_reference,
+        idempotency_key,
+    };
+    let side_effects_before = side_effect_counts(&client).await;
+
+    let response = get_http(
+        &app,
+        &availability_path(&context.promise_reference, &context.realm_id),
+        Some(involved.token.as_str()),
+    )
+    .await;
+
+    assert_unavailable_response(&response, &context);
+    assert_eq!(side_effect_counts(&client).await, side_effects_before);
+}
+
+#[tokio::test]
+async fn narrow_api_fails_closed_when_competing_snapshot_is_suppressed() {
+    let (_test_state, app, config, client) = test_context().await;
+    let store = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let involved = sign_in(
+        &app,
+        "pi-user-promise-completion-narrow-api-competing",
+        "promise-completion-narrow-api-competing",
+    )
+    .await;
+    let counterparty = sign_in(
+        &app,
+        "pi-user-promise-completion-narrow-api-competing-counterparty",
+        "promise-completion-narrow-api-competing-counterparty",
+    )
+    .await;
+    let promise_key = unique_idempotency_key("participant-display-narrow-api-competing");
+    let promise_case = create_promise_intent(&app, &involved, &counterparty, &promise_key).await;
+
+    let clear_key = unique_idempotency_key("participant-display-narrow-api-clear");
+    let clear_acknowledgement_reference = format!("ordinary-acknowledgement-{clear_key}");
+    let clear_prior = record_prior_pending_mutual_acknowledgement(
+        &store,
+        &clear_key,
+        &clear_acknowledgement_reference,
+        &promise_case.promise_reference,
+        &promise_case.realm_id,
+    )
+    .await;
+    let clear = store
+        .record_mutual_acknowledgement_accepted_transition(transition_input(
+            accepted_transition_fact(
+                &clear_key,
+                &clear_prior.writer_fact_id,
+                &clear_acknowledgement_reference,
+                &promise_case.promise_reference,
+                &promise_case.realm_id,
+            ),
+        ))
+        .await
+        .expect("clear accepted transition should persist");
+
+    let suppressed_key = unique_idempotency_key("participant-display-narrow-api-competing-held");
+    let suppressed_acknowledgement_reference = format!("ordinary-acknowledgement-{suppressed_key}");
+    let suppressed_prior = record_prior_pending_mutual_acknowledgement(
+        &store,
+        &suppressed_key,
+        &suppressed_acknowledgement_reference,
+        &promise_case.promise_reference,
+        &promise_case.realm_id,
+    )
+    .await;
+    let mut suppressed_fact = accepted_transition_fact(
+        &suppressed_key,
+        &suppressed_prior.writer_fact_id,
+        &suppressed_acknowledgement_reference,
+        &promise_case.promise_reference,
+        &promise_case.realm_id,
+    );
+    suppressed_fact.legal_hold_intersection_reference =
+        Some(format!("legal-hold-active-{suppressed_key}"));
+    let suppressed = store
+        .record_mutual_acknowledgement_accepted_transition(transition_input(suppressed_fact))
+        .await
+        .expect("suppressed accepted transition should persist");
+    let context = ExposureContext {
+        accepted_writer_fact_id: clear.writer_fact_id.clone(),
+        prior_writer_fact_id: clear_prior.writer_fact_id.clone(),
+        promise_reference: clear.promise_reference.clone(),
+        realm_id: clear.realm_id.clone(),
+        promise_terms_reference: format!("promise-terms-{clear_key}"),
+        participant_set_reference: format!("participant-set-{clear_key}"),
+        acknowledgement_reference: clear_acknowledgement_reference,
+        idempotency_key: clear_key,
+    };
+    let suppressed_context = ExposureContext {
+        accepted_writer_fact_id: suppressed.writer_fact_id.clone(),
+        prior_writer_fact_id: suppressed_prior.writer_fact_id.clone(),
+        promise_reference: suppressed.promise_reference.clone(),
+        realm_id: suppressed.realm_id.clone(),
+        promise_terms_reference: format!("promise-terms-{suppressed_key}"),
+        participant_set_reference: format!("participant-set-{suppressed_key}"),
+        acknowledgement_reference: suppressed_acknowledgement_reference,
+        idempotency_key: suppressed_key,
+    };
+    let side_effects_before = side_effect_counts(&client).await;
+
+    let response = get_http(
+        &app,
+        &availability_path(&context.promise_reference, &context.realm_id),
+        Some(involved.token.as_str()),
+    )
+    .await;
+
+    assert_unavailable_response(&response, &context);
+    assert_no_completion_exposure(&response, &suppressed_context);
+    assert_eq!(side_effect_counts(&client).await, side_effects_before);
+}
+
+#[tokio::test]
+async fn narrow_api_does_not_treat_acknowledgement_reference_format_as_membership() {
+    let (_test_state, app, config, _client) = test_context().await;
+    let store = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let initiator = sign_in(
+        &app,
+        "pi-user-promise-completion-narrow-api-membership-initiator",
+        "promise-completion-narrow-api-membership-initiator",
+    )
+    .await;
+    let counterparty = sign_in(
+        &app,
+        "pi-user-promise-completion-narrow-api-membership-counterparty",
+        "promise-completion-narrow-api-membership-counterparty",
+    )
+    .await;
+    let outsider = sign_in(
+        &app,
+        "pi-user-promise-completion-narrow-api-membership-outsider",
+        "promise-completion-narrow-api-membership-outsider",
+    )
+    .await;
+
+    let idempotency_key = unique_idempotency_key("participant-display-narrow-api-membership");
+    let promise_case =
+        create_promise_intent(&app, &initiator, &counterparty, &idempotency_key).await;
+    let acknowledgement_reference = account_acknowledgement_reference(&outsider.account_id);
+    let prior = record_prior_pending_mutual_acknowledgement(
+        &store,
+        &idempotency_key,
+        &acknowledgement_reference,
+        &promise_case.promise_reference,
+        &promise_case.realm_id,
+    )
+    .await;
+    let accepted = store
+        .record_mutual_acknowledgement_accepted_transition(transition_input(
+            accepted_transition_fact(
+                &idempotency_key,
+                &prior.writer_fact_id,
+                &acknowledgement_reference,
+                &promise_case.promise_reference,
+                &promise_case.realm_id,
+            ),
+        ))
+        .await
+        .expect("accepted transition should persist");
+    let context = ExposureContext {
+        accepted_writer_fact_id: accepted.writer_fact_id.clone(),
+        prior_writer_fact_id: prior.writer_fact_id.clone(),
+        promise_reference: accepted.promise_reference.clone(),
+        realm_id: accepted.realm_id.clone(),
+        promise_terms_reference: format!("promise-terms-{idempotency_key}"),
+        participant_set_reference: format!("participant-set-{idempotency_key}"),
+        acknowledgement_reference,
+        idempotency_key,
+    };
+
+    let response = get_http(
+        &app,
+        &availability_path(&context.promise_reference, &context.realm_id),
+        Some(outsider.token.as_str()),
+    )
+    .await;
+
+    assert_unavailable_response(&response, &context);
+}
+
+async fn test_context() -> (
+    musubi_backend::TestState,
+    Router,
+    DbConfig,
+    tokio_postgres::Client,
+) {
+    let test_state = new_test_state()
+        .await
+        .expect("test database state should initialize");
+    let app = build_app(test_state.state.clone());
+    let database_url = std::env::var("MUSUBI_TEST_DATABASE_URL")
+        .or_else(|_| std::env::var("DATABASE_URL"))
+        .expect("integration tests require MUSUBI_TEST_DATABASE_URL or DATABASE_URL to be set");
+    let migrations_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("migrations")
+        .canonicalize()
+        .expect("migrations directory should resolve");
+    let migrations_dir = migrations_dir
+        .to_str()
+        .expect("migrations directory should be utf-8")
+        .to_owned();
+    let config = DbConfig::from_lookup(|name| match name {
+        "APP_ENV" => Some("test".to_owned()),
+        "DATABASE_URL" => Some(database_url.clone()),
+        "MIGRATIONS_DIR" => Some(migrations_dir.clone()),
+        "REQUIRE_LATEST_SCHEMA" => Some("true".to_owned()),
+        _ => None,
+    })
+    .expect("test db config should parse");
+
+    let (client, connection) = tokio_postgres::connect(&database_url, NoTls)
+        .await
+        .expect("failed to connect to test database");
+    tokio::spawn(async move {
+        if let Err(error) = connection.await {
+            eprintln!("test database connection error: {error}");
+        }
+    });
+
+    (test_state, app, config, client)
+}
+
+fn unique_idempotency_key(label: &str) -> String {
+    format!("{label}-{}", uuid::Uuid::new_v4())
+}
+
+fn account_acknowledgement_reference(account_id: &str) -> String {
+    format!("ordinary-participant-acknowledgement-{account_id}")
+}
+
+async fn record_writer_fact(
+    store: &PromiseCompletionWriterFactStore,
+    fact: ProposedPromiseCompletionWriterFact,
+) -> musubi_backend::services::promise_completion::PromiseCompletionWriterFactSnapshot {
+    store
+        .record_writer_fact(RecordPromiseCompletionWriterFactInput { fact })
+        .await
+        .expect("writer fact should persist")
+}
+
+async fn record_prior_pending_mutual_acknowledgement(
+    store: &PromiseCompletionWriterFactStore,
+    idempotency_key: &str,
+    acknowledgement_reference: &str,
+    promise_reference: &str,
+    realm_id: &str,
+) -> musubi_backend::services::promise_completion::PromiseCompletionWriterFactSnapshot {
+    let mut fact = base_fact(
+        idempotency_key,
+        acknowledgement_reference,
+        promise_reference,
+        realm_id,
+    );
+    fact.fact_family = PromiseCompletionWriterFactFamily::SourceRouteCandidate;
+    fact.previous_completion_state_class = None;
+    fact.completion_state_class =
+        PromiseCompletionStateClass::CompletionPendingMutualAcknowledgement;
+    fact.completed_reference_eligible = false;
+    fact.fact_idempotency_key = Some(format!("prior-{idempotency_key}"));
+    fact.reason_code_class = Some(format!("completion-pending-mutual-ack-{idempotency_key}"));
+    record_writer_fact(store, fact).await
+}
+
+fn accepted_transition_fact(
+    idempotency_key: &str,
+    prior_writer_fact_id: &str,
+    acknowledgement_reference: &str,
+    promise_reference: &str,
+    realm_id: &str,
+) -> ProposedPromiseCompletionWriterFact {
+    let mut fact = base_fact(
+        idempotency_key,
+        acknowledgement_reference,
+        promise_reference,
+        realm_id,
+    );
+    fact.fact_family = PromiseCompletionWriterFactFamily::CompletionStateTransition;
+    fact.previous_completion_state_class =
+        Some(PromiseCompletionStateClass::CompletionPendingMutualAcknowledgement);
+    fact.completion_state_class = PromiseCompletionStateClass::CompletionAccepted;
+    fact.completed_reference_eligible = true;
+    fact.prior_writer_fact_id = Some(prior_writer_fact_id.to_owned());
+    fact.fact_idempotency_key = Some(format!(
+        "completion-accepted-from-prior-{prior_writer_fact_id}"
+    ));
+    fact.reason_code_class = Some(format!("completion-accepted-{idempotency_key}"));
+    fact
+}
+
+fn base_fact(
+    idempotency_key: &str,
+    acknowledgement_reference: &str,
+    promise_reference: &str,
+    realm_id: &str,
+) -> ProposedPromiseCompletionWriterFact {
+    ProposedPromiseCompletionWriterFact {
+        promise_reference: Some(promise_reference.to_owned()),
+        realm_id: Some(realm_id.to_owned()),
+        fact_family: PromiseCompletionWriterFactFamily::CompletionStateTransition,
+        source_route_class:
+            PromiseCompletionSourceRouteClass::MutualAccountableCompletionAcknowledgement,
+        previous_completion_state_class: Some(
+            PromiseCompletionStateClass::CompletionPendingMutualAcknowledgement,
+        ),
+        completion_state_class: PromiseCompletionStateClass::CompletionAccepted,
+        completed_reference_eligible: true,
+        promise_terms_reference: Some(format!("promise-terms-{idempotency_key}")),
+        participant_set_reference: Some(format!("participant-set-{idempotency_key}")),
+        ordinary_participant_acknowledgement_reference: Some(acknowledgement_reference.to_owned()),
+        governed_review_reference: None,
+        review_authority_reference: None,
+        proof_eligibility_reference: None,
+        proof_evidence_writer_fact_reference: None,
+        consent_at_formation_reference: Some(format!("consent-formation-{idempotency_key}")),
+        consent_at_resolution_reference: Some(format!("consent-resolution-{idempotency_key}")),
+        block_withdrawal_state_reference: Some(format!("block-withdrawal-clear-{idempotency_key}")),
+        age_assurance_state_reference: Some(format!(
+            "age-assurance-adult-eligible-{idempotency_key}"
+        )),
+        legal_hold_intersection_reference: Some(format!("legal-hold-clear-{idempotency_key}")),
+        critical_harm_case_reference: Some(format!("critical-harm-clear-{idempotency_key}")),
+        account_lifecycle_reference: Some(format!("account-lifecycle-active-{idempotency_key}")),
+        anti_abuse_continuity_reference: Some(format!("anti-abuse-clear-{idempotency_key}")),
+        safety_case_reference: Some(format!("safety-case-clear-{idempotency_key}")),
+        reason_code_class: Some(format!("completion-accepted-{idempotency_key}")),
+        evidence_level_reference: Some(format!("evidence-level-bounded-{idempotency_key}")),
+        correction_or_supersession_reference: None,
+        prior_writer_fact_id: None,
+        policy_version: Some(1),
+        fact_idempotency_key: Some(format!("accepted-transition-{idempotency_key}")),
+        retention_class_reference: Some("R4 Trust / moderation / case".to_owned()),
+        access_audit_reference: Some(format!("access-audit-{idempotency_key}")),
+        projection_non_authority_posture: Some(
+            PromiseCompletionProjectionNonAuthorityPosture::ProjectionNonAuthoritative,
+        ),
+        authority_posture: Some(PromiseCompletionAuthorityPosture::WriterTruthOnly),
+    }
+}
+
+fn transition_input(
+    fact: ProposedPromiseCompletionWriterFact,
+) -> RecordMutualAcknowledgementAcceptedTransitionInput {
+    RecordMutualAcknowledgementAcceptedTransitionInput {
+        transition: ProposedMutualAcknowledgementAcceptedTransition { fact },
+    }
+}
+
+fn availability_path(promise_reference: &str, realm_id: &str) -> String {
+    format!(
+        "/api/promise-completion/participant-safe-display-availability/{promise_reference}?realm_id={realm_id}"
+    )
+}
+
+fn availability_path_without_realm(promise_reference: &str) -> String {
+    format!("/api/promise-completion/participant-safe-display-availability/{promise_reference}")
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct SideEffectCounts {
+    promise_completion_writer_facts: i64,
+    projection_promise_views: i64,
+    projection_settlement_views: i64,
+    projection_trust_snapshots: i64,
+    projection_realm_trust_snapshots: i64,
+    projection_room_progression_views: i64,
+    social_trust_intake_attempts: i64,
+    social_trust_categorical_sources: i64,
+    social_trust_categorical_mutations: i64,
+    room_progression_tracks: i64,
+    room_progression_facts: i64,
+    settlement_cases: i64,
+    settlement_intents: i64,
+    settlement_submissions: i64,
+    settlement_observations: i64,
+    provider_attempts: i64,
+    outbox_events: i64,
+    outbox_attempts: i64,
+    command_inbox: i64,
+}
+
+async fn side_effect_counts(client: &tokio_postgres::Client) -> SideEffectCounts {
+    let row = client
+        .query_one(
+            "
+            SELECT
+                (SELECT COUNT(*)::bigint FROM promise_completion.writer_fact_records) AS promise_completion_writer_facts,
+                (SELECT COUNT(*)::bigint FROM projection.promise_views) AS projection_promise_views,
+                (SELECT COUNT(*)::bigint FROM projection.settlement_views) AS projection_settlement_views,
+                (SELECT COUNT(*)::bigint FROM projection.trust_snapshots) AS projection_trust_snapshots,
+                (SELECT COUNT(*)::bigint FROM projection.realm_trust_snapshots) AS projection_realm_trust_snapshots,
+                (SELECT COUNT(*)::bigint FROM projection.room_progression_views) AS projection_room_progression_views,
+                (SELECT COUNT(*)::bigint FROM social_trust.proposed_mutation_attempts) AS social_trust_intake_attempts,
+                (SELECT COUNT(*)::bigint FROM social_trust.categorical_source_references) AS social_trust_categorical_sources,
+                (SELECT COUNT(*)::bigint FROM social_trust.categorical_mutation_facts) AS social_trust_categorical_mutations,
+                (SELECT COUNT(*)::bigint FROM dao.room_progression_tracks) AS room_progression_tracks,
+                (SELECT COUNT(*)::bigint FROM dao.room_progression_facts) AS room_progression_facts,
+                (SELECT COUNT(*)::bigint FROM dao.settlement_cases) AS settlement_cases,
+                (SELECT COUNT(*)::bigint FROM dao.settlement_intents) AS settlement_intents,
+                (SELECT COUNT(*)::bigint FROM dao.settlement_submissions) AS settlement_submissions,
+                (SELECT COUNT(*)::bigint FROM dao.settlement_observations) AS settlement_observations,
+                (SELECT COUNT(*)::bigint FROM dao.provider_attempts) AS provider_attempts,
+                (SELECT COUNT(*)::bigint FROM outbox.events) AS outbox_events,
+                (SELECT COUNT(*)::bigint FROM outbox.outbox_attempts) AS outbox_attempts,
+                (SELECT COUNT(*)::bigint FROM outbox.command_inbox) AS command_inbox
+            ",
+            &[],
+        )
+        .await
+        .expect("side-effect counts should load");
+
+    SideEffectCounts {
+        promise_completion_writer_facts: row.get("promise_completion_writer_facts"),
+        projection_promise_views: row.get("projection_promise_views"),
+        projection_settlement_views: row.get("projection_settlement_views"),
+        projection_trust_snapshots: row.get("projection_trust_snapshots"),
+        projection_realm_trust_snapshots: row.get("projection_realm_trust_snapshots"),
+        projection_room_progression_views: row.get("projection_room_progression_views"),
+        social_trust_intake_attempts: row.get("social_trust_intake_attempts"),
+        social_trust_categorical_sources: row.get("social_trust_categorical_sources"),
+        social_trust_categorical_mutations: row.get("social_trust_categorical_mutations"),
+        room_progression_tracks: row.get("room_progression_tracks"),
+        room_progression_facts: row.get("room_progression_facts"),
+        settlement_cases: row.get("settlement_cases"),
+        settlement_intents: row.get("settlement_intents"),
+        settlement_submissions: row.get("settlement_submissions"),
+        settlement_observations: row.get("settlement_observations"),
+        provider_attempts: row.get("provider_attempts"),
+        outbox_events: row.get("outbox_events"),
+        outbox_attempts: row.get("outbox_attempts"),
+        command_inbox: row.get("command_inbox"),
+    }
+}
+
+async fn set_account_class(client: &tokio_postgres::Client, account_id: &str, account_class: &str) {
+    let account_id = uuid::Uuid::parse_str(account_id).expect("account id must be UUID");
+    client
+        .execute(
+            "
+            UPDATE core.accounts
+            SET account_class = $2
+            WHERE account_id = $1
+            ",
+            &[&account_id, &account_class],
+        )
+        .await
+        .expect("account class should update");
+}
+
+#[derive(Debug)]
+struct ExposureContext {
+    accepted_writer_fact_id: String,
+    prior_writer_fact_id: String,
+    promise_reference: String,
+    realm_id: String,
+    promise_terms_reference: String,
+    participant_set_reference: String,
+    acknowledgement_reference: String,
+    idempotency_key: String,
+}
+
+fn assert_available_response(response: &HttpResponse, context: &ExposureContext) {
+    assert_eq!(response.status, StatusCode::OK);
+    let body = response
+        .body_json
+        .as_ref()
+        .expect("availability response should be json");
+    assert_minimized_response_fields(body);
+    assert_eq!(body["display_availability"], "available");
+    assert_eq!(body["completed_reference_available"], true);
+    assert_no_completion_exposure(response, context);
+}
+
+fn assert_unavailable_response(response: &HttpResponse, context: &ExposureContext) {
+    assert_eq!(response.status, StatusCode::OK);
+    let body = response
+        .body_json
+        .as_ref()
+        .expect("unavailable response should be json");
+    assert_minimized_response_fields(body);
+    assert_eq!(body["display_availability"], "unavailable");
+    assert_eq!(body["completed_reference_available"], false);
+    assert_no_completion_exposure(response, context);
+}
+
+fn assert_minimized_response_fields(body: &Value) {
+    let object = body.as_object().expect("response must be an object");
+    assert_eq!(object.len(), 2);
+    assert!(object.contains_key("display_availability"));
+    assert!(object.contains_key("completed_reference_available"));
+}
+
+fn assert_no_completion_exposure(response: &HttpResponse, context: &ExposureContext) {
+    for sensitive_value in [
+        context.accepted_writer_fact_id.as_str(),
+        context.prior_writer_fact_id.as_str(),
+        context.promise_reference.as_str(),
+        context.realm_id.as_str(),
+        context.promise_terms_reference.as_str(),
+        context.participant_set_reference.as_str(),
+        context.acknowledgement_reference.as_str(),
+        context.idempotency_key.as_str(),
+        "mutual_accountable_completion_acknowledgement",
+        "completion_accepted",
+        "promise_completed_reference",
+        "legal-hold-active",
+    ] {
+        assert!(
+            !response.body_text.contains(sensitive_value),
+            "response must not expose Promise completion sensitive value `{sensitive_value}`: {:?}",
+            response
+        );
+    }
+
+    for field in [
+        "display_audience",
+        "display_meaning",
+        "display_class",
+        "policy_version",
+        "accepted_writer_fact_id",
+        "prior_writer_fact_id",
+        "participant_set_reference",
+        "ordinary_participant_acknowledgement_reference",
+        "fact_idempotency_key",
+        "source_route_class",
+        "completion_state_class",
+        "raw_personal_data",
+        "raw_evidence",
+        "provider_payload",
+        "proof_payload",
+        "operator_note",
+        "review_narrative",
+        "legal_hold",
+        "critical_harm",
+        "child_safety",
+        "sensitive_trait",
+        "abuse_marker",
+        "internal_safety_classification",
+        "support_status",
+        "payment_state",
+        "shame_label",
+        "accusation_label",
+        "public_trust_label",
+        "social_trust",
+        "relationship_depth",
+        "settlement_progression",
+        "room_transition",
+        "contact_unlock",
+        "discovery_priority",
+        "recommendation_boost",
+    ] {
+        assert!(
+            !response.body_text.contains(field),
+            "response must not expose Promise completion field `{field}`: {:?}",
+            response
+        );
+    }
+}
+
+#[derive(Debug)]
+struct SignedInUser {
+    token: String,
+    account_id: String,
+}
+
+#[derive(Debug)]
+struct PromiseCase {
+    promise_reference: String,
+    realm_id: String,
+}
+
+async fn sign_in(app: &Router, pi_uid: &str, username: &str) -> SignedInUser {
+    let response = request_http(
+        app,
+        "POST",
+        "/api/auth/pi",
+        None,
+        Some(json!({
+            "pi_uid": pi_uid,
+            "username": username,
+            "wallet_address": format!("wallet-{pi_uid}"),
+            "access_token": format!("access-token-{pi_uid}")
+        })),
+    )
+    .await;
+    assert_eq!(response.status, StatusCode::OK);
+    let body = response.body_json.expect("sign-in response should be json");
+
+    SignedInUser {
+        token: body["token"].as_str().expect("token must exist").to_owned(),
+        account_id: body["user"]["id"]
+            .as_str()
+            .expect("user id must exist")
+            .to_owned(),
+    }
+}
+
+async fn create_promise_intent(
+    app: &Router,
+    initiator: &SignedInUser,
+    counterparty: &SignedInUser,
+    suffix: &str,
+) -> PromiseCase {
+    let realm_id = format!("realm-{suffix}");
+    let response = post_json(
+        app,
+        "/api/promise/intents",
+        Some(initiator.token.as_str()),
+        json!({
+            "internal_idempotency_key": format!("promise-intent-{suffix}"),
+            "realm_id": realm_id,
+            "counterparty_account_id": counterparty.account_id,
+            "deposit_amount_minor_units": 10000,
+            "currency_code": "PI"
+        }),
+    )
+    .await;
+    assert_eq!(response.status, StatusCode::OK);
+    let body = response
+        .body_json
+        .expect("create Promise response should be json");
+    PromiseCase {
+        promise_reference: body["promise_intent_id"]
+            .as_str()
+            .expect("promise_intent_id must exist")
+            .to_owned(),
+        realm_id,
+    }
+}
+
+#[derive(Debug)]
+struct HttpResponse {
+    status: StatusCode,
+    body_text: String,
+    body_json: Option<Value>,
+}
+
+async fn get_http(app: &Router, path: &str, bearer_token: Option<&str>) -> HttpResponse {
+    request_http(app, "GET", path, bearer_token, None).await
+}
+
+async fn post_json(
+    app: &Router,
+    path: &str,
+    bearer_token: Option<&str>,
+    body: Value,
+) -> HttpResponse {
+    request_http(app, "POST", path, bearer_token, Some(body)).await
+}
+
+async fn request_http(
+    app: &Router,
+    method: &str,
+    path: &str,
+    bearer_token: Option<&str>,
+    body: Option<Value>,
+) -> HttpResponse {
+    let mut builder = Request::builder().method(method).uri(path);
+    if let Some(token) = bearer_token {
+        builder = builder.header("authorization", format!("Bearer {token}"));
+    }
+
+    let request = builder
+        .header("content-type", "application/json")
+        .body(match body {
+            Some(body) => Body::from(body.to_string()),
+            None => Body::empty(),
+        })
+        .expect("request must build");
+
+    let response = app
+        .clone()
+        .oneshot(request)
+        .await
+        .expect("app should respond");
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body must be readable");
+    let body_text = String::from_utf8(bytes.to_vec()).expect("response body should be utf-8");
+    let body_json = if body_text.trim().is_empty() {
+        None
+    } else {
+        serde_json::from_str(&body_text).ok()
+    };
+
+    HttpResponse {
+        status,
+        body_text,
+        body_json,
+    }
+}

--- a/docs/foundation_lock.md
+++ b/docs/foundation_lock.md
@@ -1,6 +1,6 @@
 # Foundation Lock
 
-Status: Draft; aligned to accepted foundation commit `4d2c2b6`
+Status: Draft; aligned to accepted foundation commit `c32921c`
 Applies to: `mt4110/pi-musubi-core`
 Purpose: Pin the constitutional and architectural source of truth that this implementation repository must follow.
 
@@ -26,14 +26,14 @@ Upstream repository:
 Pinned reference for implementation work:
 
 - Foundation reference type: `commit`
-- Foundation commit SHA: `4d2c2b6dbaf61e6d056382f7d611bb7aa551c0ab`
-- Foundation commit title: `Merge pull request #478 from mt4110/feat/promise-completion-display-api-non-exposure-route`
-- Foundation PR title: `docs: select Promise completion display API non-exposure route`
-- Foundation PR URL: `https://github.com/mt4110/musubi-foundation/pull/478`
+- Foundation commit SHA: `c32921c1aec9d1f7e5829de01d4ea1f0b99b3a43`
+- Foundation commit title: `Merge pull request #484 from mt4110/feat/promise-completion-display-narrow-api-handoff-route`
+- Foundation PR title: `docs: select Promise completion display narrow API handoff route`
+- Foundation PR URL: `https://github.com/mt4110/musubi-foundation/pull/484`
 - Date pinned: `2026-06-20`
 - Pinned by: `Masaki Takemura`
-- Pinned commit URL: `https://github.com/mt4110/musubi-foundation/commit/4d2c2b6dbaf61e6d056382f7d611bb7aa551c0ab`
-- Previous pinned reference: `0cd0e2b` / `Merge pull request #472 from mt4110/feat/promise-completion-display-implementation-handoff-route`
+- Pinned commit URL: `https://github.com/mt4110/musubi-foundation/commit/c32921c1aec9d1f7e5829de01d4ea1f0b99b3a43`
+- Previous pinned reference: `4d2c2b6` / `Merge pull request #478 from mt4110/feat/promise-completion-display-api-non-exposure-route`
 - Post-C2 evidence source: `cfdba28` / `Merge pull request #114 from mt4110/feat/post-c2-runtime-handoff-evidence-package`
 - Alignment allowance source: `69b7aa4` / `Merge pull request #116 from mt4110/feat/evaluate-post-c2-runtime-handoff-gate`
 - Post-C2 implementation handoff evidence source: `ef23e88` / `Merge pull request #122 from mt4110/feat/post-c2-implementation-handoff-evidence-package`
@@ -205,6 +205,12 @@ Pinned reference for implementation work:
 - Promise completion participant-safe display API boundary decision packet source: `bb0a32f` / `Merge pull request #476 from mt4110/feat/promise-completion-display-api-boundary-packet`
 - Promise completion participant-safe display API boundary packet sufficiency decision source: `ccd26c3` / `Merge pull request #477 from mt4110/feat/promise-completion-display-api-boundary-sufficiency`
 - Promise completion participant-safe display API non-exposure test-only route selection source: `4d2c2b6` / `Merge pull request #478 from mt4110/feat/promise-completion-display-api-non-exposure-route`
+- Promise completion participant-safe display API non-exposure test-only closeout source: `0e43be7` / `Merge pull request #479 from mt4110/feat/promise-completion-display-api-non-exposure-closeout`
+- Promise completion participant-safe display API non-exposure closeout sufficiency decision source: `495deec` / `Merge pull request #480 from mt4110/feat/promise-completion-display-api-non-exposure-sufficiency`
+- Promise completion participant-safe display narrow API handoff packet route selection source: `29ededd` / `Merge pull request #481 from mt4110/feat/promise-completion-display-api-handoff-packet-route`
+- Promise completion participant-safe display narrow API handoff packet source: `0bdb958` / `Merge pull request #482 from mt4110/feat/promise-completion-display-narrow-api-handoff-packet`
+- Promise completion participant-safe display narrow API handoff packet sufficiency decision source: `88961f7` / `Merge pull request #483 from mt4110/feat/promise-completion-display-narrow-api-handoff-sufficiency`
+- Promise completion participant-safe display narrow API handoff route selection source: `c32921c` / `Merge pull request #484 from mt4110/feat/promise-completion-display-narrow-api-handoff-route`
 
 No release tag is asserted for this alignment.
 Do not invent a foundation version label for this commit.
@@ -449,6 +455,12 @@ Current Promise completion display chain:
 - `docs/readiness/promise_completion_participant_safe_display_api_boundary_decision_packet.md`
 - `docs/readiness/promise_completion_participant_safe_display_api_boundary_packet_sufficiency_decision.md`
 - `docs/readiness/promise_completion_participant_safe_display_post_api_boundary_packet_sufficiency_route_selection.md`
+- `docs/readiness/promise_completion_participant_safe_display_api_non_exposure_test_only_closeout_ledger.md`
+- `docs/readiness/promise_completion_participant_safe_display_api_non_exposure_closeout_sufficiency_decision.md`
+- `docs/readiness/promise_completion_participant_safe_display_post_api_non_exposure_closeout_route_selection.md`
+- `docs/readiness/promise_completion_participant_safe_display_narrow_api_handoff_decision_packet.md`
+- `docs/readiness/promise_completion_participant_safe_display_narrow_api_handoff_packet_sufficiency_decision.md`
+- `docs/readiness/promise_completion_participant_safe_display_post_narrow_api_handoff_packet_sufficiency_route_selection.md`
 
 ### Operations layer
 203. `docs/operations/readiness_routine.md`
@@ -616,17 +628,36 @@ Foundation PR #474 found the implementation closeout sufficient for later route 
 Foundation PR #475 selected a foundation-only API boundary packet route.
 Foundation PR #476 prepared the participant-safe display API boundary packet.
 Foundation PR #477 found that packet sufficient for later route selection only.
-Foundation PR #478 provides the current one-use downstream API non-exposure test-only verification authority for one later implementation-repo PR only.
-This implementation-repo PR consumes that allowance.
-The PR #478 allowance authorizes only:
+Foundation PR #478 provided the consumed one-use downstream API non-exposure test-only verification authority for one later implementation-repo PR only.
+That allowance was consumed by `mt4110/pi-musubi-core` PR #175 and closed out by foundation PR #479.
+No remaining work may inherit permission from foundation PR #478 or implementation PR #175.
+The PR #478 allowance authorized only:
 
 - `docs/foundation_lock.md`
 - one backend test file dedicated to Promise completion participant-safe display API non-exposure verification
 
-It authorizes only deterministic test coverage proving that the current implementation does not expose Promise completion participant-safe display availability through public API, unauthenticated API, non-involved caller API, mobile UI, public profile, public directory, discovery, recommendation, contact, room, settlement, Social Trust, Relationship Depth, proof, provider, worker, queue, outbox, inbox, analytics, observability, or external side-effect surfaces.
-It may update this foundation lock before consuming the allowance.
-It does not authorize runtime implementation, production backend code, API implementation, API routes, exact API fields, response field changes, public API behavior, mobile UI behavior, participant display implementation, public completed-reference display, DDL, migrations, durable projection schema, projection refresh, Promise completion source-route evaluation from raw user input, participant acknowledgement collection, governed review runtime workflow, governed review accepted transition runtime, correction or supersession runtime, proof runtime behavior, proof eligibility runtime behavior, additional writer fact persistence, additional state transition runtime behavior, Social Trust source fact persistence, Social Trust mutation, Relationship Depth mutation, settlement release, refund, forfeiture, escrow movement, reward movement, room progression, contact unlock, discovery priority, recommendation boost, outbox, inbox, worker, provider, queue, adapter, external side-effect behavior, raw Personal Data exposure, raw evidence exposure, provider payload exposure, proof payload exposure, operator-note exposure, review-narrative exposure, Legal Hold material exposure, Critical Harm material exposure, child-safety material exposure, sensitive-trait exposure, abuse-marker visibility, internal safety classification visibility, shame labels, accusation labels, paid romantic advantage, payment-based direct-message unlock, new durable product vocabulary, or broad `pi-musubi-core` changes.
-After this downstream PR is merged, closed without merge, or replaced by a different accepted foundation decision, foundation must receive `docs/readiness/promise_completion_participant_safe_display_api_non_exposure_test_only_closeout_ledger.md` before any later Promise completion display, public display, trust, depth, settlement, API, UI, provider, outbox, inbox, worker, governed review, correction, or broader core route may inherit from it.
+It authorized only deterministic test coverage proving that the current implementation does not expose Promise completion participant-safe display availability through public API, unauthenticated API, non-involved caller API, mobile UI, public profile, public directory, discovery, recommendation, contact, room, settlement, Social Trust, Relationship Depth, proof, provider, worker, queue, outbox, inbox, analytics, observability, or external side-effect surfaces.
+It permitted updating this foundation lock before consuming the allowance.
+It did not authorize runtime implementation, production backend code, API implementation, API routes, exact API fields, response field changes, public API behavior, mobile UI behavior, participant display implementation, public completed-reference display, DDL, migrations, durable projection schema, projection refresh, Promise completion source-route evaluation from raw user input, participant acknowledgement collection, governed review runtime workflow, governed review accepted transition runtime, correction or supersession runtime, proof runtime behavior, proof eligibility runtime behavior, additional writer fact persistence, additional state transition runtime behavior, Social Trust source fact persistence, Social Trust mutation, Relationship Depth mutation, settlement release, refund, forfeiture, escrow movement, reward movement, room progression, contact unlock, discovery priority, recommendation boost, outbox, inbox, worker, provider, queue, adapter, external side-effect behavior, raw Personal Data exposure, raw evidence exposure, provider payload exposure, proof payload exposure, operator-note exposure, review-narrative exposure, Legal Hold material exposure, Critical Harm material exposure, child-safety material exposure, sensitive-trait exposure, abuse-marker visibility, internal safety classification visibility, shame labels, accusation labels, paid romantic advantage, payment-based direct-message unlock, new durable product vocabulary, or broad `pi-musubi-core` changes.
+Foundation PR #480 found that closeout sufficient for later route selection only.
+Foundation PR #481 selected the narrow API handoff packet route only.
+Foundation PR #482 prepared the narrow API handoff packet.
+Foundation PR #483 found that packet sufficient for later route selection only.
+Foundation PR #484 provides the current one-use downstream narrow API handoff authority for one later implementation-repo PR only.
+This implementation-repo PR consumes that allowance.
+The PR #484 allowance authorizes only:
+
+- `docs/foundation_lock.md`
+- the smallest existing backend API boundary files needed for one side-effect-free authenticated directly-involved Ordinary Account availability read
+- the existing backend route inventory guardrail baselines required to review that API boundary
+- the smallest existing backend service or repository read path needed for the same boundary
+- focused backend tests dedicated to this one-use handoff
+
+It authorizes only a narrow side-effect-free authenticated directly-involved Ordinary Account availability read boundary for Promise completion participant-safe display.
+It may reuse the existing participant-safe display availability semantics already selected by earlier foundation work.
+It must return hidden or unavailable when caller eligibility, suppression, projection freshness, account lifecycle, Age Assurance, or writer truth is uncertain.
+It does not authorize public API, mobile UI, public completed-reference display, public profile display, public count, public badge, public score, public status marker, public trust label, accusation label, caller-supplied source-route authority, caller-supplied participant-set authority, caller-supplied acknowledgement authority, caller-supplied writer fact authority, caller-supplied prior fact authority, caller-supplied idempotency authority, caller-supplied suppression authority, caller-supplied reason-code authority, writer fact creation, projection row creation, projection refresh, durable projection schema, DDL, migrations, provider calls, outbox or inbox enqueueing, worker, queue, adapter, analytics, observability, external side-effect behavior, Social Trust mutation, Relationship Depth mutation, settlement release, refund, forfeiture, escrow movement, reward movement, room progression, contact unlock, off-platform handoff permission, discovery priority, recommendation boost, raw Personal Data exposure, raw evidence exposure, provider payload exposure, proof payload exposure, operator-note exposure, review-narrative exposure, Legal Hold material exposure, Critical Harm material exposure, child-safety material exposure, sensitive-trait exposure, abuse-marker visibility, internal safety classification visibility, support status exposure, payment-state exposure, shame labels, paid romantic advantage, payment-based direct-message unlock, new durable product vocabulary, or broad `pi-musubi-core` changes.
+After this downstream PR is merged, closed without merge, or replaced by a different accepted foundation decision, foundation must receive a closeout ledger for the narrow API handoff before any later Promise completion display, public display, trust, depth, settlement, API, UI, provider, outbox, inbox, worker, governed review, correction, or broader core route may inherit from it.
 
 The C2 and post-C2 readiness and closeout chain is accepted for docs-only foundation semantic scope:
 


### PR DESCRIPTION
## Summary
- pin the foundation lock to musubi-foundation #484 / c32921c
- add a narrow authenticated Promise completion participant-safe display availability read boundary
- keep availability account-bound and fail closed for non-involved callers, Controlled Exceptional Accounts, wrong context, caller-supplied truth, and suppressed writer truth
- update route guard inventories for the reviewed API boundary

## Boundary
This PR consumes the one-use #484 narrow API handoff allowance only. It does not add DDL, migrations, projection refresh, provider/outbox/inbox/worker behavior, mobile UI, public completed-reference display, Social Trust or Relationship Depth mutation, settlement/room/contact/discovery/recommendation behavior, or caller-supplied writer-truth authority.

## Verification
- `cargo check --workspace --all-targets`
- `cargo test --test promise_completion_participant_safe_display_narrow_api_handoff`
- `cargo test --test promise_completion_participant_safe_display_api_non_exposure`
- `cargo test --test promise_completion_projection_non_authority`
- `make guardrail-sweep`
- `cargo test -p musubi_backend`
- `git diff --check`
