### PR TITLE
feat: add Promise completion display narrow UI handoff

### DIFF
--- a/apps/mobile/lib/features/promise/models/promise_models.dart
+++ b/apps/mobile/lib/features/promise/models/promise_models.dart
@@ -127,18 +127,44 @@ class ExpandedSettlementView {
   }
 }
 
+class ParticipantSafeDisplayAvailability {
+  const ParticipantSafeDisplayAvailability({
+    required this.displayAvailability,
+    required this.completedReferenceAvailable,
+  });
+
+  final String displayAvailability;
+  final bool completedReferenceAvailable;
+
+  bool get isAvailable {
+    return displayAvailability == 'available' && completedReferenceAvailable;
+  }
+
+  factory ParticipantSafeDisplayAvailability.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return ParticipantSafeDisplayAvailability(
+      displayAvailability: _stringField(json, 'display_availability'),
+      completedReferenceAvailable:
+          json['completed_reference_available'] == true,
+    );
+  }
+}
+
 class PromiseStatusBundle {
   const PromiseStatusBundle({
     required this.promiseIntentId,
     required this.initialSettlementCaseId,
     required this.promise,
     required this.settlement,
+    this.participantSafeDisplayAvailability,
   });
 
   final String promiseIntentId;
   final String? initialSettlementCaseId;
   final PromiseProjectionView? promise;
   final ExpandedSettlementView? settlement;
+  final ParticipantSafeDisplayAvailability? participantSafeDisplayAvailability;
 
   String? get settlementCaseId {
     return settlement?.settlementCaseId ??
@@ -162,6 +188,10 @@ class PromiseStatusBundle {
 
   bool get hasParticipantSafeProjection {
     return promise != null || settlement != null;
+  }
+
+  bool get completedReferenceDisplayAvailable {
+    return participantSafeDisplayAvailability?.isAvailable ?? false;
   }
 }
 

--- a/apps/mobile/lib/features/promise/presentation/promise_status_screen.dart
+++ b/apps/mobile/lib/features/promise/presentation/promise_status_screen.dart
@@ -222,6 +222,7 @@ class _CompletionPanel extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final proofUnavailable = bundle.proofStatus == 'unavailable';
+    final displayAvailable = bundle.completedReferenceDisplayAvailable;
     return Container(
       width: double.infinity,
       padding: const EdgeInsets.all(14),
@@ -236,9 +237,11 @@ class _CompletionPanel extends StatelessWidget {
           Text('完了について', style: Theme.of(context).textTheme.titleMedium),
           const SizedBox(height: 8),
           Text(
-            proofUnavailable
-                ? 'この画面の操作だけで完了は確定しません。証明や確認の準備が整うまで、状態だけを確認できます。'
-                : '完了は証明や確認結果に基づいて扱われます。この画面だけで預かり金や評価は変わりません。',
+            displayAvailable
+                ? '完了の確認材料を参加者向けに扱える準備ができています。この画面だけで預かり金、関係の扱い、相手へのアクセスは変わりません。'
+                : proofUnavailable
+                    ? 'この画面の操作だけで完了は確定しません。証明や確認の準備が整うまで、状態だけを確認できます。'
+                    : '完了は証明や確認結果に基づいて扱われます。この画面だけで預かり金や関係の扱いは変わりません。',
             style: Theme.of(context).textTheme.bodyMedium,
           ),
         ],

--- a/apps/mobile/lib/repositories/promise/api_promise_repository.dart
+++ b/apps/mobile/lib/repositories/promise/api_promise_repository.dart
@@ -63,11 +63,18 @@ class ApiPromiseRepository implements PromiseRepository {
           );
         }
       }
+      final displayAvailability = promise == null
+          ? null
+          : await _fetchParticipantSafeDisplayAvailability(
+              promise,
+            ).timeout(const Duration(seconds: 1), onTimeout: () => null);
+
       return PromiseStatusBundle(
         promiseIntentId: promiseIntentId,
         initialSettlementCaseId: settlementCaseId,
         promise: promise,
         settlement: settlement,
+        participantSafeDisplayAvailability: displayAvailability,
       );
     } catch (error) {
       throw _mapPromiseError(error);
@@ -107,6 +114,34 @@ class ApiPromiseRepository implements PromiseRepository {
         return null;
       }
       rethrow;
+    }
+  }
+
+  Future<ParticipantSafeDisplayAvailability?>
+      _fetchParticipantSafeDisplayAvailability(
+    PromiseProjectionView promise,
+  ) async {
+    final promiseReference = promise.promiseIntentId.trim();
+    final realmId = promise.realmId.trim();
+    if (promiseReference.isEmpty || realmId.isEmpty) {
+      return null;
+    }
+
+    try {
+      final response = await _apiClient.dio.get<Map<String, dynamic>>(
+        '/api/promise-completion/participant-safe-display-availability/'
+        '${Uri.encodeComponent(promiseReference)}',
+        queryParameters: {'realm_id': realmId},
+      );
+      return ParticipantSafeDisplayAvailability.fromJson(
+        response.data ?? const <String, dynamic>{},
+      );
+    } on DioException {
+      return null;
+    } on FormatException {
+      return null;
+    } on TypeError {
+      return null;
     }
   }
 

