### PR TITLE
test: harden Promise completion display boundary

### DIFF
--- a/apps/backend/tests/promise_completion_participant_safe_display_narrow_api_handoff.rs
+++ b/apps/backend/tests/promise_completion_participant_safe_display_narrow_api_handoff.rs
@@ -247,6 +247,305 @@ async fn narrow_api_returns_unavailable_for_suppressed_writer_truth_without_reas
 }
 
 #[tokio::test]
+async fn narrow_api_hides_boundary_condition_families_without_reason_leakage() {
+    let (_test_state, app, config, client) = test_context().await;
+    let store = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let involved = sign_in(
+        &app,
+        "pi-user-promise-completion-narrow-api-boundary-families",
+        "promise-completion-narrow-api-boundary-families",
+    )
+    .await;
+    let counterparty = sign_in(
+        &app,
+        "pi-user-promise-completion-narrow-api-boundary-families-counterparty",
+        "promise-completion-narrow-api-boundary-families-counterparty",
+    )
+    .await;
+
+    for boundary_row in ["accepted", "prior"] {
+        for boundary_field in [
+            "block_withdrawal_state_reference",
+            "age_assurance_state_reference",
+            "legal_hold_intersection_reference",
+            "critical_harm_case_reference",
+            "account_lifecycle_reference",
+            "anti_abuse_continuity_reference",
+            "safety_case_reference",
+        ] {
+            let case_label = format!("{boundary_row}-{boundary_field}");
+            let idempotency_key = unique_idempotency_key(&format!(
+                "participant-display-narrow-api-boundary-{case_label}"
+            ));
+            let promise_case =
+                create_promise_intent(&app, &involved, &counterparty, &idempotency_key).await;
+            let acknowledgement_reference = format!("ordinary-acknowledgement-{idempotency_key}");
+            let mut prior_fact = prior_pending_mutual_acknowledgement_fact(
+                &idempotency_key,
+                &acknowledgement_reference,
+                &promise_case.promise_reference,
+                &promise_case.realm_id,
+            );
+            if boundary_row == "prior" {
+                apply_suppressed_boundary_reference(
+                    &mut prior_fact,
+                    boundary_field,
+                    &idempotency_key,
+                );
+            }
+            let prior = record_writer_fact(&store, prior_fact).await;
+            let mut accepted_fact = accepted_transition_fact(
+                &idempotency_key,
+                &prior.writer_fact_id,
+                &acknowledgement_reference,
+                &promise_case.promise_reference,
+                &promise_case.realm_id,
+            );
+            if boundary_row == "accepted" {
+                apply_suppressed_boundary_reference(
+                    &mut accepted_fact,
+                    boundary_field,
+                    &idempotency_key,
+                );
+            }
+            let accepted = store
+                .record_mutual_acknowledgement_accepted_transition(transition_input(accepted_fact))
+                .await
+                .expect("suppressed boundary transition should persist");
+            let context = ExposureContext {
+                accepted_writer_fact_id: accepted.writer_fact_id.clone(),
+                prior_writer_fact_id: prior.writer_fact_id.clone(),
+                promise_reference: accepted.promise_reference.clone(),
+                realm_id: accepted.realm_id.clone(),
+                promise_terms_reference: format!("promise-terms-{idempotency_key}"),
+                participant_set_reference: format!("participant-set-{idempotency_key}"),
+                acknowledgement_reference,
+                idempotency_key,
+            };
+            let side_effects_before = side_effect_counts(&client).await;
+
+            let response = get_http(
+                &app,
+                &availability_path(&context.promise_reference, &context.realm_id),
+                Some(involved.token.as_str()),
+            )
+            .await;
+
+            assert_unavailable_response(&response, &context);
+            assert_eq!(
+                side_effect_counts(&client).await,
+                side_effects_before,
+                "participant-safe display availability must be side-effect free for {case_label}",
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn narrow_api_hides_writer_truth_contradictions_without_reason_leakage() {
+    let (_test_state, app, config, client) = test_context().await;
+    let store = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let involved = sign_in(
+        &app,
+        "pi-user-promise-completion-narrow-api-contradiction",
+        "promise-completion-narrow-api-contradiction",
+    )
+    .await;
+    let counterparty = sign_in(
+        &app,
+        "pi-user-promise-completion-narrow-api-contradiction-counterparty",
+        "promise-completion-narrow-api-contradiction-counterparty",
+    )
+    .await;
+
+    for state in [
+        PromiseCompletionStateClass::CompletionRejected,
+        PromiseCompletionStateClass::CompletionExpired,
+        PromiseCompletionStateClass::CompletionCorrectedOrSuperseded,
+    ] {
+        let state_name = state.as_str();
+        let idempotency_key =
+            unique_idempotency_key(&format!("participant-display-narrow-api-{state_name}"));
+        let promise_case =
+            create_promise_intent(&app, &involved, &counterparty, &idempotency_key).await;
+        let acknowledgement_reference = format!("ordinary-acknowledgement-{idempotency_key}");
+        let prior = record_prior_pending_mutual_acknowledgement(
+            &store,
+            &idempotency_key,
+            &acknowledgement_reference,
+            &promise_case.promise_reference,
+            &promise_case.realm_id,
+        )
+        .await;
+        let accepted = store
+            .record_mutual_acknowledgement_accepted_transition(transition_input(
+                accepted_transition_fact(
+                    &idempotency_key,
+                    &prior.writer_fact_id,
+                    &acknowledgement_reference,
+                    &promise_case.promise_reference,
+                    &promise_case.realm_id,
+                ),
+            ))
+            .await
+            .expect("valid accepted transition should persist");
+        let mut non_accepted = accepted_transition_fact(
+            &idempotency_key,
+            &prior.writer_fact_id,
+            &acknowledgement_reference,
+            &promise_case.promise_reference,
+            &promise_case.realm_id,
+        );
+        non_accepted.completion_state_class = state;
+        non_accepted.completed_reference_eligible = false;
+        non_accepted.fact_idempotency_key = Some(format!("{state_name}-{idempotency_key}"));
+        non_accepted.reason_code_class = Some(format!("{state_name}-{idempotency_key}"));
+        let non_accepted = record_writer_fact(&store, non_accepted).await;
+        let context = ExposureContext {
+            accepted_writer_fact_id: accepted.writer_fact_id.clone(),
+            prior_writer_fact_id: prior.writer_fact_id.clone(),
+            promise_reference: accepted.promise_reference.clone(),
+            realm_id: accepted.realm_id.clone(),
+            promise_terms_reference: format!("promise-terms-{idempotency_key}"),
+            participant_set_reference: format!("participant-set-{idempotency_key}"),
+            acknowledgement_reference: acknowledgement_reference.clone(),
+            idempotency_key: idempotency_key.clone(),
+        };
+        let non_accepted_context = ExposureContext {
+            accepted_writer_fact_id: non_accepted.writer_fact_id.clone(),
+            prior_writer_fact_id: prior.writer_fact_id.clone(),
+            promise_reference: non_accepted.promise_reference.clone(),
+            realm_id: non_accepted.realm_id.clone(),
+            promise_terms_reference: format!("promise-terms-{idempotency_key}"),
+            participant_set_reference: format!("participant-set-{idempotency_key}"),
+            acknowledgement_reference,
+            idempotency_key,
+        };
+        let side_effects_before = side_effect_counts(&client).await;
+
+        let response = get_http(
+            &app,
+            &availability_path(&context.promise_reference, &context.realm_id),
+            Some(involved.token.as_str()),
+        )
+        .await;
+
+        assert_unavailable_response(&response, &context);
+        assert_no_completion_exposure(&response, &non_accepted_context);
+        assert_eq!(
+            side_effect_counts(&client).await,
+            side_effects_before,
+            "participant-safe display availability must be side-effect free for {state_name}",
+        );
+    }
+}
+
+#[tokio::test]
+async fn narrow_api_hides_prior_linked_correction_drift() {
+    let (_test_state, app, config, client) = test_context().await;
+    let store = PromiseCompletionWriterFactStore::connect(&config)
+        .await
+        .expect("store should connect");
+    let involved = sign_in(
+        &app,
+        "pi-user-promise-completion-narrow-api-linked-correction",
+        "promise-completion-narrow-api-linked-correction",
+    )
+    .await;
+    let counterparty = sign_in(
+        &app,
+        "pi-user-promise-completion-narrow-api-linked-correction-counterparty",
+        "promise-completion-narrow-api-linked-correction-counterparty",
+    )
+    .await;
+    let idempotency_key =
+        unique_idempotency_key("participant-display-narrow-api-linked-correction");
+    let promise_case =
+        create_promise_intent(&app, &involved, &counterparty, &idempotency_key).await;
+    let acknowledgement_reference = format!("ordinary-acknowledgement-{idempotency_key}");
+    let prior = record_prior_pending_mutual_acknowledgement(
+        &store,
+        &idempotency_key,
+        &acknowledgement_reference,
+        &promise_case.promise_reference,
+        &promise_case.realm_id,
+    )
+    .await;
+    let accepted = store
+        .record_mutual_acknowledgement_accepted_transition(transition_input(
+            accepted_transition_fact(
+                &idempotency_key,
+                &prior.writer_fact_id,
+                &acknowledgement_reference,
+                &promise_case.promise_reference,
+                &promise_case.realm_id,
+            ),
+        ))
+        .await
+        .expect("valid accepted transition should persist");
+    let mut correction = accepted_transition_fact(
+        &idempotency_key,
+        &accepted.writer_fact_id,
+        &acknowledgement_reference,
+        &promise_case.promise_reference,
+        &promise_case.realm_id,
+    );
+    correction.fact_family = PromiseCompletionWriterFactFamily::CorrectionOrSupersession;
+    correction.previous_completion_state_class =
+        Some(PromiseCompletionStateClass::CompletionAccepted);
+    correction.completion_state_class =
+        PromiseCompletionStateClass::CompletionCorrectedOrSuperseded;
+    correction.completed_reference_eligible = false;
+    correction.promise_terms_reference = Some(format!("drifted-promise-terms-{idempotency_key}"));
+    correction.participant_set_reference =
+        Some(format!("drifted-participant-set-{idempotency_key}"));
+    correction.policy_version = Some(2);
+    correction.fact_idempotency_key =
+        Some(format!("prior-linked-correction-drift-{idempotency_key}"));
+    correction.reason_code_class = Some(format!("prior-linked-correction-drift-{idempotency_key}"));
+    correction.correction_or_supersession_reference = Some(format!(
+        "prior-linked-correction-reference-{idempotency_key}"
+    ));
+    let correction = record_writer_fact(&store, correction).await;
+    let context = ExposureContext {
+        accepted_writer_fact_id: accepted.writer_fact_id.clone(),
+        prior_writer_fact_id: prior.writer_fact_id.clone(),
+        promise_reference: accepted.promise_reference.clone(),
+        realm_id: accepted.realm_id.clone(),
+        promise_terms_reference: format!("promise-terms-{idempotency_key}"),
+        participant_set_reference: format!("participant-set-{idempotency_key}"),
+        acknowledgement_reference: acknowledgement_reference.clone(),
+        idempotency_key: idempotency_key.clone(),
+    };
+    let correction_context = ExposureContext {
+        accepted_writer_fact_id: correction.writer_fact_id.clone(),
+        prior_writer_fact_id: accepted.writer_fact_id.clone(),
+        promise_reference: correction.promise_reference.clone(),
+        realm_id: correction.realm_id.clone(),
+        promise_terms_reference: format!("drifted-promise-terms-{idempotency_key}"),
+        participant_set_reference: format!("drifted-participant-set-{idempotency_key}"),
+        acknowledgement_reference,
+        idempotency_key,
+    };
+    let side_effects_before = side_effect_counts(&client).await;
+
+    let response = get_http(
+        &app,
+        &availability_path(&context.promise_reference, &context.realm_id),
+        Some(involved.token.as_str()),
+    )
+    .await;
+
+    assert_unavailable_response(&response, &context);
+    assert_no_completion_exposure(&response, &correction_context);
+    assert_eq!(side_effect_counts(&client).await, side_effects_before);
+}
+
+#[tokio::test]
 async fn narrow_api_fails_closed_when_competing_snapshot_is_suppressed() {
     let (_test_state, app, config, client) = test_context().await;
     let store = PromiseCompletionWriterFactStore::connect(&config)
@@ -484,6 +783,24 @@ async fn record_prior_pending_mutual_acknowledgement(
     promise_reference: &str,
     realm_id: &str,
 ) -> musubi_backend::services::promise_completion::PromiseCompletionWriterFactSnapshot {
+    record_writer_fact(
+        store,
+        prior_pending_mutual_acknowledgement_fact(
+            idempotency_key,
+            acknowledgement_reference,
+            promise_reference,
+            realm_id,
+        ),
+    )
+    .await
+}
+
+fn prior_pending_mutual_acknowledgement_fact(
+    idempotency_key: &str,
+    acknowledgement_reference: &str,
+    promise_reference: &str,
+    realm_id: &str,
+) -> ProposedPromiseCompletionWriterFact {
     let mut fact = base_fact(
         idempotency_key,
         acknowledgement_reference,
@@ -497,7 +814,7 @@ async fn record_prior_pending_mutual_acknowledgement(
     fact.completed_reference_eligible = false;
     fact.fact_idempotency_key = Some(format!("prior-{idempotency_key}"));
     fact.reason_code_class = Some(format!("completion-pending-mutual-ack-{idempotency_key}"));
-    record_writer_fact(store, fact).await
+    fact
 }
 
 fn accepted_transition_fact(
@@ -524,6 +841,50 @@ fn accepted_transition_fact(
     ));
     fact.reason_code_class = Some(format!("completion-accepted-{idempotency_key}"));
     fact
+}
+
+fn apply_suppressed_boundary_reference(
+    fact: &mut ProposedPromiseCompletionWriterFact,
+    boundary_field: &str,
+    idempotency_key: &str,
+) {
+    let value = match boundary_field {
+        "block_withdrawal_state_reference" => {
+            format!("block-withdrawal-active-{idempotency_key}")
+        }
+        "age_assurance_state_reference" => format!("age-assurance-conflict-{idempotency_key}"),
+        "legal_hold_intersection_reference" => format!("legal-hold-active-{idempotency_key}"),
+        "critical_harm_case_reference" => format!("critical-harm-open-{idempotency_key}"),
+        "account_lifecycle_reference" => format!("account-lifecycle-held-{idempotency_key}"),
+        "anti_abuse_continuity_reference" => format!("anti-abuse-interrupted-{idempotency_key}"),
+        "safety_case_reference" => format!("safety-case-open-{idempotency_key}"),
+        _ => panic!("unsupported boundary field {boundary_field}"),
+    };
+
+    match boundary_field {
+        "block_withdrawal_state_reference" => {
+            fact.block_withdrawal_state_reference = Some(value);
+        }
+        "age_assurance_state_reference" => {
+            fact.age_assurance_state_reference = Some(value);
+        }
+        "legal_hold_intersection_reference" => {
+            fact.legal_hold_intersection_reference = Some(value);
+        }
+        "critical_harm_case_reference" => {
+            fact.critical_harm_case_reference = Some(value);
+        }
+        "account_lifecycle_reference" => {
+            fact.account_lifecycle_reference = Some(value);
+        }
+        "anti_abuse_continuity_reference" => {
+            fact.anti_abuse_continuity_reference = Some(value);
+        }
+        "safety_case_reference" => {
+            fact.safety_case_reference = Some(value);
+        }
+        _ => panic!("unsupported boundary field {boundary_field}"),
+    }
 }
 
 fn base_fact(

--- a/docs/foundation_lock.md
+++ b/docs/foundation_lock.md
@@ -1,6 +1,6 @@
 # Foundation Lock
 
-Status: Draft; aligned to accepted foundation commit `ab401c4`
+Status: Draft; aligned to accepted foundation commit `5d2d676`
 Applies to: `mt4110/pi-musubi-core`
 Purpose: Pin the constitutional and architectural source of truth that this implementation repository must follow.
 
@@ -26,14 +26,14 @@ Upstream repository:
 Pinned reference for implementation work:
 
 - Foundation reference type: `commit`
-- Foundation commit SHA: `ab401c48b16b7178eb05486b2351f8a22ed563d2`
-- Foundation commit title: `Merge pull request #504 from mt4110/feat/promise-completion-display-ui-non-exposure-test-route`
-- Foundation PR title: `docs: select Promise completion display UI non-exposure test route`
-- Foundation PR URL: `https://github.com/mt4110/musubi-foundation/pull/504`
-- Date pinned: `2026-06-20`
+- Foundation commit SHA: `5d2d676de4c7556469b111d5754ec3e1b5775e0e`
+- Foundation commit title: `Merge pull request #524 from mt4110/feat/promise-completion-display-post-hardening-handoff-route`
+- Foundation PR title: `docs: select Promise completion display handoff route`
+- Foundation PR URL: `https://github.com/mt4110/musubi-foundation/pull/524`
+- Date pinned: `2026-06-21`
 - Pinned by: `Masaki Takemura`
-- Pinned commit URL: `https://github.com/mt4110/musubi-foundation/commit/ab401c48b16b7178eb05486b2351f8a22ed563d2`
-- Previous pinned reference: `d671448` / `Merge pull request #495 from mt4110/feat/promise-completion-display-narrow-ui-handoff-route`
+- Pinned commit URL: `https://github.com/mt4110/musubi-foundation/commit/5d2d676de4c7556469b111d5754ec3e1b5775e0e`
+- Previous pinned reference: `ab401c4` / `Merge pull request #504 from mt4110/feat/promise-completion-display-ui-non-exposure-test-route`
 - Post-C2 evidence source: `cfdba28` / `Merge pull request #114 from mt4110/feat/post-c2-runtime-handoff-evidence-package`
 - Alignment allowance source: `69b7aa4` / `Merge pull request #116 from mt4110/feat/evaluate-post-c2-runtime-handoff-gate`
 - Post-C2 implementation handoff evidence source: `ef23e88` / `Merge pull request #122 from mt4110/feat/post-c2-implementation-handoff-evidence-package`
@@ -231,6 +231,26 @@ Pinned reference for implementation work:
 - Promise completion participant-safe display post-narrow-UI non-exposure decision packet source: `917d6d7` / `Merge pull request #502 from mt4110/feat/promise-completion-display-ui-non-exposure-packet`
 - Promise completion participant-safe display post-narrow-UI non-exposure packet sufficiency decision source: `6b36a61` / `Merge pull request #503 from mt4110/feat/promise-completion-display-ui-non-exposure-sufficiency`
 - Promise completion participant-safe display post-narrow-UI non-exposure test-only route selection source: `ab401c4` / `Merge pull request #504 from mt4110/feat/promise-completion-display-ui-non-exposure-test-route`
+- Promise completion participant-safe display post-narrow-UI non-exposure test-only closeout source: `3d2c2f5` / `Merge pull request #505 from mt4110/feat/promise-completion-display-ui-non-exposure-closeout`
+- Promise completion participant-safe display post-narrow-UI non-exposure closeout sufficiency decision source: `8fbf4a6` / `Merge pull request #506 from mt4110/feat/promise-completion-display-ui-non-exposure-closeout-sufficiency`
+- Promise completion participant-safe display post-narrow-UI non-exposure closeout route selection source: `b814fac` / `Merge pull request #507 from mt4110/feat/promise-completion-display-post-ui-non-exposure-closeout-route`
+- Promise completion participant-safe display post-narrow-UI non-exposure closeout readiness runway source: `6d7b127` / `Merge pull request #508 from mt4110/feat/promise-completion-display-post-ui-non-exposure-runway`
+- Promise completion participant-safe display post-narrow-UI non-exposure closeout runway sufficiency decision source: `1134099` / `Merge pull request #509 from mt4110/feat/promise-completion-display-post-ui-non-exposure-runway-sufficiency`
+- Promise completion participant-safe display post-narrow-UI non-exposure closeout runway route selection source: `f4feffa` / `Merge pull request #510 from mt4110/feat/promise-completion-display-post-ui-non-exposure-runway-route`
+- Promise completion participant-safe display post-internal-stop reopen route selection source: `2d05a32` / `Merge pull request #511 from mt4110/feat/promise-completion-display-reopen-route-selection`
+- Promise completion participant-safe display post-internal-stop display hardening packet source: `28439c3` / `Merge pull request #512 from mt4110/feat/promise-completion-display-hardening-packet`
+- Promise completion participant-safe display post-internal-stop display hardening packet sufficiency decision source: `9328e97` / `Merge pull request #513 from mt4110/feat/promise-completion-display-hardening-sufficiency`
+- Promise completion participant-safe display post-internal-stop display hardening route selection source: `da66b7a` / `Merge pull request #514 from mt4110/feat/promise-completion-display-hardening-route`
+- Promise completion participant-safe display post-display-hardening internal-stop reopen route selection source: `e7c439f` / `Merge pull request #515 from mt4110/feat/promise-completion-display-post-hardening-reopen-route`
+- Promise completion participant-safe display post-display-hardening readiness runway source: `e9c3989` / `Merge pull request #516 from mt4110/feat/promise-completion-display-post-hardening-runway`
+- Promise completion participant-safe display post-display-hardening runway sufficiency decision source: `dfb050f` / `Merge pull request #517 from mt4110/feat/promise-completion-display-post-hardening-runway-sufficiency`
+- Promise completion participant-safe display post-display-hardening runway route selection source: `7a95f85` / `Merge pull request #518 from mt4110/feat/promise-completion-display-post-hardening-route-selection`
+- Promise completion participant-safe display post-display-hardening consolidation packet source: `f4770bb` / `Merge pull request #519 from mt4110/feat/promise-completion-display-post-hardening-consolidation`
+- Promise completion participant-safe display post-display-hardening consolidation packet sufficiency decision source: `9918646` / `Merge pull request #520 from mt4110/feat/promise-completion-display-post-hardening-consolidation-sufficiency`
+- Promise completion participant-safe display post-display-hardening consolidation route selection source: `d82e14b` / `Merge pull request #521 from mt4110/feat/promise-completion-display-post-hardening-consolidation-route-selection`
+- Promise completion participant-safe display post-display-hardening downstream handoff boundary packet source: `b4bf76a` / `Merge pull request #522 from mt4110/feat/promise-completion-display-post-hardening-boundary-packet`
+- Promise completion participant-safe display post-display-hardening downstream handoff boundary packet sufficiency decision source: `4f8f507` / `Merge pull request #523 from mt4110/feat/promise-completion-display-post-hardening-boundary-sufficiency`
+- Promise completion participant-safe display post-display-hardening downstream handoff route selection source: `5d2d676` / `Merge pull request #524 from mt4110/feat/promise-completion-display-post-hardening-handoff-route`
 
 No release tag is asserted for this alignment.
 Do not invent a foundation version label for this commit.
@@ -1200,11 +1220,11 @@ When updating:
 - Review completed by:
 
 ### Current drift note
-- Updated from foundation SHA: `d671448ab0674ce9d939b62d5f00da4b908e76f1` -> `ab401c48b16b7178eb05486b2351f8a22ed563d2`
-- Reason: Align implementation-repo lock with the accepted Promise completion participant-safe display post-narrow-UI non-exposure test-only route after foundation PR #504 (`docs: select Promise completion display UI non-exposure test route`) and consume its one-use downstream test-only verification allowance.
-- New required docs: Promise completion participant-safe display narrow UI handoff closeout ledger, narrow UI handoff closeout sufficiency decision, post-narrow-UI closeout route selection, post-narrow-UI readiness runway, post-narrow-UI runway sufficiency decision, post-narrow-UI runway route selection, post-narrow-UI non-exposure verification decision packet, post-narrow-UI non-exposure verification packet sufficiency decision, and post-narrow-UI non-exposure verification route selection.
+- Updated from foundation SHA: `ab401c48b16b7178eb05486b2351f8a22ed563d2` -> `5d2d676de4c7556469b111d5754ec3e1b5775e0e`
+- Reason: Align implementation-repo lock with the accepted Promise completion participant-safe display post-display-hardening downstream handoff route selection after foundation PR #524 (`docs: select Promise completion display handoff route`) before consuming its one-use downstream handoff allowance.
+- New required docs: Promise completion participant-safe display post-narrow-UI non-exposure closeout ledger, closeout sufficiency decision, closeout route selection, closeout readiness runway, closeout runway sufficiency decision, closeout runway route selection, post-internal-stop reopen route selection, post-internal-stop display hardening packet, display hardening packet sufficiency decision, display hardening route selection, post-display-hardening internal-stop reopen route selection, post-display-hardening readiness runway, runway sufficiency decision, runway route selection, consolidation packet, consolidation packet sufficiency decision, consolidation route selection, downstream handoff boundary packet, downstream handoff boundary packet sufficiency decision, and downstream handoff route selection.
 - Removed docs: None.
-- Implementation impact: This update consumes the one-use foundation PR #504 allowance and permits only test-only verification that the consumed narrow Flutter Web participant-safe display UI handoff remains non-exposing and non-converting. Production behavior, backend API changes, route changes, API field changes, native mobile UI, public completed-reference display, public profile/count/badge/score/status/trust/depth/settlement/accusation display, DDL, migrations, writer fact creation, projection row creation, projection refresh, provider calls, outbox, inbox, worker behavior, analytics, observability, Social Trust mutation, Relationship Depth mutation, settlement movement, room/contact behavior, discovery, recommendation, raw Personal Data / raw evidence / provider payload exposure, paid romantic advantage, payment-based direct-message unlock, new durable product vocabulary, and broader `pi-musubi-core` changes remain NO-GO.
+- Implementation impact: This update pins the accepted foundation route that permits one later downstream PR inside the recorded post-display-hardening participant-safe display boundary envelope. This lock pin alone does not implement boundary hardening, does not add runtime behavior, and does not authorize a second downstream PR. The later downstream work remains limited to the existing participant-safe display boundary plus co-located deterministic verification. Public completed-reference display, public profile/count/badge/score/status/proof/trust/depth/settlement/accusation display, public API, API expansion, native iOS or Android implementation, additional UI implementation, DDL, migrations, durable projection schema, projection refresh, writer fact creation, state transition creation, source-route evaluation from raw user input, participant acknowledgement collection, governed review runtime, correction or supersession runtime, proof runtime, proof eligibility runtime, provider calls, outbox, inbox, worker behavior, analytics, observability, Social Trust mutation, Relationship Depth mutation, settlement movement, room/contact behavior, discovery, recommendation, raw Personal Data / raw evidence / provider payload / proof payload / operator-note / review-narrative / Legal Hold / Critical Harm / child-safety / sensitive-trait / abuse-marker / suppression-reason exposure, paid romantic advantage, payment-based direct-message unlock, new durable product vocabulary, and broader `pi-musubi-core` changes remain NO-GO.
 - Review completed by: Masaki Takemura
 
 ---


### PR DESCRIPTION
## Scope

- Pins `docs/foundation_lock.md` to `mt4110/musubi-foundation#524` / merge commit `5d2d676de4c7556469b111d5754ec3e1b5775e0e`.
- Adds deterministic backend verification for the existing narrow participant-safe display availability boundary.
- Verifies accepted/prior boundary suppression families return unavailable without reason leakage.
- Verifies rejected, expired, corrected/superseded, and prior-linked correction drift writer truth fail closed at the API boundary.
- Keeps the response minimized to the existing two-field availability shape and side-effect free.

## Non-Goals

- No public completed-reference display.
- No public profile display.
- No API expansion, new route, or new response field.
- No UI, native app, schema, migration, projection refresh, writer/state fact creation route, trust, depth, settlement, room, contact, discovery, recommendation, provider, outbox, inbox, worker, analytics, observability, or external side effect behavior.

## Validation

- `git diff --check`
- `rustfmt --edition 2024 --check apps/backend/tests/promise_completion_participant_safe_display_narrow_api_handoff.rs`
- `APP_ENV=local DATABASE_URL=postgres://musubi:musubi_local_dev@127.0.0.1:55432/musubi_dev MUSUBI_TEST_DATABASE_URL=postgres://musubi:musubi_local_dev@127.0.0.1:55432/musubi_test MIGRATIONS_DIR=./migrations REQUIRE_LATEST_SCHEMA=true cargo test --test promise_completion_participant_safe_display_narrow_api_handoff`
- `APP_ENV=local DATABASE_URL=postgres://musubi:musubi_local_dev@127.0.0.1:55432/musubi_dev MUSUBI_TEST_DATABASE_URL=postgres://musubi:musubi_local_dev@127.0.0.1:55432/musubi_test MIGRATIONS_DIR=./migrations REQUIRE_LATEST_SCHEMA=true cargo test --test promise_completion_participant_safe_display_api_non_exposure`

## Notes

- This remains inside the one-use downstream scope selected by foundation #524.
- Global `cargo fmt --check` is not used here because this checkout has unrelated pre-existing rustfmt diffs in operator-review files; this PR formats and checks only the touched test file.