--- a/apps/mobile/test/features/promise/promise_models_test.dart
+++ b/apps/mobile/test/features/promise/promise_models_test.dart
@@ -76,4 +76,21 @@ void main() {
     expect(view.promiseIntentId, 'promise-1');
     expect(view.latestSettlementStatus, 'pending_funding');
   });
+
+  test('participant-safe display availability requires both accepted fields',
+      () {
+    final available = ParticipantSafeDisplayAvailability.fromJson({
+      'display_availability': 'available',
+      'completed_reference_available': true,
+      'accepted_writer_fact_id': 'must-not-be-modeled',
+      'reason_code': 'must-not-be-modeled',
+    });
+    final mismatched = ParticipantSafeDisplayAvailability.fromJson({
+      'display_availability': 'unavailable',
+      'completed_reference_available': true,
+    });
+
+    expect(available.isAvailable, isTrue);
+    expect(mismatched.isAvailable, isFalse);
+  });
 }

--- a/apps/mobile/test/features/promise/promise_status_screen_test.dart
+++ b/apps/mobile/test/features/promise/promise_status_screen_test.dart
@@ -90,6 +90,63 @@ void main() {
     expect(find.text('約束を作成しました'), findsNothing);
     expect(find.text('約束を表示できませんでした'), findsNothing);
   });
+
+  testWidgets(
+      'available completion display stays inside bounded participant copy',
+      (tester) async {
+    await tester.pumpWidget(
+      _buildApp(
+        repository: const _FakePromiseRepository(
+          bundle: PromiseStatusBundle(
+            promiseIntentId: 'promise-1',
+            initialSettlementCaseId: 'settlement-1',
+            promise: PromiseProjectionView(
+              promiseIntentId: 'promise-1',
+              realmId: 'realm-tokyo-day1',
+              initiatorAccountId: 'account-a',
+              counterpartyAccountId: 'account-b',
+              currentIntentStatus: 'proposed',
+              depositAmountMinorUnits: 10000,
+              currencyCode: 'PI',
+              depositScale: 3,
+              latestSettlementCaseId: 'settlement-1',
+              latestSettlementStatus: 'pending_funding',
+            ),
+            settlement: ExpandedSettlementView(
+              settlementCaseId: 'settlement-1',
+              promiseIntentId: 'promise-1',
+              realmId: 'realm-tokyo-day1',
+              currentSettlementStatus: 'pending_funding',
+              totalFundedMinorUnits: 0,
+              currencyCode: 'PI',
+              proofStatus: 'unavailable',
+              proofSignalCount: 0,
+            ),
+            participantSafeDisplayAvailability:
+                ParticipantSafeDisplayAvailability(
+              displayAvailability: 'available',
+              completedReferenceAvailable: true,
+            ),
+          ),
+        ),
+        promiseIntentId: 'promise-1',
+        settlementCaseId: 'settlement-1',
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('完了について'), findsOneWidget);
+    expect(
+      find.text(
+        '完了の確認材料を参加者向けに扱える準備ができています。この画面だけで預かり金、関係の扱い、相手へのアクセスは変わりません。',
+      ),
+      findsOneWidget,
+    );
+    expect(find.textContaining('バッジ'), findsNothing);
+    expect(find.textContaining('スコア'), findsNothing);
+    expect(find.textContaining('ランキング'), findsNothing);
+    expect(find.textContaining('非難'), findsNothing);
+  });
 }
 
 Widget _buildApp({

--- a/apps/mobile/test/repositories/promise/api_promise_repository_test.dart
+++ b/apps/mobile/test/repositories/promise/api_promise_repository_test.dart
@@ -67,6 +67,8 @@ void main() {
             'proof_status': 'unavailable',
             'proof_signal_count': 0,
           });
+        case '/api/promise-completion/participant-safe-display-availability/promise-1':
+          return _jsonResponse(500, {'error': 'temporarily unavailable'});
       }
       throw StateError('unexpected path: ${options.path}');
     });
@@ -99,6 +101,7 @@ void main() {
     final bundle = await future;
     expect(bundle.promise?.promiseIntentId, 'promise-1');
     expect(bundle.settlement?.settlementCaseId, 'settlement-1');
+    expect(bundle.completedReferenceDisplayAvailable, isFalse);
   });
 
   test(
@@ -134,6 +137,122 @@ void main() {
     expect(bundle.settlement, isNull);
     expect(bundle.settlementStatus, 'pending_projection');
     expect(bundle.proofStatus, 'unavailable');
+  });
+
+  test(
+      'api promise repository reads participant-safe display availability from promise realm',
+      () async {
+    final requestedPaths = <String>[];
+    final dio = Dio();
+    dio.httpClientAdapter = _StubHttpClientAdapter((options) async {
+      requestedPaths.add(options.path);
+      switch (options.path) {
+        case '/api/projection/promise-views/promise-1':
+          return _jsonResponse(200, {
+            'promise_intent_id': 'promise-1',
+            'realm_id': 'realm-1',
+            'initiator_account_id': 'account-a',
+            'counterparty_account_id': 'account-b',
+            'current_intent_status': 'proposed',
+            'deposit_amount_minor_units': 10000,
+            'currency_code': 'PI',
+            'deposit_scale': 3,
+            'latest_settlement_case_id': null,
+            'latest_settlement_status': null,
+          });
+        case '/api/promise-completion/participant-safe-display-availability/promise-1':
+          expect(options.queryParameters, {'realm_id': 'realm-1'});
+          return _jsonResponse(200, {
+            'display_availability': 'available',
+            'completed_reference_available': true,
+            'accepted_writer_fact_id': 'must-not-be-modeled',
+            'operator_note_internal': 'must-not-be-modeled',
+          });
+      }
+      throw StateError('unexpected path: ${options.path}');
+    });
+    final repository = ApiPromiseRepository(ApiClient(dio));
+
+    final bundle = await repository.fetchPromiseStatus('promise-1');
+
+    expect(bundle.promise?.realmId, 'realm-1');
+    expect(bundle.completedReferenceDisplayAvailable, isTrue);
+    expect(requestedPaths, [
+      '/api/projection/promise-views/promise-1',
+      '/api/promise-completion/participant-safe-display-availability/promise-1',
+    ]);
+  });
+
+  test(
+      'api promise repository hides completion display availability on availability errors',
+      () async {
+    final dio = Dio();
+    dio.httpClientAdapter = _StubHttpClientAdapter((options) async {
+      switch (options.path) {
+        case '/api/projection/promise-views/promise-1':
+          return _jsonResponse(200, {
+            'promise_intent_id': 'promise-1',
+            'realm_id': 'realm-1',
+            'initiator_account_id': 'account-a',
+            'counterparty_account_id': 'account-b',
+            'current_intent_status': 'proposed',
+            'deposit_amount_minor_units': 10000,
+            'currency_code': 'PI',
+            'deposit_scale': 3,
+            'latest_settlement_case_id': null,
+            'latest_settlement_status': null,
+          });
+        case '/api/promise-completion/participant-safe-display-availability/promise-1':
+          return _jsonResponse(500, {'error': 'internal server error'});
+      }
+      throw StateError('unexpected path: ${options.path}');
+    });
+    final repository = ApiPromiseRepository(ApiClient(dio));
+
+    final bundle = await repository.fetchPromiseStatus('promise-1');
+
+    expect(bundle.promise?.promiseIntentId, 'promise-1');
+    expect(bundle.participantSafeDisplayAvailability, isNull);
+    expect(bundle.completedReferenceDisplayAvailable, isFalse);
+  });
+
+  test(
+      'api promise repository bounds slow completion display availability reads',
+      () async {
+    final availabilityRequested = Completer<void>();
+    final slowAvailability = Completer<ResponseBody>();
+    final dio = Dio();
+    dio.httpClientAdapter = _StubHttpClientAdapter((options) async {
+      switch (options.path) {
+        case '/api/projection/promise-views/promise-1':
+          return _jsonResponse(200, {
+            'promise_intent_id': 'promise-1',
+            'realm_id': 'realm-1',
+            'initiator_account_id': 'account-a',
+            'counterparty_account_id': 'account-b',
+            'current_intent_status': 'proposed',
+            'deposit_amount_minor_units': 10000,
+            'currency_code': 'PI',
+            'deposit_scale': 3,
+            'latest_settlement_case_id': null,
+            'latest_settlement_status': null,
+          });
+        case '/api/promise-completion/participant-safe-display-availability/promise-1':
+          availabilityRequested.complete();
+          return slowAvailability.future;
+      }
+      throw StateError('unexpected path: ${options.path}');
+    });
+    final repository = ApiPromiseRepository(ApiClient(dio));
+    final stopwatch = Stopwatch()..start();
+
+    final bundle = await repository.fetchPromiseStatus('promise-1');
+    stopwatch.stop();
+
+    expect(availabilityRequested.isCompleted, isTrue);
+    expect(stopwatch.elapsedMilliseconds, lessThan(1900));
+    expect(bundle.promise?.promiseIntentId, 'promise-1');
+    expect(bundle.completedReferenceDisplayAvailable, isFalse);
   });
 }
 

--- a/docs/foundation_lock.md
+++ b/docs/foundation_lock.md
@@ -1,6 +1,6 @@
 # Foundation Lock
 
-Status: Draft; aligned to accepted foundation commit `c32921c`
+Status: Draft; aligned to accepted foundation commit `d671448`
 Applies to: `mt4110/pi-musubi-core`
 Purpose: Pin the constitutional and architectural source of truth that this implementation repository must follow.
 
@@ -26,14 +26,14 @@ Upstream repository:
 Pinned reference for implementation work:
 
 - Foundation reference type: `commit`
-- Foundation commit SHA: `c32921c1aec9d1f7e5829de01d4ea1f0b99b3a43`
-- Foundation commit title: `Merge pull request #484 from mt4110/feat/promise-completion-display-narrow-api-handoff-route`
-- Foundation PR title: `docs: select Promise completion display narrow API handoff route`
-- Foundation PR URL: `https://github.com/mt4110/musubi-foundation/pull/484`
+- Foundation commit SHA: `d671448ab0674ce9d939b62d5f00da4b908e76f1`
+- Foundation commit title: `Merge pull request #495 from mt4110/feat/promise-completion-display-narrow-ui-handoff-route`
+- Foundation PR title: `docs: select Promise completion display narrow UI handoff route`
+- Foundation PR URL: `https://github.com/mt4110/musubi-foundation/pull/495`
 - Date pinned: `2026-06-20`
 - Pinned by: `Masaki Takemura`
-- Pinned commit URL: `https://github.com/mt4110/musubi-foundation/commit/c32921c1aec9d1f7e5829de01d4ea1f0b99b3a43`
-- Previous pinned reference: `4d2c2b6` / `Merge pull request #478 from mt4110/feat/promise-completion-display-api-non-exposure-route`
+- Pinned commit URL: `https://github.com/mt4110/musubi-foundation/commit/d671448ab0674ce9d939b62d5f00da4b908e76f1`
+- Previous pinned reference: `c32921c` / `Merge pull request #484 from mt4110/feat/promise-completion-display-narrow-api-handoff-route`
 - Post-C2 evidence source: `cfdba28` / `Merge pull request #114 from mt4110/feat/post-c2-runtime-handoff-evidence-package`
 - Alignment allowance source: `69b7aa4` / `Merge pull request #116 from mt4110/feat/evaluate-post-c2-runtime-handoff-gate`
 - Post-C2 implementation handoff evidence source: `ef23e88` / `Merge pull request #122 from mt4110/feat/post-c2-implementation-handoff-evidence-package`
@@ -211,6 +211,17 @@ Pinned reference for implementation work:
 - Promise completion participant-safe display narrow API handoff packet source: `0bdb958` / `Merge pull request #482 from mt4110/feat/promise-completion-display-narrow-api-handoff-packet`
 - Promise completion participant-safe display narrow API handoff packet sufficiency decision source: `88961f7` / `Merge pull request #483 from mt4110/feat/promise-completion-display-narrow-api-handoff-sufficiency`
 - Promise completion participant-safe display narrow API handoff route selection source: `c32921c` / `Merge pull request #484 from mt4110/feat/promise-completion-display-narrow-api-handoff-route`
+- Promise completion participant-safe display narrow API handoff closeout and RunAlways delegation source: `497b6dd` / `Merge pull request #485 from mt4110/feat/promise-completion-display-runalways-closeout`
+- Promise completion participant-safe display copy and state route selection source: `722174d` / `Merge pull request #486 from mt4110/feat/promise-completion-display-copy-state-route`
+- Promise completion participant-safe display copy and state packet source: `f8f3ded` / `Merge pull request #487 from mt4110/feat/promise-completion-display-copy-state-packet`
+- Promise completion participant-safe display copy and state packet sufficiency decision source: `74b3bd0` / `Merge pull request #488 from mt4110/feat/promise-completion-display-copy-state-sufficiency`
+- Promise completion participant-safe display UI preflight route selection source: `b114197` / `Merge pull request #489 from mt4110/feat/promise-completion-display-ui-preflight-route`
+- Promise completion participant-safe display UI preflight packet source: `839a1af` / `Merge pull request #490 from mt4110/feat/promise-completion-display-ui-preflight-packet`
+- Promise completion participant-safe display UI preflight packet sufficiency decision source: `d62ef4e` / `Merge pull request #491 from mt4110/feat/promise-completion-display-ui-preflight-sufficiency`
+- Promise completion participant-safe display UI handoff packet route selection source: `5d8f299` / `Merge pull request #492 from mt4110/feat/promise-completion-display-post-ui-preflight-route`
+- Promise completion participant-safe display narrow UI handoff packet source: `fa2d0fa` / `Merge pull request #493 from mt4110/feat/promise-completion-display-narrow-ui-handoff-packet`
+- Promise completion participant-safe display narrow UI handoff packet sufficiency decision source: `76a2372` / `Merge pull request #494 from mt4110/feat/promise-completion-display-narrow-ui-handoff-sufficiency`
+- Promise completion participant-safe display narrow UI handoff route selection source: `d671448` / `Merge pull request #495 from mt4110/feat/promise-completion-display-narrow-ui-handoff-route`
 
 No release tag is asserted for this alignment.
 Do not invent a foundation version label for this commit.
@@ -461,6 +472,19 @@ Current Promise completion display chain:
 - `docs/readiness/promise_completion_participant_safe_display_narrow_api_handoff_decision_packet.md`
 - `docs/readiness/promise_completion_participant_safe_display_narrow_api_handoff_packet_sufficiency_decision.md`
 - `docs/readiness/promise_completion_participant_safe_display_post_narrow_api_handoff_packet_sufficiency_route_selection.md`
+- `docs/readiness/promise_completion_participant_safe_display_narrow_api_handoff_closeout_ledger.md`
+- `docs/readiness/promise_completion_participant_safe_display_runalways_delegation_envelope.md`
+- `docs/readiness/promise_completion_participant_safe_display_narrow_api_handoff_closeout_sufficiency_decision.md`
+- `docs/readiness/promise_completion_participant_safe_display_post_narrow_api_handoff_closeout_route_selection.md`
+- `docs/readiness/promise_completion_participant_safe_display_copy_and_state_decision_packet.md`
+- `docs/readiness/promise_completion_participant_safe_display_copy_and_state_packet_sufficiency_decision.md`
+- `docs/readiness/promise_completion_participant_safe_display_post_copy_state_packet_sufficiency_route_selection.md`
+- `docs/readiness/promise_completion_participant_safe_display_ui_preflight_decision_packet.md`
+- `docs/readiness/promise_completion_participant_safe_display_ui_preflight_packet_sufficiency_decision.md`
+- `docs/readiness/promise_completion_participant_safe_display_post_ui_preflight_packet_sufficiency_route_selection.md`
+- `docs/readiness/promise_completion_participant_safe_display_narrow_ui_handoff_decision_packet.md`
+- `docs/readiness/promise_completion_participant_safe_display_narrow_ui_handoff_packet_sufficiency_decision.md`
+- `docs/readiness/promise_completion_participant_safe_display_post_narrow_ui_handoff_packet_sufficiency_route_selection.md`
 
 ### Operations layer
 203. `docs/operations/readiness_routine.md`
@@ -643,8 +667,9 @@ Foundation PR #480 found that closeout sufficient for later route selection only
 Foundation PR #481 selected the narrow API handoff packet route only.
 Foundation PR #482 prepared the narrow API handoff packet.
 Foundation PR #483 found that packet sufficient for later route selection only.
-Foundation PR #484 provides the current one-use downstream narrow API handoff authority for one later implementation-repo PR only.
-This implementation-repo PR consumes that allowance.
+Foundation PR #484 provided the consumed one-use downstream narrow API handoff authority for one later implementation-repo PR only.
+That allowance was consumed by `mt4110/pi-musubi-core` PR #176 and closed out by foundation PR #485.
+No remaining work may inherit permission from foundation PR #484 or implementation PR #176.
 The PR #484 allowance authorizes only:
 
 - `docs/foundation_lock.md`
@@ -657,7 +682,29 @@ It authorizes only a narrow side-effect-free authenticated directly-involved Ord
 It may reuse the existing participant-safe display availability semantics already selected by earlier foundation work.
 It must return hidden or unavailable when caller eligibility, suppression, projection freshness, account lifecycle, Age Assurance, or writer truth is uncertain.
 It does not authorize public API, mobile UI, public completed-reference display, public profile display, public count, public badge, public score, public status marker, public trust label, accusation label, caller-supplied source-route authority, caller-supplied participant-set authority, caller-supplied acknowledgement authority, caller-supplied writer fact authority, caller-supplied prior fact authority, caller-supplied idempotency authority, caller-supplied suppression authority, caller-supplied reason-code authority, writer fact creation, projection row creation, projection refresh, durable projection schema, DDL, migrations, provider calls, outbox or inbox enqueueing, worker, queue, adapter, analytics, observability, external side-effect behavior, Social Trust mutation, Relationship Depth mutation, settlement release, refund, forfeiture, escrow movement, reward movement, room progression, contact unlock, off-platform handoff permission, discovery priority, recommendation boost, raw Personal Data exposure, raw evidence exposure, provider payload exposure, proof payload exposure, operator-note exposure, review-narrative exposure, Legal Hold material exposure, Critical Harm material exposure, child-safety material exposure, sensitive-trait exposure, abuse-marker visibility, internal safety classification visibility, support status exposure, payment-state exposure, shame labels, paid romantic advantage, payment-based direct-message unlock, new durable product vocabulary, or broad `pi-musubi-core` changes.
-After this downstream PR is merged, closed without merge, or replaced by a different accepted foundation decision, foundation must receive a closeout ledger for the narrow API handoff before any later Promise completion display, public display, trust, depth, settlement, API, UI, provider, outbox, inbox, worker, governed review, correction, or broader core route may inherit from it.
+Foundation PR #485 recorded the narrow API handoff closeout and RunAlways delegation posture.
+Foundation PR #486 selected a foundation-only copy-and-state packet route.
+Foundation PR #487 prepared the participant-safe display copy-and-state packet.
+Foundation PR #488 found that packet sufficient for later route selection only.
+Foundation PR #489 selected a foundation-only UI preflight route.
+Foundation PR #490 prepared the UI preflight packet.
+Foundation PR #491 found that packet sufficient for later route selection only.
+Foundation PR #492 selected the narrow UI handoff packet route only.
+Foundation PR #493 prepared the narrow UI handoff packet.
+Foundation PR #494 found that packet sufficient for later route selection only.
+Foundation PR #495 provides the current one-use downstream narrow participant-safe display UI handoff authority for one later implementation-repo PR only.
+This implementation-repo PR consumes that allowance.
+The PR #495 allowance authorizes only:
+
+- `docs/foundation_lock.md`
+- the smallest existing Flutter Web frontend presentation files needed to consume the already accepted narrow participant-safe display availability read
+- the smallest existing frontend API client, repository, or state files needed for the same read
+- focused frontend tests and deterministic verification for this one-use UI handoff
+
+It authorizes only a narrow Promise-context participant surface for an authenticated directly involved Ordinary Account to consume the existing availability-only, side-effect-free API.
+It must keep unavailable or uncertain API results quiet and non-causal.
+It must not add public display, public profile display, public count, public badge, public score, public status marker, public trust label, accusation label, public API expansion, API route changes, exact backend field changes, native iOS or Android UI, directory, discovery, recommendation, feed, ranking, notification, share, contact, room, settlement, provider, worker, queue, outbox, inbox, analytics, observability, external side-effect behavior, writer fact creation, projection row creation, projection refresh, durable projection schema, DDL, migrations, Social Trust mutation, Relationship Depth mutation, settlement release, refund, forfeiture, escrow movement, reward movement, room progression, contact unlock, off-platform handoff permission, raw Personal Data exposure, raw evidence exposure, provider payload exposure, proof payload exposure, operator-note exposure, review-narrative exposure, Legal Hold material exposure, Critical Harm material exposure, child-safety material exposure, sensitive-trait exposure, abuse-marker visibility, internal safety classification visibility, support status exposure, payment-state exposure, shame labels, paid romantic advantage, payment-based direct-message unlock, new durable product vocabulary, or broad `pi-musubi-core` changes.
+After this downstream PR is merged, closed without merge, or replaced by a different accepted foundation decision, foundation must receive a closeout ledger for the narrow UI handoff before any later Promise completion display, public display, trust, depth, settlement, API, UI, provider, outbox, inbox, worker, governed review, correction, or broader core route may inherit from it.
 
 The C2 and post-C2 readiness and closeout chain is accepted for docs-only foundation semantic scope:
 
@@ -1115,11 +1162,11 @@ When updating:
 - Review completed by:
 
 ### Current drift note
-- Updated from foundation SHA: `a5a55ee8b86dc20b04890f302bc062301e2e1f6c` -> `0c7d0c5a0470bd406432d9318ad5248ad2f1850a`
-- Reason: Align implementation-repo lock with the accepted Promise completion narrow projection non-authority route selection after foundation PR #454 (`docs: select Promise completion projection route`) and consume its one-use downstream accepted completion projection snapshot allowance.
-- New required docs: Promise completion narrow state transition runtime closeout ledger, Promise completion projection non-authority preflight decision packet, Promise completion projection non-authority preflight packet sufficiency decision, and Promise completion post-projection-non-authority-preflight sufficiency route selection.
+- Updated from foundation SHA: `c32921c1aec9d1f7e5829de01d4ea1f0b99b3a43` -> `d671448ab0674ce9d939b62d5f00da4b908e76f1`
+- Reason: Align implementation-repo lock with the accepted Promise completion participant-safe display narrow UI handoff route after foundation PR #495 (`docs: select Promise completion display narrow UI handoff route`) and consume its one-use downstream Flutter Web UI handoff allowance.
+- New required docs: Promise completion participant-safe display narrow API handoff closeout ledger, post-narrow-API handoff route selection, copy-and-state packet, copy-and-state sufficiency decision, UI preflight route selection, UI preflight packet, UI preflight sufficiency decision, UI handoff packet route selection, narrow UI handoff packet, narrow UI handoff packet sufficiency decision, and post-narrow-UI-handoff-packet sufficiency route selection.
 - Removed docs: None.
-- Implementation impact: This update consumes the one-use foundation PR #454 allowance and permits only the exact five-file narrow projection non-authority scope listed above. It authorizes only an internal repository-derived read-only helper that derives minimized accepted completion snapshots from the existing `promise_completion.writer_fact_records` table when writer truth is `completion_state_transition`, `mutual_accountable_completion_acknowledgement`, `completion_accepted`, `completed_reference_eligible = true`, prior-bound, and boundary-consistent. The helper must not write writer facts or projection rows. Migrations, DDL, new tables, projection refresh, source-route evaluation runtime, participant acknowledgement collection runtime, governed review runtime, correction/supersession runtime, API, UI, participant display, Social Trust source fact persistence, Social Trust mutation, Relationship Depth mutation, settlement movement, room behavior, contact behavior, discovery, recommendation, outbox, inbox, worker behavior, provider I/O, provider callbacks, raw Personal Data / raw evidence / provider payloads in derived snapshots, paid romantic advantage, payment-based direct-message unlock, and broader `pi-musubi-core` changes remain NO-GO.
+- Implementation impact: This update consumes the one-use foundation PR #495 allowance and permits only the narrow Flutter Web participant-safe display UI handoff scope listed above. It authorizes the existing Promise status surface to consume the already accepted side-effect-free availability-only API for directly involved Ordinary Accounts, with unavailable and uncertain results remaining quiet and non-causal. Backend API changes, route changes, API field changes, native mobile UI, public completed-reference display, public profile/count/badge/score/status/trust/accusation display, DDL, migrations, writer fact creation, projection row creation, projection refresh, provider calls, outbox, inbox, worker behavior, analytics, observability, Social Trust mutation, Relationship Depth mutation, settlement movement, room/contact behavior, discovery, recommendation, raw Personal Data / raw evidence / provider payload exposure, paid romantic advantage, payment-based direct-message unlock, new durable product vocabulary, and broader `pi-musubi-core` changes remain NO-GO.
 - Review completed by: Masaki Takemura
 
 ---


### PR DESCRIPTION
## Summary
- Pin `docs/foundation_lock.md` to foundation PR #495 and mark the prior #484 API handoff as consumed by #176.
- Thread the existing participant-safe display availability API through the mobile Promise repository and status bundle.
- Keep the UI change inside the existing Promise completion panel, with unavailable or uncertain availability remaining quiet and non-causal.

## Guardrails
- No backend API route, API field, schema, migration, provider, worker, outbox, inbox, analytics, or observability changes.
- No public completed-reference display, badge, score, status marker, trust label, accusation label, discovery, recommendation, contact unlock, room, settlement, Social Trust, or Relationship Depth behavior.
- Availability is treated as display-only and fails closed on API errors or mismatched response fields.

## Verification
- `mise exec -- dart format apps/mobile/lib/features/promise/models/promise_models.dart apps/mobile/lib/repositories/promise/api_promise_repository.dart apps/mobile/lib/features/promise/presentation/promise_status_screen.dart apps/mobile/test/features/promise/promise_models_test.dart apps/mobile/test/features/promise/promise_status_screen_test.dart apps/mobile/test/repositories/promise/api_promise_repository_test.dart`
- `mise exec -- flutter test`
- `mise exec -- flutter analyze`
- `git diff --check`
- `git diff --cached --check`